### PR TITLE
Convert from midje tests to vanilla clojure.test code

### DIFF
--- a/src/com/puppetlabs/cmdb/catalog.clj
+++ b/src/com/puppetlabs/cmdb/catalog.clj
@@ -211,7 +211,7 @@
    "require"   {:direction :reverse :relationship :required-by}})
 
 (defn build-dependencies-for-resource
-  "Given a resource, return a list of dependency specifications
+  "Given a resource, return a lazy seq of dependency specifications
   applicable to that resource.
 
   This will include relationships extracted from dependency-signifying


### PR DESCRIPTION
Midje has some issues with proper support for fixtures, and in general I
dislike how all tests are evaluated on _compile_, as opposed to running them
specifically during test invokation at _run time_. We can still make use of its
convenient "checker" methods to do collection comparisons, though, which is
nice.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
