### PR TITLE
Switch from clj-json to data.json

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,9 +2,9 @@
   :description "FIXME: write description"
   :dependencies [[org.clojure/clojure "1.2.1"]
                  [org.clojure/clojure-contrib "1.2.0"]
+                 [org.clojure/data.json "0.1.1"]
                  [postgresql/postgresql "9.0-801.jdbc4"]
                  [org.clojure/java.jdbc "0.0.6"]
-                 [clj-json "0.4.0"]
                  [digest "1.2.1"]
                  [com.h2database/h2 "1.3.159"]
                  [log4j "1.2.16" :exclusions [javax.mail/mail

--- a/src/com/puppetlabs/cmdb/catalog.clj
+++ b/src/com/puppetlabs/cmdb/catalog.clj
@@ -83,7 +83,7 @@
 ;;
 (ns com.puppetlabs.cmdb.catalog
   (:require [clojure.contrib.logging :as log]
-            [clj-json.core :as json]
+            [clojure.data.json :as json]
             [clojure.contrib.duck-streams :as ds]
             [digest]
             [com.puppetlabs.utils :as pl-utils]))
@@ -335,7 +335,7 @@
   "Parse a wire-format JSON catalog string contained in `s`, returning a
   cmdb-suitable representation."
   [s]
-  (-> (json/parse-string s)
+  (-> (json/read-json s false)
       (parse-from-json-obj)))
 
 (defn parse-from-json-file


### PR DESCRIPTION
data.json has similar features to clj-json, but uses a protocol to extend the
serializer to new types. This is a handy feature we can use to implement easy
serialization of CMDB types directly to JSON, so we should make that switch
now.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
