### PR TITLE
Clean up orphaned resources after catalog delete

### DIFF
--- a/src/com/puppetlabs/cmdb/scf/storage.clj
+++ b/src/com/puppetlabs/cmdb/scf/storage.clj
@@ -301,7 +301,9 @@ then we'll lookup a resource with that key and use its hash."
   [certname]
   {:pre [(string? certname)]}
   (sql/transaction
-   (sql/delete-rows :certnames ["name=?" certname])))
+   ;; Should cascade through everything
+   (sql/delete-rows :certnames ["name=?" certname])
+   (sql/delete-rows :resources ["hash NOT IN (SELECT resource FROM certname_resources WHERE certname=?)" certname])))
 
 (defn replace-catalog!
   "Given a catalog, replace the current catalog, if any, for its


### PR DESCRIPTION
A cascade delete is triggered when a row from a master table is deleted; then
all FK pointers to that record are also deleted. We've actually got 2 master
tables: certnames and resources, so we need to actually delete manually from
both for a catalog to be fully expunged.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
