### PR TITLE
Restore compatibility with swank-clojure 1.4.0 series.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
                  [cheshire "2.0.4"]
                  [org.clojure/core.incubator "0.1.0"]
                  [org.clojure/tools.cli "0.2.1"]
+                 [clj-stacktrace "0.2.4"]
                  ;; Filesystem utilities
                  [fs "1.0.0"]
                  ;; Configuration file parsing


### PR DESCRIPTION
We're using a pretty antiquated version of clj-stacktrace (pulled in via our
use of Clothesline, which is itself fairly antiquated). By manually specifying
a recent-enough version, we avoid incompatibilities between older copies of
clj-stacktrace and newer libraries (like swank-clojure).

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
