### PR TITLE
Fix shadowing of core functions

### DIFF
--- a/src/com/puppetlabs/cmdb/query/resource.clj
+++ b/src/com/puppetlabs/cmdb/query/resource.clj
@@ -38,7 +38,7 @@ An empty query gathers all resources."
     (-> (table :resources)
         (project [:hash])
         (distinct)
-        (clojureql.core/compile db))
+        (compile db))
     (compile-query->sql db query)))
 
 (defn malformed-request?
@@ -163,7 +163,7 @@ JSON array, and returning them as the body of the request."
               ;; ...else, failure
               :else (throw (IllegalArgumentException.
                            (str term " is not a valid query term"))))
-        [sql & params] (clojureql.core/compile tbl db)]
+        [sql & params] (compile tbl db)]
       (apply vector (format "(%s)" sql) params)))
 
 (defn- alias-subqueries


### PR DESCRIPTION
This causes a problem with a persistent compilation process, like swank,
wherein it can't determine which is the correct implementation of a function
that is imported from 2 different namespaces without a prefix. Since clojureql
uses function names like "conj!" and "distinct" that also exist in
clojure.core, there's no good way for the compiler to determine which function
is being referred to in the code.

I've implemented a temporary fix, which is to simply exclude all overlapping
functions from clojure.core.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
