### PR TITLE
Fix terminus server/port settings

### DIFF
--- a/module/lib/puppet/indirector/catalog/grayskull.rb
+++ b/module/lib/puppet/indirector/catalog/grayskull.rb
@@ -6,11 +6,11 @@ class Puppet::Resource::Catalog::Grayskull < Puppet::Indirector::REST
   #use_server_setting :grayskull_server
   #use_port_setting :grayskull_port
 
-  def server
+  def self.server
     "grayskull"
   end
 
-  def port
+  def self.port
     8080
   end
 

--- a/module/lib/puppet/indirector/facts/grayskull.rb
+++ b/module/lib/puppet/indirector/facts/grayskull.rb
@@ -6,11 +6,11 @@ class Puppet::Node::Facts::Grayskull < Puppet::Indirector::REST
   #use_server_setting :grayskull_server
   #use_port_setting :grayskull_port
 
-  def server
+  def self.server
     "grayskull"
   end
 
-  def port
+  def self.port
     8080
   end
 

--- a/module/lib/puppet/indirector/resource/grayskull.rb
+++ b/module/lib/puppet/indirector/resource/grayskull.rb
@@ -1,8 +1,16 @@
 require 'puppet/indirector/rest'
 
 class Puppet::Resource::Grayskull < Puppet::Indirector::REST
-  use_server_setting :grayskull_server
-  use_port_setting :grayskull_port
+  #use_server_setting :grayskull_server
+  #use_port_setting :grayskull_port
+
+  def self.server
+    "grayskull"
+  end
+
+  def self.port
+    8080
+  end
 
   def search(request)
     type   = canonicalize_type(request.key)


### PR DESCRIPTION
These overrides were incorrectly implemented as instance methods, when
they actually need to be class methods on the terminus. Additionally,
they were missed in the resource terminus.
