### PR TITLE
Correctly string-ify catalog versions

### DIFF
--- a/src/com/puppetlabs/cmdb/catalog.clj
+++ b/src/com/puppetlabs/cmdb/catalog.clj
@@ -325,7 +325,7 @@
       (assoc :cmdb-version CMDB-VERSION)
       (assoc :api-version (get-in wire-catalog ["metadata" "api_version"]))
       (assoc :certname (get-in wire-catalog ["data" "name"]))
-      (assoc :version (get-in wire-catalog ["data" "version"]))))
+      (assoc :version (str (get-in wire-catalog ["data" "version"])))))
 
 ;; ## Deserialization
 ;;

--- a/test/com/puppetlabs/cmdb/test/catalog.clj
+++ b/test/com/puppetlabs/cmdb/test/catalog.clj
@@ -268,7 +268,7 @@
  {:certname "myhost.mydomain.com"
   :cmdb-version CMDB-VERSION
   :api-version 1
-  :version 123456789
+  :version "123456789"
   :tags #{"class" "foobar"}
   :classes #{"foobar"}
   :edges #{{:source {:type "Class" :title "foobar"}


### PR DESCRIPTION
While we were always converting catalog versions to string for persistence in
the database, the catalog object itself should reflect this constraint.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
