### PR TITLE
Improved default log4j config

### DIFF
--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -1,4 +1,13 @@
-log4j.rootLogger=DEBUG, A1
+log4j.rootLogger=INFO, A1
 log4j.appender.A1=org.apache.log4j.ConsoleAppender
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=[%d] [%p] [%t] %m%n
+log4j.appender.A1.layout.ConversionPattern=%d %-5p [%t] [%c{2}] %m%n
+
+# Shut up, ActiveMQ!
+log4j.logger.org.apache.activemq=WARN
+
+# Shut up, Spring Framework!
+log4j.logger.org.springframework.jms.connection=WARN
+
+# Turn on to see verbose storage activity
+# log4j.logger.com.puppetlabs.cmdb.scf.storage=DEBUG


### PR DESCRIPTION
This includes the category in the output, and defaults to quieting down chatty packages like ActiveMQ.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
