### PR TITLE
Ring middleware that computes metrics for all HTTP requests

### DIFF
--- a/src/com/puppetlabs/cmdb/http/server.clj
+++ b/src/com/puppetlabs/cmdb/http/server.clj
@@ -1,4 +1,4 @@
-;; REST server
+;; ## REST server
 ;;
 ;; Consolidates our disparate REST endpoints into a single Ring
 ;; application.
@@ -7,6 +7,8 @@
   (:use [com.puppetlabs.cmdb.http.command :only (command-app)]
         [com.puppetlabs.cmdb.http.facts :only (facts-app)]
         [com.puppetlabs.cmdb.http.resources :only (resources-app)]
+        [com.puppetlabs.middleware :only (wrap-with-globals wrap-with-metrics)]
+        [com.puppetlabs.utils :only (uri-segments)]
         [net.cgrand.moustache :only (app)]
         [ring.middleware.params :only (wrap-params)]))
 
@@ -22,18 +24,11 @@
    ["commands"]
    {:post command-app}))
 
-(defn wrap-with-globals
-  "Ring middleware that will add to each request a :globals attribute:
-  a map containing various global settings"
-  [app globals]
-  (fn [req]
-    (let [new-req (assoc req :globals globals)]
-      (app new-req))))
-
 (defn build-app
   "Given an attribute map representing connectivity to the SCF
   database, generate a Ring application that handles queries"
   [globals]
   (-> routes
       (wrap-params)
+      (wrap-with-metrics (atom {}) #(first (uri-segments %)))
       (wrap-with-globals globals)))

--- a/src/com/puppetlabs/middleware.clj
+++ b/src/com/puppetlabs/middleware.clj
@@ -1,0 +1,68 @@
+;; ## Ring middleware
+
+(ns com.puppetlabs.middleware
+  (:use [metrics.timers :only (timer time!)]
+        [metrics.meters :only (meter mark!)]))
+
+(defn wrap-with-globals
+  "Ring middleware that will add to each request a :globals attribute:
+  a map containing various global settings"
+  [app globals]
+  (fn [req]
+    (let [new-req (assoc req :globals globals)]
+      (app new-req))))
+
+(defn wrap-with-metrics*
+  "Ring middleware that will tack performance counters for each
+  URL. Arguments are the same as for `wrap-with-metrics`, except:
+
+  `prefix`: string to use as the first component of each generated
+  metric."
+  [app prefix storage normalize-uri]
+  (fn [req]
+    (let [metric-root (str (normalize-uri (:uri req)))
+          timer-key   [:timers metric-root]]
+      (when-not (get-in @storage timer-key)
+        (swap! storage assoc-in timer-key (timer [prefix metric-root "service-time"])))
+
+      (time! (get-in @storage timer-key)
+
+             (let [response  (app req)
+                   status    (:status response)
+                   meter-key [:meters metric-root status]]
+               (when-not (get-in @storage meter-key)
+                 (swap! storage assoc-in meter-key (meter [prefix metric-root (str status)] "reqs/s")))
+               (mark! (get-in @storage meter-key))
+               response)))))
+
+(defmacro wrap-with-metrics
+  "Ring middleware that will tack performance counters for each URL.
+  We track the following metrics per-app, at a top-level
+
+  * `service-time`: how long it took to service the request
+
+  We track the following meters per-app, and per-response-code:
+
+  * `reqs/s`: the rate at which responses of a given status are
+    reported
+
+  Created metrics are stored in the supplied `storage` atom with the
+  following structure:
+
+    {:timers {<normalized uri> <service time metric>
+              <normalized uri> <service time metric>}
+     :meters {<normalized uri> {<status code> <reqs/s>
+                                <status code> <reqs/s>}}}
+
+  `app`: The ring app to be wrapped
+
+  `storage`: An atom that will be used to hold references to all
+  created metrics.
+
+  `normalize-uri`: A function that takes a URI, and returns a
+  transformed string. The result will be used to organize the metrics:
+  URI's with the same normalized representation will share timers and
+  meters. To have all URIs share the same metrics, use `identity`."
+ [app storage normalize-uri]
+  `(let [prefix# ~(str *ns*)]
+     (wrap-with-metrics* ~app prefix# ~storage ~normalize-uri)))

--- a/src/com/puppetlabs/utils.clj
+++ b/src/com/puppetlabs/utils.clj
@@ -65,6 +65,13 @@
                  (class)
                  (.isArray)))
 
+(defn keyset
+  "Retuns a set of keys from the supplied map"
+  [m]
+  {:pre  [(map? m)]
+   :post [(set? %)]}
+  (set (keys m)))
+
 ;; ## Stubbing
 ;;
 ;; These redef functions are backported from Clojure 1.3 core
@@ -201,3 +208,10 @@
       (json/generate-string)
       (rr/response)
       (rr/header "Content-Type" "application/json")))
+
+(defn uri-segments
+  "Converts the given URI into a seq of path segments. Empty segments
+  (from a `//`, for example) are elided from the result"
+  [uri]
+  (remove #{""} (.split uri "/")))
+

--- a/test/com/puppetlabs/test/middleware.clj
+++ b/test/com/puppetlabs/test/middleware.clj
@@ -1,0 +1,42 @@
+(ns com.puppetlabs.test.middleware
+  (:require [ring.util.response :as rr])
+  (:use [com.puppetlabs.middleware]
+        [com.puppetlabs.utils :only (keyset)]
+        [clojure.test]))
+
+(deftest wrapping
+  (testing "Should create per-status metrics"
+    (let [storage       (atom {})
+          normalize-uri identity]
+      (doseq [status (range 200 210)]
+        (let [handler (fn [req] (-> (rr/response nil)
+                                    (rr/status status)))
+              app (wrap-with-metrics handler storage normalize-uri)]
+          (app {:uri "/foo/bar/baz"})))
+
+      ;; Should create both timers and meters
+      (is (= #{:timers :meters} (keyset @storage)))
+
+      ;; Should have timers and meters for the given URL
+      (is (= #{"/foo/bar/baz"} (keyset (@storage :timers))))
+      (is (= #{"/foo/bar/baz"} (keyset (@storage :meters))))
+
+      ;; Should have separate meters for each status code
+      (is (= (set (range 200 210)) (keyset (get-in @storage [:meters "/foo/bar/baz"]))))))
+
+  (testing "Should normalize according to supplied func"
+    (let [storage       (atom {})
+          ;; Normalize urls based on reversing the url
+          normalize-uri #(apply str (reverse %))
+          handler       (fn [req] (-> (rr/response nil)
+                                      (rr/status 200)))
+          app           (wrap-with-metrics handler storage normalize-uri)]
+
+      (app {:uri "/foo"})
+      (app {:uri "/bar"})
+      (app {:uri "/baz"})
+
+      ;; Verify that the metrics are stored using the normalized
+      ;; representation
+      (is (= #{"oof/" "rab/" "zab/"} (keyset (@storage :timers))))
+      (is (= #{"oof/" "rab/" "zab/"} (keyset (@storage :meters)))))))

--- a/test/com/puppetlabs/test/utils.clj
+++ b/test/com/puppetlabs/test/utils.clj
@@ -27,21 +27,36 @@
       (is (= 10 (quotient 1 0 10))))))
 
 (deftest conneg
-  (testing "should match an exact accept header"
-    (is (= "text/html" (acceptable-content-type "text/html" "text/html"))))
+  (testing "content negotiation"
+    (testing "should match an exact accept header"
+      (is (= "text/html" (acceptable-content-type "text/html" "text/html"))))
 
-  (testing "should match an exact accept header that includes other types"
-    (is (= "text/html" (acceptable-content-type "text/html" "text/html, text/plain"))))
+    (testing "should match an exact accept header that includes other types"
+      (is (= "text/html" (acceptable-content-type "text/html" "text/html, text/plain"))))
 
-  (testing "should match a wildcard accept header"
-    (is (= "text/*" (acceptable-content-type "text/html" "text/*"))))
+    (testing "should match a wildcard accept header"
+      (is (= "text/*" (acceptable-content-type "text/html" "text/*"))))
 
-  (testing "should match a wildcard accept header that includes other types"
-    (is (= "text/*" (acceptable-content-type "text/html" "text/plain, text/*"))))
+    (testing "should match a wildcard accept header that includes other types"
+      (is (= "text/*" (acceptable-content-type "text/html" "text/plain, text/*"))))
 
-  (testing "should return nil if a single header doesn't match"
-    (is (= nil (acceptable-content-type "text/html" "application/json"))))
+    (testing "should return nil if a single header doesn't match"
+      (is (= nil (acceptable-content-type "text/html" "application/json"))))
 
-  (testing "should return nil if no headers match"
-    (is (= nil (acceptable-content-type "text/html" "text/plain, application/json")))
-    (is (= nil (acceptable-content-type "text/html" "text/plain, application/*")))))
+    (testing "should return nil if no headers match"
+      (is (= nil (acceptable-content-type "text/html" "text/plain, application/json")))
+      (is (= nil (acceptable-content-type "text/html" "text/plain, application/*"))))))
+
+(deftest uri-to-segments
+  (testing "splitting a url into segments"
+    (testing "should work for partial urls"
+      (is (= ["foo" "bar"] (uri-segments "foo/bar"))))
+
+    (testing "should work for empty urls"
+      (is (= [] (uri-segments ""))))
+
+    (testing "should work for common urls"
+      (is (= ["foo" "bar" "baz"] (uri-segments "/foo/bar/baz"))))
+
+    (testing "should remove empty segments"
+      (is (= ["foo" "bar"] (uri-segments "/foo//bar"))))))


### PR DESCRIPTION
(wrap-with-metrics ...) will track performance counters for each URI encountered
by the wrapped Ring app. Users supply a function that tells the middleware how
to "normalize" a URI; in doing so, the mapping of what URIs correspond to which
metrics is entirely customizable.

For each normalized path, we track the time required to service a request as
well as independent meters for each status code.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
