### PR TITLE
Much faster string hashing

### DIFF
--- a/src/com/puppetlabs/cmdb/scf/storage.clj
+++ b/src/com/puppetlabs/cmdb/scf/storage.clj
@@ -23,7 +23,6 @@
             [com.puppetlabs.utils :as utils]
             [clojure.java.jdbc :as sql]
             [clojure.tools.logging :as log]
-            [digest]
             [cheshire.core :as json])
   (:use [metrics.meters :only (meter mark!)]
         [metrics.counters :only (counter inc! value)]
@@ -258,7 +257,7 @@ must be supplied as the value to be matched."
   {:pre  [(map? resource)]
    :post [(string? %)]}
   (-> (resource-identity-string resource)
-      (digest/sha-1)))
+      (utils/utf8-string->sha1)))
 
 (defn- resource->values
   "Given a catalog-hash and a resource, return a map representing the
@@ -320,7 +319,7 @@ must be supplied as the value to be matched."
   {:pre  [(map? edge)]
    :post [(string? %)]}
   (-> (edge-identity-string edge)
-      (digest/sha-1)))
+      (utils/utf8-string->sha1)))
 
 (defn add-edges!
   "Persist the given edges in the database
@@ -369,7 +368,7 @@ must be supplied as the value to be matched."
                               [type title (sort tags) exported file line])))
       (assoc :edges (sort (map edge-identity-string edges)))
       (pr-str)
-      (digest/sha-1)))
+      (utils/utf8-string->sha1)))
 
 (defn add-catalog!
   "Persist the supplied catalog in the database, returning its

--- a/src/com/puppetlabs/utils.clj
+++ b/src/com/puppetlabs/utils.clj
@@ -10,6 +10,7 @@
             [clojure.string :as string]
             [clojure.tools.cli :as cli]
             [cheshire.core :as json]
+            [digest]
             [ring.util.response :as rr])
   (:use [clojure.core.incubator :only (-?>)]
         [clojure.java.io :only (reader)]
@@ -177,3 +178,14 @@
   [uri]
   (remove #{""} (.split uri "/")))
 
+;; ## Hashing
+
+(defn utf8-string->sha1
+  "Compute a SHA-1 hash for the UTF-8 encoded version of the supplied
+  string"
+  [s]
+  {:pre  [(string? s)]
+   :post [(string? %)]}
+  (-> s
+      (.getBytes "UTF-8")
+      (digest/sha-1)))

--- a/test/com/puppetlabs/test/utils.clj
+++ b/test/com/puppetlabs/test/utils.clj
@@ -60,3 +60,16 @@
 
     (testing "should remove empty segments"
       (is (= ["foo" "bar"] (uri-segments "/foo//bar"))))))
+
+(deftest string-hashing
+  (testing "Computing a SHA-1 for a UTF-8 string"
+    (testing "should fail if not passed a string"
+      (is (thrown? AssertionError (utf8-string->sha1 1234))))
+
+    (testing "should produce a stable hash"
+      (is (= (utf8-string->sha1 "foobar")
+             (utf8-string->sha1 "foobar"))))
+
+    (testing "should produce the correct hash"
+      (is (= "8843d7f92416211de9ebb963ff4ce28125932878"
+             (utf8-string->sha1 "foobar"))))))


### PR DESCRIPTION
We previously didn't bother specifying an encoding to use when converting a
string to bytes. This causes the JVM to use the platform's default encoding,
which has several drawbacks:
- The default platform encoding could be really slow (like, say, MacRoman)
- Switching a Grayskull instance from one platform to another would result in
  completely different hashes for the same input

This patchset specifies UTF-8 as the target encoding when computing a hash.
This makes Grayskull more portable, and the hash computation on my laptop is
60% faster than before.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
