### PR TITLE
Fix arity error in command parsing error handler

### DIFF
--- a/src/com/puppetlabs/cmdb/command.clj
+++ b/src/com/puppetlabs/cmdb/command.clj
@@ -274,7 +274,7 @@
       (if (instance? Throwable parse-result)
         (do
           (mark! (global-metric :fatal))
-          (on-failure parse-result))
+          (on-failure msg parse-result))
         (f parse-result)))))
 
 (defn wrap-with-discard


### PR DESCRIPTION
We were previously calling the on-error callback with too few arguments.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
