### PR TITLE
Fix ordering of arguments to log/error

### DIFF
--- a/src/com/puppetlabs/cmdb/cli/services.clj
+++ b/src/com/puppetlabs/cmdb/cli/services.clj
@@ -74,7 +74,7 @@
   [mq mq-endpoint db]
   (pl-utils/keep-going
    (fn [exception]
-     (log/error "Error during command processing; reestablishing connection after 10s" exception)
+     (log/error exception "Error during command processing; reestablishing connection after 10s")
      (Thread/sleep 10000))
 
    (with-open [conn (mq/connect! mq)]
@@ -88,7 +88,7 @@
   [db interval]
   (pl-utils/keep-going
    (fn [exception]
-     (log/error "Error during DB compaction" exception))
+     (log/error exception "Error during DB compaction"))
 
    (Thread/sleep interval)
    (log/info "Beginning database compaction")

--- a/src/com/puppetlabs/cmdb/command.clj
+++ b/src/com/puppetlabs/cmdb/command.clj
@@ -327,7 +327,7 @@
 (defn handle-command-failure
   "Dump the error encountered during command-handling to the log"
   [msg e]
-  (log/error "Fatal error processing msg" e))
+  (log/error e "Fatal error processing msg"))
 
 ;; ### Retry callback
 
@@ -336,7 +336,7 @@
   with an incremented retry counter"
   [{:keys [command version] :as msg} e publish-fn]
   (mark! (get-in @metrics [command version :retried]))
-  (log/error "Retrying message due to:" e)
+  (log/error e "Retrying message due to:")
   (publish-fn (json/generate-string msg)))
 
 ;; ### Principal function


### PR DESCRIPTION
The new version of tools.logging swapped the order of arguments to log/error, and the exception now comes first before any other messages. This patchset shuffles around our arguments when calling log/error accordingly.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
