### PR TITLE
Change benchmark to use string payloads for commands

### DIFF
--- a/src/com/puppetlabs/cmdb/catalog.clj
+++ b/src/com/puppetlabs/cmdb/catalog.clj
@@ -334,6 +334,7 @@
   "Parse a wire-format JSON catalog object contained in `o`, returning a
   cmdb-suitable representation."
   [o]
+  {:post [(map? %)]}
   (-> o
       (restructure-catalog)
       (keywordify-resources)
@@ -347,6 +348,8 @@
   "Parse a wire-format JSON catalog string contained in `s`, returning a
   cmdb-suitable representation."
   [s]
+  {:pre  [(string? s)]
+   :post [(map? %)]}
   (-> (json/parse-string s)
       (parse-from-json-obj)))
 

--- a/src/com/puppetlabs/cmdb/cli/benchmark.clj
+++ b/src/com/puppetlabs/cmdb/cli/benchmark.clj
@@ -57,7 +57,7 @@
   [host catalog]
   (let [msg    (-> {:command "replace catalog"
                     :version 1
-                    :payload catalog}
+                    :payload (json/generate-string catalog)}
                    (json/generate-string))
         body   (format "payload=%s" (util/url-encode msg))
         result (client/post rest-url {:body             body


### PR DESCRIPTION
The wire format was updated, but benchmark.clj was not. This patch adds
pre-conditions and post-conditions to catalog parsing to ensure that the
correct types are used (useful when debugging this issue), and modifies
benchmark to do the right thing.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
