### PR TITLE
Require checksums for HTTP submitted commands

### DIFF
--- a/src/com/puppetlabs/cmdb/cli/benchmark.clj
+++ b/src/com/puppetlabs/cmdb/cli/benchmark.clj
@@ -43,7 +43,7 @@
             [cheshire.core :as json]
             [clj-http.client :as client]
             [clj-http.util :as util])
-  (:use [com.puppetlabs.utils :only (cli! ini-to-map)]
+  (:use [com.puppetlabs.utils :only (cli! ini-to-map utf8-string->sha1)]
         [com.puppetlabs.cmdb.scf.migrate :only [migrate!]]))
 
 (def hosts nil)
@@ -59,7 +59,9 @@
                     :version 1
                     :payload catalog}
                    (json/generate-string))
-        body   (format "payload=%s" (util/url-encode msg))
+        body   (format "checksum=%s&payload=%s"
+                       (utf8-string->sha1 msg)
+                       (util/url-encode msg))
         result (client/post rest-url {:body             body
                                       :throw-exceptions false
                                       :content-type     :x-www-form-urlencoded

--- a/src/com/puppetlabs/cmdb/http/command.clj
+++ b/src/com/puppetlabs/cmdb/http/command.clj
@@ -50,6 +50,14 @@
    (-> (rr/response "missing payload")
        (rr/status 400))
 
+   (not (params "checksum"))
+   (-> (rr/response "missing checksum")
+       (rr/status 400))
+
+   (not= (params "checksum") (pl-utils/utf8-string->sha1 (params "payload")))
+   (-> (rr/response "checksums don't match")
+       (rr/status 400))
+
    (not (pl-utils/acceptable-content-type
          "application/json"
          (headers "accept")))


### PR DESCRIPTION
This ensure that nothing has disturbed the payload during transit.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
