### PR TITLE
Normalize resource aliases during cataog parsing

### DIFF
--- a/src/com/puppetlabs/cmdb/catalog.clj
+++ b/src/com/puppetlabs/cmdb/catalog.clj
@@ -217,8 +217,10 @@
   [{:keys [type title] :as resource}]
   {:pre [(string? type)
          (string? title)]}
-  (if-let [alias (get-in resource [:parameters "alias"])]
-    {{:type type :title alias} {:type type :title title}}))
+  (if-let [aliases (get-in resource [:parameters "alias"])]
+    (let [aliases (if (coll? aliases) aliases [aliases])]
+      (for [alias aliases]
+        [{:type type :title alias} {:type type :title title}]))))
 
 (defn build-alias-map
   "Returns a version of the supplied catalog augmented with an
@@ -229,7 +231,7 @@
   {:pre [(map? resources)]}
   (let [aliases (->> resources
                      (vals)
-                     (map alias-for-resource)
+                     (mapcat alias-for-resource)
                      (remove nil?)
                      (into {}))]
     (assoc catalog :aliases aliases)))

--- a/test/com/puppetlabs/cmdb/test/catalog.clj
+++ b/test/com/puppetlabs/cmdb/test/catalog.clj
@@ -75,6 +75,15 @@
                  (random-kw-resource "Foo" "bar" {"parameters" {"alias" "baz"}})}}))
              {{:type "Foo" :title "baz"} {:type "Foo" :title "bar"}})))
 
+    (testing "should work for resources with multiple aliases"
+      (is (= (:aliases
+              (build-alias-map
+               {:resources
+                {{:type "Foo" :title "bar"}
+                 (random-kw-resource "Foo" "bar" {"parameters" {"alias" ["baz" "boo"]}})}}))
+             {{:type "Foo" :title "baz"} {:type "Foo" :title "bar"}
+              {:type "Foo" :title "boo"} {:type "Foo" :title "bar"}})))
+
     (testing "should work for multiple resources"
       (is (= (:aliases
               (build-alias-map


### PR DESCRIPTION
If an edge source or target refers to a resource alias (as opposed to the resource itself), we now modify that edge to refer directly to resources (sans aliasing). This preserves the integrity of a catalog; all edges must refer to a valid resource-spec.
