### PR TITLE
Don't fail when inserting an "empty" catalog

### DIFF
--- a/src/com/puppetlabs/cmdb/scf/storage.clj
+++ b/src/com/puppetlabs/cmdb/scf/storage.clj
@@ -375,7 +375,7 @@ must be supplied as the value to be matched."
   similarity hash"
   [{:keys [api-version version resources classes edges tags] :as catalog}]
   {:pre [(number? api-version)
-         (every? coll? #{classes tags edges})
+         (every? coll? [classes tags edges])
          (map? resources)]}
 
   (time! (:add-catalog metrics)

--- a/test/com/puppetlabs/cmdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/cmdb/test/scf/storage.clj
@@ -12,6 +12,34 @@
 
 (def db (test-db))
 
+(def empty-catalog
+  {:certname "simple.mydomain.com"
+   :cmdb-version cat/CMDB-VERSION
+   :api-version 1
+   :version "1330463884"
+   :tags #{"settings"}
+   :classes #{"settings"}
+   :edges #{{:source {:type "Stage" :title "main"}
+             :target {:type "Class" :title "Settings"}
+             :relationship :contains}
+            {:source {:type "Stage" :title "main"}
+             :target {:type "Class" :title "Main"}
+             :relationship :contains}}
+   :resources {{:type "Class" :title "Main"} {:exported false
+                                              :title      "Main"
+                                              :tags       #{"class" "main"}
+                                              :type       "Class"
+                                              :parameters {"name" "main"}}
+               {:type "Class" :title "Settings"} {:exported false
+                                                  :title    "Settings"
+                                                  :tags     #{"settings" "class"}
+                                                  :type     "Class"}
+               {:type "Stage" :title "main"} {:exported false
+                                              :title    "main"
+                                              :tags     #{"main" "stage"}
+                                              :type     "Stage"}}
+   :aliases {}})
+
 (def basic-catalog
   {:certname "myhost.mydomain.com"
    :cmdb-version cat/CMDB-VERSION
@@ -286,6 +314,11 @@
 
             (is (= (query-to-vec ["SELECT hash FROM catalogs"])
                    [{:hash hash}])))))
+
+      (testing "should not fail when inserting an 'empty' catalog"
+        (sql/with-connection db
+          (migrate!)
+          (add-catalog! empty-catalog)))
 
       (testing "should noop if replaced by themselves after using manual deletion"
         (sql/with-connection db


### PR DESCRIPTION
This was previously failing because in an "empty" catalog (one
containing only the default resources), both `tags` and
`classes` contain only the value "settings", which caused an incorrect
precondition to fail. This commit fixes that and adds a test case for
the standard empty catalog.
