### PR TITLE
Specify the charset of HTTP POST's

### DIFF
--- a/module/lib/puppet/indirector/catalog/grayskull.rb
+++ b/module/lib/puppet/indirector/catalog/grayskull.rb
@@ -30,7 +30,7 @@ class Puppet::Resource::Catalog::Grayskull < Puppet::Indirector::REST
   def headers
     {
       "Accept" => "application/json",
-      "Content-Type" => "application/x-www-form-urlencoded",
+      "Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8",
     }
   end
 

--- a/module/lib/puppet/indirector/facts/grayskull.rb
+++ b/module/lib/puppet/indirector/facts/grayskull.rb
@@ -30,7 +30,7 @@ class Puppet::Node::Facts::Grayskull < Puppet::Indirector::REST
   def headers
     {
       "Accept" => "application/json",
-      "Content-Type" => "application/x-www-form-urlencoded",
+      "Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8",
     }
   end
 

--- a/src/com/puppetlabs/cmdb/cli/benchmark.clj
+++ b/src/com/puppetlabs/cmdb/cli/benchmark.clj
@@ -64,10 +64,11 @@
         body   (format "checksum=%s&payload=%s"
                        (utf8-string->sha1 msg)
                        (util/url-encode msg))
-        result (client/post rest-url {:body             body
-                                      :throw-exceptions false
-                                      :content-type     :x-www-form-urlencoded
-                                      :accept           :json})]
+        result (client/post rest-url {:body               body
+                                      :throw-exceptions   false
+                                      :content-type       :x-www-form-urlencoded
+                                      :character-encoding "UTF-8"
+                                      :accept             :json})]
     (if (not= 200 (:status result))
       (log/error result))))
 


### PR DESCRIPTION
This ensures that the server-side can correctly interpret our data without
relying on unspecified (or presumed default) behavior.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
