### PR TITLE
Implement conversion to UTF-8 when submitting data to Grayskull

### DIFF
--- a/module/lib/puppet/indirector/catalog/grayskull.rb
+++ b/module/lib/puppet/indirector/catalog/grayskull.rb
@@ -15,9 +15,42 @@ class Puppet::Resource::Catalog::Grayskull < Puppet::Indirector::REST
     8080
   end
 
+  # These methods don't really belong here, but this is the best we can do to
+  # share them inside a module.
+  def self.utf8_string(str)
+    # Ruby 1.8 doesn't have String#encode, and String#encode('UTF-8') on an
+    # invalid UTF-8 string will leave the invalid byte sequences, so we have
+    # to use iconv in both of those cases.
+    if RUBY_VERSION =~ /1.8/ or str.encoding == Encoding::UTF_8
+      iconv_to_utf8(str)
+    else
+      begin
+        str.encode('UTF-8')
+      rescue Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError => e
+        # If we got an exception, the string is either invalid or not
+        # convertible to UTF-8, so drop those bytes.
+        Puppet.warning "Ignoring invalid UTF-8 byte sequences in data to be sent to Grayskull"
+        str.encode('UTF-8', :invalid => :replace, :undef => :replace)
+      end
+    end
+  end
+
+  def self.iconv_to_utf8(str)
+    iconv = Iconv.new('UTF-8//IGNORE', 'UTF-8')
+
+    # http://po-ru.com/diary/fixing-invalid-utf-8-in-ruby-revisited/
+    converted_str = iconv.iconv(str + " ")[0..-2]
+    if converted_str != str
+      Puppet.warning "Ignoring invalid UTF-8 byte sequences in data to be sent to Grayskull"
+    end
+    converted_str
+  end
+
   def save(request)
     catalog = munge_catalog(request.instance)
-    msg = message(catalog).to_pson
+
+    msg = self.class.utf8_string(message(catalog).to_pson)
+
     checksum = Digest::SHA1.hexdigest(msg)
     payload = CGI.escape(msg)
 

--- a/module/lib/puppet/indirector/facts/grayskull.rb
+++ b/module/lib/puppet/indirector/facts/grayskull.rb
@@ -17,6 +17,7 @@ class Puppet::Node::Facts::Grayskull < Puppet::Indirector::REST
 
   def save(request)
     msg = message(request.instance).to_pson
+    msg = Puppet::Resource::Catalog::Grayskull.utf8_string(msg)
     checksum = Digest::SHA1.hexdigest(msg)
     payload = CGI.escape(msg)
 

--- a/module/spec/unit/indirector/catalog/grayskull_spec.rb
+++ b/module/spec/unit/indirector/catalog/grayskull_spec.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env rspec
+# encoding: UTF-8
+
 require 'spec_helper'
 
 require 'puppet/indirector/catalog/grayskull'
@@ -31,22 +33,98 @@ describe Puppet::Resource::Catalog::Grayskull do
 
       CGI.unescape(@sent_payload).should == payload
     end
+  end
 
-    describe "#munge_catalog" do
-      it "should add namevar to aliases if it's not already present" do
-        name = 'with a different name'
-        notify = Puppet::Resource.new(:notify, 'notify_me', :parameters => {:name => name})
+  describe "#munge_catalog" do
+    let(:catalog) do
+      Puppet::Resource::Catalog.new('foo')
+    end
 
-        catalog.add_resource(notify)
+    it "should add namevar to aliases if it's not already present" do
+      name = 'with a different name'
+      notify = Puppet::Resource.new(:notify, 'notify_me', :parameters => {:name => name})
 
-        hash = subject.munge_catalog(catalog)
+      catalog.add_resource(notify)
 
-        resource = hash['data']['resources'].find do |res|
-          res['type'] == 'Notify' and res['title'] == 'notify_me'
-        end
+      hash = subject.munge_catalog(catalog)
 
-        resource.should_not be_nil
-        resource['parameters']['alias'].should include(name)
+      resource = hash['data']['resources'].find do |res|
+        res['type'] == 'Notify' and res['title'] == 'notify_me'
+      end
+
+      resource.should_not be_nil
+      resource['parameters']['alias'].should include(name)
+    end
+  end
+
+  describe ".utf8_string" do
+    describe "on ruby 1.8", :if => RUBY_VERSION =~ /^1.8/ do
+      it "should convert from ascii without a warning" do
+        Puppet.expects(:warning).never
+
+        str = "any ascii string"
+        described_class.utf8_string(str).should == str
+      end
+
+      it "should convert from non-overlapping latin-1 with a warning" do
+        Puppet.expects(:warning).with {|msg| msg =~ /Ignoring invalid UTF-8 byte sequences/}
+
+        str = "a latin-1 string \xd6"
+        described_class.utf8_string(str).should == "a latin-1 string "
+      end
+
+      it "should remove invalid bytes and warn if the string is invalid UTF-8" do
+        Puppet.expects(:warning).with {|msg| msg =~ /Ignoring invalid UTF-8 byte sequences/}
+
+        str = "an invalid utf-8 string \xff"
+        described_class.utf8_string(str).should == "an invalid utf-8 string "
+      end
+
+      it "should return a valid utf-8 string without warning" do
+        Puppet.expects(:warning).never
+
+        str = "a valid utf-8 string \xc3\x96"
+        described_class.utf8_string(str).should == str
+      end
+    end
+
+    describe "on ruby > 1.8", :if => RUBY_VERSION !~ /^1.8/ do
+      it "should convert from ascii without a warning" do
+        Puppet.expects(:warning).never
+
+        str = "any ascii string".force_encoding('us-ascii')
+        described_class.utf8_string(str).should == str
+      end
+
+      it "should convert from latin-1 without a warning" do
+        Puppet.expects(:warning).never
+
+        str = "a latin-1 string \xd6".force_encoding('iso-8859-1')
+        described_class.utf8_string(str).should == "a latin-1 string Ö"
+      end
+
+      # UndefinedConversionError
+      it "should replace undefined characters and warn when converting from binary" do
+        Puppet.expects(:warning).with {|msg| msg =~ /Ignoring invalid UTF-8 byte sequences/}
+
+        str = "an invalid binary string \xff".force_encoding('binary')
+        # \ufffd == unicode replacement character
+        described_class.utf8_string(str).should == "an invalid binary string \ufffd"
+      end
+
+      # InvalidByteSequenceError
+      it "should remove invalid bytes and warn if the string is invalid UTF-8" do
+        Puppet.expects(:warning).with {|msg| msg =~ /Ignoring invalid UTF-8 byte sequences/}
+
+        str = "an invalid utf-8 string \xff".force_encoding('utf-8')
+        described_class.utf8_string(str).should == "an invalid utf-8 string "
+      end
+
+      it "should leave the string alone if it's valid UTF-8" do
+        Puppet.expects(:warning).never
+
+        str = "a valid utf-8 string".force_encoding('utf-8')
+        described_class.utf8_string(str).should == str
       end
     end
   end


### PR DESCRIPTION
On Ruby 1.8, this will assume all input is UTF-8-ish, and will drop
invalid UTF-8 byte sequences. On Ruby 1.9, it will properly convert, as
long as the original encoding is correctly known, otherwise it will
replace invalid or undefined characters with the unicode replacement
character \ufffd. In all cases, if bytes are dropped, a warning will be
issued.
