### PR TITLE
Fix resource terminus content type, and look up type correctly

### DIFF
--- a/module/lib/puppet/indirector/resource/grayskull.rb
+++ b/module/lib/puppet/indirector/resource/grayskull.rb
@@ -13,7 +13,7 @@ class Puppet::Resource::Grayskull < Puppet::Indirector::REST
   end
 
   def search(request)
-    type   = canonicalize_type(request.key)
+    type   = request.key
     host   = request.options[:host]
     filter = request.options[:filter]
     scope  = request.options[:scope]
@@ -47,12 +47,6 @@ class Puppet::Resource::Grayskull < Puppet::Indirector::REST
     end
   end
 
-  def canonicalize_type(typename)
-    type = Puppet::Type.type(typename)
-    raise Puppet::Error, "Could not find type #{typename}" unless type
-    type.name.to_s.capitalize
-  end
-
   def validate_filter(filter)
     return true unless filter
 
@@ -74,6 +68,6 @@ class Puppet::Resource::Grayskull < Puppet::Indirector::REST
   end
 
   def headers
-    {'Accept' => 'application/vnd.com.puppetlabs.cmdb.resource-list+json'}
+    {'Accept' => 'application/json'}
   end
 end

--- a/module/spec/unit/indirector/resource/grayskull_spec.rb
+++ b/module/spec/unit/indirector/resource/grayskull_spec.rb
@@ -32,10 +32,6 @@ describe Puppet::Resource::Grayskull do
       subject.search(Puppet::Resource.indirection.request(:search, type, args))
     end
 
-    it "should fail if the type is not known to Puppet" do
-      expect { search("banana") }.to raise_error Puppet::Error, /Could not find type/
-    end
-
     it "should return an empty array if no resources match" do
       subject.stubs(:http_get).returns(stub('response', :body => '[]'))
       search("exec").should == []
@@ -91,18 +87,6 @@ describe Puppet::Resource::Grayskull do
   describe "#filter" do
   end
 
-  describe "#canonicalize_type" do
-    it "should return the canonical type name" do
-      subject.canonicalize_type('file').should == 'File'
-    end
-
-    it "should raise an error if it doesn't recognize the type" do
-      expect do
-        subject.canonicalize_type("types_you_haven't_heard_of")
-      end.to raise_error(Puppet::Error, /Could not find type/)
-    end
-  end
-
   describe "#validate_filter" do
     it "should be valid if there is no filter" do
       subject.validate_filter(nil).should == true
@@ -140,7 +124,7 @@ describe Puppet::Resource::Grayskull do
 
   describe "#headers" do
     it "should accept the correct mime type" do
-      subject.headers['Accept'].should == 'application/vnd.com.puppetlabs.cmdb.resource-list+json'
+      subject.headers['Accept'].should == 'application/json'
     end
   end
 end


### PR DESCRIPTION
The canonicalize_type here wasn't really doing anything useful, and was
causing defined types not to be collectable.
