### PR TITLE
Use JSON parser's built in ability to turn map keys into keywords

### DIFF
--- a/src/com/puppetlabs/cmdb/catalog/utils.clj
+++ b/src/com/puppetlabs/cmdb/catalog/utils.clj
@@ -4,7 +4,8 @@
 ;; randomly modifying an existing catalog (wire format or parsed).
 
 (ns com.puppetlabs.cmdb.catalog.utils
-  (:require [com.puppetlabs.cmdb.catalog :as cat]))
+  (:require [com.puppetlabs.cmdb.catalog :as cat])
+  (:use [clojure.walk :only [keywordize-keys]]))
 
 (defn random-string
   "Generate a random string of optional length"
@@ -39,7 +40,7 @@
 
 ;; A version of random-resource that returns resources with keyword
 ;; keys instead of strings
-(def random-kw-resource (comp cat/keys-to-keywords random-resource))
+(def random-kw-resource (comp keywordize-keys random-resource))
 
 (defn add-random-resource-to-wire-catalog
   "Adds a random resource to the given wire-format catalog"

--- a/src/com/puppetlabs/cmdb/scf/storage.clj
+++ b/src/com/puppetlabs/cmdb/scf/storage.clj
@@ -285,8 +285,8 @@ must be supplied as the value to be matched."
 
     (if persisted?
       values
-      (assoc values :parameters (for [[name value] parameters]
-                                  [resource-hash name (db-serialize value)])))))
+      (assoc values :parameters (for [[key value] parameters]
+                                  [resource-hash (name key) (db-serialize value)])))))
 
 (defn add-resources!
   "Persist the given resource and associate it with the given catalog."

--- a/test/com/puppetlabs/cmdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/cmdb/test/scf/storage.clj
@@ -29,7 +29,7 @@
                                               :title      "Main"
                                               :tags       #{"class" "main"}
                                               :type       "Class"
-                                              :parameters {"name" "main"}}
+                                              :parameters {:name "main"}}
                {:type "Class" :title "Settings"} {:exported false
                                                   :title    "Settings"
                                                   :tags     #{"settings" "class"}
@@ -63,19 +63,19 @@
                                                     :file       "/tmp/foo"
                                                     :line       10
                                                     :tags       #{"file" "class" "foobar"}
-                                                    :parameters {"ensure" "directory"
-                                                                 "group"  "root"
-                                                                 "user"   "root"}}
+                                                    :parameters {:ensure "directory"
+                                                                 :group  "root"
+                                                                 :user   "root"}}
                {:type "File" :title "/etc/foobar/baz"} {:type       "File"
                                                         :title      "/etc/foobar/baz"
                                                         :exported   false
                                                         :file       "/tmp/bar"
                                                         :line       20
                                                         :tags       #{"file" "class" "foobar"}
-                                                        :parameters {"ensure"  "directory"
-                                                                     "group"   "root"
-                                                                     "user"    "root"
-                                                                     "require" "File[/etc/foobar]"}}}})
+                                                        :parameters {:ensure  "directory"
+                                                                     :group   "root"
+                                                                     :user    "root"
+                                                                     :require "File[/etc/foobar]"}}}})
 
 (deftest serialization
   (let [values ["foo" 0 "0" nil "nil" "null" [1 2 3] ["1" "2" "3"] {"a" 1 "b" [1 2 3]}]]


### PR DESCRIPTION
Cheshire can automatically "keywordize" JSON maps, so we no longer need our own
hand-rolled code that did the same. The only change in semantics is that now
resource parameters are maps with keywords as keys, whereas previously those
keys were simply strings. This involved making some changes to the utility
functions we've got that create random resources (ensuring that parameter maps
use keys for keywords), and some minor changes to our storage code to assume
keywords for parameter keys. The bulk of the changes end up affecting our test
code, as all our hand-constructed input data needed to change to conform to the
new format.

One item of note: clojure 1.3 has the clojure.walk/keywordize-keys function,
that obsoletes our hand-rolled keys-to-keywords func.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
