### PR TITLE
Fix random test failures in catalog storage

### DIFF
--- a/src/com/puppetlabs/cmdb/catalog/utils.clj
+++ b/src/com/puppetlabs/cmdb/catalog/utils.clj
@@ -19,7 +19,7 @@
 (defn random-parameters
   "Generate a random set of parameters."
   []
-  (into {} (repeatedly (rand-int 10) #(vector (random-string) (random-string)))))
+  (into {} (repeatedly (inc (rand-int 10)) #(vector (random-string) (random-string)))))
 
 (defn random-resource
   "Generate a random resource. Can optionally specify type/title, as

--- a/test/com/puppetlabs/cmdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/cmdb/test/scf/storage.clj
@@ -128,7 +128,7 @@
                     (resource-identity-hash r2))))))))
 
 (deftest catalog-dedupe
-  (testing "Catalogs with different metadata but the same content should hash to the same thing"
+  (testing "Catalogs with the same metadata but different content should have different hashes"
     (let [catalog       basic-catalog
           hash          (catalog-similarity-hash catalog)
           ;; List of all the tweaking functions
@@ -158,7 +158,7 @@
           (is (not= hash tweaked-hash)
               (str catalog "\n has hash: " hash "\n and \n" tweaked-catalog "\n has hash: " tweaked-hash))))))
 
-  (testing "Catalogs with the same metadata but different content should have different hashes"
+  (testing "Catalogs with different metadata but the same content should have the same hashes"
     (let [catalog            basic-catalog
           hash               (catalog-similarity-hash catalog)
           ;; Functions that tweak various attributes of a catalog


### PR DESCRIPTION
These were failing because it was possible to modify a resource to have
an empty parameter list, which previously had a nil parameter list.
These two resources are not equal, but have the same hash, causing
a failed assertion.
