### PR TITLE
Basic web-based console

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ using Grayskull's REST APIs. Each REST endpoint is documented in the
 For debugging purposes, you can open up a remote clojure REPL and use
 it to modify the behavior of Grayskull, live.
 
+Vim support would be a welcome addition; please submit patches!
+
 **Puppet module**
 
 There is a puppet module for automated installation of Grayskull. It
@@ -112,6 +114,28 @@ choice. Look at resources/config.ini for an example configuration
 file.
 
 * `java -jar *standalone.jar services -h`
+
+## Web Console
+
+Once you have Grayskull running, visit:
+
+    http://your-grayskull-host:your-grayskull-port/dashboard/index.html?pollingInterval=1000
+
+Grayskull includes a simple, web-based console that displays a fixed
+set of key metrics around Grayskull operations: memory use, queue
+depth, command processing metrics, duplication rate, and REST endpoint
+stats.
+
+We display min/max/median of each metric over a configurable duration,
+as well as an animated SVG sparkline.
+
+Currently the only way to change the attributes of the dashboard is via URL
+parameters:
+
+* width = width of each sparkline
+* height = height of each sparkline
+* nHistorical = how many historical data points to use in each sparkline
+* pollingInterval = how often to poll Grayskull for updates, in milliseconds
 
 ## Configuration
 

--- a/resources/public/dashboard/charts.js
+++ b/resources/public/dashboard/charts.js
@@ -1,0 +1,282 @@
+/*
+  Displays a set of counters and a sparkline for a metric (JSON that's
+  fetched via AJAX).
+*/
+function counterAndSparkline() {
+    // Defaults
+
+    // How many data points to retain for the sparkline
+    var nHistorical = 60;
+    // How often to poll for new data
+    var pollingInterval = 5000;
+    // Width of the sparkline
+    var width = 200;
+    // Height of the sparkline
+    var height = 40;
+    // What URL to poll for JSON
+    var url = null;
+    // Function used to return a number from the JSON response;
+    // defaults to the identity function
+    var snag = function(j) { return j; };
+    // How to format the snagged number for display
+    var format = d3.format(",.1f");
+    // Top-line label to use
+    var description = "\u00a0";
+    // Sub-heading describing the metric
+    var addendum = "\u00a0";
+    // What DOM element to use
+    var container = null;
+
+    function chart() {
+        var n = nHistorical;
+        var duration = pollingInterval;
+        var w = width;
+        var h = height;
+        var now = new Date();
+
+        // X axis, chronological scale
+        var x = d3.time.scale()
+            .domain([now - n*duration, now])
+            .range([0, w]);
+
+        // Y axis, linear scale
+        var y = d3.scale.linear()
+            .range([h, 0]);
+
+        // Initial data set. Datums are maps with a time and a
+        // value. The initial data set is seeded to have values of 0
+        // spread out uniformly across the x-axis.
+        var data = d3.range(n).map(function(i) {
+            return {time: x.ticks(n)[i],
+                    value: 0};
+        });
+        var data = [];
+
+        // Function that extracts values from a datum
+        var value = function(d) { return d.value; };
+
+        // SVG pathing computation, plotting time vs. value. We use
+        // linear interpolation to provide better visibility of data
+        // points. For prettier lines, try "basis" or "monotone".
+        var line = d3.svg.line()
+            .interpolate("linear")
+            .x(function(d) { return x(d.time); })
+            .y(function(d) { return y(d.value); });
+
+        // The "box" represents all DOM elements for this metrics'
+        // display
+        var box = d3.select(container).append("div")
+            .attr("class", "counterbox");
+
+        // Add the description and addendum
+        box.append("div")
+            .attr("class", "counterdesc")
+            .text(description);
+        box.append("div")
+            .attr("class", "counteraddendum")
+            .text(addendum);
+
+        // Add the placeholder for the actual metric value
+        var counter = box.append("div")
+            .attr("class", "countertext");
+
+        // Add DOM elements for min/median/max values
+        var details = box.append("table");
+        var detailed_stats = details.append("tr");
+        detailed_stats.append("td").attr("class", "countermin");
+        detailed_stats.append("td").attr("class", "countermed");
+        detailed_stats.append("td").attr("class", "countermax");
+        var details_legend = details.append("tr").attr("class", "counterlegend");
+        details_legend.append("td").text("min");
+        details_legend.append("td").text("med");
+        details_legend.append("td").text("max");
+
+        // Add an SVG element for the sparkline
+        var svg = box.append("svg")
+            .attr("width", w)
+            .attr("height", h)
+            .append("g");
+
+        // Add an SVG clip path, to make the scolling sparkline look
+        // nicer.
+        svg.append("defs").append("clipPath")
+            .attr("id", "clip")
+            .append("rect")
+            .attr("width", w)
+            .attr("height", h);
+
+        // The actual SVG line, associated with our clip path and
+        // seeded with our initial data
+        var path = svg.append("g")
+            .attr("clip-path", "url(#clip)")
+            .append("path")
+            .attr("d", line(data))
+            .attr("class", "line");
+
+        // Footer that mentiones the time-scale of the sparkline
+        var timescale = box.append("div")
+            .attr("class", "countertimescale")
+            .text(d3.format(".1f")(duration * n / 60000) + " min trend");
+
+        // Update function
+        function tick() {
+            // Grab our metric over HTTP
+            d3.json(url, function cb(res) {
+                var now = new Date();
+
+                // Append the new datum to our data set.
+                //
+                // If we didn't get a response, add a 0.
+                if (res != null) {
+                    // Use the user-supplied callback to parse out a
+                    // value
+                    data.push({time: now, value: snag(res)});
+                } else {
+                    data.push({time: now, value: 0});
+                }
+
+                var datavals = data.map(value);
+
+                // Update our axes (axises?)
+
+                // Scale the x-axis to go from the second datapoint to
+                // the next-to-last datapoint. We do this to make the
+                // scolling smooth.
+                //
+                // By having the x-axis exclude the
+                // most recent datum (the one we just received), that
+                // part of the line will be rendered off the side of
+                // the graph, invisible.
+                //
+                // We can then animate the line to scroll to the left,
+                // bringing the new datum into view smoothly.
+                //
+                // So much effort just to have smooth scrolling...
+                if (data.length > 1) {
+                    x.domain([now - (n-2)*duration, data[data.length-2].time]);
+                } else {
+                    // If we don't have 2 data points, estimate 2 data
+                    // points out by adding our duration to the
+                    // timestamp of the last data point.
+                    x.domain([now - (n-2)*duration, data[data.length-1].time - duration]);
+                };
+
+                // Scale the y-axis to go from the min value to max
+                // value, and round to nice, even numbers to reduce
+                // flickering from the scale changing too much
+                y.domain([d3.min(datavals), d3.max(datavals)]).nice();
+
+                // Display the most recent datum, or error text if
+                // none was available
+                if (res != null) {
+                    box.select(".countertext")
+                        .text(format(data[data.length-1].value));
+                } else {
+                    box.select(".countertext")
+                        .text("?");
+                }
+
+                // Display the min/median/max of the data set
+                box.select(".countermin")
+                    .text(format(d3.min(datavals)));
+                box.select(".countermax")
+                    .text(format(d3.max(datavals)));
+                box.select(".countermed")
+                    .text(format(d3.median(datavals)));
+
+                // Redraw our line. We draw it in-place, with the
+                // newest data point off the screen. We then
+                // transition the line to the left, bringing in the
+                // new datum.
+                //
+                // We use a "linear" easing function to make the
+                // scolling perfectly smooth relative to the polling
+                // interval; the scroll rate matches the data update
+                // rate (in theory, anyways)
+                //
+                // After the transition is done, call the tick()
+                // function again to re-update.
+                svg.select(".line")
+                    .attr("d", line(data))
+                    .attr("transform", null)
+                    .transition()
+                    .duration(duration)
+                    .ease("linear")
+                    .attr("transform", "translate(" + x(now-(n-1)*duration) + ")")
+                    .each("end", tick);
+
+                // pop the old data point off the front
+                if (data.length > n) {
+                    data.shift();
+                };
+            });
+        };
+
+        // Start the update routine.
+        tick();
+    }
+
+    // Functions allowing for overrides of default values
+
+    chart.width = function(_) {
+        if (!arguments.length) return width;
+        width = _;
+        return chart;
+    };
+
+    chart.height = function(_) {
+        if (!arguments.length) return height;
+        height = _;
+        return chart;
+    };
+
+    chart.url = function(_) {
+        if (!arguments.length) return url;
+        url = _;
+        return chart;
+    };
+
+    chart.snag = function(_) {
+        if (!arguments.length) return snag;
+        snag = _;
+        return chart;
+    };
+
+    chart.container = function(_) {
+        if (!arguments.length) return container;
+        container = _;
+        return chart;
+    };
+
+    chart.nHistorical = function(_) {
+        if (!arguments.length) return nHistorical;
+        nHistorical = _;
+        return chart;
+    };
+
+    chart.pollingInterval = function(_) {
+        if (!arguments.length) return pollingInterval;
+        pollingInterval = _;
+        return chart;
+    };
+
+    chart.format = function(_) {
+        if (!arguments.length) return format;
+        format = _;
+        return chart;
+    };
+
+    chart.description = function(_) {
+        if (!arguments.length) return description;
+        description = _;
+        return chart;
+    };
+
+    chart.addendum = function(_) {
+        if (!arguments.length) return addendum;
+        addendum = _;
+        return chart;
+    };
+
+    return chart;
+}

--- a/resources/public/dashboard/index.html
+++ b/resources/public/dashboard/index.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Grayskull: Dashboard</title>
+
+<style>
+@import url(http://fonts.googleapis.com/css?family=Lato);
+@import url(http://fonts.googleapis.com/css?family=Oswald);
+
+body {
+  background-color: white;
+}
+
+.x.axis line {
+  shape-rendering: auto;
+}
+
+.line {
+  fill: none;
+  stroke: #43a2ca;
+  stroke-width: 2.0px;
+}
+
+.graph {
+  float: left;
+  margin: 20px;
+}
+
+.counterbox {
+  font-family: 'Lato', sans-serif;
+  text-align: center;
+}
+
+.counterdesc {
+  font-size: 20px;
+  color: #ef8a62;
+}
+
+.counteraddendum {
+  font-size: 15px;
+  height: 100%;
+  color: #666;
+}
+
+.countertext {
+  font-size: 50px;
+  color: #43a2ca;
+}
+
+.counterbox table {
+  width: 100%;
+  padding: 5px;
+  margin-bottom: 5px;
+}
+
+.counterbox td {
+  padding: 0px;
+  color: #999;
+}
+
+.counterlegend, .countertimescale {
+  color: #999;
+  font-variant: small-caps;
+}
+</style>
+
+<script src="http://mbostock.github.com/d3/d3.v2.js?2.8.1"></script>
+<script src="charts.js"></script>
+
+<span id="heap" class="graph"></span>
+<span id="queue" class="graph"></span>
+<span id="proctime" class="graph"></span>
+<span id="procrate" class="graph"></span>
+<span id="processed" class="graph"></span>
+<span id="retried" class="graph"></span>
+<span id="discarded" class="graph"></span>
+<span id="failed" class="graph"></span>
+<span id="dupepct" class="graph"></span>
+<span id="gc-time" class="graph"></span>
+<span id="rest-commands-time" class="graph"></span>
+<span id="rest-resources-time" class="graph"></span>
+
+<script>(function() {
+  // Formatting middleware that collapses small values to 0
+  function clampToZero(f, window) {
+    return function(n) {
+      return f(Math.abs(n) < window ? 0 : n);
+    };
+  };
+
+  // Parse URL arguments
+  function getParameter(paramName) {
+    var searchString = window.location.search.substring(1),
+        i, val, params = searchString.split("&");
+
+    for (i=0;i<params.length;i++) {
+      val = params[i].split("=");
+      if (val[0] == paramName) {
+        return unescape(val[1]);
+      }
+    }
+    return null;
+  };
+
+  var nHistorical = getParameter("nHistorical") || 60;
+  var pollingInterval = getParameter("pollingInterval") || 5000;
+  var width = getParameter("width") || 200;
+  var height = getParameter("height") || 40;
+
+  counterAndSparkline()
+  .url("/metrics/mbean/java.lang:type=Memory")
+  .snag(function(res) { return res["HeapMemoryUsage"]["used"]; })
+  .format(d3.format(",.3s"))
+  .description("JVM Heap")
+  .addendum("bytes")
+  .container("#heap")
+  .nHistorical(nHistorical)
+  .pollingInterval(pollingInterval)
+  .width(width)
+  .height(height)
+  .call();
+
+  counterAndSparkline()
+  .url("/metrics/mbean/org.apache.activemq:BrokerName=localhost,Type=Queue,Destination=com.puppetlabs.cmdb.commands")
+  .snag(function(res) { return res["QueueSize"]; })
+  .format(d3.format(",s"))
+  .description("Command Queue")
+  .addendum("depth")
+  .container("#queue")
+  .nHistorical(nHistorical)
+  .pollingInterval(pollingInterval)
+  .width(width)
+  .height(height)
+  .call();
+
+  counterAndSparkline()
+  .url("/metrics/mbean/com.puppetlabs.cmdb.command:type=global,name=processing-time")
+  .snag(function(res) { return res["50thPercentile"] / 1000; })
+  .format(d3.format(",.3s"))
+  .description("Command Processing")
+  .addendum("sec/command")
+  .container("#proctime")
+  .nHistorical(nHistorical)
+  .pollingInterval(pollingInterval)
+  .width(width)
+  .height(height)
+  .call();
+
+  counterAndSparkline()
+  .url("/metrics/mbean/com.puppetlabs.cmdb.command:type=global,name=processed")
+  .snag(function(res) { return res["FiveMinuteRate"]; })
+  .format(clampToZero(d3.format(",.3s"), 0.001))
+  .description("Command Processing")
+  .addendum("commands/sec")
+  .container("#procrate")
+  .nHistorical(nHistorical)
+  .pollingInterval(pollingInterval)
+  .width(width)
+  .height(height)
+  .call();
+
+  counterAndSparkline()
+  .url("/metrics/mbean/com.puppetlabs.cmdb.command:type=global,name=processed")
+  .snag(function(res) { return res["Count"]; })
+  .format(d3.format(","))
+  .description("Processed")
+  .addendum("since startup")
+  .container("#processed")
+  .nHistorical(nHistorical)
+  .pollingInterval(pollingInterval)
+  .width(width)
+  .height(height)
+  .call();
+
+  counterAndSparkline()
+  .url("/metrics/mbean/com.puppetlabs.cmdb.command:type=global,name=retried")
+  .snag(function(res) { return res["Count"]; })
+  .format(d3.format(","))
+  .description("Retried")
+  .addendum("since startup")
+  .container("#retried")
+  .nHistorical(nHistorical)
+  .pollingInterval(pollingInterval)
+  .width(width)
+  .height(height)
+  .call();
+
+  counterAndSparkline()
+  .url("/metrics/mbean/com.puppetlabs.cmdb.command:type=global,name=discarded")
+  .snag(function(res) { return res["Count"]; })
+  .format(d3.format(","))
+  .description("Discarded")
+  .addendum("since startup")
+  .container("#discarded")
+  .nHistorical(nHistorical)
+  .pollingInterval(pollingInterval)
+  .width(width)
+  .height(height)
+  .call();
+
+  counterAndSparkline()
+  .url("/metrics/mbean/com.puppetlabs.cmdb.command:type=global,name=fatal")
+  .snag(function(res) { return res["Count"]; })
+  .format(d3.format(","))
+  .description("Rejected")
+  .addendum("since startup")
+  .container("#failed")
+  .nHistorical(nHistorical)
+  .pollingInterval(pollingInterval)
+  .width(width)
+  .height(height)
+  .call();
+
+  counterAndSparkline()
+  .url("/metrics/mbean/com.puppetlabs.cmdb.scf.storage:type=default,name=duplicate-pct")
+  .snag(function(res) { return res["Value"]; })
+  .format(d3.format(",.1%"))
+  .description("Catalog duplication")
+  .addendum("% of catalogs encountered")
+  .container("#dupepct")
+  .nHistorical(nHistorical)
+  .pollingInterval(pollingInterval)
+  .width(width)
+  .height(height)
+  .call();
+
+  counterAndSparkline()
+  .url("/metrics/mbean/com.puppetlabs.cmdb.scf.storage:type=default,name=gc-time")
+  .snag(function(res) { return res["50thPercentile"] / 1000; })
+  .format(d3.format(",.3s"))
+  .description("DB Compaction")
+  .addendum("round trip time, seconds")
+  .container("#gc-time")
+  .nHistorical(nHistorical)
+  .pollingInterval(pollingInterval)
+  .width(width)
+  .height(height)
+  .call();
+
+  counterAndSparkline()
+  .url("/metrics/mbean/com.puppetlabs.cmdb.http.server:type=commands,name=service-time")
+  .snag(function(res) { return res["50thPercentile"] / 1000; })
+  .format(d3.format(",.3s"))
+  .description("Enqueueing")
+  .addendum("service time, seconds")
+  .container("#rest-commands-time")
+  .nHistorical(nHistorical)
+  .pollingInterval(pollingInterval)
+  .width(width)
+  .height(height)
+  .call();
+
+  counterAndSparkline()
+  .url("/metrics/mbean/com.puppetlabs.cmdb.http.server:type=resources,name=service-time")
+  .snag(function(res) { return res["50thPercentile"] / 1000; })
+  .format(d3.format(",.3s"))
+  .description("Collection Queries")
+  .addendum("service time, seconds")
+  .container("#rest-resources-time")
+  .nHistorical(nHistorical)
+  .pollingInterval(pollingInterval)
+  .width(width)
+  .height(height)
+  .call();
+
+})()</script>
+

--- a/src/com/puppetlabs/cmdb/http/server.clj
+++ b/src/com/puppetlabs/cmdb/http/server.clj
@@ -12,6 +12,7 @@
         [com.puppetlabs.middleware :only (wrap-with-globals wrap-with-metrics)]
         [com.puppetlabs.utils :only (uri-segments)]
         [net.cgrand.moustache :only (app)]
+        [ring.middleware.resource :only (wrap-resource)]
         [ring.middleware.params :only (wrap-params)]))
 
 (def routes
@@ -37,6 +38,7 @@
   database, generate a Ring application that handles queries"
   [globals]
   (-> routes
+      (wrap-resource "public")
       (wrap-params)
       (wrap-with-metrics (atom {}) #(first (uri-segments %)))
       (wrap-with-globals globals)))


### PR DESCRIPTION
Simple, polling-based web console for Grayskull. Displays a fixed set of the
key metrics around Grayskull operations: memory use, queue depth, command
processing metrics, duplication rate, and REST endpoint stats.

We display min/max/median of each metric over a configurable duration, as well
as an animated SVG sparkline.

Currently the only way to change the attributes of the dashboard is via URL
parameters:
- width = width of each sparkline
- height = height of each sparkline
- nHistorical = how many historical data points to use in each sparkline
- pollingInterval = how often to poll Grayskull for updates

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
