### PR TITLE
Cache computation of resource hashes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
                  [cheshire "2.2.0"]
                  [org.clojure/core.incubator "0.1.0"]
                  [org.clojure/core.match "0.2.0-alpha9"]
+                 [org.clojure/core.memoize "0.5.1"]
                  [org.clojure/math.combinatorics "0.0.2"]
                  [org.clojure/tools.logging "0.2.3"]
                  [org.clojure/tools.cli "0.2.1"]


### PR DESCRIPTION
The hash computation is a pure, referentially transparent function. Therefore,
we can easily memoize the function to return a previously computed result when
encountering an argument list we've already seen.

For catalogs with many resources, this provides a meaningful performance
improvement. In my testing with a catalog using 1000 resources, this drops
hash-computation time during add-catalog! from ~200ms to ~20ms.

Initial sizing of the cache is based on the "medium" site persona, which is
said to have ~40k unique resources in the population.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
