### PR TITLE
The number of command-processing threads should be end-user configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,27 @@ What username to use when connecting.
 
 A password to use when connecting.
 
+**[command-processing]**
+
+Options relating to the commang-processing subsystem. Every change to
+Grayskull's data stores comes in via commands that are inserted into
+an MQ. Command processor threads pull items off of that queue,
+persisting those changes.
+
+`threads`
+
+How many command processing threads to use. Each thread can process a
+single command at a time. If you notice your MQ depth is rising and
+you've got CPU to spare, increasing the number of threads may help
+churn through the backlog faster.
+
+If you are saturating your CPU, we recommend lowering the number of
+threads.  This prevents other Grayskull subsystems (such as the web
+server, or the MQ itself) from being starved of resources, and can
+actually _increase_ throughput.
+
+This setting defaults to half the number of cores in your system.
+
 **[mq]**
 
 Message queue configuration options.

--- a/resources/config.ini
+++ b/resources/config.ini
@@ -24,6 +24,10 @@ subname = file:/tmp/grayskull;hsqldb.tx=mvcc;sql.syntax_pgs=true
 # Use a specific password
 # password = foobar
 
+[command-processing]
+# How many command-processing threads to use, defaults to (CPUs / 2)
+# threads = 4
+
 [mq]
 # Where to persist message queue data
 dir = /tmp/mq-data


### PR DESCRIPTION
We previously automatically used N threads, where N is 2 + (# of CPUs). This
default could work great or horribly depending on the complexity and rate of
incoming catalogs. If command processing takes up too much CPU, it can
starve other subsystems (jetty, activemq) of CPU resources. While that doesn't
affect correctness or stability, it can reduce overall throughput.

This patchset makes the number of threads configurable. We'll default to half
the number of CPUs in the system, and allow the user to override this via
configuration file directives.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
