### PR TITLE
(#13439) refactor spec_helper to provide compatibility with both puppet 2.7 and master

### DIFF
--- a/module/spec/spec_helper.rb
+++ b/module/spec/spec_helper.rb
@@ -10,10 +10,7 @@ RSpec.configure do |config|
   config.mock_with :mocha
 
   config.before :each do
-    # Set the confdir and vardir to gibberish so that tests
-    # have to be correctly mocked.
-    Puppet[:confdir] = "/dev/null"
-    Puppet[:vardir] = "/dev/null"
+    Puppet.settings.send(:initialize_everything_for_tests)
 
     @logs = []
     Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(@logs))
@@ -22,7 +19,7 @@ RSpec.configure do |config|
   end
 
   config.after :each do
-    Puppet.settings.clear
+    Puppet.settings.send(:clear_everything_for_tests)
     Puppet::Node::Environment.clear
     Puppet::Util::Storage.clear
 


### PR DESCRIPTION
This change is intended to allow specs in external projects (grayskull, puppetlabs-stdlib) to be compatible with both 2.7 and master versions of puppet.  It basically just abstracts the interactions with the Settings objects that was happening in spec_helper into private setup / teardown methods in the Settings class itself.

We'd already started this pattern in master, so this change just exposes it in 2.7 as well.

Should be merged after pull request 602:

https://github.com/puppetlabs/puppet/pull/602
