### PR TITLE
Stringify fact values before submitting them to Grayskull

### DIFF
--- a/module/lib/puppet/indirector/facts/grayskull.rb
+++ b/module/lib/puppet/indirector/facts/grayskull.rb
@@ -16,7 +16,11 @@ class Puppet::Node::Facts::Grayskull < Puppet::Indirector::REST
   end
 
   def save(request)
-    msg = message(request.instance).to_pson
+    facts = request.instance.dup
+    facts.values = facts.values.dup
+    facts.stringify
+
+    msg = message(facts).to_pson
     msg = Puppet::Resource::Catalog::Grayskull.utf8_string(msg)
     checksum = Digest::SHA1.hexdigest(msg)
     payload = CGI.escape(msg)

--- a/src/com/puppetlabs/cmdb/scf/storage.clj
+++ b/src/com/puppetlabs/cmdb/scf/storage.clj
@@ -588,6 +588,7 @@ facts associated with the certname."
 
 (defn replace-facts!
   [certname facts]
+  {:pre [(every? string? (vals facts))]}
   (time! (:replace-facts metrics)
    (sql/transaction
     (delete-facts! certname)


### PR DESCRIPTION
These should technically already be strings, but in case of extenuating
circumstances (eg. ZAML bugs), we ought to make sure to enforce that
precondition ourselves.
