### PR TITLE
(#13694) use puppetlabs_spec_helper instead of maintaining a copy

### DIFF
--- a/module/spec/spec_helper.rb
+++ b/module/spec/spec_helper.rb
@@ -1,30 +1,4 @@
 dir = File.expand_path(File.dirname(__FILE__))
 $LOAD_PATH.unshift File.join(dir, "../lib")
 
-require 'puppet'
-require 'mocha'
-gem 'rspec', '>=2.0.0'
-require 'rspec/expectations'
-
-RSpec.configure do |config|
-  config.mock_with :mocha
-
-  config.before :each do
-    Puppet.settings.send(:initialize_everything_for_tests)
-
-    @logs = []
-    Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(@logs))
-
-    @log_level = Puppet::Util::Log.level
-  end
-
-  config.after :each do
-    Puppet.settings.send(:clear_everything_for_tests)
-    Puppet::Node::Environment.clear
-    Puppet::Util::Storage.clear
-
-    @logs.clear
-    Puppet::Util::Log.close_all
-    Puppet::Util::Log.level = @log_level
-  end
-end
+require 'puppet_spec_helper'


### PR DESCRIPTION
This introduces a dependency on puppetlabs_spec_helper project;
you'll need to clone that into your working copy at the same
level as the rest of your projects, and make sure that the
root directory of it is in your RUBYLIB.  Jenkins jobs will
need to be changed accordingly.

---

This isn't quite ready yet, will edit the title when it is.
