### PR TITLE
Fix keep-going to actually keep-going

### DIFF
--- a/src/com/puppetlabs/utils.clj
+++ b/src/com/puppetlabs/utils.clj
@@ -133,6 +133,7 @@
   [f on-error]
   (if (try
         (f)
+        true
         (catch InterruptedException e
           false)
         (catch Throwable e


### PR DESCRIPTION
This function was changed to return true/false on exceptions so that it
could conditionally continue, and thus halt on InterruptedException.
However, the success case was omitted, and was left using whatever the
wrapped function returned. Since keep-going doesn't return a value, its
wrapped function likely returns nil (for instance, in the case of the
garbage collection function), and thus it wasn't recurring after
success.
