### PR TITLE
Ensure a minimum number of command processors

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -106,14 +106,17 @@
 (defn configure-commandproc-threads
   "Update the supplied config map with the number of
   command-processing threads to use. If no value exists in the config
-  map, default to half the number of CPUs."
+  map, default to half the number of CPUs. If only one CPU exists, we
+  will use one command-processing thread."
   [config]
   {:pre [(map? config)]
-   :post [(map? %)]}
+   :post [(map? %)
+          (pos? (get-in % [:command-processing :threads]))]}
   (let [default-nthreads (-> (Runtime/getRuntime)
                              (.availableProcessors)
                              (/ 2)
-                             (int))]
+                             (int)
+                             (max 1))]
     (update-in config [:command-processing :threads] #(or % default-nthreads))))
 
 (defn configure-web-server


### PR DESCRIPTION
The default setting for the number of command processing threads is set to half
the number of cores in your system (rounded down due to integer division). That
works great until you've got a system with only one core, in which case we ended
up starting 0 command-processing threads. This patch ensures a minumim of one
command processing thread.

It's 2012...who's still rocking a single core? :)

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
