### PR TITLE
Make command-proc tests work on single-core systems

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -112,8 +112,7 @@
   {:pre [(map? config)]
    :post [(map? %)
           (pos? (get-in % [:command-processing :threads]))]}
-  (let [default-nthreads (-> (Runtime/getRuntime)
-                             (.availableProcessors)
+  (let [default-nthreads (-> (pl-utils/num-cpus)
                              (/ 2)
                              (int)
                              (max 1))]

--- a/src/com/puppetlabs/utils.clj
+++ b/src/com/puppetlabs/utils.clj
@@ -309,3 +309,12 @@
   "Generate a random UUID and return its string representation"
   []
   (str (java.util.UUID/randomUUID)))
+
+;; System interface
+
+(defn num-cpus
+  "Grabs the number of available CPUs for the local host"
+  []
+  {:post [(pos? %)]}
+  (-> (Runtime/getRuntime)
+      (.availableProcessors)))


### PR DESCRIPTION
While a prior patchset fixes the main code for auto-configuring threads on a
single-core system, it didn't fix the test cases. So if you ran the tests on a
single core system, they'd fail.

This patchset abstracts out the code that determines the number of cores in a
host into a utility func, and test cases override that func during verification
of behavior.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
