### PR TITLE
Ensure config.ini and log4j config files are not world-readable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -135,6 +135,7 @@ task :template => [ ] do
    # files for deb and rpm
    erb "ext/templates/log4j.properties.erb", "ext/files/log4j.properties"
    erb "ext/templates/config.ini.erb" , "ext/files/config.ini"
+   chmod 640 , "ext/files/config.ini"
 
    # files for deb
    erb "ext/templates/init_debian.erb", "ext/files/debian/#{@name}.init"
@@ -195,6 +196,8 @@ task :install => [  JAR_FILE  ] do
   cp_p JAR_FILE, "#{DESTDIR}/#{@install_dir}"
   cp_pr "ext/files/log4j.properties", "#{DESTDIR}/#{@config_dir}/log4j.properties"
   cp_pr "ext/files/config.ini", "#{DESTDIR}/#{@config_dir}/config.ini"
+  chmod 640, "#{DESTDIR}/#{@config_dir}/config.ini"
+  chmod 640, "#{DESTDIR}/#{@config_dir}/log4j.properties"
   cp_pr "ext/files/puppetdb.logrotate", "#{DESTDIR}/etc/logrotate.d/#{@name}"
 
   # figure out which init script to install based on facter


### PR DESCRIPTION
Prior to this commit, the files in /etc/puppetdb were world-readable.  This is bad since config files could have database passwords in them.
