### PR TITLE
Support config.d-style configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,10 @@ Here is an example configuration file:
     [jetty]
     port = 8080
 
+You can specify either a single configuration file or a directory of
+.ini files. If you specify a directory (_conf.d_ style) we'll merge
+all the .ini files together in alphabetical order.
+
 There's not much to it, as you can see. Here's a more detailed
 breakdown of each available section:
 

--- a/src/com/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/com/puppetlabs/puppetdb/cli/benchmark.clj
@@ -46,7 +46,7 @@
             [clj-http.client :as client]
             [clj-http.util :as util]
             [fs.core :as fs])
-  (:use [com.puppetlabs.utils :only (cli! ini-to-map configure-logging! utf8-string->sha1)]
+  (:use [com.puppetlabs.utils :only (cli! inis-to-map configure-logging! utf8-string->sha1)]
         [com.puppetlabs.puppetdb.scf.migrate :only [migrate!]]))
 
 (def cli-description "Development-only benchmarking tool")
@@ -132,7 +132,7 @@
 
         config      (-> options
                         :config
-                        (ini-to-map)
+                        (inis-to-map)
                         (configure-logging!))
 
         dir         (:dir options)

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -58,7 +58,7 @@
   (:use [clojure.java.io :only [file]]
         [clojure.tools.nrepl.transport :only (tty tty-greeting)]
         [com.puppetlabs.jdbc :only (with-transacted-connection)]
-        [com.puppetlabs.utils :only (cli! configure-logging! ini-to-map with-error-delivery)]
+        [com.puppetlabs.utils :only (cli! configure-logging! inis-to-map with-error-delivery)]
         [com.puppetlabs.puppetdb.scf.migrate :only [migrate!]]))
 
 (def cli-description "Main PuppetDB daemon")
@@ -180,7 +180,7 @@
   "Parses the given config file (if present) and configure its various
   subcomponents."
   [file]
-  (let [config (if file (ini-to-map file) {})]
+  (let [config (if file (inis-to-map file) {})]
     (-> config
         (configure-logging!)
         (configure-commandproc-threads)


### PR DESCRIPTION
Previously, you could only configure puppetdb by passing in a fully-realized
configuration file. This patchset allows you to pass in a directory instead,
and we'll parse-and-merge all configuration files contained therein.

This allows people to separate different logical bits of configuration into
their own files. For example, you can have your Jetty configuration in a
jetty.ini file. This, for example, makes it easier for puppet to manage subsets
of PuppetDB configuration.
