### PR TITLE
Fix documentation generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Other useful commands:
 
 * `lein test` to run the test suite
 
-* `lein marg` to build docs in `docs/uberdoc.html`
+* `lein docs` to build docs in `docs/uberdoc.html`
 
 To use the Puppet module from source, add the Ruby code to $RUBYLIB.
 

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,6 @@
         (#(take 4 %))
         (#(s/join "." %)))))
 
-
 (defproject puppetdb (version-string)
   :description "Puppet-integrated catalog and fact storage"
   :dependencies [[org.clojure/clojure "1.3.0"]
@@ -66,6 +65,8 @@
   :dev-dependencies [[lein-marginalia "0.7.0"]
                      ;; WebAPI support libraries.
                      [ring-mock "0.1.1"]]
+
+  :jar-exclusions [#"leiningen/"]
 
   :aot [com.puppetlabs.puppetdb.core]
   :main com.puppetlabs.puppetdb.core

--- a/src/leiningen/docs.clj
+++ b/src/leiningen/docs.clj
@@ -1,0 +1,9 @@
+;; Wrapper for marginalia that passes in the correct name,
+;; description, and version to the marginalia parser.
+
+(ns leiningen.docs
+  (:require [leiningen.marg :as marg]))
+
+(defn docs
+  [project]
+  (marg/marg project "-n" (:name project) "-D" (:description project) "-v" (:version project)))


### PR DESCRIPTION
The lein-marginalia plugin is stupid, and instead of snagging things like the
project name, description, and version from function arguments, it simply
defers to marginalia to parse the project.clj file. This is dumb, because
there's no need to parse that file at all...the whole point of running as a
lein plugin is that you get access to the project file, post-any-parsing.
Furthermore, the marginalia parser can't cope with the special code we have in
our project.clj file that auto-determines the version number by looking at git
tags.

This patchset simply inserts our own "lein marg" plugin that Does The Right
Thing with arguments prior to calling the stock plugin.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
