### PR TITLE
Properly formulate title and tag queries

### DIFF
--- a/puppet/lib/puppet/indirector/resource/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/resource/puppetdb.rb
@@ -62,7 +62,18 @@ class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
   def build_filter_expression(filter)
     return nil unless filter
 
-    equal_expr = ['=', ['parameter', filter.first], filter.last]
+    field = filter.first
+    value = filter.last
+
+    # Title and tag aren't parameters, so we have to special-case them.
+    path = case field
+           when "tag", "title"
+             field
+           else
+             ['parameter', field]
+           end
+
+    equal_expr = ['=', path, value]
 
     filter[1] == '!=' ? ['not', equal_expr] : equal_expr
   end

--- a/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
@@ -110,6 +110,14 @@ describe Puppet::Resource::Puppetdb do
     it "should return a not-equal query if the operator is '!='" do
       subject.build_filter_expression(['param','!=','value']).should == ['not', ['=',['parameter','param'],'value']]
     end
+
+    it "should handle title correctly" do
+      subject.build_filter_expression(['title','=','value']).should == ['=', 'title', 'value']
+    end
+
+    it "should handle tag correctly" do
+      subject.build_filter_expression(['tag','=','value']).should == ['=', 'tag', 'value']
+    end
   end
 
   describe "#headers" do


### PR DESCRIPTION
Previously, we were treating everything like a parameter query, and
producing queries that looked like ["=", ["parameter", "title"], "foo"].
Unfortunately, title isn't actually a parameter, so the query should be
["=", "title", "foo"]. Similarly for tags.
