### PR TITLE
Fix resource queries involving tags

### DIFF
--- a/src/com/puppetlabs/puppetdb/http/resources.clj
+++ b/src/com/puppetlabs/puppetdb/http/resources.clj
@@ -80,10 +80,12 @@
   If the query can't be parsed, a 400 is returned."
   [query db]
   (try
-    (let [q (r/query->sql (json/parse-string query true))]
-      (-> (with-transacted-connection db
-            (r/query-resources q))
-          (utils/json-response)))
+    (with-transacted-connection db
+      (-> query
+        (json/parse-string true)
+        (r/query->sql)
+        (r/query-resources)
+        (utils/json-response)))
     (catch com.fasterxml.jackson.core.JsonParseException e
       (utils/error-response e))
     (catch IllegalArgumentException e


### PR DESCRIPTION
Compiling this query needs to know the kind of database being used, with
requires it be compiled with a connection available. We were using a
connection immediately after compilation already, so we can just move
the compile inside it.
