### PR TITLE
Fix package building for Debian + PE

### DIFF
--- a/ext/templates/deb/control.erb
+++ b/ext/templates/deb/control.erb
@@ -3,7 +3,7 @@ Section: utils
 Priority: optional
 Maintainer: Puppet Labs <info@puppetlabs.com>
 <% if @pe -%>
-Build-Depends: debhelper (>= 7.0.0~), cdbs, pe-rake, pe-facter, pe-puppet
+Build-Depends: debhelper (>= 7.0.0~), cdbs, pe-rake, pe-facter, pe-puppet-agent
 <% else -%>
 Build-Depends: debhelper (>= 7.0.0~), cdbs, rake, facter, puppet
 <% end -%>
@@ -13,7 +13,7 @@ Homepage: http://puppetlabs.com
 Package: <%= @name %>
 Architecture: all
 <% if @pe -%>
-Depends: ${misc:Depends},  java6-runtime-headless, adduser, pe-puppet (>= 2.7.12)
+Depends: ${misc:Depends},  java6-runtime-headless, adduser, pe-puppet-agent (>= 2.7.12)
 <% else -%>
 Depends: ${misc:Depends},  java6-runtime-headless, adduser, puppet (>= 2.7.12)
 <% end -%>

--- a/ext/templates/deb/rules.erb
+++ b/ext/templates/deb/rules.erb
@@ -16,9 +16,15 @@ install::
 	echo $(CURDIR)
 	echo $(BUILD_ROOT)
 	mkdir -p $(BUILD_ROOT)
+<% if @pe -%>
+	/opt/puppet/bin/rake install DESTDIR=$(BUILD_ROOT) PE_BUILD=true
+	/opt/puppet/bin/rake terminus DESTDIR=$(BUILD_ROOT) PE_BUILD=true
+	dh_installdocs -p pe-puppetdb spec
+<% else -%>
 	rake install DESTDIR=$(BUILD_ROOT)
 	rake terminus DESTDIR=$(BUILD_ROOT)
 	dh_installdocs -p puppetdb spec
+<% end -%>
 
 binary-indep: build install
 	dh_testdir
@@ -27,8 +33,13 @@ binary-indep: build install
 	dh_installdocs -i
 	dh_installlogcheck
 	dh_installman
+<% if @pe -%>
+	dh_installinit -ppe-puppetdb
+	dh_installlogrotate -i -ppe-puppetdb
+<% else -%>
 	dh_installinit -ppuppetdb
 	dh_installlogrotate -i -ppuppetdb
+<% end -%>
 	dh_compress -i
 	dh_fixperms -i -X puppetdb-ssl-setup -X etc
 	dh_installdeb -i

--- a/ext/templates/deb/terminus.install.erb
+++ b/ext/templates/deb/terminus.install.erb
@@ -1,5 +1,5 @@
 <% if @pe  -%>
-opt/puppet/ruby/1.8/puppet
+opt/puppet/lib/ruby/1.8/puppet
 <% else -%>
 usr/lib/ruby/1.8/puppet
 <% end -%>


### PR DESCRIPTION
This commit fixes a few issues that were causing issues when attempting
to build puppetdb for Puppet Enterprise.

The Rakefile now prepends /opt/puppet/bin as your first path search to
ensure the tools being used are from Puppet Enterprise.

The templates and erb files had some minor errors and ommissions that
needed to be fixed to build out packages for pe-puppetdb and
pe-puppetdb-terminus on Debian/Ubuntu.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
