### PR TITLE
Ensure that upgrades don't overwrite java/jetty conf

### DIFF
--- a/ext/templates/deb/postinst.erb
+++ b/ext/templates/deb/postinst.erb
@@ -3,7 +3,7 @@
 
 # Setup the SSL stuff
 
-if ! [ "$1" =  "upgrade" ] ; then
+if [ ! -f "<%= @config_dir -%>/../ssl/puppetdb_keystore_pw.txt" ] ; then
   <%= @sbin_dir -%>/puppetdb-ssl-setup
 
   pw=`cat <%= @config_dir -%>/../ssl/puppetdb_keystore_pw.txt`


### PR DESCRIPTION
Since postinst is not  able to tell if a pkg is getting upgraded vs
installed, we have switched to detecting the presense of the ssl
passphrase file.
