### PR TITLE
Ensure facter is called via PE path if present

### DIFF
--- a/ext/templates/deb/postinst.erb
+++ b/ext/templates/deb/postinst.erb
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+<%= if @pe -%>
+export PATH=/opt/puppet/bin:$PATH
+<% end -%>
 
 # Setup the SSL stuff
 

--- a/ext/templates/puppetdb.spec.erb
+++ b/ext/templates/puppetdb.spec.erb
@@ -97,6 +97,9 @@ useradd -r -g %{name} -d /opt/puppet/share/%{realname} -s /sbin/nologin \
      -c "PuppetDB daemon"  %{name}
 
 %post
+<% if @pe -%>
+export PATH=/opt/puppet/bin:$PATH
+<% end -%>
 # If this is an install (as opposed to an upgrade)...
 if [ "$1" = "1" ]; then
   # Register the puppetDB service


### PR DESCRIPTION
If doing a PE build, ensure that PATH has been prepended with
/opt/puppet/bin.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
