### PR TITLE
Fix jar file location/name for PE rpm

### DIFF
--- a/ext/templates/init_redhat.erb
+++ b/ext/templates/init_redhat.erb
@@ -37,7 +37,7 @@ PATH=/opt/puppet/bin:/opt/puppet/sbin:/sbin:/usr/sbin:/bin:/usr/bin
 <% else -%>
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 <% end -%>
-JARFILE="<%= @name -%>.jar"
+JARFILE="puppetdb.jar"
 JAVA_ARGS="${JAVA_ARGS} -jar ${INSTALL_DIR}/${JARFILE} services -c ${CONFIG} "
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile=/var/lock/subsys/$prog


### PR DESCRIPTION
Previously the init script referenced the name of the package in the jar
file which is not correct for PE. The jar file is still puppetdb.jar.
This was already fixed in the debian init script and now is fixed in the
EL init script.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
