### PR TITLE
Don't fail when collecting exec resources

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -47,6 +47,11 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
     hash['resources'].each do |resource|
       real_resource = catalog.resource(resource['type'], resource['title'])
 
+      # Non-isomorphic resources aren't unique based on namevar, so we can't
+      # use it as an alias
+      type = real_resource.resource_type
+      next if type.respond_to?(:isomorphic?) and !type.isomorphic?
+
       aliases = [real_resource[:alias]].flatten.compact
 
       name = real_resource[real_resource.send(:namevar)]

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -105,6 +105,24 @@ describe Puppet::Resource::Catalog::Puppetdb do
         resource.should_not be_nil
         resource['parameters']['alias'].should be_nil
       end
+
+      describe "for non-isomorphic resources" do
+        let(:resource) do
+          Puppet::Resource.new(:exec, 'an_exec', :parameters => {:command => '/bin/true'})
+        end
+
+        it "should not create aliases" do
+          hash = subject.add_parameters_if_missing(catalog_data_hash)
+          result = subject.add_namevar_aliases(hash, catalog)
+
+          resource = result['resources'].find do |res|
+            res['type'] == 'Exec' and res['title'] == 'an_exec'
+          end
+
+          resource.should_not be_nil
+          resource['parameters']['alias'].should be_nil
+        end
+      end
     end
 
     describe "#munge_edges" do


### PR DESCRIPTION
We were adding aliases for exec resources based on their command, which
is the namevar. This is so that we can properly lookup resources
referred to by relationship metaparameters when producing relationship
edges. However, exec resources aren't isomorphic, meaning they aren't
unique based on their namevar. This means we don't need to add those
aliases, because it's illegal to specify a relationship to an exec
resource using its command. It also means we were adding non-unique
aliases, which were evaluated on the agent after collecting the
resources, and could cause conflicts.
