### PR TITLE
(#14659) Compatibility with PG 8.1.x

### DIFF
--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -72,7 +72,7 @@ must be supplied as the value to be matched."
 
 (defmethod sql-array-type-string "PostgreSQL"
   [basetype]
-  (format "%s ARRAY" basetype))
+  (format "%s ARRAY[1]" basetype))
 
 (defmethod sql-array-query-string "PostgreSQL"
   [column]


### PR DESCRIPTION
RHEL5 ships with 8.1.23, and ARRAY declaration syntax was different waaaaaay
back then. Running PuppetDB with that vintage PG results in SQLExceptions
during initial migration.

In particular, while more recent PG versions support data type definitions like
“foo ARRAY NOT NULL”, PG 8.1 requires “foo ARRAY[1] NOT NULL”. The “1” is
ignored by PG (much like how it ignores the size of a VARCHAR column).

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
