### PR TITLE
(#14665) Removal of SSL provider fails when class not available

### DIFF
--- a/src/com/puppetlabs/jetty.clj
+++ b/src/com/puppetlabs/jetty.clj
@@ -18,10 +18,12 @@
 ;; https://bugs.launchpad.net/ubuntu/+source/openjdk-6/+bug/948875
 (if (re-find #"OpenJDK" (System/getProperty "java.vm.name"))
   (try
-    (let [blacklist (filter #(instance? sun.security.pkcs11.SunPKCS11 %) (java.security.Security/getProviders))]
+    (let [klass     (Class/forName "sun.security.pkcs11.SunPKCS11")
+          blacklist (filter #(instance? klass %) (java.security.Security/getProviders))]
       (doseq [provider blacklist]
         (log/info (str "Removing buggy security provider " provider))
         (java.security.Security/removeProvider (.getName provider))))
+    (catch ClassNotFoundException e)
     (catch Throwable e
       (log/error e "Could not remove security providers; HTTPS may not work!"))))
 


### PR DESCRIPTION
For compatibility with OpenJDK and OpenSSL 1.0+, we remove a buggy OpenJDK
security provider. We do this by enumerating the current set of security
providers and removing the problematic ones by checking if they are the
instance of a specific class.

However, if that class doesn't exist on the system at all, we get a
ClassNotFoundException. We had a try/catch around this code for just that
reason, only it turns out the try/catch isn't getting invoked when the error is
thrown.

This is because that code lives at the top-level of the namespace, and is
executed when the namespace is compiled. But the compiler can't find all the
classes mentioned in the code it's trying to compile, and the
ClassNotFoundException is actually thrown at compile-time...before the
try/catch code is compiled and live.

The fix is to change the declaration of the class (which may not actually
exist) from a compile-time declaration to a run-time declaration (using
Class/forName).

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
