### PR TITLE
(#14586) Incorrect start-stop-daemon args in Debian init script

### DIFF
--- a/ext/templates/init_debian.erb
+++ b/ext/templates/init_debian.erb
@@ -78,17 +78,9 @@ do_stop()
     #   1 if daemon was already stopped
     #   2 if daemon could not be stopped
     #   other if a failure occurred
-    start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $NAME
+    start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --exec $JAVA_BIN
     RETVAL="$?"
     [ "$RETVAL" = 2 ] && return 2
-    # Wait for children to finish too if this is a daemon that forks
-    # and if the daemon is only ever run from this initscript.
-    # If the above conditions are not satisfied then add some other code
-    # that waits for the process to drop all resources that could be
-    # needed by services started subsequently.  A last resort is to
-    # sleep for some time.
-    start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $JAVA_BIN
-    [ "$?" = 2 ] && return 2
     # Many daemons don't delete their pidfiles when they exit.
     rm -f $PIDFILE
     return "$RETVAL"


### PR DESCRIPTION
When we try to stop the daemon, we were passing in `--name puppetdb` instead of
`--exec $JAVA_BIN`. Since our process isn't actually named puppetdb, that
initial call wouldn't actually terminate the process. It would then
fall-through to a second code path where the init script would then try to kill
_all_ processes with $JAVA_BIN as the executable. That's, like, not so great
and stuff.

I've corrected the args to start-stop-daemon to use both the pidfile and the
executable name to give us a precise match. With that in place, the secondary
code path is no longer necessary.

A pleasant side-effect of this fix is that now stopping PuppetDB is extremely
fast, instead of taking 30 seconds or so.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
