### PR TITLE
Fix init script for EL based PE installations

### DIFF
--- a/ext/templates/init_redhat.erb
+++ b/ext/templates/init_redhat.erb
@@ -55,7 +55,7 @@ find_my_pid() {
       mkdir -p /var/run/$prog
       chown -R $USER:$USER /var/run/$prog
     fi
-    pid=`ps -ef | grep $JAVA_BIN | grep ^$USER | grep " services -c " | awk '{print $2}'`
+    pid=`ps -ef | grep $JAVA_BIN | grep $JARFILE | grep " services -c " | awk '{print $2}'`
 }
 
 start() {


### PR DESCRIPTION
Previously, we were grepping on username in the find_my_pid function of
the init script.  This was fine if the username was <= 8 characters, but
since pe-puppetdb is not, 'ps -ef' would fall back to using UID in the
processes table, thus causing the function to fail.  This in turn led to
empty pid files and puppetdb potentially starting lots of times.

We now grep the jarfile name rather than user to confine the process
listing.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
