### PR TITLE
Allow introspection of version number

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,24 +1,26 @@
 (require '[clojure.string :as s])
 (use '[clojure.java.shell :only (sh)])
 
-(defn version-string
-  "Determine the version number using 'git describe'"
-  []
-  (let [command                ["git" "describe"]
-        {:keys [exit out err]} (apply sh command)]
-    (when-not (zero? exit)
-      (println (format "Non-zero exit status during version check:\n%s\n%s\n%s\n%s"
-                       command exit out err))
-      (System/exit 1))
+(def version-string
+  (memoize
+   (fn []
+     "Determine the version number using 'git describe'"
+     []
+     (let [command                ["git" "describe"]
+           {:keys [exit out err]} (apply sh command)]
+       (when-not (zero? exit)
+         (println (format "Non-zero exit status during version check:\n%s\n%s\n%s\n%s"
+                          command exit out err))
+         (System/exit 1))
 
-    ;; We just want the first 4 "components" of the version string,
-    ;; joined with dots
-    (-> out
-        (s/trim)
-        (s/replace #"-" ".")
-        (s/split #"\.")
-        (#(take 4 %))
-        (#(s/join "." %)))))
+       ;; We just want the first 4 "components" of the version string,
+       ;; joined with dots
+       (-> out
+           (s/trim)
+           (s/replace #"-" ".")
+           (s/split #"\.")
+           (#(take 4 %))
+           (#(s/join "." %)))))))
 
 (defproject puppetdb (version-string)
   :description "Puppet-integrated catalog and fact storage"
@@ -68,6 +70,7 @@
                      [ring-mock "0.1.1"]]
 
   :jar-exclusions [#"leiningen/"]
+  :manifest {"Build-Version" ~(version-string)}
 
   :aot [com.puppetlabs.puppetdb.core]
   :main com.puppetlabs.puppetdb.core

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -68,6 +68,7 @@
 ;; The following functions setup interaction between the main
 ;; PuppetDB components.
 
+(def version (pl-utils/get-version-from-manifest))
 (def configuration nil)
 (def mq-addr "vm://localhost?jms.prefetchPolicy.all=1&create=false")
 (def mq-endpoint "com.puppetlabs.puppetdb.commands")
@@ -201,6 +202,9 @@
                                                     :command-mq {:connection-string mq-addr
                                                                  :endpoint          mq-endpoint}}
         ring-app                                   (server/build-app globals)]
+
+    (when version
+      (log/info (format "PuppetDB version %s" version)))
 
     ;; Ensure the database is migrated to the latest version
     (sql/with-connection db

--- a/src/com/puppetlabs/utils.clj
+++ b/src/com/puppetlabs/utils.clj
@@ -327,14 +327,14 @@
     (let [bytes (.getBytes s "UTF-8")]
       (digest-func "sha-1" [bytes]))))
 
-;; UUID handling
+;; ## UUID handling
 
 (defn uuid
   "Generate a random UUID and return its string representation"
   []
   (str (java.util.UUID/randomUUID)))
 
-;; System interface
+;; ## System interface
 
 (defn num-cpus
   "Grabs the number of available CPUs for the local host"
@@ -342,3 +342,24 @@
   {:post [(pos? %)]}
   (-> (Runtime/getRuntime)
       (.availableProcessors)))
+
+;; ## META-INF parsing
+
+(defn get-version-from-manifest
+  "Returns the PuppetDB version number as indicated by a maven POM
+  file embedded in the current JAR. If we aren't running from within a
+  a JAR, or if we can't locate a maven artifact on the CLASSPATH, we
+  return nil.
+
+  Yes, this code is kind of inscrutable and impossible to unit test
+  (usefully) without building actual artifacts. :("
+  []
+  (let [props-path (->> ["META-INF" "maven" "puppetdb" "puppetdb" "pom.properties"]
+                        (apply clojure.java.io/file)
+                        (.getPath))
+        props-file (clojure.java.io/resource props-path)]
+    (when props-file
+      (with-open [rdr (clojure.java.io/reader props-file)]
+        (let [props (java.util.Properties.)]
+          (.load props rdr)
+          (get props "version"))))))


### PR DESCRIPTION
This patchset stores the auto-computed version number for PuppetDB:
- on-disk, inside of a generated JAR file
- in-memory, in `com.puppetlabs.puppetdb.cli.services/version`

This is done by modifying our build file slightly to add a custom metadata
field to build outputs, and adding a func that can parse that field back into
memory.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
