### PR TITLE
Change SSL setup to use master SSL keys instead of agent.

### DIFF
--- a/ext/templates/puppetdb-ssl-setup
+++ b/ext/templates/puppetdb-ssl-setup
@@ -10,9 +10,9 @@ set -e
 fqdn=`facter fqdn`
 password=`export LC_ALL=C; dd if=/dev/urandom count=20 2> /dev/null | tr -cd '[:alnum:]' | head -c 25`
 tmpdir=`mktemp -t -d tmp.puppetdbXXXXX`
-mycert=`puppet agent --configprint  hostcert`
-myca=`puppet agent --configprint localcacert`
-privkey=`puppet agent --configprint hostprivkey`
+mycert=`puppet master --configprint  hostcert`
+myca=`puppet master --configprint localcacert`
+privkey=`puppet master --configprint hostprivkey`
 
 if [ -d "/etc/puppetlabs/puppetdb" ] ; then
   confdir="/etc/puppetlabs/puppetdb"


### PR DESCRIPTION
In normal PuppetDB installations it is connected to a puppet master, not a standalone agent. So This should make more sense.

It only makes a difference though if you have separate ssldirs for the agent & master.
