### PR TITLE
Garbage-collect DB at startup

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -210,6 +210,12 @@
     (sql/with-connection db
       (migrate!))
 
+    ;; Do an initial GC, to clean up anything left over from previous
+    ;; runs of the daemon
+    (log/info "Compacting database")
+    (with-transacted-connection db
+      (scf-store/garbage-collect!))
+
     ;; Initialize database-dependent metrics
     (pop/initialize-metrics db)
 


### PR DESCRIPTION
Daemon startup is a good place to do an explicit DB garbage-collection run. That
helps clean up any lingering database bloat from previous invokations of the
daemon, and it doesn't delay startup in the common case as GC typically lasts
less than a second.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
