### PR TITLE
Tweak terminus specs to get them passing against Telly

### DIFF
--- a/puppet/spec/unit/indirector/node/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/node/puppetdb_spec.rb
@@ -5,10 +5,14 @@ require 'spec_helper'
 require 'puppet/indirector/node/puppetdb'
 
 describe Puppet::Node::Puppetdb do
+  before :each do
+    Puppet::Node.indirection.stubs(:terminus).returns(subject)
+  end
+
   let(:node) { "something.example.com" }
 
   def destroy
-    subject.destroy(Puppet::Node.indirection.request(:destroy, node))
+    Puppet::Node.indirection.destroy(node)
   end
 
   describe "#destroy" do

--- a/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
@@ -6,6 +6,7 @@ require 'puppet/indirector/resource/puppetdb'
 describe Puppet::Resource::Puppetdb do
   before :each do
     Puppet::Util::Puppetdb.stubs(:load_puppetdb_config).returns ['localhost', 0]
+    Puppet::Resource.indirection.stubs(:terminus).returns(subject)
   end
 
   describe "#search" do
@@ -14,7 +15,7 @@ describe Puppet::Resource::Puppetdb do
     def search(type)
       scope = Puppet::Parser::Scope.new
       args = { :host => host, :filter => nil, :scope => scope }
-      subject.search(Puppet::Resource.indirection.request(:search, type, args))
+      Puppet::Resource.indirection.search(type, args)
     end
 
     it "should return an empty array if no resources match" do


### PR DESCRIPTION
The indirector request API changed a bit in Telly; this
commit changes all of the terminus specs to stub the
indirection.terminus method and then call methods on
the test subject directly, bypassing the use of the
indirector Request objects.
