### PR TITLE
Support a "version" file instead of `git describe`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,8 +12,10 @@ DESTDIR=  ENV['DESTDIR'] || ''
 
 
 def version
-# This ugly bit removes the gSHA1 portion of the describe as that causes failing tests
-  if File.exists?('.git')
+  if File.exists?('version')
+    File.read('version').chomp
+  elsif File.exists?('.git')
+    # This ugly bit removes the gSHA1 portion of the describe as that causes failing tests
     %x{git describe}.chomp.gsub('-', '.').split('.')[0..3].join('.').gsub('v', '')
   else
     %x{pwd}.strip!.split('.')[-1]

--- a/project.clj
+++ b/project.clj
@@ -6,21 +6,23 @@
    (fn []
      "Determine the version number using 'git describe'"
      []
-     (let [command                ["git" "describe"]
-           {:keys [exit out err]} (apply sh command)]
-       (when-not (zero? exit)
-         (println (format "Non-zero exit status during version check:\n%s\n%s\n%s\n%s"
-                          command exit out err))
-         (System/exit 1))
+     (if (.exists (file "version"))
+       (s/trim (slurp "version"))
+       (let [command                ["git" "describe"]
+             {:keys [exit out err]} (apply sh command)]
+         (when-not (zero? exit)
+           (println (format "Non-zero exit status during version check:\n%s\n%s\n%s\n%s"
+                            command exit out err))
+           (System/exit 1))
 
-       ;; We just want the first 4 "components" of the version string,
-       ;; joined with dots
-       (-> out
+         ;; We just want the first 4 "components" of the version string,
+         ;; joined with dots
+         (-> out
            (s/trim)
            (s/replace #"-" ".")
            (s/split #"\.")
            (#(take 4 %))
-           (#(s/join "." %)))))))
+           (#(s/join "." %))))))))
 
 (defproject puppetdb (version-string)
   :description "Puppet-integrated catalog and fact storage"


### PR DESCRIPTION
When running from source but not a git repository (for instance, after
copying the code to another machine to build a package..), lein fails
because it can't find the version. This allows the use of a file called
"version" which contains the version. If this file exists, it will be
used preferentially over `git describe`.
