### PR TITLE
Fix path issue w/rt ca.pem in puppetdb-ssl-setup script

### DIFF
--- a/ext/templates/puppetdb-ssl-setup
+++ b/ext/templates/puppetdb-ssl-setup
@@ -22,7 +22,7 @@ fi
 
 rm -rf $tmpdir
 mkdir -p $tmpdir
-cp $myca $tmpdir
+cp $myca $tmpdir/ca.pem
 cp $privkey $tmpdir/privkey.pem
 cp $mycert $tmpdir/pubkey.pem
 


### PR DESCRIPTION
Prior to this commit, the puppetdb-ssl-setup script
could fail if your ca certificate .pem file had
any other filename besides "ca.pem"; when copying
the private and public key pem files into the temp
dir, we made sure to copy them to a specific filename
that could then be referenced in the later keytool
commands; however, we were not specifying the target
filename when we copied the CA pem into the temp directory.

This commit simply adds the explicit filename in the copy
operation so that we know for sure what the filename will
be when working with the CA pem inside of the temp directory.
