### PR TITLE
Exclude the metrics-clojure dependency on clojure [1.2.1,1.3.0]

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [org.clojure/tools.nrepl "0.2.0-beta2"]
                  [swank-clojure "1.4.0"]
                  [clj-stacktrace "0.2.4"]
-                 [metrics-clojure "0.7.0"]
+                 [metrics-clojure "0.7.0" :exclusions [org.clojure/clojure]]
                  [clj-time "0.3.7"]
                  [org.clojure/java.jmx "0.1"]
                  ;; Filesystem utilities


### PR DESCRIPTION
This causes problems in CI, when it, for some reason, fails to resolve
the dependency appropriately. Also, it will be incompatible if we try to
move from clojure 1.3.0 to 1.4.0.
