### PR TITLE
Use explicit data structure naming

### DIFF
--- a/src/com/puppetlabs/puppetdb/catalog/utils.clj
+++ b/src/com/puppetlabs/puppetdb/catalog/utils.clj
@@ -37,7 +37,7 @@
                          "exported"   (random-bool)
                          "file"       (random-string)
                          "line"       (rand-int 1000)
-                         "tags"       (into #{} (repeatedly (rand-int 10) #(random-string)))
+                         "tags"       (set (repeatedly (rand-int 10) #(random-string)))
                          "parameters" (merge (random-parameters) extra-params)}]
        (merge r overrides))))
 

--- a/src/com/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/com/puppetlabs/puppetdb/cli/benchmark.clj
@@ -142,10 +142,10 @@
                              (catch Exception e
                                (log/error (format "Error parsing %s; skipping" file)))))
                          (remove nil?)
-                         (into []))
+                         (vec))
 
         nhosts      (:numhosts options)
-        hostnames   (into #{} (map #(str "host-" %) (range 1 (Integer/parseInt nhosts))))]
+        hostnames   (set (map #(str "host-" %) (range 1 (Integer/parseInt nhosts))))]
 
     (def hostname (get-in config [:jetty :host] "localhost"))
     (def port (get-in config [:jetty :port] 8080))
@@ -154,10 +154,10 @@
 
     ;; Create an agent for each host
     (def hosts
-      (into [] (map #(agent {:host    %,
-                             :lastrun (- (System/currentTimeMillis) (rand-int runinterval)),
-                             :catalog (associate-catalog-with-host % (rand-nth catalogs))})
-                    hostnames)))
+      (vec (map #(agent {:host    %,
+                         :lastrun (- (System/currentTimeMillis) (rand-int runinterval)),
+                         :catalog (associate-catalog-with-host % (rand-nth catalogs))})
+                hostnames)))
 
     ;; Loop forever
     (world-loop)))

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -219,9 +219,9 @@
                           (mq/start-broker! (mq/build-embedded-broker mq-dir)))
           command-procs (let [nthreads (get-in config [:command-processing :threads])]
                           (log/info (format "Starting %d command processor threads" nthreads))
-                          (into [] (for [n (range nthreads)]
-                                     (future (with-error-delivery error
-                                               (load-from-mq mq-addr mq-endpoint discard-dir db))))))
+                          (vec (for [n (range nthreads)]
+                                 (future (with-error-delivery error
+                                           (load-from-mq mq-addr mq-endpoint discard-dir db))))))
           web-app       (do
                           (log/info "Starting query server")
                           (future (with-error-delivery error

--- a/src/com/puppetlabs/puppetdb/core.clj
+++ b/src/com/puppetlabs/puppetdb/core.clj
@@ -23,10 +23,10 @@
   "Return a set of namespaces underneath the .cli parent"
   []
   {:post [(set? %)]}
-  (into #{} (for [namespace (ns/find-namespaces-on-classpath)
-                  :let [ns-str (name namespace)]
-                  :when (.startsWith ns-str ns-prefix)]
-              namespace)))
+  (set (for [namespace (ns/find-namespaces-on-classpath)
+             :let [ns-str (name namespace)]
+             :when (.startsWith ns-str ns-prefix)]
+         namespace)))
 
 (defn var-from-ns
   "Resolve a var, by name, from a (potentially un-required)
@@ -46,10 +46,10 @@
   "Return the set of available subcommands for this application"
   []
   {:post [(set? %)]}
-  (into #{} (for [namespace (cli-namespaces)
-                  :let [ns-str (name namespace)
-                        subcmd (last (split ns-str #"\."))]]
-              subcmd)))
+  (set (for [namespace (cli-namespaces)
+             :let [ns-str (name namespace)
+                   subcmd (last (split ns-str #"\."))]]
+         subcmd)))
 
 (defn usage
   "Display help text to the user"

--- a/src/com/puppetlabs/puppetdb/query/catalog.clj
+++ b/src/com/puppetlabs/puppetdb/query/catalog.clj
@@ -21,10 +21,10 @@
   (let [query (str "SELECT sources.type AS source_type, sources.title AS source_title, targets.type AS target_type, targets.title AS target_title, edges.type AS relationship "
                    "FROM certname_catalogs INNER JOIN edges USING(catalog) INNER JOIN catalog_resources sources ON edges.catalog = sources.catalog AND source = sources.resource "
                    "INNER JOIN catalog_resources targets ON edges.catalog = targets.catalog AND target = targets.resource WHERE certname = ?")]
-    (into #{} (for [{:keys [source_type source_title target_type target_title relationship]} (query-to-vec query node)]
-                {:source       {:type source_type :title source_title}
-                 :target       {:type target_type :title target_title}
-                 :relationship relationship}))))
+    (set (for [{:keys [source_type source_title target_type target_title relationship]} (query-to-vec query node)]
+           {:source       {:type source_type :title source_title}
+            :target       {:type target_type :title target_title}
+            :relationship relationship}))))
 
 (defn catalog-for-node
   "Retrieve the catalog for `node`."

--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -301,7 +301,7 @@ must be supplied as the value to be matched."
         sql-params (vec (cons query resource-hashes))]
     (sql/with-query-results result-set
       sql-params
-      (into #{} (map :resource result-set)))))
+      (set (map :resource result-set)))))
 
 (defn resource-identity-hash*
   "Compute a hash for a given resource that will uniquely identify it
@@ -535,7 +535,7 @@ must be supplied as the value to be matched."
   [certname]
   (sql/with-query-results result-set
     ["SELECT catalog FROM certname_catalogs WHERE certname=?" certname]
-    (into [] (map :catalog result-set))))
+    (vec (map :catalog result-set))))
 
 (defn catalog-newer-than?
   "Returns true if the most current catalog for `certname` is more recent than

--- a/test/com/puppetlabs/puppetdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/storage.clj
@@ -28,7 +28,7 @@
             (is (= str1 str2)))
           (when-not (= value1 value2)
             (is (not= str1 str2)
-              (str value1 " should not serialize the same as " value2))))))))
+                (str value1 " should not serialize the same as " value2))))))))
 
 (deftest hash-computation
   (testing "Hashes for resources"
@@ -54,11 +54,11 @@
              (resource-identity-hash {:tags #{3 2 1}}))))
 
     (testing "should be different for non-equivalent resources"
-      ; Take a population of 5 resource, put them into a set to make
-      ; sure we only care about a population of unique resources, take
-      ; any 2 elements from that set, and those 2 resources should
-      ; have different hashes.
-      (let [candidates (into #{} (repeatedly 5 catutils/random-kw-resource))
+                                        ; Take a population of 5 resource, put them into a set to make
+                                        ; sure we only care about a population of unique resources, take
+                                        ; any 2 elements from that set, and those 2 resources should
+                                        ; have different hashes.
+      (let [candidates (set (repeatedly 5 catutils/random-kw-resource))
             pairs      (combinations candidates 2)]
         (doseq [[r1 r2] pairs]
           (is (not= (resource-identity-hash r1)
@@ -138,7 +138,7 @@
                   {:certname certname :fact "operatingsystem" :value "Debian"}])))
         (testing "should add the certname if necessary"
           (is (= (query-to-vec "SELECT name FROM certnames"))
-                 [{:name certname}]))
+              [{:name certname}]))
         (testing "replacing facts"
           (let [new-facts {"domain" "mynewdomain.com"
                            "fqdn" "myhost.mynewdomain.com"
@@ -324,19 +324,19 @@
           ;; no tags for myhost
           (is (= (query-to-vec [(str "SELECT t.name FROM tags t, certname_catalogs cc "
                                      "WHERE t.catalog=cc.catalog AND cc.certname=?")
-                                     certname])
+                                certname])
                  []))
 
           ;; no classes for myhost
           (is (= (query-to-vec [(str "SELECT c.name FROM classes c, certname_catalogs cc "
                                      "WHERE c.catalog=cc.catalog AND cc.certname=?")
-                                     certname])
+                                certname])
                  []))
 
           ;; no edges for myhost
           (is (= (query-to-vec [(str "SELECT COUNT(*) as c FROM edges e, certname_catalogs cc "
                                      "WHERE e.catalog=cc.catalog AND cc.certname=?")
-                                     certname])
+                                certname])
                  [{:c 0}]))
 
           ;; All the other resources should still be there
@@ -405,18 +405,18 @@
           (migrate!)
           (is (thrown? AssertionError (add-catalog! {})))
 
-          ; Nothing should have been persisted for this catalog
+                                        ; Nothing should have been persisted for this catalog
           (is (= (query-to-vec ["SELECT count(*) as nrows from certnames"])
                  [{:nrows 0}]))))
 
       (testing "on input that violates referential integrity"
-        ; This catalog has an edge that points to a non-existant resource
+                                        ; This catalog has an edge that points to a non-existant resource
         (let [catalog (:invalid catalogs)]
           (with-transacted-connection db
             (migrate!)
             (is (thrown? AssertionError (add-catalog! {})))
 
-            ; Nothing should have been persisted for this catalog
+                                        ; Nothing should have been persisted for this catalog
             (is (= (query-to-vec ["SELECT count(*) as nrows from certnames"])
                    [{:nrows 0}]))))))))
 


### PR DESCRIPTION
Rather than using `into` to `conj` onto an empty data structure that we're expecting, directly create a `PersistentHashSet` or `LazilyPersistentVector` directly from the provided collection.
