### PR TITLE
Fix a broken scf/storage assertion

### DIFF
--- a/test/com/puppetlabs/puppetdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/storage.clj
@@ -137,8 +137,8 @@
                   {:certname certname :fact "kernel" :value "Linux"}
                   {:certname certname :fact "operatingsystem" :value "Debian"}])))
         (testing "should add the certname if necessary"
-          (is (= (query-to-vec "SELECT name FROM certnames"))
-                 [{:name certname}]))
+          (is (= (query-to-vec "SELECT name FROM certnames")
+                 [{:name certname}])))
         (testing "replacing facts"
           (let [new-facts {"domain" "mynewdomain.com"
                            "fqdn" "myhost.mynewdomain.com"


### PR DESCRIPTION
This was trying to assert that the result of a query was equal to a
specific value, but the expected value was outside the (= ...) call,
rather directly inside the (is ...). So the test didn't fail, but it
didn't test what it was intended to.
