### PR TITLE
Added fqdn check and handling of jetty.ini update in puppetdb-ssl-setup

### DIFF
--- a/ext/templates/puppetdb-ssl-setup
+++ b/ext/templates/puppetdb-ssl-setup
@@ -8,9 +8,14 @@ PATH=/opt/puppet/bin:$PATH
 set -e
 
 fqdn=`facter fqdn`
+# use hostname if fqdn is not available
+if [ ! -n "$fqdn" ] ; then
+  fqdn=`facter hostname`
+fi
+
 password=`export LC_ALL=C; dd if=/dev/urandom count=20 2> /dev/null | tr -cd '[:alnum:]' | head -c 25`
 tmpdir=`mktemp -t -d tmp.puppetdbXXXXX`
-mycert=`puppet agent --configprint  hostcert`
+mycert=`puppet agent --configprint hostcert`
 myca=`puppet agent --configprint localcacert`
 privkey=`puppet agent --configprint hostprivkey`
 
@@ -27,15 +32,26 @@ cp $privkey $tmpdir/privkey.pem
 cp $mycert $tmpdir/pubkey.pem
 
 cd $tmpdir
-keytool -import -alias "PuppetDB CA" -keystore truststore.jks -storepass "$password" -trustcacerts  -file ca.pem -noprompt
+keytool -import -alias "PuppetDB CA" -keystore truststore.jks -storepass "$password" -trustcacerts -file ca.pem -noprompt
 cat privkey.pem pubkey.pem > temp.pem
-echo "$password" | openssl pkcs12 -export -in temp.pem -out puppetdb.p12 -name $fqdn  -passout fd:0
-keytool -importkeystore  -destkeystore keystore.jks -srckeystore puppetdb.p12 -srcstoretype PKCS12 -alias $fqdn   -deststorepass "$password" -srcstorepass "$password"
+echo "$password" | openssl pkcs12 -export -in temp.pem -out puppetdb.p12 -name $fqdn -passout fd:0
+keytool -importkeystore -destkeystore keystore.jks -srckeystore puppetdb.p12 -srcstoretype PKCS12 -alias $fqdn -deststorepass "$password" -srcstorepass "$password"
 
 rm -rf $confdir/ssl
 mkdir -p $confdir/ssl
-cp -pr  *jks $confdir/ssl
+cp -pr *jks $confdir/ssl
 echo $password > ${confdir}/ssl/puppetdb_keystore_pw.txt
 chmod 600 ${confdir}/ssl/*
 chmod 700 ${confdir}/ssl
+
+# add new password to jetty.ini
+sed -e 's/^key-password.*/key-password = '"$password"'/' ${confdir}/conf.d/jetty.ini > ${tmpdir}/tmp.jetty
+sed -e 's/^trust-password.*/trust-password = '"$password"'/' ${tmpdir}/tmp.jetty > ${confdir}/conf.d/jetty.ini
+
+# permission fixes
+chown -R puppetdb:puppetdb ${confdir}/ssl
+chown -R puppetdb:puppetdb ${confdir}/ssl
+chmod 640 ${confdir}/conf.d/jetty.ini
+
+# cleanup
 rm -rf $tmpdir


### PR DESCRIPTION
- use facter hostname if facter fqdn is not set
- Handles adding new password to jetty.ini (key-password and trust-password)

Per my comments on http://projects.puppetlabs.com/issues/14837
