### PR TITLE
Fix broken test

### DIFF
--- a/acceptance/tests/storeconfigs/basic_collection.rb
+++ b/acceptance/tests/storeconfigs/basic_collection.rb
@@ -33,10 +33,10 @@ node "#{name}" {
     step "Run agent to collect resources" do
 
       run_agent_on hosts, "--test --server #{master}", :acceptable_exit_codes => [0,2] do
-        host = result.host
+        hostname = result.host
 
         names.each do |name|
-          assert_match(/Hello from #{CGI.escape(name)}/, result.output, "#{host.name} failed to collect from #{name}")
+          assert_match(/Hello from #{CGI.escape(name)}/, result.output, "#{hostname} failed to collect from #{name}")
         end
       end
     end


### PR DESCRIPTION
There was a recent change in the acceptance framework that
caused "result.host" ("result" being the return value from an exec
command) from an instance of Host to just a String containing the
hostname.  We had one test that was relying on the old behavior;
this changes it to be compatible with the new behavior.
