### PR TITLE
(#14837) Auto-insert new keystore/truststore pw into config

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,18 @@ deactivate. However, this behavior may change in future, and the
 command is not specific to PuppetDB, so the preferred method is
 `puppet node deactivate`.
 
+### Redoing SSL setup after changing certs
+
+If you've recently changed the certificates in use by the PuppetDB
+server, you'll need to update the SSL configuration for PuppetDB
+itself.
+
+If you've installed PuppetDB from Puppet Labs packages, you can simply
+re-run the `puppetdb-ssl-setup` script.
+
+Otherwise, you'll need to perform again all the steps in the _SSL
+Configuration_ section of this document.
+
 ### Connecting to a remote REPL
 
 If you have configured your PuppetDB instance to start up a remote

--- a/ext/templates/puppetdb-ssl-setup
+++ b/ext/templates/puppetdb-ssl-setup
@@ -34,15 +34,28 @@ cp $privkey $tmpdir/privkey.pem
 cp $mycert $tmpdir/pubkey.pem
 
 cd $tmpdir
-keytool -import -alias "PuppetDB CA" -keystore truststore.jks -storepass "$password" -trustcacerts  -file ca.pem -noprompt
+keytool -import -alias "PuppetDB CA" -keystore truststore.jks -storepass "$password" -trustcacerts -file ca.pem -noprompt
 cat privkey.pem pubkey.pem > temp.pem
-echo "$password" | openssl pkcs12 -export -in temp.pem -out puppetdb.p12 -name $fqdn  -passout fd:0
-keytool -importkeystore  -destkeystore keystore.jks -srckeystore puppetdb.p12 -srcstoretype PKCS12 -alias $fqdn   -deststorepass "$password" -srcstorepass "$password"
+echo "$password" | openssl pkcs12 -export -in temp.pem -out puppetdb.p12 -name $fqdn -passout fd:0
+keytool -importkeystore -destkeystore keystore.jks -srckeystore puppetdb.p12 -srcstoretype PKCS12 -alias $fqdn -deststorepass "$password" -srcstorepass "$password"
 
 rm -rf $confdir/ssl
 mkdir -p $confdir/ssl
-cp -pr  *jks $confdir/ssl
+cp -pr *jks $confdir/ssl
 echo $password > ${confdir}/ssl/puppetdb_keystore_pw.txt
+
+jettyfile="${confdir}/conf.d/jetty.ini"
+if [ -f "$jettyfile" ] ; then
+  if grep "key-password" ${jettyfile} >/dev/null && grep "trust-password" ${jettyfile} >/dev/null; then
+    sed -e 's/^key-password.*/key-password = '"$password"'/' ${jettyfile} > ${tmpdir}/tmp.jetty
+    sed -e 's/^trust-password.*/trust-password = '"$password"'/' ${tmpdir}/tmp.jetty > ${jettyfile}
+  else
+    echo "$jettyfile exists, but could not find key-password and trust-password settings. Please update those settings to the password contained in ${confdir}/ssl/puppetdb_keystore_pw.txt"
+  fi
+else
+  echo "Please update your key-password and trust-password settings to the password contained in ${confdir}/ssl/puppetdb_keystore_pw.txt"
+fi
+
 chmod 600 ${confdir}/ssl/*
 chmod 700 ${confdir}/ssl
 chown -R ${user}:${user} ${confdir}/ssl


### PR DESCRIPTION
Previously, the ssl-setup script would generate new keystore and
truststore files but would fail to update an existing jetty.ini file
with the updated password to those files. Thus, re-running the setup
script would leave a user's puppetdb installation in a broken state.

This patch checks to see if there's a jetty.ini file, and that it
contains the settings for keystore and truststore passwords. If so,
then we update the passwords contained within. If not, we output a
message telling the user to manually update their password settings,
as we can't do it automatically.
