### PR TITLE
Fix test that was broken on 1.8.5

### DIFF
--- a/puppet/spec/unit/util/puppetdb/char_encoding_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/char_encoding_spec.rb
@@ -12,7 +12,7 @@ describe Puppet::Util::Puppetdb::CharEncoding do
       instr = in_bytes.pack('c*')
       out = described_class.ruby18_clean_utf8(instr)
       #pp out.bytes.to_a.map { |b| "0x%02x" % b }.join(" ")
-      out.bytes.to_a.should == expected_bytes
+      out.should == expected_bytes.pack('c*')
     end
 
 


### PR DESCRIPTION
I'm 99% sure that this will fix the spec failure, though I still haven't quite been able to get rspec running in a local 1.8.5 to confirm.
