### PR TITLE
Add a shutdown hook with a log message

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -189,6 +189,12 @@
         (configure-database)
         (set-global-configuration!))))
 
+(defn on-shutdown
+  "General cleanup when a shutdown request is received."
+  []
+  ;; nothing much to do here for now, but let's at least log that we're shutting down.
+  (log/info "Shutdown request received; puppetdb exiting."))
+
 (defn -main
   [& args]
   (let [[options _]                                (cli! args)
@@ -205,6 +211,9 @@
 
     (when version
       (log/info (format "PuppetDB version %s" version)))
+
+    ;; Add a shutdown hook where we can handle any required cleanup
+    (pl-utils/add-shutdown-hook! on-shutdown)
 
     ;; Ensure the database is migrated to the latest version
     (sql/with-connection db

--- a/src/com/puppetlabs/utils.clj
+++ b/src/com/puppetlabs/utils.clj
@@ -264,6 +264,17 @@
                        (f thread exception)))]
        (Thread/setDefaultUncaughtExceptionHandler handler))))
 
+(defn add-shutdown-hook!
+  "Adds a shutdown hook to the JVM runtime.
+
+  `f` is a function that takes 0 arguments; the return value is ignored.  This
+  function will be called if the JVM receiveds an interrupt signal (e.g. from
+  `kill` or CTRL-C); you can use it to log shutdown messages, handle state
+  cleanup, etc."
+  [f]
+  {:pre [(fn? f)]}
+  (.addShutdownHook (Runtime/getRuntime) (Thread. f)))
+
 (defn configure-logger-via-file!
   "Reconfigures the current logger based on the supplied configuration
   file. You can optionally supply a delay (in millis) that governs how


### PR DESCRIPTION
This commit basically does two things:
- creates a "shutdown-hook" function that we can potentially use
  for any cleanup that we need to do when we receive an interrupt.
- logs a message that indicates that we're shutting down.
