### PR TITLE
Use correct puppetlabs-release package for platform

### DIFF
--- a/acceptance/setup/pre_suite/00_setup.rb
+++ b/acceptance/setup/pre_suite/00_setup.rb
@@ -47,8 +47,8 @@ end
 
 if (PuppetDBExtensions.test_mode == :package)
   step "Install Puppet on all systems" do
-    on hosts, "wget http://apt.puppetlabs.com/puppetlabs-release_1.0-3_all.deb"
-    on hosts, "dpkg -i puppetlabs-release_1.0-3_all.deb"
+    on hosts, "wget http://apt.puppetlabs.com/puppetlabs-release-$(lsb_release -sc).deb"
+    on hosts, "dpkg -i puppetlabs-release-$(lsb_release -sc).deb"
     on hosts, "apt-get update"
     on hosts, "apt-get install --force-yes -y puppet"
   end


### PR DESCRIPTION
This used to be a single package, but now is platform-specific. So we'll
use lsb_release to figure that out and install the right one.
