### PR TITLE
(#15075) Improve handling of service start/stop during rpm upgrade/unins...

### DIFF
--- a/ext/templates/puppetdb.spec.erb
+++ b/ext/templates/puppetdb.spec.erb
@@ -101,6 +101,11 @@ touch  $RPM_BUILD_ROOT/%{_localstatedir}/log/%{name}/%{name}.log
 rm -rf $RPM_BUILD_ROOT
 
 %pre
+# Here we'll do a little bit of cleanup just in case something went horribly
+# awry during a previous install/uninstall:
+if [ -f "<%= @install_dir %>/start_service_after_upgrade" ] ; then
+   rm <%= @install_dir %>/start_service_after_upgrade
+fi
 # If this is an upgrade (as opposed to an install) then we need to check
 #  and see if the service is running.  If it is, we need to stop it.
 #  we want to shut down and disable the service.


### PR DESCRIPTION
...tall

Prior to this commit there were a few issues with the way we were
handling interacting with the system's puppetdb service during
rpm upgrade and downgrade.  Basically, we were _always_ stopping
(and disabling) the service whenever an uninstall occurred; however,
during an upgrade, rpm does an install of the new package followed
by an uninstall of the old package.  We weren't treating this
situation differently, so the service was being stopped.  This
commit does the following:
- On uninstall, we now check to see if this is part of an upgrade
  or not, and we only stop and disable the service if this is
  _not_ part of an upgrade.
- On upgrade, we stop the service before we install the new package,
  and restart it after we finish removing the old package.
