### PR TITLE
(#15446) Improve handling of user/group removal on rpm removal

### DIFF
--- a/ext/templates/puppetdb.spec.erb
+++ b/ext/templates/puppetdb.spec.erb
@@ -104,7 +104,7 @@ rm -rf $RPM_BUILD_ROOT
 # Add PuppetDB user
 getent group %{name} > /dev/null || groupadd -r %{name}
 getent passwd %{name} > /dev/null || \
-useradd -r -g %{name} -d /opt/puppet/share/%{realname} -s /sbin/nologin \
+useradd -r -g %{name} -d <%= @install_dir %> -s /sbin/nologin \
      -c "PuppetDB daemon"  %{name}
 
 %post
@@ -148,10 +148,13 @@ fi
 /sbin/chkconfig --del %{name}
 
 %postun
-# Remove PuppetDB user
-getent group %{name} > /dev/null || groupdel -r %{name}
-getent passwd %{name} > /dev/null || userdel -r %{name}
-rm -rf %{_rundir}/%{name} || :
+# Remove PuppetDB user if this is an uninstall (as opposed to
+#  an upgrade)...
+if [ "$1" = "0" ]; then
+    getent passwd %{name} > /dev/null && userdel %{name}
+    getent group %{name} > /dev/null && groupdel %{name}
+    rm -rf %{_rundir}/%{name} || :
+fi
 
 
 %files


### PR DESCRIPTION
Prior to this commit, we had a few bugs in our handling of
user/group removal during rpm removal:
1. We were not conditioning the calls to groupdel / userdel to
   avoid running them during an upgrade, which meant that we
   were trying to delete them even during upgrades... which would
   have been bad.
2. We had an || where we needed an &&, so we weren't actually
   calling the groupdel / userdel commands.
3. We were hard-coding the user's home dir to a bad path.
4. We had some '-r' flags that were wrong and/or unnecessary.

This commit fixes those issues.
