### PR TITLE
Verify config path before starting up

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -178,10 +178,16 @@
   config)
 
 (defn parse-config
-  "Parses the given config file (if present) and configure its various
+  "Parses the given config file/directory and configures its various
   subcomponents."
-  [file]
-  (let [config (if file (inis-to-map file) {})]
+  [path]
+  (let [file (file path)]
+    (if-not (and (.exists file)
+                 (.canRead file))
+      (throw (IllegalArgumentException.
+        (format "Configuration path '%s' must be exist and must be readable." path)))))
+
+  (let [config (if path (inis-to-map path) {})]
     (-> config
         (configure-logging!)
         (configure-commandproc-threads)


### PR DESCRIPTION
Prior to this commit, if the config path that the user
specified did not exist or was not readable, we'd silently
ignore it and then fail a bit later with a confusing
error message about not finding a "vardir" setting.

This commit adds a bit of explicit checking to make
sure that the specified config path exists and is
readable before we try to parse the ini file(s).
