### PR TITLE
Fix an incorrect username in the puppetdb-ssl-setup script

### DIFF
--- a/ext/templates/puppetdb-ssl-setup
+++ b/ext/templates/puppetdb-ssl-setup
@@ -49,7 +49,7 @@ else
       user=pe-puppetdb
     else
       puppetdb_confdir="/etc/puppetdb"
-      user=pe-puppet
+      user=puppetdb
     fi
 fi
 


### PR DESCRIPTION
Somehow we recently ended up with an invalid username in
the puppetdb-ssl-setup script; it was set to "pe-puppet" when
it should have been set to "puppetdb".
