### PR TITLE
Work around non-string resource titles

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -25,6 +25,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
 
     add_parameters_if_missing(data)
     add_namevar_aliases(data, catalog)
+    stringify_titles(data)
     sort_unordered_metaparams(data)
     munge_edges(data)
     synthesize_edges(data)
@@ -42,6 +43,14 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   # Metaparams that may contain arrays, but whose semantics are
   # fundamentally unordered
   UnorderedMetaparams = [:alias, :audit, :before, :check, :notify, :require, :subscribe, :tag]
+
+  def stringify_titles(hash)
+    hash['resources'].each do |resource|
+      resource['title'] = resource['title'].to_s
+    end
+
+    hash
+  end
 
   def add_parameters_if_missing(hash)
     hash['resources'].each do |resource|

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -78,6 +78,22 @@ describe Puppet::Resource::Catalog::Puppetdb do
       end
     end
 
+    describe "#stringify_titles" do
+      it "should make all resource titles strings if they aren't" do
+        Puppet[:code] = <<-MANIFEST
+          $foo = true
+          notify { $foo: }
+        MANIFEST
+
+        hash = catalog.to_pson_data_hash['data']
+        result = subject.stringify_titles(hash)
+
+        result['resources'].should be_any { |res|
+          res['type'] == 'Notify' and res['title'] == 'true'
+        }
+      end
+    end
+
     describe "#add_namevar_aliases" do
       it "should add namevar to aliases if it's not already present" do
         name = 'with a different name'


### PR DESCRIPTION
It's possible in some cases for Puppet to generate a resource whose
title isn't a string. However, since the generated edges refer to the
resource using a string title, we end up with a mismatch. Now we will
stringify all resource titles on the way out. In future, Puppet should
do this for us.
