### PR TITLE
(#14688) Improve stdout/stderr handling for redhat init script

### DIFF
--- a/ext/templates/init_redhat.erb
+++ b/ext/templates/init_redhat.erb
@@ -64,7 +64,7 @@ start() {
     [ -x $JAVA_BIN ] || exit 5
     [ -d $config ] || exit 6
     echo -n $"Starting $prog: "
-    $SU $USER -s /bin/bash -c "$EXEC &"
+    daemon --user $USER --pidfile $PIDFILE "$EXEC >> <%= @log_dir %>/puppetdb-daemon.log 2>&1 &"
     sleep 1
     find_my_pid
     echo $pid > $PIDFILE


### PR DESCRIPTION
Prior to this commit, the redhat init script was keeping stdout/stderr
opening when you called "service puppetdb stop".  This resulted
in some undesirable behavior; starting the service over an ssh
connection would not release the ssh connection, errors would
appear on the console rather than in the log file, etc.

This commit simply changes the init script to call "daemon" and
to redirect stdout/stderr to a file.  In local testing, this
appears to solve both of the reported problems (ssh hangs and console
errors).
