### PR TITLE
(#15388) Add redirect from '/' to the dashboard

### DIFF
--- a/src/com/puppetlabs/puppetdb/http/server.clj
+++ b/src/com/puppetlabs/puppetdb/http/server.clj
@@ -16,7 +16,8 @@
         [com.puppetlabs.utils :only (uri-segments)]
         [net.cgrand.moustache :only (app)]
         [ring.middleware.resource :only (wrap-resource)]
-        [ring.middleware.params :only (wrap-params)]))
+        [ring.middleware.params :only (wrap-params)]
+        [ring.util.response :only (redirect)]))
 
 (def routes
   (app
@@ -40,7 +41,10 @@
    {:get status-app}
 
    ["metrics" &]
-   {:get metrics-app}))
+   {:get metrics-app}
+
+   [""]
+   {:get (constantly (redirect "/dashboard/index.html"))}))
 
 (defn build-app
   "Generate a Ring application that handles PuppetDB requests


### PR DESCRIPTION
Prior to this commit, if you started up puppetdb and
then attempted to browse to "/", you'd get an error
message that might lead you to believe that the
server wasn't actually running (depending on your
browser).

This commit simply adds a redirect from "/" to
the dashboard index page.
