### PR TITLE
Don't alias resources with composite namevars

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -64,6 +64,14 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
     hash['resources'].each do |resource|
       real_resource = catalog.resource(resource['type'], resource['title'])
 
+      # Resources with composite namevars can't be referred to by
+      # anything other than their title when declaring
+      # relationships. Trying to snag the :alias for these resources
+      # will only return _part_ of the name (a problem with Puppet
+      # proper), so skipping the adding of aliases for these resources
+      # is both an optimization and a safeguard.
+      next if real_resource.key_attributes.count > 1
+
       # Non-isomorphic resources aren't unique based on namevar, so we can't
       # use it as an alias
       type = real_resource.resource_type

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -166,6 +166,26 @@ describe Puppet::Resource::Catalog::Puppetdb do
         resource['parameters']['alias'].should be_nil
       end
 
+      describe "for resources with composite namevars" do
+        let(:resource) do
+          r = Puppet::Resource.new(:notify, 'yo matey')
+          r.stubs(:key_attributes).returns [:name, :message]
+          r
+        end
+
+        it "should not create aliases" do
+          hash = subject.add_parameters_if_missing(catalog_data_hash)
+          result = subject.add_namevar_aliases(hash, catalog)
+
+          resource = result['resources'].find do |res|
+            res['type'] == 'Notify' and res['title'] == 'yo matey'
+          end
+
+          resource.should_not be_nil
+          resource['parameters']['alias'].should be_nil
+        end
+      end
+
       describe "for non-isomorphic resources" do
         let(:resource) do
           Puppet::Resource.new(:exec, 'an_exec', :parameters => {:command => '/bin/true'})


### PR DESCRIPTION
Normally, as part of converting a catalog to the PuppetDB wire format,
we ensure that every resource has its namevar as one of its aliases.
This allows us to handle edges that refer to said resource using its
namevar instead of its title.

However, Puppet implements `#namevar` for resources with composite
namevars in a strange way, only returning part of the composite name.
This can result in bugs in the generated catalog, where we may have 2
resources with the same alias (because `#namevar` returns the same thing
for both of them).

Because resources with composite namevars can't be referred to by
anything other than their title when declaring relationships, there's no
real point to adding their aliases in anyways. That neatly side-steps
the problem.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
