### PR TITLE
(#15378) Improve behavior of acceptance tests in single-node environment

### DIFF
--- a/acceptance/tests/storeconfigs/collections_with_queries.rb
+++ b/acceptance/tests/storeconfigs/collections_with_queries.rb
@@ -1,5 +1,10 @@
 test_name "collections with queries" do
 
+  if hosts.length <= 1
+    skip_test "This test requires more than one host"
+    next
+  end
+
   exporter, *collectors = hosts
 
   dir = collectors.first.tmpdir('collections')

--- a/acceptance/tests/storeconfigs/deactivated_nodes.rb
+++ b/acceptance/tests/storeconfigs/deactivated_nodes.rb
@@ -1,5 +1,10 @@
 test_name "queries against deactivated nodes" do
 
+  if hosts.length <= 1
+    skip_test "This test requires more than one host"
+    next
+  end
+
   exporter, *collectors = hosts
 
   dir = collectors.first.tmpdir('collections')

--- a/acceptance/tests/storeconfigs/non_parameter_queries.rb
+++ b/acceptance/tests/storeconfigs/non_parameter_queries.rb
@@ -1,5 +1,10 @@
 test_name "non-parameter queries" do
 
+  if hosts.length <= 1
+    skip_test "This test requires more than one host"
+    next
+  end
+
   exporter, *collectors = hosts
 
   dir = collectors.first.tmpdir('collections')


### PR DESCRIPTION
We have some acceptance tests that require multiple nodes in order
to execute successfully (mostly around exporting / collecting
resources).  If you tried to run them in a single-node environment,
they would give a weird ruby error about 'nil' not defining a certain
method.

This commit simply modifies those tests so that they will be skipped
if you are running without more than one host.
