### PR TITLE
Add release ENV var to puppetdb packaging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,6 @@ end
 PATH = ENV['PATH']
 DESTDIR=  ENV['DESTDIR'] || ''
 
-
 def version
   if File.exists?('version')
     File.read('version').chomp
@@ -59,6 +58,7 @@ if PE_BUILD.downcase.strip == "true"
     @name ="pe-puppetdb"
     @pe = true
     @version = version
+    @release = ENV['RELEASE'] ||= "1"
     @sbin_dir = "/opt/puppet/sbin"
 else
     @install_dir = "/usr/share/puppetdb"
@@ -70,6 +70,7 @@ else
     @name = "puppetdb"
     @pe = false
     @version = version
+    @release = ENV['RELEASE'] ||= "1"
     @sbin_dir = "/usr/sbin"
 end
 

--- a/ext/templates/deb/changelog.erb
+++ b/ext/templates/deb/changelog.erb
@@ -5,7 +5,7 @@
   tag = 'puppetlabs'
   dists = 'hardy lucid maverick natty oneiric unstable lenny sid squeeze wheezy precise'
   end -%>
-<%= @name -%> (<%= version -%>-1<%= tag -%>1) <%= dists -%>; urgency=low
+<%= @name -%> (<%= version -%>-1<%= tag -%><%= @release -%>) <%= dists -%>; urgency=low
 
   * Add postgresql to suggests
   * Adding an init script from Puppet Labs Ops


### PR DESCRIPTION
This commit modifies the packaging of puppetdb
to allow the user to specify a tag release, e.g.
0.9.2-1puppetlabs2 vs 0.9.2-1puppetlabs1.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
