### PR TITLE
Add SRPMS directory creation to rake:SRPM task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -276,6 +276,7 @@ task :srpm => [ :package ] do
   mkdir_p 'pkg/rpm'
   mkdir_p "#{temp}/SOURCES"
   mkdir_p "#{temp}/SPECS"
+  mkdir_p "#{temp}/SRPMS"
   cp_p "pkg/puppetdb-#{@version}.tar.gz", "#{temp}/SOURCES"
   cp_p "ext/files/#{@name}.spec", "#{temp}/SPECS"
   sh "rpmbuild #{args} -bs --nodeps #{temp}/SPECS/#{@name}.spec"


### PR DESCRIPTION
Some configurations of rpmbuild won't make the SRPMS directory automatically
when building an RPM, so this commit adds a mkdir_p to the rake task to make
the directory before running rpmbuild. Otherwise, the rpmbuild call fails when
rpmbuild can't write the src rpm to the SRPMS directory (because it doesn't
exist).
