### PR TITLE
Add a `rake version` task to print the version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -143,6 +143,9 @@ task :clobber => [ :clean ] do
   rm_rf FileList["puppetdb*jar"]
 end
 
+task :version do
+  puts version
+end
 
 file "ext/files/config.ini" => [ :template, JAR_FILE ]   do
 end


### PR DESCRIPTION
This is useful for CI, where we need to determine what version of the
code is being tested, for building packages, etc.
