### PR TITLE
Add acceptance setup support for RPM-based systems

### DIFF
--- a/acceptance/setup/pre_suite/00_setup.rb
+++ b/acceptance/setup/pre_suite/00_setup.rb
@@ -62,7 +62,7 @@ def setup_postgres()
     config_hash => {
         'ip_mask_allow_all_users' => '0.0.0.0/0',
         'listen_addresses' => '*',
-        'manage_redhat_firewall' => true,
+        'manage_redhat_firewall' => false,
 
         'ip_mask_deny_postgres_user' => '0.0.0.0/32',
         'postgres_password' => 'puppet',
@@ -97,24 +97,53 @@ end
 install_type = options[:type] == 'git' ? :git : :package
 PuppetDBExtensions.test_mode = install_type
 
-
 pkg_dir = File.join(File.dirname(__FILE__), '..', '..', '..', 'pkg')
 
-# This is used for handling metrics
-step "Install JSON on the PuppetDB server" do
-  on database, "apt-get install -y libjson-ruby"
+# Determine whether we're Debian or RedHat. Note that "git" installs are
+# currently assumed to be *Debian only*.
+on(database, "which yum", :silent => true)
+if result.exit_code == 0
+  osfamily = 'RedHat'
+else
+  osfamily = 'Debian'
 end
 
 # TODO: I think it would be nice to get rid of all of these conditionals; maybe
 #  we could refactor this into a base class with two child classes that handle
 #  the differences... or something less ugly than this :)
-if (PuppetDBExtensions.test_mode == :git)
-  step "Install rake on the PuppetDB server" do
-    on database, "apt-get install -y rake"
+if (PuppetDBExtensions.test_mode == :package)
+  step "Install Puppet on all systems" do
+    if osfamily == 'Debian'
+      on hosts, "wget http://apt.puppetlabs.com/puppetlabs-release-$(lsb_release -sc).deb"
+      on hosts, "dpkg -i puppetlabs-release-$(lsb_release -sc).deb"
+      on hosts, "apt-get update"
+      on hosts, "apt-get install --force-yes -y puppet"
+    else
+      create_remote_file hosts, '/etc/yum.repos.d/puppetlabs-products.repo', <<-REPO.gsub(' '*6, '')
+      [puppetlabs-products]
+      name=Puppet Labs Products - $basearch
+      baseurl=http://yum.puppetlabs.com/el/$releasever/products/$basearch
+      gpgkey=http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
+      enabled=1
+      gpgcheck=1
+      REPO
+
+      create_remote_file database, '/etc/yum.repos.d/puppetlabs-prerelease.repo', <<-REPO.gsub(' '*6, '')
+      [puppetlabs-prerelease]
+      name=Puppet Labs Prerelease - $basearch
+      baseurl=http://neptune.puppetlabs.lan/dev/el/$releasever/products/$basearch
+      enabled=1
+      gpgcheck=0
+      REPO
+
+      on hosts, "yum install -y puppet"
+    end
   end
-  step "Install java on the PuppetDB server" do
-    on database, "apt-get install -y openjdk-6-jre-headless"
+else (PuppetDBExtensions.test_mode == :git)
+  step "Install dependencies on the PuppetDB server" do
+    on database, "apt-get install -y openjdk-6-jre-headless libjson-ruby"
   end
+
   step "Install lein on the PuppetDB server" do
     which_result = on database, "which lein", :acceptable_exit_codes => [0,1]
     needs_lein = which_result.exit_code == 1
@@ -126,31 +155,25 @@ if (PuppetDBExtensions.test_mode == :git)
   end
 end
 
-if (PuppetDBExtensions.test_mode == :package)
-  step "Install Puppet on all systems" do
-    on hosts, "wget http://apt.puppetlabs.com/puppetlabs-release-$(lsb_release -sc).deb"
-    on hosts, "dpkg -i puppetlabs-release-$(lsb_release -sc).deb"
-    on hosts, "apt-get update"
-    on hosts, "apt-get install --force-yes -y puppet"
+step "Run an agent to create the SSL certs" do
+  with_master_running_on master, "--autosign true" do
+    run_agent_on database, "--test --server #{master}"
   end
 end
 
 step "Install PuppetDB on the PuppetDB server" do
-  step "Run an agent to create the SSL certs" do
-    with_master_running_on master, "--autosign true" do
-      run_agent_on database, "--test --server #{master}"
-    end
-  end
-
   if (PuppetDBExtensions.test_mode == :package)
-    step "Copy the package" do
-      on database, "mkdir -p /tmp/packages/puppetdb"
-      scp_to database, File.join(pkg_dir, "puppetdb.deb"), "/tmp/packages/puppetdb"
-    end
-
     step "Install the package" do
-      on database, "dpkg -i /tmp/packages/puppetdb/puppetdb.deb", :acceptable_exit_codes => (0..255)
-      on database, "apt-get -f -y install"
+      if osfamily == 'Debian'
+        on database, "apt-get install -y libjson-ruby"
+        on database, "mkdir -p /tmp/packages/puppetdb"
+        scp_to database, File.join(pkg_dir, "puppetdb.deb"), "/tmp/packages/puppetdb"
+        on database, "dpkg -i /tmp/packages/puppetdb/puppetdb.deb", :acceptable_exit_codes => (0..255)
+        on database, "apt-get -f -y install"
+      else
+        on database, "yum install -y ruby-json"
+        on database, "yum install --disablerepo puppetlabs-products -y puppetdb"
+      end
     end
   else
     step "Install PuppetDB via rake" do
@@ -179,14 +202,14 @@ end
 
 step "Install the PuppetDB terminuses on the master" do
   if (PuppetDBExtensions.test_mode == :package)
-    step "Copy the package" do
+    if osfamily == 'Debian'
       on master, "mkdir -p /tmp/packages/puppetdb"
       scp_to master, File.join(pkg_dir, "puppetdb-terminus.deb"), "/tmp/packages/puppetdb"
-    end
 
-    step "Install the package" do
       on master, "dpkg -i /tmp/packages/puppetdb/puppetdb-terminus.deb", :acceptable_exit_codes => (0..255)
       on master, "apt-get -f -y install"
+    else
+      on master, "yum install --disablerepo puppetlabs-products -y puppetdb-terminus"
     end
   else
     step "Install the termini via rake" do


### PR DESCRIPTION
This supports running the acceptance tests against the development yum
repo on neptune.
