### PR TITLE
Add support for package upgrades during acceptance 

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -21,7 +21,10 @@ module PuppetDBExtensions
 
   def start_puppetdb(host)
     on host, "service puppetdb start"
+    sleep_until_started(host)
+  end
 
+  def sleep_until_started(host)
     on host, "curl http://localhost:8080", :acceptable_exit_codes => [0,7]
     num_retries = 0
     until exit_code == 0
@@ -36,6 +39,19 @@ module PuppetDBExtensions
 
   def stop_puppetdb(host)
     on host, "service puppetdb stop"
+  end
+
+  def sleep_until_stopped(host, timeout=nil)
+    on host, "curl http://localhost:8080", :acceptable_exit_codes => [0,7]
+    num_retries = 0
+    until exit_code == 7
+      sleep 1
+      on host, "curl http://localhost:8080", :acceptable_exit_codes => [0,7]
+      num_retries += 1
+      if (num_retries > 60)
+        fail("Unable to stop puppetdb")
+      end
+    end
   end
 
   def restart_puppetdb(host)

--- a/acceptance/options/common.rb
+++ b/acceptance/options/common.rb
@@ -1,8 +1,21 @@
 def common_options_hash()
   puppetdb_acceptance_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
+  def get_install_mode()
+    mode = :install
+    if (ENV['PUPPETDB_INSTALL_MODE'])
+      mode = ENV['PUPPETDB_INSTALL_MODE'].intern
+      puts "Found environment variable 'PUPPETDB_INSTALL_MODE' with value '#{ENV['PUPPETDB_INSTALL_MODE']}'; setting puppetdb options[:puppetdb_install_mode] to value '#{mode.inspect}'"
+    end
+    unless [:install, :upgrade].include?(mode)
+      raise ArgumentError, "Unsupported puppetdb install mode '#{mode}'"
+    end
+    mode
+  end
+
   {
-      :helper     => File.join(puppetdb_acceptance_dir, "helper.rb"),
-      :setup_dir  => File.join(puppetdb_acceptance_dir, "setup"),
+      :helper                 => File.join(puppetdb_acceptance_dir, "helper.rb"),
+      :setup_dir              => File.join(puppetdb_acceptance_dir, "setup"),
+      :puppetdb_install_mode  => get_install_mode(),
   }
 end

--- a/acceptance/setup/post_suite/99_teardown.rb
+++ b/acceptance/setup/post_suite/99_teardown.rb
@@ -1,5 +1,38 @@
 #!/usr/bin/env ruby
 
+# TODO: this is copied and pasted from the setup script.  It needs to be
+#  DRY'd up in the refactor.
+step "DETERMINE OSFAMILY AGAIN BECAUSE WE HAVEN'T REFACTORED SETUP SCRIPT YET" do
+  # Determine whether we're Debian or RedHat. Note that "git" installs are
+  # currently assumed to be *Debian only*.
+  on(database, "which yum", :silent => true)
+  if result.exit_code == 0
+    # TODO: this is basically a global variable right now, need to clean it up.
+    @osfamily = :redhat
+  else
+    @osfamily = :debian
+  end
+end
+
+
+
+def uninstall_package(pkg_name)
+  if (@osfamily == :debian)
+    on(database, "apt-get -f -y purge #{pkg_name}")
+  elsif (@osfamily == :redhat)
+    on(database, "yum -y remove #{pkg_name}")
+  else
+    raise ArgumentError, "Unsupported OS family: '#{@osfamily}'"
+  end
+end
+
 step "Stop puppetdb" do
   stop_puppetdb(database)
+end
+
+if (PuppetDBExtensions.test_mode == :package)
+  step "Uninstall packages" do
+    uninstall_package("puppetdb")
+    uninstall_package("puppetdb-terminus")
+  end
 end


### PR DESCRIPTION
This will probably need to be rebased after some of the previous pull reqs are merged.. only the second commit is relevant.  Just wanted to get it posted for review in case anyone has time.

---

This commit adds the ability for us to toggle
    between running acceptance tests against packages
    that were simply installed from a clean state, or
    installed as an upgrade over the latest production
    package.

```
This will still need some cleanup; it contains
some workarounds... however, it will still be
a valuable incremental step to make sure
everything is working OK on jenkins before
we refactor the setup script.
```
