### PR TITLE
Fix deb packaging so that service is restarted on upgrade

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -169,6 +169,7 @@ task :template => [ :clean ] do
    erb "ext/templates/init_debian.erb", "ext/files/debian/#{@name}.init"
    erb "ext/templates/puppetdb_default.erb", "ext/files/debian/#{@name}.default"
    erb "ext/templates/deb/control.erb", "ext/files/debian/control"
+   erb "ext/templates/deb/prerm.erb", "ext/files/debian/#{@name}.prerm"
    erb "ext/templates/deb/postrm.erb", "ext/files/debian/#{@name}.postrm"
    erb "ext/templates/deb/base.install.erb", "ext/files/debian/#{@name}.install"
    erb "ext/templates/deb/terminus.install.erb", "ext/files/debian/#{@name}-terminus.install"

--- a/ext/templates/deb/postinst.erb
+++ b/ext/templates/deb/postinst.erb
@@ -12,3 +12,12 @@ fi
 
 <%= ERB.new(File.read("ext/templates/directory_perms.erb")).result %>
 
+
+set -e
+if [ -x "/etc/init.d/puppetdb" ]; then
+    if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
+        invoke-rc.d puppetdb start || exit $?
+    else
+        /etc/init.d/puppetdb start || exit $?
+    fi
+fi

--- a/ext/templates/deb/postrm.erb
+++ b/ext/templates/deb/postrm.erb
@@ -20,6 +20,4 @@ case "$1" in
 
 esac
 
-#DEBHELPER#
-
 exit 0

--- a/ext/templates/deb/prerm.erb
+++ b/ext/templates/deb/prerm.erb
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+if [ -x "/etc/init.d/puppetdb" ]; then
+    if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
+        invoke-rc.d puppetdb stop || exit $?
+    else
+        /etc/init.d/puppetdb stop || exit $?
+    fi
+fi
+

--- a/ext/templates/deb/terminus.postinst.erb
+++ b/ext/templates/deb/terminus.postinst.erb
@@ -12,4 +12,3 @@ if [ "$1" = "configure" ]; then
 
 fi
 
-#DEBHELPER#


### PR DESCRIPTION
Prior to this commit, when you ran a debian package upgrade,
the puppetdb service would be stopped but would not be
restarted.  This commit removes some DEBHELPER stuff in
order to give us some more explicit control over the
lifecycle.  It adds a "prerm" script to shut down the
service, and adds a block to the "postinst" script to make
it explicitly start the service again.
