### PR TITLE
Better 'curl' example for resource spec

### DIFF
--- a/spec/resource.md
+++ b/spec/resource.md
@@ -99,4 +99,4 @@ following form:
 
 [You can use `curl`](curl.md) to query information about resources like so:
 
-    curl -G -H "Accept: application/json" 'http://localhost:8080/resources' --data-urlencode 'query=["=", "type", "File"]'
+    curl -G -H "Accept: application/json" 'http://localhost:8080/resources' --data-urlencode 'query=["and", ["=", "type", "File"], ["=", "title", "/etc/ipsec.conf"]]'


### PR DESCRIPTION
The previous example showed a query that was:
1. not quite complex enough to be very illustrative, and
2. likely to bring your system to its knees if you have real data

This commit just makes a minor improvement to that example.
