### PR TITLE
Fix issues with using new version of jetty.ini on upgrade

### DIFF
--- a/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
+++ b/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
@@ -12,9 +12,6 @@ step "Install development build of PuppetDB on the PuppetDB server" do
   when :package
     Log.notify("Installing puppetdb from package; install mode: '#{options[:puppetdb_install_mode].inspect}'")
 
-    # Remove this so that the SSL setup script will run again
-    on database, "rm -f /etc/puppetdb/ssl/puppetdb_keystore_pw.txt"
-
     install_puppetdb(database)
 
     validate_package_version(database)

--- a/ext/templates/deb/postinst.erb
+++ b/ext/templates/deb/postinst.erb
@@ -6,9 +6,7 @@ export PATH=/opt/puppet/bin:$PATH
 
 # Setup the SSL stuff
 
-if [ ! -f "<%= @config_dir -%>/../ssl/puppetdb_keystore_pw.txt" ] ; then
-  <%= @sbin_dir -%>/puppetdb-ssl-setup
-fi
+<%= @sbin_dir -%>/puppetdb-ssl-setup
 
 <%= ERB.new(File.read("ext/templates/directory_perms.erb")).result %>
 

--- a/ext/templates/puppetdb-ssl-setup
+++ b/ext/templates/puppetdb-ssl-setup
@@ -61,30 +61,35 @@ if [ ! -n "$fqdn" ] ; then
   fqdn=`facter hostname`
 fi
 
-password=`export LC_ALL=C; dd if=/dev/urandom count=20 2> /dev/null | tr -cd '[:alnum:]' | head -c 25`
-tmpdir=`mktemp -t -d tmp.puppetdbXXXXX`
 mycertname=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint  certname`
 mycert=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint  hostcert`
 myca=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint localcacert`
 privkey=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint hostprivkey`
 
+pw_file=${puppetdb_confdir}/ssl/puppetdb_keystore_pw.txt
 
-rm -rf $tmpdir
-mkdir -p $tmpdir
-cp $myca $tmpdir/ca.pem
-cp $privkey $tmpdir/privkey.pem
-cp $mycert $tmpdir/pubkey.pem
+if [ -f $pw_file ]; then
+  password=`cat $pw_file`
+else
+  password=`export LC_ALL=C; dd if=/dev/urandom count=20 2> /dev/null | tr -cd '[:alnum:]' | head -c 25`
+  tmpdir=`mktemp -t -d tmp.puppetdbXXXXX`
+  rm -rf $tmpdir
+  mkdir -p $tmpdir
+  cp $myca $tmpdir/ca.pem
+  cp $privkey $tmpdir/privkey.pem
+  cp $mycert $tmpdir/pubkey.pem
 
-cd $tmpdir
-keytool -import -alias "PuppetDB CA" -keystore truststore.jks -storepass "$password" -trustcacerts -file ca.pem -noprompt
-cat privkey.pem pubkey.pem > temp.pem
-echo "$password" | openssl pkcs12 -export -in temp.pem -out puppetdb.p12 -name $fqdn -passout fd:0
-keytool -importkeystore -destkeystore keystore.jks -srckeystore puppetdb.p12 -srcstoretype PKCS12 -alias $fqdn -deststorepass "$password" -srcstorepass "$password"
+  cd $tmpdir
+  keytool -import -alias "PuppetDB CA" -keystore truststore.jks -storepass "$password" -trustcacerts -file ca.pem -noprompt
+  cat privkey.pem pubkey.pem > temp.pem
+  echo "$password" | openssl pkcs12 -export -in temp.pem -out puppetdb.p12 -name $fqdn -passout fd:0
+  keytool -importkeystore -destkeystore keystore.jks -srckeystore puppetdb.p12 -srcstoretype PKCS12 -alias $fqdn -deststorepass "$password" -srcstorepass "$password"
 
-rm -rf $puppetdb_confdir/ssl
-mkdir -p $puppetdb_confdir/ssl
-cp -pr *jks $puppetdb_confdir/ssl
-echo $password > ${puppetdb_confdir}/ssl/puppetdb_keystore_pw.txt
+  rm -rf $puppetdb_confdir/ssl
+  mkdir -p $puppetdb_confdir/ssl
+  cp -pr *jks $puppetdb_confdir/ssl
+  echo $password > ${puppetdb_confdir}/ssl/puppetdb_keystore_pw.txt
+fi
 
 jettyfile="${puppetdb_confdir}/conf.d/jetty.ini"
 if [ -f "$jettyfile" ] ; then

--- a/ext/templates/puppetdb.spec.erb
+++ b/ext/templates/puppetdb.spec.erb
@@ -132,9 +132,9 @@ export PATH=/opt/puppet/bin:$PATH
 if [ "$1" = "1" ]; then
   # Register the puppetDB service
   /sbin/chkconfig --add %{name}
-
-  <%= @sbin_dir -%>/puppetdb-ssl-setup
 fi
+
+<%= @sbin_dir -%>/puppetdb-ssl-setup
 
 <%= ERB.new(File.read("ext/templates/directory_perms.erb")).result %>
 


### PR DESCRIPTION
Previously the user could choose to use the "new" version of jetty.ini,
which was a template including a placeholder password. During a regular
install, we run puppetdb-ssl-setup, which replaces the placeholder with
the actual password. However, during an upgrade, we weren't running it.
Now, we will always run the script, and determine whether or not to
generate a keystore/truststore/password based on the existence of the
password file. If it already exists, we will update the jetty.ini to use
it.
