### PR TITLE
Fix redhat 'service stop' bug

### DIFF
--- a/ext/templates/init_redhat.erb
+++ b/ext/templates/init_redhat.erb
@@ -79,7 +79,7 @@ stop() {
     find_my_pid
     if [ -s "$PIDFILE" ] ; then
         kill `cat $PIDFILE`
-    else
+    elif [ "$pid" != "" ] ; then
         kill $pid
     fi
     retval=$?


### PR DESCRIPTION
On redhat, if you ran "service puppetdb stop" when the service
wasn't running, you'd get a (harmless) error/warning message.

This commit fixes that.
