### PR TITLE
(maint) Update puppetdb packaging to correctly handle RCs

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -98,10 +98,10 @@ module PuppetDBExtensions
         case os
           when :debian
             result = on host, "dpkg-query --showformat \"\\${Version}\" --show puppetdb"
-            result.stdout.strip.gsub(/-.*$/, "")
-          when :redhat
-            result = on host, "rpm -q puppetdb --queryformat \"%{VERSION}\""
             result.stdout.strip
+          when :redhat
+            result = on host, "rpm -q puppetdb --queryformat \"%{VERSION}-%{RELEASE}\""
+            result.stdout.strip.split('.')[0...-1].join('.')
           else
             raise ArgumentError, "Unsupported OS family: '#{os}'"
         end

--- a/ext/templates/deb/changelog.erb
+++ b/ext/templates/deb/changelog.erb
@@ -1,11 +1,9 @@
 <% if @pe
-  tag = 'puppet'
   dists = 'lucid squeeze precise'
   else
-  tag = 'puppetlabs'
   dists = 'hardy lucid maverick natty oneiric unstable lenny sid squeeze wheezy precise'
   end -%>
-<%= @name -%> (<%= version -%>-1<%= tag -%><%= @release -%>) <%= dists -%>; urgency=low
+<%= @name -%> (<%= @debversion -%>) <%= dists -%>; urgency=low
 
   * Add postgresql to suggests
   * Adding an init script from Puppet Labs Ops

--- a/ext/templates/puppetdb.spec.erb
+++ b/ext/templates/puppetdb.spec.erb
@@ -1,4 +1,6 @@
 %global   realname puppetdb
+%global realversion <%= @version %>
+%global rpmversion <%= @rpmversion %>
 
 %global ruby_sitelib     %(PATH=/opt/puppet/bin:$PATH ruby -rrbconfig -e "puts Config::CONFIG['sitelibdir']")
 
@@ -22,14 +24,14 @@ Name:           pe-puppetdb
 <% else -%>
 Name:           puppetdb
 <% end -%>
-Version:        <%= @version %>
-Release:        1%{?dist}
+Version:        <%= @rpmversion %>
+Release:        <%= @rpmrelease %>%{?dist}
 BuildRoot:      %{_tmppath}/%{realname}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 Summary:        Puppet Centralized Storage Daemon
 License:       ASL 2.0
 URL:           http://github.com/puppetlabs/puppetdb
-Source0:       http://downloads.puppetlabs.com/puppetdb/%{realname}-%{version}.tar.gz
+Source0:       http://downloads.puppetlabs.com/puppetdb/%{realname}-%{realversion}.tar.gz
 Group:         System Environment/Daemons
 
 <% if @pe -%>
@@ -72,7 +74,7 @@ Requires: puppet >= 2.7.12
 Connect Puppet to PuppetDB by setting up a terminus for PuppetDB.
 
 %prep
-%setup -q -n %{realname}-%{version}
+%setup -q -n %{realname}-%{realversion}
 
 %build
 
@@ -207,7 +209,7 @@ fi
 hostname = `hostname --fqdn`
 dt=`date +"%a %b %d %Y"`
 -%>
-* <%= dt.strip -%> <%= ENV['USER'] -%> <<%= ENV['USER'].strip -%>@<%= hostname.strip -%>> - <%= version %>
+* <%= dt.strip -%> <%= ENV['USER'] -%> <<%= ENV['USER'].strip -%>@<%= hostname.strip -%>> - <%= @rpmversion %>-<%= @rpmrelease -%>
 - Autobuild from Rake task
 
 * Mon Apr 02 2012 Michael Stahnke <stahnma@puppetlabs.com> - 0.1.0-1


### PR DESCRIPTION
Previously the puppetdb packaging would create packages with versions like
1.0.0rc1, which is a problem for rpm and deb packages because 1.0.0 < 1.0.0rc1,
so 1.0.0 would never be installed after 1.0.0rc1 had been. This commit updates
the packaging tasks to correctly build packages named to our RC standard, such
as 1.0.0-0.1rc1, which will be less than 1.0.0-1, the final version. The commit
adds instance variables for @debversion, @rpmversion, @origversion,
@debrelease, and @rpmrelease as well as helper methods to populate those
variables. It also updates the changelog template for debian and the spec file
template for redhat to correctly use the new variables.
