### PR TITLE
Fix --debug flag and add HeapDump JVM option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -100,6 +100,9 @@ else
     @sbin_dir = "/usr/sbin"
 end
 
+
+@default_java_args = "-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=#{@log_dir}/puppetdb-oom.hprof "
+
 @version      ||= get_version
 @debversion   ||= get_debversion
 @origversion  ||= get_origversion

--- a/ext/templates/puppetdb-foreground.erb
+++ b/ext/templates/puppetdb-foreground.erb
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-su <%= @name -%> -s /bin/bash -c "<%= @java_bin || "/usr/bin/java"  -%> <%= @java_args || "-Xmx192m " -%> -jar <%= @install_dir || "/usr/share/puppetdb" -%>/puppetdb.jar services -c <%= @config_dir -%> $@"
+su <%= @name -%> -s /bin/bash -c "<%= @java_bin || "/usr/bin/java"  -%> <%= @java_args || @default_java_args -%> -jar <%= @install_dir || "/usr/share/puppetdb" -%>/puppetdb.jar services -c <%= @config_dir -%> $@"

--- a/ext/templates/puppetdb_default.erb
+++ b/ext/templates/puppetdb_default.erb
@@ -6,7 +6,7 @@
 JAVA_BIN="<%= @java_bin || "/usr/bin/java"  -%>"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="<%= @java_args || "-Xmx192m " -%>"
+JAVA_ARGS="<%= @java_args || @default_java_args -%>"
 
 # These normally shouldn't need to be edited if using OS packages
 USER="<%= @name -%>"


### PR DESCRIPTION
This commit does the following:
- Change the services/parse-config function back to accepting an optional
  map of initial config values.  Because this function does lots of
  side-effect things, including initializing the logging, it needs
  access to some of the command-line options such as --debug in order
  to work properly.
- Change the name of services/parse-config to include an exclamation point,
  because it has lots of side effects.
- Add a couple of JVM args to our default jvm args; specifically,
  HeapDumpOnOutOfMemoryError and HeapDumpPath, so that we will have
  the opportunity to collect heap dump files from users if they
  encounter OOM errors.
