### PR TITLE
Don't remove puppetdb user/group on RedHat systems

### DIFF
--- a/ext/templates/puppetdb.spec.erb
+++ b/ext/templates/puppetdb.spec.erb
@@ -170,11 +170,8 @@ if [ "$1" = "0" ] ; then
 fi
 
 %postun
-# Remove PuppetDB user if this is an uninstall (as opposed to
-#  an upgrade)...
+# Remove the rundir if this is an uninstall (as opposed to an upgrade)...
 if [ "$1" = "0" ]; then
-    getent passwd %{name} > /dev/null && userdel %{name}
-    getent group %{name} > /dev/null && groupdel %{name}
     rm -rf %{_rundir}/%{name} || :
 fi
 


### PR DESCRIPTION
We never did this on Debian systems, and most other packages seem not to
as well. Also, removing the user and not all files owned by it can cause
problems if another service later usurps the user id.
