### PR TITLE
Refactor catalog transformations

### DIFF
--- a/src/com/puppetlabs/puppetdb/catalog.clj
+++ b/src/com/puppetlabs/puppetdb/catalog.clj
@@ -182,7 +182,7 @@
 ;;
 ;; Functions to ensure that the catalog structure is coherent.
 
-(defn validate-edges!
+(defn validate-edges
   "Ensure that all edges have valid sources and targets, and that the
   relationship types are acceptable."
   [{:keys [edges resources] :as catalog}]
@@ -241,9 +241,9 @@
     transform-metadata
     collapse))
 
-(def validate!
+(def validate
   "Applies every validation step to the catalog."
-  validate-edges!)
+  validate-edges)
 
 ;; ## Deserialization
 ;;
@@ -252,7 +252,7 @@
 (def parse-from-json-obj
   "Parse a wire-format JSON catalog object contained in `o`, returning a
   puppetdb-suitable representation."
-  (comp validate! transform))
+  (comp validate transform))
 
 (defn parse-from-json-string
   "Parse a wire-format JSON catalog string contained in `s`, returning a

--- a/test/com/puppetlabs/puppetdb/test/catalog.clj
+++ b/test/com/puppetlabs/puppetdb/test/catalog.clj
@@ -70,12 +70,12 @@
             target {:type "Type" :title "target"}]
         (testing "should fail when edges mention missing resources"
           (is (thrown? IllegalArgumentException
-                       (validate-edges! {:edges #{{:source source :target target :relationship :before}}
+                       (validate-edges {:edges #{{:source source :target target :relationship :before}}
                                          :resources {}}))))
 
         (testing "should fail when edges have an invalid relationship"
           (is (thrown? IllegalArgumentException
-                       (validate-edges! {:edges #{{:source source :target target :relationship :madly-in-love-with}}
+                       (validate-edges {:edges #{{:source source :target target :relationship :madly-in-love-with}}
                                          :resources {source source
                                                      target target}}))))
 
@@ -85,7 +85,7 @@
                 catalog {:edges edges
                          :resources {source source
                                      target target}}]
-            (is (= catalog (validate-edges! catalog)))))))))
+            (is (= catalog (validate-edges catalog)))))))))
 
 (deftest resource-normalization
   (let [; Synthesize some fake resources


### PR DESCRIPTION
This series refactors the transformation operations we apply to catalogs to make them hopefully a little easier to modify. Basically there are high-level transform operations which work on subsections of the catalog, and then lower-level transforms for individual elements. This way there's a function corresponding to each subset of the catalog that may need to be transformed, at any level.
