### PR TITLE
Bug/master/15903 more fun with utf8

### DIFF
--- a/puppet/spec/unit/util/puppetdb/char_encoding_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/char_encoding_spec.rb
@@ -22,16 +22,15 @@ describe Puppet::Util::Puppetdb::CharEncoding do
       test_utf8_clean(in_bytes, expected_bytes)
     end
 
+    Utf8ReplacementChar = [0xEF, 0xBF, 0xBD]
     it "should replace invalid multi-byte characters with the unicode replacement character" do
       in_bytes = [0xE2, 0xCB, 0x87]
-      expected_bytes = [0xEF, 0xBF, 0xBD]
-      test_utf8_clean(in_bytes, expected_bytes)
+      test_utf8_clean(in_bytes, Utf8ReplacementChar)
     end
 
     it "should replace an incomplete multi-byte character with the unicode replacement character" do
       in_bytes = [0xE2, 0x9B]
-      expected_bytes = [0xEF, 0xBF, 0xBD]
-      test_utf8_clean(in_bytes, expected_bytes)
+      test_utf8_clean(in_bytes, Utf8ReplacementChar)
     end
 
     it "should replace invalid characters with the unicode replacement character" do
@@ -41,8 +40,8 @@ describe Puppet::Util::Puppetdb::CharEncoding do
       #  was handling it was causing certain strings to decode differently in
       #  clojure, thus causing checksum errors.
       in_bytes = [0x21, 0x7F, 0xFD, 0x80, 0xBD, 0xBB, 0xB6, 0xA1]
-      expected_bytes = [0x21, 0x7F, 0xEF, 0xBF, 0xBD, 0xEF, 0xBF, 0xBD, 0xEF, 0xBF,
-                  0xBD, 0xEF, 0xBF, 0xBD, 0xEF, 0xBF, 0xBD, 0xEF, 0xBF, 0xBD]
+      expected_bytes = [0x21, 0x7F]
+      expected_bytes.concat(Utf8ReplacementChar * 6)
       test_utf8_clean(in_bytes, expected_bytes)
     end
 
@@ -56,10 +55,21 @@ describe Puppet::Util::Puppetdb::CharEncoding do
         it "should replace invalid #{num_bytes}-byte character starting with 0x#{first_byte.to_s(16)}" do
           in_bytes = [first_byte]
           (num_bytes - 1).times { in_bytes << 0x80 }
-          expected_bytes = []
-          num_bytes.times { expected_bytes.concat [0xEF, 0xBF, 0xBD ] }
-          test_utf8_clean(in_bytes, expected_bytes)
+          test_utf8_clean(in_bytes, Utf8ReplacementChar * num_bytes)
         end
+      end
+    end
+
+    context "when dealing with multi-byte sequences beginning with 0xF4" do
+      it "should accept characters that are below the 0x10FFFF limit of Unicode" do
+        in_bytes = [0xF4, 0x8f, 0xbf, 0xbf]
+        expected_bytes = [0xF4, 0x8f, 0xbf, 0xbf]
+        test_utf8_clean(in_bytes, expected_bytes)
+      end
+
+      it "should reject characters that are above the 0x10FFFF limit of Unicode" do
+        in_bytes = [0xF4, 0x90, 0xbf, 0xbf]
+        test_utf8_clean(in_bytes, Utf8ReplacementChar)
       end
     end
   end


### PR DESCRIPTION
commit b0167a4b54d42db62407bcd5c9ce1efc4d6ff9d2
Author: Chris Price chris@puppetlabs.com
Date:   Tue Aug 21 18:43:58 2012 -0700

```
(#15903) Detect invalid multi-byte sequences starting with 0xF4

The UTF-8 spec says that codepoints greater than 0x10FFFF are
illegal.  The first character that is over that limit is
0xF490bfbf, so if the first byte of a multibyte character is F4,
then we have to check for that condition.  This commit adds that
check, along with corresponding tests.
```

commit 0e23b96b6de5cd38b0e2e2938dcade092eafacd5
Author: Chris Price chris@puppetlabs.com
Date:   Tue Aug 21 16:00:25 2012 -0700

```
(#15903) Detect invalid multi-byte sequences from 0xC0, 0xC1, 0xF5-0xFF

Prior to this commit, our UTF-8 sanitizer was not recognizing
multi-byte sequences starting with 0xC0, 0xC1, or anything in
the range of 0xF5-0xFF invalid.  Java/Clojure *do* consider
these invalid (which matches up with the explanation on the
UTF-8 page on wikipedia).  This commit adds detection for
those byte sequences.
```
