### PR TITLE
Expand tag pattern to match all allowed characters

### DIFF
--- a/src/com/puppetlabs/puppetdb/catalog.clj
+++ b/src/com/puppetlabs/puppetdb/catalog.clj
@@ -184,7 +184,7 @@
 ;; Functions to ensure that the catalog structure is coherent.
 
 (def ^:const tag-pattern
-  #"\A[a-z0-9_][a-z0-9_:]*\Z")
+  #"\A[a-z0-9_][a-z0-9_:\-.]*\Z")
 
 (defn validate-tags
   "Ensure that all catalog tags conform to the allowed tag pattern."

--- a/test/com/puppetlabs/puppetdb/test/catalog.clj
+++ b/test/com/puppetlabs/puppetdb/test/catalog.clj
@@ -78,13 +78,17 @@
                        (validate-tags catalog)))))
 
       (testing "should reject tags with bad characters"
-        (let [tags #{"foo" "bar" "b@d"}
-              catalog {:tags tags}]
-          (is (thrown-with-msg? IllegalArgumentException #"invalid tag 'b@d'"
-                       (validate-tags catalog)))))
+        (doseq [invalid-tag #{"a!" "b@" "c#" "d$" "e%"
+                              "f^" "g&" "h*" "i(" "j)"
+                              "k=" "l+" "m\\" "n<" "o>"
+                              "p," "q/" "r?" "s`" "t~"}]
+          (let [tags #{invalid-tag}
+                catalog {:tags tags}]
+            (is (thrown-with-msg? IllegalArgumentException #"invalid tag"
+                                  (validate-tags catalog))))))
 
       (testing "should accept correct tags"
-        (let [tags #{"good" "better" "best"}
+        (let [tags #{"_good" "bet-ter" "best." "0bester"}
               catalog {:tags tags}]
               (is (= catalog (validate-tags catalog))))))
 


### PR DESCRIPTION
The language reference incorrectly defined the allowed pattern for tags,
which was copied for use here. Now tags with - or . will be accepted.
