### PR TITLE
(#15748) Better logging of malformed relationships

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -160,7 +160,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
             # and try that
             other_resource = find_resource(hash['resources'], other_hash) || find_resource(hash['resources'], aliases[other_array])
 
-            raise "Can't find resource #{other_ref} for relationship" unless other_resource
+            raise "Can't synthesize edge: #{resource_hash_to_ref(resource_hash)} -#{relation[:relationship]}- #{other_ref} (param #{param})" unless other_resource
 
             if other_resource['exported']
               raise "Can't create an edge between #{resource_hash_to_ref(resource_hash)} and exported resource #{other_ref}"

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -365,7 +365,7 @@ foo::bar { bar: }
         hash = subject.add_parameters_if_missing(catalog_data_hash)
         expect {
           subject.synthesize_edges(hash)
-        }.to raise_error(/Can't find resource Notify\[non-existent\] for relationship/)
+        }.to raise_error("Can't synthesize edge: Notify\[anyone\] -required-by- Notify\[non-existent\] (param require)")
       end
     end
 


### PR DESCRIPTION
If puppet generates a catalog that’s malformed, we output an error
message like so:

```
Can't find resource Rvm_system_ruby['ruby-1.9.3-p0'] for relationship
```

While it tells you one part of the problem, it doesn’t display the full
relationship edge (making it hard to triangulate where the error is).

We now display a message that includes both resources involved in the
edge, what their relationship is supposed to be, and which parameter is
attempting to create this edge.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
