### PR TITLE
Move aside old heap dumps prior to daemon startup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -105,7 +105,8 @@ else
 end
 
 
-@default_java_args = "-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=#{@log_dir}/puppetdb-oom.hprof "
+@heap_dump_path = "#{@log_dir}/puppetdb-oom.hprof"
+@default_java_args = "-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=#{@heap_dump_path} "
 
 @version      ||= get_version
 @debversion   ||= get_debversion

--- a/ext/templates/init_debian.erb
+++ b/ext/templates/init_debian.erb
@@ -51,6 +51,11 @@ do_start()
 {
     # We need to do something with the log file...
 
+    # Move any heap dumps aside
+    if [ -e "<%= @heap_dump_path %>" ] ; then
+      mv "<%= @heap_dump_path %>" "<%= @heap_dump_path %>.prev"
+    fi
+
     # Return
     #   0 if daemon has been started
     #   1 if daemon was already running
@@ -63,9 +68,6 @@ do_start()
     # Add code here, if necessary, that waits for the process to be ready
     # to handle requests from services started subsequently which depend
     # on this one.  As a last resort, sleep for some time.
-
-    # <%= @name -%> takes a long time to spin up on ningyo, waiting for it
-    # would be bad.
 }
 
 #

--- a/ext/templates/init_redhat.erb
+++ b/ext/templates/init_redhat.erb
@@ -63,6 +63,10 @@ start() {
     rh_status_q
     [ -x $JAVA_BIN ] || exit 5
     [ -d $config ] || exit 6
+    # Move any heap dumps aside
+    if [ -e "<%= @heap_dump_path %>" ] ; then
+      mv "<%= @heap_dump_path %>" "<%= @heap_dump_path %>.prev"
+    fi
     echo -n $"Starting $prog: "
     daemon --user $USER --pidfile $PIDFILE "$EXEC >> <%= @log_dir %>/puppetdb-daemon.log 2>&1 &"
     sleep 1


### PR DESCRIPTION
The JVM can't successfully write out a heap snapshot if a file already
exists at the target location (which is stupid, but them's the breaks).
This commit adds logic to our init scripts to move any pre-existing heap
snapshot out of the way prior to starting the daemon. This means that we
retain one previous heap snapshot, but that should help during
situations where an OutOfMemoryError prompted an immediate service
restart (to restore operations), but we'd still like a heap dump for
forensic analysis.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
