### PR TITLE
(#15645) Daemon should terminate upon OOM error

### DIFF
--- a/ext/templates/init_debian.erb
+++ b/ext/templates/init_debian.erb
@@ -63,7 +63,7 @@ do_start()
     start-stop-daemon --start $EXTRA_ARGS --quiet --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN --test > /dev/null \
         || return 1
     start-stop-daemon --start $EXTRA_ARGS --quiet --pidfile $PIDFILE --chdir $INSTALL_DIR --exec $JAVA_BIN -- \
-        $JAVA_ARGS \
+        -XX:OnOutOfMemoryError="kill -9 %p" $JAVA_ARGS \
         || return 2
     # Add code here, if necessary, that waits for the process to be ready
     # to handle requests from services started subsequently which depend

--- a/ext/templates/init_redhat.erb
+++ b/ext/templates/init_redhat.erb
@@ -41,7 +41,7 @@ JARFILE="puppetdb.jar"
 JAVA_ARGS="${JAVA_ARGS} -jar ${INSTALL_DIR}/${JARFILE} services -c ${CONFIG} "
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile=/var/lock/subsys/$prog
-EXEC="$JAVA_BIN $JAVA_ARGS"
+EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" $JAVA_ARGS"
 PIDFILE="/var/run/$prog/$prog"
 
 if `which runuser &> /dev/null` ; then


### PR DESCRIPTION
Though we can potentially catch an OOM error and do something about it,
it’s not guaranteed that the error will occur in a thread in which we
can interpose our own logic. But certainly we shouldn’t keep the process
going if an OOM renders it effectively inoperative...better to just kill
the process altogether than to leave a zombie around.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
