### PR TITLE
Don't show WARN messages when running unit tests

### DIFF
--- a/test-resources/log4j.properties
+++ b/test-resources/log4j.properties
@@ -1,0 +1,8 @@
+# When in test mode, don't show anything below the ERROR level.
+log4j.rootLogger = ERROR, ConsoleAppender
+
+# As this is just a test log4j config, send everything to the
+# console rather than a file appender.
+log4j.appender.ConsoleAppender = org.apache.log4j.ConsoleAppender
+log4j.appender.ConsoleAppender.layout = org.apache.log4j.PatternLayout
+log4j.appender.ConsoleAppender.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n


### PR DESCRIPTION
Do not show migrate messages (WARN level) when running `lein test`,
instead hide them as we'll only need to look out for ERROR level
messages or higher whilst unit testing.

Fixes the work outlined in story #97
