### PR TITLE
Update uberjar task for lein2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -148,7 +148,7 @@ desc "Build the uberjar"
 task :uberjar => [  ] do
   if `which lein`
     sh "lein uberjar"
-    mv JAR_FILE_V, JAR_FILE
+    mv "target/#{JAR_FILE_V}", JAR_FILE
   else
     puts "You need lein on your system"
     exit 1


### PR DESCRIPTION
Lein 2 puts the generated jar file in target instead of in the project root, so
this commit updates the uberjar task to look in the target directory when
moving the jar into place.
