### PR TITLE
(#16437) Additional database pool config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,11 +679,22 @@ A password to use when connecting.
 
 `log-slow-statements`
 
-The number of seconds that any individual SQL query may run before it is considered
-"slow" and is logged as a warning.  Note that this does not actually interrupt
-the query in any way; it simply checks queries after they complete and logs them
-if their duration exceeded this setting.  The default value is 10 seconds.  You
-may set this setting to zero to disable this feature.
+The number of seconds that any individual SQL query may run before it
+is considered "slow" and is logged as a warning.  Note that this does
+not actually interrupt the query in any way; it simply checks queries
+after they complete and logs them if their duration exceeded this
+setting.  The default value is 10 seconds.  You may set this setting
+to zero to disable this feature.
+
+`conn-max-age`
+
+How many minutes a database connection can be idle before we terminate
+the connection. We default to 60 minutes.
+
+`conn-keep-alive`
+
+How often, in minutes, should we send a keep-alive query to the
+database. We default to every 240 minutes.
 
 **[command-processing]**
 

--- a/src/com/puppetlabs/jdbc.clj
+++ b/src/com/puppetlabs/jdbc.clj
@@ -105,7 +105,8 @@
   "Create a new database connection pool"
   [{:keys [classname subprotocol subname username password
            partition-conn-min partition-conn-max partition-count
-           stats log-statements log-slow-statements]
+           stats log-statements log-slow-statements
+           conn-max-age conn-keep-alive]
     :or   {partition-conn-min  1
            partition-conn-max  10
            partition-count     5
@@ -113,7 +114,9 @@
            ;; setting this to a String value, because that's what it would
            ;;  be in the config file and we're manually converting it to a boolean
            log-statements      "true"
-           log-slow-statements 10}
+           log-slow-statements 10
+           conn-max-age        60
+           conn-keep-alive     240}
     :as   db}]
   ;; Load the database driver class
   (Class/forName classname)
@@ -125,6 +128,8 @@
                           (.setMaxConnectionsPerPartition partition-conn-max)
                           (.setPartitionCount partition-count)
                           (.setStatisticsEnabled stats)
+                          (.setIdleMaxAgeInMinutes conn-max-age)
+                          (.setIdleConnectionTestPeriodInMinutes conn-keep-alive)
                           ;; paste the URL back together from parts.
                           (.setJdbcUrl (str "jdbc:" subprotocol ":" subname))
                           (.setConnectionHook (connection-hook log-statements? log-slow-statements)))]


### PR DESCRIPTION
- conn-max-age: How many minutes a database connection can be idle
  before we terminate the connection. We default to 60 minutes.
- conn-keep-alive: How often, in minutes, should we send a keep-alive
  query to the database. We default to every 240 minutes.

Both of these can be used to configure PuppetDB so that it doesn't run
afoul of things like idle connection termination on load balancers.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
