### PR TITLE
Fix proposal for #16529: allow building a puppetdb-terminus gem

### DIFF
--- a/puppet/Gemfile
+++ b/puppet/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in puppetdb-terminus.gemspec
+gemspec

--- a/puppet/puppetdb-terminus.gemspec
+++ b/puppet/puppetdb-terminus.gemspec
@@ -1,0 +1,18 @@
+# -*- encoding: utf-8 -*-
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |gem|
+  gem.name          = "puppetdb-terminus"
+  gem.version       = "1.0"
+  gem.authors       = ["Puppet Labs"]
+  gem.email         = ["puppet@puppetlabs.com"]
+  gem.description   = "Centralized Puppet Storage"
+  gem.summary       = "PuppetDB is a Puppet data warehouse; it manages storage and retrieval of all platform-generated data, such as catalogs, facts, reports"
+  gem.homepage      = "https://github.com/puppetlabs/puppetdb"
+
+  gem.files         = `git ls-files`.split($/)
+  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.require_paths = ["lib"]
+end


### PR DESCRIPTION
In some cases, puppet installations are deployed through gems to nodes in rvm or rbenv In that scenario, it is hard to hook-up puppetdb, since it isn’t a gem and the best way to install it is through the available packages from puppetlabs.

A puppetdb-terminus gem would circumvent this and allow for deployment in rvm, bundler, etc.
