### PR TITLE
Introduce a constant for "application/json"

### DIFF
--- a/src/com/puppetlabs/http.clj
+++ b/src/com/puppetlabs/http.clj
@@ -44,6 +44,7 @@
                 (.get nil))]
     (intern *ns* key val)))
 
+(def content-type-json "application/json")
 
 ;; ## HTTP/Ring utility functions
 
@@ -83,7 +84,7 @@
      (-> body
          (json/generate-string {:date-format "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"})
          (rr/response)
-         (rr/header "Content-Type" "application/json")
+         (rr/header "Content-Type" content-type-json)
          (rr/status code))))
 
 (defn error-response

--- a/test/com/puppetlabs/puppetdb/test/http/experimental/catalog.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/experimental/catalog.clj
@@ -11,12 +11,10 @@
 
 (use-fixtures :each with-test-db with-http-app)
 
-(def c-t "application/json")
-
 (defn get-request
   [path]
   (let [request (request :get path)]
-    (update-in request [:headers] assoc "Accept" c-t)))
+    (update-in request [:headers] assoc "Accept" pl-http/content-type-json)))
 
 (defn get-response
   ([]      (get-response nil))
@@ -27,7 +25,7 @@
 to the result of the form supplied to this method."
   [response body]
   (is (= pl-http/status-ok   (:status response)))
-  (is (= c-t (get-in response [:headers "Content-Type"])))
+  (is (= pl-http/content-type-json (get-in response [:headers "Content-Type"])))
   (is (= (when-let [body (:body response)]
            (let [body (json/parse-string body)
                  resources (body "resources")]

--- a/test/com/puppetlabs/puppetdb/test/http/experimental/population.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/experimental/population.clj
@@ -11,12 +11,10 @@
 
 (use-fixtures :each with-test-db with-http-app)
 
-(def c-t "application/json")
-
 (defn get-request
   [path]
   (let [request (request :get path)]
-    (update-in request [:headers] assoc "Accept" c-t)))
+    (update-in request [:headers] assoc "Accept" pl-http/content-type-json)))
 
 (defn get-response
   ([]      (get-response nil))
@@ -27,7 +25,7 @@
 to the result of the form supplied to this method."
   [response body]
   (is (= pl-http/status-ok   (:status response)))
-  (is (= c-t (get-in response [:headers "Content-Type"])))
+  (is (= pl-http/content-type-json (get-in response [:headers "Content-Type"])))
   (is (= (when-let [body (:body response)]
            (json/parse-string body true))
          body)))

--- a/test/com/puppetlabs/puppetdb/test/http/v1/command.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v1/command.clj
@@ -16,7 +16,7 @@
   [post-body]
   (let [request (request :post "/v1/commands")]
     (-> request
-        (assoc-in [:headers "accept"] "application/json")
+        (assoc-in [:headers "accept"] pl-http/content-type-json)
         (body post-body))))
 
 (deftest command-endpoint
@@ -28,7 +28,7 @@
             req      (make-request {:payload payload :checksum checksum})
             resp     (*app* req)]
         (is (= (:status resp) pl-http/status-ok))
-        (is (= (get-in resp [:headers "Content-Type"]) "application/json"))
+        (is (= (get-in resp [:headers "Content-Type"]) pl-http/content-type-json))
         (is (= (instance? java.util.UUID
                           (-> (:body resp)
                               (json/parse-string true)

--- a/test/com/puppetlabs/puppetdb/test/http/v1/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v1/facts.clj
@@ -11,14 +11,12 @@
 
 (use-fixtures :each with-test-db with-http-app)
 
-(def c-t "application/json")
-
 (defn make-request
   "Return a GET request against path, suitable as an argument to a ring
   app. Params supported are content-type and query-string."
   ([path] (make-request path {}))
   ([path {keys [:query-string :content-type]
-          :or {:query-string "" :content-type c-t} :as params}]
+          :or {:query-string "" :content-type pl-http/content-type-json} :as params}]
      (let [request (request :get path (:query-string params))
            headers (:headers request)]
        (assoc request :headers (assoc headers "Accept" (:content-type params))))))
@@ -40,7 +38,7 @@
       (let [request (make-request "/v1/facts/imaginary_node")
             response (*app* request)]
         (is (= (:status response) pl-http/status-not-found))
-        (is (= (get-in response [:headers "Content-Type"]) c-t))
+        (is (= (get-in response [:headers "Content-Type"]) pl-http/content-type-json))
         (is (= (json/parse-string (:body response) true)
                {:error "Could not find facts for imaginary_node"}))))
 
@@ -48,7 +46,7 @@
       (let [request (make-request (format "/v1/facts/%s" certname_without_facts))
             response (*app* request)]
         (is (= (:status response) pl-http/status-not-found))
-        (is (= (get-in response [:headers "Content-Type"]) c-t))
+        (is (= (get-in response [:headers "Content-Type"]) pl-http/content-type-json))
         (is (= (json/parse-string (:body response) true)
                {:error (str "Could not find facts for " certname_without_facts)}))))
 
@@ -56,6 +54,6 @@
       (let [request (make-request (format "/v1/facts/%s" certname_with_facts))
             response (*app* request)]
         (is (= (:status response) pl-http/status-ok))
-        (is (= (get-in response [:headers "Content-Type"]) c-t))
+        (is (= (get-in response [:headers "Content-Type"]) pl-http/content-type-json))
         (is (= (json/parse-string (:body response))
                {"name" certname_with_facts "facts" facts}))))))

--- a/test/com/puppetlabs/puppetdb/test/http/v1/metrics.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v1/metrics.clj
@@ -28,13 +28,11 @@
         (is (= (filter-mbean {:key {:key TimeUnit/SECONDS}})
                {:key {:key "SECONDS"}}))))))
 
-(def c-t "application/json")
-
 (defn make-request
   "Return a GET request against path, suitable as an argument to the
   metrics app."
   ([path] (make-request path {}))
-  ([path {keys [:content-type] :or {:content-type c-t} :as params}]
+  ([path {keys [:content-type] :or {:content-type pl-http/content-type-json} :as params}]
      (let [request (request :get (format "/v1/metrics/%s" path))
            headers (:headers request)]
        (assoc request :headers (assoc headers "accept" (:content-type params))))))
@@ -55,7 +53,7 @@
       (let [request (make-request "mbean/java.lang:type=Memory")
             response (*app* request)]
         (is (= (:status response) pl-http/status-ok))
-        (is (= (get-in response [:headers "Content-Type"]) c-t))
+        (is (= (get-in response [:headers "Content-Type"]) pl-http/content-type-json))
         (is (= (map? (json/parse-string (:body response) true))
                true))))
 
@@ -63,7 +61,7 @@
       (let [request (make-request "mbeans")
             response (*app* request)]
         (is (= (:status response) pl-http/status-ok))
-        (is (= (get-in response [:headers "Content-Type"]) c-t))
+        (is (= (get-in response [:headers "Content-Type"]) pl-http/content-type-json))
 
         ;; Retrieving all the resulting mbeans should work
         (let [mbeans (json/parse-string (:body response))]
@@ -71,4 +69,4 @@
           (doseq [[name uri] mbeans
                   :let [request (make-request uri)]]
             (is (= (:status response pl-http/status-ok)))
-            (is (= (get-in response [:headers "Content-Type"]) c-t))))))))
+            (is (= (get-in response [:headers "Content-Type"]) pl-http/content-type-json))))))))

--- a/test/com/puppetlabs/puppetdb/test/http/v1/node.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v1/node.clj
@@ -14,8 +14,6 @@
 
 (use-fixtures :each with-test-db with-http-app)
 
-(def c-t "application/json")
-
 (defn get-request
   ([path] (get-request path nil))
   ([path query]
@@ -24,7 +22,7 @@
                               {"query" (if (string? query) query (json/generate-string query))})
                      (request :get path))
            headers (:headers request)]
-       (assoc request :headers (assoc headers "Accept" c-t)))))
+       (assoc request :headers (assoc headers "Accept" pl-http/content-type-json)))))
 
 (defn get-response
   ([]      (get-response nil))
@@ -35,7 +33,7 @@
 to the result of the form supplied to this method."
   [response expected]
   (is (= pl-http/status-ok   (:status response)))
-  (is (= c-t (get-in response [:headers "Content-Type"])))
+  (is (= pl-http/content-type-json (get-in response [:headers "Content-Type"])))
   (let [actual (if (:body response)
                    (set (json/parse-string (:body response) true))
                    nil)]

--- a/test/com/puppetlabs/puppetdb/test/http/v1/resources.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v1/resources.clj
@@ -22,7 +22,7 @@
                               {"query" (if (string? query) query (json/generate-string query))})
                      (request :get path))
            headers (:headers request)]
-       (assoc request :headers (assoc headers "Accept" c-t)))))
+       (assoc request :headers (assoc headers "Accept" pl-http/content-type-json)))))
 
 (defn get-response
   ([]      (get-response nil))

--- a/test/com/puppetlabs/puppetdb/test/http/v1/status.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v1/status.clj
@@ -13,12 +13,10 @@
 
 (use-fixtures :each with-test-db with-http-app)
 
-(def c-t "application/json")
-
 (defn get-request
   [path]
   (let [request (request :get path)]
-    (update-in request [:headers] assoc "Accept" c-t)))
+    (update-in request [:headers] assoc "Accept" pl-http/content-type-json)))
 
 (defn get-response
   ([]      (get-response nil))


### PR DESCRIPTION
We were using a hard-coded string literal of
"application/json" in a ton of places around the
code base; this simply introduces a constant to
use in place of the hard-coded string.
