### PR TITLE
DRY up http error handling

### DIFF
--- a/src/com/puppetlabs/http.clj
+++ b/src/com/puppetlabs/http.clj
@@ -101,6 +101,21 @@
            (rr/response)
            (rr/status code)))))
 
+(defmacro with-http-error-handling
+  "Provides error handling and generates HTTP error responses for ring apps.
+  Returns an HTTP Bad Request response (with the exception message) for
+  JsonParseExceptions and IllegalArgumentExceptions, and an HTTP Internal Error
+  response for IllegalStateExceptions."
+  [& body]
+  `(try
+    ~@body
+    (catch com.fasterxml.jackson.core.JsonParseException e#
+      (error-response e#))
+    (catch IllegalArgumentException e#
+      (error-response e#))
+    (catch IllegalStateException e#
+      (error-response e# status-internal-error))))
+
 (defn uri-segments
   "Converts the given URI into a seq of path segments. Empty segments
   (from a `//`, for example) are elided from the result"

--- a/src/com/puppetlabs/puppetdb/http/v1/node.clj
+++ b/src/com/puppetlabs/puppetdb/http/v1/node.clj
@@ -39,16 +39,12 @@
   "Produce a response body for a request to search for nodes based on
   `query`. If no `query` is supplied, all nodes will be returned."
   [query db]
-  (try
+  (pl-http/with-http-error-handling
     (with-transacted-connection db
       (let [query (if query (json/parse-string query true))
             sql   (node/query->sql query)
             nodes (node/search sql)]
-        (pl-http/json-response nodes)))
-    (catch com.fasterxml.jackson.core.JsonParseException e
-      (pl-http/error-response e))
-    (catch IllegalArgumentException e
-      (pl-http/error-response e))))
+        (pl-http/json-response nodes)))))
 
 ;; TODO: Add an API to specify whether to include facts
 (defn node-app

--- a/src/com/puppetlabs/puppetdb/http/v1/resources.clj
+++ b/src/com/puppetlabs/puppetdb/http/v1/resources.clj
@@ -82,19 +82,13 @@
   If the query would return more than `limit` results, `status-internal-error` is returned."
   [limit query db]
   {:pre [(and (integer? limit) (>= limit 0))]}
-  (try
+  (pl-http/with-http-error-handling
     (with-transacted-connection db
       (-> query
           (json/parse-string true)
           (r/query->sql)
           ((partial r/limited-query-resources limit))
-          (pl-http/json-response)))
-    (catch com.fasterxml.jackson.core.JsonParseException e
-      (pl-http/error-response e))
-    (catch IllegalArgumentException e
-      (pl-http/error-response e))
-    (catch IllegalStateException e
-      (pl-http/error-response e pl-http/status-internal-error))))
+          (pl-http/json-response)))))
 
 (defn resources-app
   "Ring app for querying resources"


### PR DESCRIPTION
We had the same lengthy try/catch block for error handling
in several of our http endpoints; this commit introduces a
macro to perform that error handling so that we're not
repeating the code in so many spots.
