### PR TITLE
Refactor/master/constants for command names

### DIFF
--- a/puppet/lib/puppet/face/node/deactivate.rb
+++ b/puppet/lib/puppet/face/node/deactivate.rb
@@ -1,9 +1,14 @@
+require 'puppet/util/puppetdb'
+
 Puppet::Face.define(:node, '0.0.1') do
+
+  CommandDeactivateNode = Puppet::Util::Puppetdb::CommandDeactivateNode
+
   action :deactivate do
     summary "Deactivate a set of nodes in PuppetDB"
     arguments "<node> [<node> ...]"
     description <<-DESC
-      This will issue 'deactivate node' commands to the PuppetDB server for
+      This will issue '#{CommandDeactivateNode}' commands to the PuppetDB server for
       each node specified. The server is found by looking in
       $confdir/puppetdb.conf. If any command submissions fail, the process will
     be aborted.
@@ -23,7 +28,7 @@ Puppet::Face.define(:node, '0.0.1') do
 
     when_rendering(:console) do |value|
       value.map do |node,uuid|
-        "Submitted 'deactivate node' for #{node} with UUID #{uuid}"
+        "Submitted '#{CommandDeactivateNode}' for #{node} with UUID #{uuid}"
       end.join("\n")
     end
   end

--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -8,7 +8,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   def save(request)
     catalog = munge_catalog(request.instance)
 
-    submit_command(request, catalog, 'replace catalog', 1)
+    submit_command(request, catalog, CommandReplaceCatalog, 1)
   end
 
   def find(request)

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -10,7 +10,7 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
     facts.values = facts.values.dup
     facts.stringify
 
-    submit_command(request, facts, 'replace facts', 1)
+    submit_command(request, facts, CommandReplaceFacts, 1)
   end
 
   def find(request)

--- a/puppet/lib/puppet/indirector/node/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/node/puppetdb.rb
@@ -12,6 +12,6 @@ class Puppet::Node::Puppetdb < Puppet::Indirector::REST
   end
 
   def destroy(request)
-    submit_command(request, request.key, 'deactivate node', 1)
+    submit_command(request, request.key, CommandDeactivateNode, 1)
   end
 end

--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -3,6 +3,13 @@ require 'puppet/util/puppetdb/char_encoding'
 require 'digest'
 
 module Puppet::Util::Puppetdb
+
+  CommandsUrl = "/v1/commands"
+
+  CommandReplaceCatalog = "replace catalog"
+  CommandReplaceFacts = "replace facts"
+  CommandDeactivateNode = "deactivate node"
+
   def self.server
     @server, @port = load_puppetdb_config unless @server
     @server
@@ -37,7 +44,7 @@ module Puppet::Util::Puppetdb
     for_whom = " for #{request.key}" if request.key
 
     begin
-      response = http_post(request, "/v1/commands", "checksum=#{checksum}&payload=#{payload}", headers)
+      response = http_post(request, CommandsUrl, "checksum=#{checksum}&payload=#{payload}", headers)
 
       log_x_deprecation_header(response)
 

--- a/puppet/spec/spec_helper.rb
+++ b/puppet/spec/spec_helper.rb
@@ -4,4 +4,5 @@ $LOAD_PATH.unshift File.join(dir, "../lib")
 # don't fail any worse than we already would.
 $LOAD_PATH.push File.join(dir, "../../../puppetlabs_spec_helper")
 
-require 'puppet_spec_helper'
+require 'rspec'
+require 'puppetlabs_spec_helper/puppet_spec_helper'

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -28,7 +28,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
     it "should POST the catalog command as a URL-encoded PSON string" do
       payload_str = subject.munge_catalog(catalog).to_pson
       payload = {
-        :command => "replace catalog",
+        :command => Puppet::Util::Puppetdb::CommandReplaceCatalog,
         :version => 1,
         :payload => payload_str,
       }.to_pson

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper'
 require 'puppet/indirector/facts/puppetdb'
 
 describe Puppet::Node::Facts::Puppetdb do
+
+  CommandReplaceFacts = Puppet::Util::Puppetdb::CommandReplaceFacts
+
   before :each do
     Puppet::Util::Puppetdb.stubs(:load_puppetdb_config).returns ['localhost', 0]
     Puppet::Node::Facts.indirection.stubs(:terminus).returns(subject)
@@ -25,7 +28,7 @@ describe Puppet::Node::Facts::Puppetdb do
 
     it "should POST the facts command as a URL-encoded PSON string" do
       payload = {
-        :command => "replace facts",
+        :command => CommandReplaceFacts,
         :version => 1,
         :payload => facts.to_pson,
       }.to_pson
@@ -44,7 +47,7 @@ describe Puppet::Node::Facts::Puppetdb do
       facts.values['something'] = 100
 
       payload = {
-        :command => "replace facts",
+        :command => CommandReplaceFacts,
         :version => 1,
         :payload => facts.to_pson,
       }.to_pson

--- a/puppet/spec/unit/indirector/node/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/node/puppetdb_spec.rb
@@ -5,6 +5,9 @@ require 'spec_helper'
 require 'puppet/indirector/node/puppetdb'
 
 describe Puppet::Node::Puppetdb do
+
+  CommandDeactivateNode = Puppet::Util::Puppetdb::CommandDeactivateNode
+
   before :each do
     Puppet::Node.indirection.stubs(:terminus).returns(subject)
   end
@@ -18,11 +21,11 @@ describe Puppet::Node::Puppetdb do
   describe "#destroy" do
     let(:response) { Net::HTTPOK.new('1.1', 200, 'OK') }
 
-    it "should POST a 'deactivate node' command as a URL-encoded PSON string" do
+    it "should POST a '#{CommandDeactivateNode}' command as a URL-encoded PSON string" do
       response.stubs(:body).returns '{"uuid": "a UUID"}'
 
       payload = {
-        :command => "deactivate node",
+        :command => CommandDeactivateNode,
         :version => 1,
         :payload => node.to_pson,
       }.to_pson


### PR DESCRIPTION
commit 215c9751624dfd545331b4eb8d1d353af9f46d4f
Author: Chris Price chris@puppetlabs.com
Date:   Sun Sep 23 20:43:06 2012 -0700

```
Introduce constants for command names

Prior to this commit, we had all of the command names
scattered around as hard-coded strings.  This introduces
constants for them and refactors the code and tests
to use the new constants.
```
