### PR TITLE
BLOCKED: Fix sourceinstall to use strings for ENV

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -119,12 +119,12 @@ end
 
 desc "Create a source install of PuppetDB"
 task :sourceinstall do
-  ENV['SOURCEINSTALL'] = 1
+  ENV['SOURCEINSTALL'] = "1"
   Rake::Task[:install].invoke
 end
 
 def erb(erbfile,  outfile)
-  if ENV['SOURCEINSTALL'] == 1
+  if ENV['SOURCEINSTALL'] == "1"
     @install_dir = "#{DESTDIR}/@install_dir"
     @config_dir = "#{DESTDIR}/@config_dir"
     @initscriptname = "#{DESTDIR}/@initscript"


### PR DESCRIPTION
PLEASE DO NOT MERGE THIS YET: need to check with release (@haus , @MosesMendoza , @stahnma ) and see if we even need this task for anything.

Prior to this commit, the rake 'sourceinstall' task
was using a numeric literal as the value for an
assignment into the ENV hash, which is a special
hash in ruby that can only accept strings for its
values.  This meant that the rake sourceinstall task
was unusable.  This commit changes things over to
use strings rather than numbers.

However, this raises the question as to whether anyone
is using this for anything and whether or not we should
just delete it.  Need to talk to release about that.
