### PR TITLE
Remove lein1 backward-compatibility stuff

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -72,10 +72,6 @@
                  [ring/ring-core "1.1.1"]
                  [ring/ring-jetty-adapter "1.1.1"]]
 
-  :dev-dependencies [[lein-marginalia "0.7.0"]
-                     ;; WebAPI support libraries.
-                     [ring-mock "0.1.1"]]
-
   :profiles {:dev {:resource-paths ["test-resources"],
                    :dependencies [[ring-mock "0.1.1"]]}}
 


### PR DESCRIPTION
This commit simply removes the lein1 backwards-compatibility
section (dev-dependencies).  Since we want to make sure
we're building with lein2 from now on, it doesn't really make
sense to keep that around.
