### PR TITLE
Add a bounded-memoize function for better memo performance

### DIFF
--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -28,7 +28,6 @@
             [cheshire.core :as json])
   (:use [clj-time.coerce :only [to-timestamp]]
         [clj-time.core :only [ago days now]]
-        [clojure.core.memoize :only [memo-lru]]
         [metrics.meters :only (meter mark!)]
         [metrics.counters :only (counter inc! value)]
         [metrics.gauges :only (gauge)]
@@ -372,7 +371,7 @@ must be supplied as the value to be matched."
 
 ;; Size of the cache is based on the number of unique resources in a
 ;; "medium" site persona
-(def resource-identity-hash* (memo-lru resource-identity-hash* 40000))
+(def resource-identity-hash* (utils/bounded-memoize resource-identity-hash* 40000))
 
 (defn resource-identity-hash
   "Compute a hash for a given resource that will uniquely identify it

--- a/src/com/puppetlabs/utils.clj
+++ b/src/com/puppetlabs/utils.clj
@@ -471,6 +471,22 @@
     (let [bytes (.getBytes s "UTF-8")]
       (digest-func "sha-1" [bytes]))))
 
+(defn bounded-memoize
+  "Similar to memoize, but the cache will be reset if it exceeds the specified
+  `bound`."
+  [f bound]
+  {:pre [(integer? bound)
+         (pos? bound)]}
+  (let [cache (atom {})]
+    (fn [& args]
+      (if-let [e (find @cache args)]
+        (val e)
+        (let [v (apply f args)]
+          (when (> (count @cache) bound)
+            (reset! cache {}))
+          (swap! cache assoc args v)
+          v)))))
+
 ;; ## UUID handling
 
 (defn uuid


### PR DESCRIPTION
`memo-lru` has a lot of smarts in it that we don't need over `memoize`,
which introduces a significant performance penalty on cache misses.
However, we still want to prevent the cache from growing unbounded, so
we use a naive approach of simply clearing the cache if it exceeds the
limit, which should be rare. The cache size is 40k, which is more than
sufficient even for my database of 26k nodes.

This change reduced the amount of time taken to compute the initial set
of resource hashes from ~15 seconds to ~225ms. Once the cache is
populated, performance is fairly similar in each case. Populations with
significant resource churn should see a good increase in the performance
of catalog storage.
