### PR TITLE
Bug/master/16407 file trailing slashes

### DIFF
--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -541,32 +541,36 @@ describe Puppet::Resource::Catalog::Puppetdb do
         result['data']['edges'].should include(edge)
       end
 
-      it "should make an edge if the other end a file resource with a missing trailing slash" do
-        other_resource = Puppet::Resource.new(:file, '/tmp/foo/')
-        resource[:require] = 'File[/tmp/foo]'
-        Puppet[:code] = [resource, other_resource].map(&:to_manifest).join
+      context "when dealing with file resources and trailing slashes in their titles" do
 
-        result = subject.munge_catalog(catalog)
+        def test_file_require(resource_title, require_title)
+          other_resource = Puppet::Resource.new(:file, resource_title)
+          resource[:require] = "File[#{require_title}]"
+          Puppet[:code] = [resource, other_resource].map(&:to_manifest).join
+          result = subject.munge_catalog(catalog)
 
-        edge = {'source' => {'type' => 'File', 'title' => '/tmp/foo/'},
-                'target' => {'type' => 'Notify', 'title' => 'anyone'},
-                'relationship' => 'required-by'}
+          edge = {'source' => {'type' => 'File', 'title' => resource_title},
+                  'target' => {'type' => 'Notify', 'title' => 'anyone'},
+                  'relationship' => 'required-by'}
 
-        result['data']['edges'].should include(edge)
-      end
+          result['data']['edges'].should include(edge)
+        end
 
-      it "should make an edge if the other end a file resource with an extra trailing slash" do
-        other_resource = Puppet::Resource.new(:file, '/tmp/foo')
-        resource[:require] = 'File[/tmp/foo/]'
-        Puppet[:code] = [resource, other_resource].map(&:to_manifest).join
+        it "should make an edge if the other end is a file resource with a missing trailing slash" do
+          test_file_require('/tmp/foo/', '/tmp/foo')
+        end
 
-        result = subject.munge_catalog(catalog)
+        it "should make an edge if the other end is a file resource with an extra trailing slash" do
+          test_file_require('/tmp/foo', '/tmp/foo/')
+        end
 
-        edge = {'source' => {'type' => 'File', 'title' => '/tmp/foo'},
-                'target' => {'type' => 'Notify', 'title' => 'anyone'},
-                'relationship' => 'required-by'}
+        it "should make an edge if the other end is a file resource with two missing trailing slashes" do
+          test_file_require('/tmp/foo//', '/tmp/foo')
+        end
 
-        result['data']['edges'].should include(edge)
+        it "should make an edge if the other end is a file resource with two extra trailing slashes" do
+          test_file_require('/tmp/foo', '/tmp/foo//')
+        end
       end
 
       it "should make an edge if the other end is an exec referred to by an alias" do


### PR DESCRIPTION
commit af6da2c3f76b18ef59524b7aafd3d8fee90dbeae
Author: Chris Price chris@puppetlabs.com
Date:   Tue Oct 2 11:36:55 2012 -0700

```
(#16407) Handle trailing slashes when creating edges for file resources

This commit adds a few more tests for specifying relationships
to File resources with a different number of trailing slashes
than the resource was originally declared with.

It also adds a special-case to the logic for synthesizing
edges to file resources, to munge off the trailing slashes and
look up the file resources in the catalog via their canonical
title.
```

commit 4133efeecbfa1a500305d18db94c30576f226fb7
Author: Nick Lewis nick@puppetlabs.com
Date:   Thu Sep 20 13:40:34 2012 -0700

```
Initial tests and possible fix for file resource relationships

These are some initial tests that Nick wrote to demonstrate the
bug where we were failing to create relationships (edges) to
File resources if the relationship was specified with a different
number of trailing slashes in the title than the title of the
original resource.  (Commit message edited by cprice.)
```
