### PR TITLE
Properly find edges that point at an exec by an alias

### DIFF
--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -201,10 +201,10 @@ describe Puppet::Resource::Catalog::Puppetdb do
 
       describe "for non-isomorphic resources" do
         let(:resource) do
-          Puppet::Resource.new(:exec, 'an_exec', :parameters => {:command => '/bin/true'})
+          Puppet::Resource.new(:exec, 'an_exec', :parameters => {:command => '/bin/true', :alias => 'something awesome'})
         end
 
-        it "should not create aliases" do
+        it "should not add a namevar alias" do
           hash = subject.add_parameters_if_missing(catalog_data_hash)
           result = subject.add_namevar_aliases(hash, catalog)
 
@@ -213,7 +213,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
           end
 
           resource.should_not be_nil
-          resource['parameters']['alias'].should be_nil
+          resource['parameters']['alias'].should == ['something awesome']
         end
       end
     end
@@ -535,6 +535,20 @@ describe Puppet::Resource::Catalog::Puppetdb do
         result = subject.munge_catalog(catalog)
 
         edge = {'source' => {'type' => 'Notify', 'title' => 'noone'},
+                'target' => {'type' => 'Notify', 'title' => 'anyone'},
+                'relationship' => 'required-by'}
+
+        result['data']['edges'].should include(edge)
+      end
+
+      it "should make an edge if the other end is an exec referred to by an alias" do
+        other_resource = Puppet::Resource.new(:exec, 'noone', :parameters => {:alias => 'completely_different', :path => '/anything'})
+        resource[:require] = 'Exec[completely_different]'
+        Puppet[:code] = [resource, other_resource].map(&:to_manifest).join
+
+        result = subject.munge_catalog(catalog)
+
+        edge = {'source' => {'type' => 'Exec', 'title' => 'noone'},
                 'target' => {'type' => 'Notify', 'title' => 'anyone'},
                 'relationship' => 'required-by'}
 


### PR DESCRIPTION
During namevar aliasing, we end up changing the :alias parameter to
'alias' and using that for the duration (to distinguish "our" aliases
form the "original" aliases). However, in the case of exec, we were
bailing out early because execs aren't isomorphic, and not adding
'alias'. Now we will always change :alias to 'alias', and just won't add
the namevar alias for execs.
