### PR TITLE
Add support for running acceptance tests on EC2

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -42,6 +42,12 @@ module PuppetDBExtensions
           "'purge packages and perform exhaustive cleanup after run'",
           "PUPPETDB_PURGE_AFTER_RUN", :false)
 
+    use_s3_repos =
+        get_option_value(options[:puppetdb_use_s3_repos],
+          [:true, :false],
+          "'use s3 yum/apt repos instead of puppetlabs.lan'",
+          "PUPPETDB_USE_S3_REPOS", :false)
+
     @config = {
         :pkg_dir => File.join(File.dirname(__FILE__), '..', '..', '..', 'pkg'),
         :os_families => os_families,
@@ -52,6 +58,7 @@ module PuppetDBExtensions
         :expected_package_version => expected_package_version,
         :use_proxies => use_proxies == :true,
         :purge_after_run => purge_after_run == :true,
+        :use_s3_repos => use_s3_repos == :true,
     }
   end
 

--- a/acceptance/options/README.md
+++ b/acceptance/options/README.md
@@ -44,3 +44,7 @@ in your hash; the environment variable names are the same but uppercased
   whether or not the post-suite cleanup phase will remove packages and perform
   exhaustive cleanup after the run.  This is useful if you would like to avoid
   resetting VMs between every run of the acceptance tests.  Defaults to `:true`.
+
+* `:puppetdb_use_s3_repos` (`PUPPETDB_USE_S3_REPOS`) : By default, the test setup
+  will install puppetdb dev packages from puppetlabs.lan; however, if this option
+  is set to `true`, then it will try to use the apt/yum repos on S3 instead.

--- a/acceptance/setup/post_suite/10_collect_artifacts.rb
+++ b/acceptance/setup/post_suite/10_collect_artifacts.rb
@@ -1,6 +1,8 @@
 
 step "Create artifacts directory" do
-  Dir.mkdir("artifacts")
+  unless File.directory?('artifacts')
+    Dir.mkdir("artifacts")
+  end
 end
 step "Collect puppetdb log file" do
   # Would like to do this through the harness, but

--- a/acceptance/setup/pre_suite/80_add_dev_repo.rb
+++ b/acceptance/setup/pre_suite/80_add_dev_repo.rb
@@ -7,15 +7,25 @@ if (test_config[:install_type] == :package)
   step "Add development repository on PuppetDB server" do
     case os
     when :debian
+      apt_url = "http://apt-dev.puppetlabs.lan"
+      if (test_config[:use_s3_repos])
+        apt_url = "http://puppetdb-apt-prerelease.s3.amazonaws.com/debian"
+      end
+
       # TODO: this could be (maybe?) ported over to use the puppetlabs-apt module.
-      on database, "echo deb http://apt-dev.puppetlabs.lan $(lsb_release -sc) main >> /etc/apt/sources.list"
-      on database, "curl http://apt-dev.puppetlabs.lan/pubkey.gpg |apt-key add -"
+      on database, "echo deb #{apt_url} $(lsb_release -sc) main >> /etc/apt/sources.list"
+      on database, "curl #{apt_url}/pubkey.gpg |apt-key add -"
       on database, "apt-get update"
     when :redhat
+      yum_url = "http://neptune.puppetlabs.lan/dev"
+      if (test_config[:use_s3_repos])
+        yum_url = "http://puppetdb-yum-prerelease.s3.amazonaws.com"
+      end
+
       create_remote_file database, '/etc/yum.repos.d/puppetlabs-prerelease.repo', <<-REPO
 [puppetlabs-development]
 name=Puppet Labs Development - $basearch
-baseurl=http://neptune.puppetlabs.lan/dev/el/$releasever/products/$basearch
+baseurl=#{yum_url}/el/$releasever/products/$basearch
 enabled=1
 gpgcheck=0
       REPO


### PR DESCRIPTION
This adds an option to toggle our apt/yum repo
urls for our dev packages to point to the S3
mirrors instead of trying to hit puppetlabs.lan.
