### PR TITLE
(#16652) Replace dir with specific files for terminus package

### DIFF
--- a/ext/templates/puppetdb.spec.erb
+++ b/ext/templates/puppetdb.spec.erb
@@ -218,7 +218,15 @@ fi
 %defattr(-, puppet, puppet)
 <% end -%>
 # There are not specs yet in our rpms
-%{puppet_libdir}/puppet
+%{puppet_libdir}/puppet/face/node/deactivate.rb
+%{puppet_libdir}/puppet/face/node/status.rb
+%{puppet_libdir}/puppet/indirector/catalog/puppetdb.rb
+%{puppet_libdir}/puppet/indirector/facts/puppetdb.rb
+%{puppet_libdir}/puppet/indirector/node/puppetdb.rb
+%{puppet_libdir}/puppet/indirector/resource/puppetdb.rb
+%{puppet_libdir}/puppet/util/puppetdb
+%{puppet_libdir}/puppet/util/puppetdb.rb
+%{puppet_libdir}/puppet/util/puppetdb/char_encoding.rb
 
 %changelog
 <%


### PR DESCRIPTION
Previously, the files section claimed ownership of Puppet's libdir, which
confuses rpm when both packages are installed. This commit breaks out all of
the files and only owns one directory, which clearly belongs to puppetdb. This
will allow rpm to correctly identify files which belong to puppet vs
puppetdb-terminus.
