### PR TITLE
Acceptance: use the new "scp_from" method from puppet-acceptance

### DIFF
--- a/acceptance/setup/post_suite/10_collect_artifacts.rb
+++ b/acceptance/setup/post_suite/10_collect_artifacts.rb
@@ -5,16 +5,7 @@ step "Create artifacts directory" do
   end
 end
 step "Collect puppetdb log file" do
-  # Would like to do this through the harness, but
-  # there is currently only an "scp_to" method on
-  # that goes *out* to the hosts, no method that
-  # scp's *from* the hosts.
 
-  ssh_host = database['ip'] || database.name
-  scp_cmd = "scp root@#{ssh_host}:/var/log/puppetdb/puppetdb.log ./artifacts 2>&1"
-  PuppetAcceptance::Log.notify("Executing scp command:\n\n#{scp_cmd}\n\n")
-  result = `#{scp_cmd}`
-  status = $?
-  PuppetAcceptance::Log.notify(result)
-  assert(status.success?, "Collecting puppetdb log file failed with exit code #{status.exitstatus}.")
+  scp_from(database, "/var/log/puppetdb/puppetdb.log", "./artifacts")
+
 end


### PR DESCRIPTION
In a recent commit to puppet-acceptance I've added an "scp_from"
method, similar to the existing "scp_to" method.  This commit
simply refactors our messy code to use this instead of shelling
out to scp directly from ruby.
