### PR TITLE
Initial scripts / rake tasks for building test packages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,7 +72,7 @@ def ln_sfT(src, dest)
   `ln -sfT "#{src}" "#{dest}"`
 end
 
-@osfamily = Facter.value(:osfamily).downcase
+@osfamily = (Facter.value(:osfamily) || "").downcase
 
 case @osfamily
   when /debian/
@@ -381,4 +381,17 @@ namespace :package do
 
   desc "Create debian package"
   task :deb => [ :deb ]
+end
+
+namespace :test do
+  desc "Build packages for testing"
+  task :package do
+    # TODO: I'm not proud of this.  The contents of the shell script(s) that
+    # we call here need to be reconciled with Moses' standardized packaging
+    # stuff, and a lot of the contents should probably be ported over to
+    # Ruby instead of just shipping the nasty scripts.  However, this first step
+    # at least gives us 1) VCS for this stuff, and 2) the ability to run
+    # the two packaging builds in parallel.
+    sh "sh ./ext/test/build_packages.sh"
+  end
 end

--- a/ext/test/README.md
+++ b/ext/test/README.md
@@ -1,0 +1,10 @@
+ This directory contains some shell scripts that are used by CI (Jenkins) to
+ build packages of PuppetDB for testing (and eventually for promotion to
+ release packages).
+
+ I'm not proud of this.  The contents of the shell script(s) that
+ here need to be reconciled with Moses' standardized packaging
+ stuff, and a lot of the contents should probably be ported over to
+ Ruby instead of just shipping the nasty scripts.  However, this first step
+ at least gives us 1) VCS for this stuff, and 2) the ability to run
+ the two packaging builds in parallel.

--- a/ext/test/build_packages.sh
+++ b/ext/test/build_packages.sh
@@ -1,0 +1,7 @@
+set -x
+DIR="$( dirname "$0" )"
+if [ "$PUPPETDB_PACKAGE_TYPE" = "rpm" ]; then
+    sh $DIR/build_packages_rpm.sh
+else
+    sh $DIR/build_packages_deb.sh
+fi

--- a/ext/test/build_packages_deb.sh
+++ b/ext/test/build_packages_deb.sh
@@ -1,0 +1,120 @@
+NAME=puppetdb
+
+echo "**********************************************"
+echo "RUNNING CLOUD DEB PACKAGING; PARAMS FROM UPSTREAM BUILD:"
+echo ""
+echo "PUPPETDB_BRANCH: ${PUPPETDB_BRANCH}"
+echo "**********************************************"
+
+# `git describe` returns something like 1.0.0-20-ga1b2c3d
+# We want 1.0.0.20, so replace - with . and get rid of the g bit
+# TODO: pass along version?
+VERSION=`git describe | sed -e 's/-/./g' -e 's/\.*g.*//'`
+REF_TYPE=$(git cat-file -t $(git describe))
+
+DEB_BUILD_BRANCH=${PUPPETDB_BRANCH}
+DEB_BUILD_DIR="~/$NAME/build/$DEB_BUILD_BRANCH"
+FREIGHT_DIR=/opt/dev/$NAME/$DEB_BUILD_BRANCH
+INCOMING=$FREIGHT_DIR/incoming
+PENDING=$FREIGHT_DIR/pending
+WORK_DIR=$DEB_BUILD_DIR/$NAME-$VERSION
+BUCKET_NAME=${NAME}-prerelease
+S3_BRANCH_PATH=s3://${BUCKET_NAME}/${NAME}/${DEB_BUILD_BRANCH}
+
+git archive --format=tar HEAD --prefix=$NAME-$VERSION/ -o $NAME-$VERSION.tar
+
+ssh deb-builder "mkdir -p $DEB_BUILD_DIR"
+
+scp $NAME-$VERSION.tar deb-builder:$DEB_BUILD_DIR
+
+rm -f $NAME-$VERSION.tar
+
+ssh neptune "mkdir -p ${INCOMING}"
+
+ssh deb-builder <<BUILD_DEBS
+#set -e
+set -x
+
+export PATH=~/bin:\$PATH
+
+#tar -C ~/$NAME/build/$BUILD_BRANCH -xvf ~/$NAME/build/$BUILD_BRANCH/$NAME-$VERSION.tar
+tar -C $DEB_BUILD_DIR -xvf $DEB_BUILD_DIR/$NAME-$VERSION.tar
+echo $VERSION > $WORK_DIR/version
+cd $WORK_DIR && rake deb
+
+set -x
+
+echo "ABOUT TO COPY OVER THE DEB"
+scp -r $WORK_DIR/pkg/deb neptune:${INCOMING}/$NAME-$VERSION
+
+rm -rf $WORK_DIR{,.tar}
+BUILD_DEBS
+
+# That's right, I'm templating a config file via shell script inside
+# a Jenkins job.  So?  Back off.
+cat <<FREIGHT_CONF > ./freight.conf
+# Example Freight configuration.
+
+# Directories for the Freight library and Freight cache.  Your web
+# server's document root should be '\$VARCACHE'.
+VARLIB="${FREIGHT_DIR}/freight.dev"
+VARCACHE="${FREIGHT_DIR}/debian"
+
+# Default 'Origin' and 'Label' fields for 'Release' files.
+ORIGIN="Puppetlabs"
+LABEL="Puppetlabs"
+
+# Defaults to just i386 and amd64, this means we can deb up scripts.
+ARCHS="i386 amd64 all"
+
+# GPG key to use to sign repositories.  This is required by the 'apt'
+# repository provider.  Use 'gpg --gen-key' (see 'gpg'(1) for more
+# details) to generate a key and put its email address here.
+GPG="pluto@puppetlabs.lan"
+FREIGHT_CONF
+
+scp ./freight.conf neptune:${FREIGHT_DIR}
+
+ssh neptune <<FREIGHT
+#set -e
+set -x
+
+for DISTRO in lucid maverick natty oneiric precise lenny squeeze wheezy; do
+  freight add -c ${FREIGHT_DIR}/freight.conf $INCOMING/$NAME-$VERSION/*.deb apt/\$DISTRO
+done
+
+freight cache -c ${FREIGHT_DIR}/freight.conf
+
+# If this is a tagged version, we want to save the results for later promotion.
+if [ "$REF_TYPE" = "tag" ]; then
+  mkdir -p $PENDING/$NAME-$VERSION/deb
+  cp $INCOMING/$NAME-$VERSION/* $PENDING/$NAME-$VERSION/deb
+fi
+
+rm -rf $INCOMING/$NAME-$VERSION
+
+
+set -x
+
+# NOTE: be careful with shell vars in here!  It's kind of a mind-f to keep track of which ones
+# you want to interpolate from the jenkins node and which from neptune!
+
+echo "BUCKET_NAME IS: ${BUCKET_NAME}"
+
+# In the /opt/dev/debian/dists dir, all that we really care about syncing are the directories
+# that match up with release names.  These happen to all be symlinks, which s3cmd doesn't like,
+# and there are a bunch of freight work directories that we don't want/need to sync.  This
+# hack finds the symlinks and syncs each one individually.
+cd $FREIGHT_DIR/debian
+find dists -type l
+for x in \`find dists -type l\`; do
+   echo "ATTEMPTING TO SYNC DIST: '\${x}'"
+   time s3cmd --verbose --acl-public --delete-removed  sync $FREIGHT_DIR/debian/\${x}/* ${S3_BRANCH_PATH}/debian/\${x}/
+done
+cd -
+
+# Now we sync the rest of the stuff besides the 'dists' dir
+time s3cmd --verbose --acl-public --delete-removed  sync ${FREIGHT_DIR}/debian/pool/* ${S3_BRANCH_PATH}/debian/pool/
+time s3cmd --verbose --acl-public sync ${FREIGHT_DIR}/debian/*.gpg ${S3_BRANCH_PATH}/debian/
+
+FREIGHT

--- a/ext/test/build_packages_rpm.sh
+++ b/ext/test/build_packages_rpm.sh
@@ -1,0 +1,97 @@
+set -v
+
+echo "**********************************************"
+echo "RUNNING RPM PACKAGING; PARAMS FROM UPSTREAM BUILD:"
+echo ""
+echo "PUPPETDB_BRANCH: ${PUPPETDB_BRANCH}"
+echo "**********************************************"
+env
+echo "**********************************************"
+
+NAME=puppetdb
+
+# `git describe` returns something like 1.0.0-20-ga1b2c3d
+# We want 1.0.0.20, so replace - with . and get rid of the g bit
+VERSION=`git describe | sed -e 's/-/./g' -e 's/\.*g.*//'`
+REF_TYPE=$(git cat-file -t $(git describe))
+
+RPM_BUILD_BRANCH=${PUPPETDB_BRANCH}
+RPM_BUILD_DIR="~/$NAME/build/$RPM_BUILD_BRANCH"
+YUM_DIR=/opt/dev/$NAME/$RPM_BUILD_BRANCH
+PENDING=$YUM_DIR/pending
+WORK_DIR=$RPM_BUILD_DIR/$NAME-$VERSION
+BUCKET_NAME=$NAME-prerelease
+S3_BRANCH_PATH=s3://${BUCKET_NAME}/${NAME}/${RPM_BUILD_BRANCH}
+
+git archive --format=tar HEAD --prefix=$NAME-$VERSION/ -o $NAME-$VERSION.tar
+
+ssh rpm-builder mkdir -p $RPM_BUILD_DIR
+ssh rpm-builder "rm -rf $RPM_BUILD_DIR/*"
+
+scp $NAME-$VERSION.tar rpm-builder:$RPM_BUILD_DIR
+
+rm -f $NAME-$VERSION.tar
+
+ssh rpm-builder <<BUILD_RPMS
+#set -e
+set -x
+
+tar -C $RPM_BUILD_DIR -xvf $RPM_BUILD_DIR/$NAME-$VERSION.tar
+
+cd $WORK_DIR
+
+echo "****************************************************"
+env
+echo "****************************************************"
+ls -l
+echo "****************************************************"
+
+# The Rake task depends on having a version file, since it's not a git repo
+echo $VERSION > version
+
+# This SRPM is built for ruby 1.8 pathing, so in the newbuild call we turn off fedora 17 building
+PATH=~/bin:\$PATH rake srpm
+
+# This file has to exist or rsync freaks out :(
+touch excludes
+
+# Clone yum.puppetlabs.com repo for its rake tasks
+git clone git@github.com:puppetlabs/yum.puppetlabs.com
+
+# Build the SRPM
+RAKE_ARGS="-Iyum.puppetlabs.com -f yum.puppetlabs.com/Rakefile"
+
+# Build the packages and ship them off to neptune
+rake \$RAKE_ARGS setup newbuild ship PKG=\$(ls pkg/rpm/$NAME-*.src.rpm) TARGET=neptune.puppetlabs.lan:$YUM_DIR NO_CHECK=true OVERRIDE=1 F17_BUILD=FALSE
+
+# Now we remove and rebuild the SRPM for ruby 1.9 and mock against fedora 17
+rm pkg/rpm/$NAME-*.src.rpm
+PATH=~/bin:\$PATH rake srpm RUBY_VER=1.9
+
+rake \$RAKE_ARGS setup newbuild ship PKG=\$(ls pkg/rpm/$NAME-*.src.rpm) TARGET=neptune.puppetlabs.lan:$YUM_DIR NO_CHECK=true OVERRIDE=1 MOCKS=fedora-17-i386
+
+# If this is a tagged version, we want to save the results for later promotion.
+if [ "$REF_TYPE" = "tag" ]; then
+  scp -r el fedora neptune.puppetlabs.lan:$PENDING/$NAME-$VERSION
+fi
+
+
+# Clean up after ourselves
+cd ~
+rm -rf $WORK_DIR{,.tar}
+
+BUILD_RPMS
+
+#
+# Now rebuild the metadata
+ssh neptune.puppetlabs.lan <<PUBLISH_RPMS
+
+find $YUM_DIR -name x86_64 -or -name i386 -or -name SRPMS | xargs -n 1 createrepo --update
+
+set -x
+
+echo "BUCKET_NAME IS: ${BUCKET_NAME}"
+
+time s3cmd --verbose --acl-public --delete-removed  sync ${YUM_DIR}/el/* ${S3_BRANCH_PATH}/el/
+
+PUBLISH_RPMS


### PR DESCRIPTION
This commit does the following:

1) Copy all of the hacky shell code that we are using in Jenkins
   for building our PuppetDB packages into shell scripts in our
   repo.
2) Add a rake task ('test:package') that calls them.

This is not an ideal solution, but it is a step forward.  For now,
it gives us the following benefits:

1) Allows us to track the nastiest parts of our current slew of
   Jenkins jobs in VCS, and get rid of it inside of the Jenkins
   console.
2) Allows us to build a Jenkins job that can run our two packaging
   tasks (rpm, deb) in parallel.

There is more work that should eventually be done here, including
reconciling with Moses' standardized packaging tasks, porting some
or all of this shell stuff over to Ruby, and refactoring to
DRY up some of the repetitive bits.  However, I think this is
a big enough step forward to warrant committing it in its current
state.
