### PR TITLE
Add a default body to HTTP responses when none is supplied

### DIFF
--- a/src/com/puppetlabs/middleware.clj
+++ b/src/com/puppetlabs/middleware.clj
@@ -35,6 +35,16 @@
           req (assoc req :ssl-client-cn cn)]
       (app req))))
 
+(defn wrap-with-default-body
+  "Ring middleware that will attach a default body based on the response code
+  if no other body is supplied."
+  [app]
+  (fn [req]
+    (let [{:keys [body] :as response} (app req)]
+      (if (empty? body)
+        (assoc response :body (pl-http/default-body req response))
+        response))))
+
 (defn wrap-with-globals
   "Ring middleware that will add to each request a :globals attribute:
   a map containing various global settings"

--- a/src/com/puppetlabs/puppetdb/http/server.clj
+++ b/src/com/puppetlabs/puppetdb/http/server.clj
@@ -9,7 +9,7 @@
         [com.puppetlabs.puppetdb.http.v2 :only (v2-app)]
         [com.puppetlabs.puppetdb.http.experimental :only (experimental-app)]
         [com.puppetlabs.middleware :only
-         (wrap-with-authorization wrap-with-certificate-cn wrap-with-globals wrap-with-metrics)]
+         (wrap-with-authorization wrap-with-certificate-cn wrap-with-globals wrap-with-metrics wrap-with-default-body)]
         [com.puppetlabs.http :only (uri-segments json-response)]
         [net.cgrand.moustache :only (app)]
         [ring.middleware.resource :only (wrap-resource)]
@@ -58,5 +58,6 @@
         (wrap-params)
         (wrap-with-authorization (opts :authorized? (constantly true)))
         (wrap-with-certificate-cn)
+        (wrap-with-default-body)
         (wrap-with-metrics (atom {}) #(first (uri-segments %)))
         (wrap-with-globals (opts :globals)))))

--- a/test/com/puppetlabs/puppetdb/test/http/server.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/server.clj
@@ -1,0 +1,16 @@
+(ns com.puppetlabs.puppetdb.test.http.server
+  (:require [com.puppetlabs.http :as pl-http])
+  (:use clojure.test
+        ring.mock.request
+        com.puppetlabs.puppetdb.fixtures))
+
+(use-fixtures :each with-http-app)
+
+(def c-t "application/json")
+
+(deftest method-not-allowed
+  (testing "provides a useful error message"
+    (let [request (header (request :post "/v1/nodes") "Accept" c-t)
+          {:keys [status body]} (*app* request)]
+      (is (= status pl-http/status-bad-method))
+      (is (= body "The POST method is not allowed for /v1/nodes")))))


### PR DESCRIPTION
For every status except 405 Method Not Allowed, this is currently the
description used in RFC 2616 section 10. For 405, we provide a message
that specifies the method being used and URL requested, and explains the
problem. If we want more specific messages for other codes in the
future, it's easy to add them.
