### PR TITLE
Fix default body for static resources

### DIFF
--- a/src/com/puppetlabs/middleware.clj
+++ b/src/com/puppetlabs/middleware.clj
@@ -41,9 +41,9 @@
   [app]
   (fn [req]
     (let [{:keys [body] :as response} (app req)]
-      (if (empty? body)
-        (assoc response :body (pl-http/default-body req response))
-        response))))
+      (if body
+        response
+        (assoc response :body (pl-http/default-body req response))))))
 
 (defn wrap-with-globals
   "Ring middleware that will add to each request a :globals attribute:


### PR DESCRIPTION
This function checks whether there is a body present before attempting
to set one, and was trying to call `(empty? body)` to do so.
Unfortunately, when serving static files, `body` is an instance of
java.io.File, which naturally doesn't implement ISeq. Now we just check
for the presence of `body`, rather than any particular predicate. This
seems more correct anyway, as it's perfectly reasonable that the correct
response for some routes may indeed be an empty string.

This also adds a test for the / redirect to the dashboard, which has
broken in the past.
