### PR TITLE
Update URLs to use new v2 endpoint

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -271,7 +271,7 @@ module PuppetDBExtensions
     begin
       Timeout.timeout(timeout) do
         until queue_size == 0
-          result = on host, %Q(curl -H 'Accept: application/json' http://localhost:8080/v1/metrics/mbean/#{CGI.escape(metric)} 2> /dev/null |awk -F"," '{for (i = 1; i <= NF; i++) { print $i } }' |grep QueueSize |awk -F ":" '{ print $2 }')
+          result = on host, %Q(curl -H 'Accept: application/json' http://localhost:8080/v2/metrics/mbean/#{CGI.escape(metric)} 2> /dev/null |awk -F"," '{for (i = 1; i <= NF; i++) { print $i } }' |grep QueueSize |awk -F ":" '{ print $2 }')
           queue_size = Integer(result.stdout.chomp)
         end
       end

--- a/acceptance/tests/security/cert_whitelist.rb
+++ b/acceptance/tests/security/cert_whitelist.rb
@@ -21,7 +21,7 @@ test_name "certificate whitelisting" do
                  "--cacert #{ssldir}/certs/ca.pem " +
                  "--cert #{ssldir}/certs/#{dbname}.pem " +
                  "--key #{ssldir}/private_keys/#{dbname}.pem "+
-                 "https://#{dbname}:8081/v1/metrics/mbeans " +
+                 "https://#{dbname}:8081/v2/metrics/mbeans " +
                  "-o /dev/null"
     actual_status_code = stdout.chomp
     assert_equal expected_status_code.to_s, actual_status_code, "Reqs from #{dbname} with whitelist '#{whitelist}' should return #{expected_status_code}, not #{actual_status_code}"

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -70,7 +70,7 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
     query_param = CGI.escape(query.to_pson)
 
     begin
-      response = http_get(request, "/v1/nodes?query=#{query_param}", headers)
+      response = http_get(request, "/v2/nodes?query=#{query_param}", headers)
       log_x_deprecation_header(response)
 
       if response.is_a? Net::HTTPSuccess

--- a/puppet/lib/puppet/indirector/resource/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/resource/puppetdb.rb
@@ -24,7 +24,7 @@ class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
     query_param = CGI.escape(expr.to_pson)
 
     begin
-      response = http_get(request, "/v1/resources?query=#{query_param}", headers)
+      response = http_get(request, "/v2/resources?query=#{query_param}", headers)
       log_x_deprecation_header(response)
 
       unless response.is_a? Net::HTTPSuccess

--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -4,7 +4,7 @@ require 'digest'
 
 module Puppet::Util::Puppetdb
 
-  CommandsUrl = "/v1/commands"
+  CommandsUrl = "/v2/commands"
 
   CommandReplaceCatalog = "replace catalog"
   CommandReplaceFacts = "replace facts"

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -173,7 +173,7 @@ describe Puppet::Node::Facts::Puppetdb do
       response.stubs(:body).returns '[]'
 
       subject.expects(:http_get).with do |_,url,_|
-        url.should == "/v1/nodes?query=#{query}"
+        url.should == "/v2/nodes?query=#{query}"
       end.returns response
 
       search_facts(args)
@@ -192,7 +192,7 @@ describe Puppet::Node::Facts::Puppetdb do
       response.stubs(:body).returns '[]'
 
       subject.expects(:http_get).with do |_,url,_|
-        url.should == "/v1/nodes?query=#{query}"
+        url.should == "/v2/nodes?query=#{query}"
       end.returns response
 
       search_facts(args)
@@ -209,7 +209,7 @@ describe Puppet::Node::Facts::Puppetdb do
       response.stubs(:body).returns '[]'
 
       subject.expects(:http_get).with do |_,url,_|
-        url.should == "/v1/nodes?query=#{query}"
+        url.should == "/v2/nodes?query=#{query}"
       end.returns response
 
       search_facts(args)
@@ -226,7 +226,7 @@ describe Puppet::Node::Facts::Puppetdb do
       response.stubs(:body).returns '[]'
 
       subject.expects(:http_get).with do |_,url,_|
-        url.should == "/v1/nodes?query=#{query}"
+        url.should == "/v2/nodes?query=#{query}"
       end.returns response
 
       search_facts(args)
@@ -249,7 +249,7 @@ describe Puppet::Node::Facts::Puppetdb do
         response.stubs(:body).returns '[]'
 
         subject.expects(:http_get).with do |_,url,_|
-          url.should == "/v1/nodes?query=#{query}"
+          url.should == "/v2/nodes?query=#{query}"
         end.returns response
 
         search_facts(args)

--- a/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
@@ -81,7 +81,7 @@ describe Puppet::Resource::Puppetdb do
 
         Net::HTTP.any_instance.stubs(:get).with do |uri, headers|
           path, query_string = uri.split('?query=')
-          path == '/v1/resources' and PSON.load(CGI.unescape(query_string)) == query
+          path == '/v2/resources' and PSON.load(CGI.unescape(query_string)) == query
         end.returns response
       end
 

--- a/src/com/puppetlabs/puppetdb/command.clj
+++ b/src/com/puppetlabs/puppetdb/command.clj
@@ -223,7 +223,7 @@
            body    (format "checksum=%s&payload=%s"
                            (pl-utils/utf8-string->sha1 message)
                            (url-encode message))
-           url     (format "http://%s:%s/v1/commands" host port)]
+           url     (format "http://%s:%s/v2/commands" host port)]
        (client/post url {:body               body
                          :throw-exceptions   false
                          :content-type       :x-www-form-urlencoded

--- a/test/com/puppetlabs/puppetdb/test/http/server.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/server.clj
@@ -11,10 +11,10 @@
 
 (deftest method-not-allowed
   (testing "provides a useful error message"
-    (let [request (header (request :post "/v1/nodes") "Accept" c-t)
+    (let [request (header (request :post "/v2/nodes") "Accept" c-t)
           {:keys [status body]} (*app* request)]
       (is (= status pl-http/status-bad-method))
-      (is (= body "The POST method is not allowed for /v1/nodes")))))
+      (is (= body "The POST method is not allowed for /v2/nodes")))))
 
 (deftest resource-requests
   (testing "/ redirects to the dashboard"


### PR DESCRIPTION
This commit should update all of the URLs that were still pointing
to v1 to point at v2, except for the test code where we are
explicitly testing the v1 endpoints for backward compatibility.
