### PR TITLE
Reduce DB connection pool partition count

### DIFF
--- a/src/com/puppetlabs/jdbc.clj
+++ b/src/com/puppetlabs/jdbc.clj
@@ -108,8 +108,8 @@
            stats log-statements log-slow-statements
            conn-max-age conn-keep-alive]
     :or   {partition-conn-min  1
-           partition-conn-max  10
-           partition-count     5
+           partition-conn-max  50
+           partition-count     1
            stats               true
            ;; setting this to a String value, because that's what it would
            ;;  be in the config file and we're manually converting it to a boolean


### PR DESCRIPTION
We defaulted to creating 5 partitions in our connection pooling code.
Partitions are useful only inasmuch as they reduce lock contention when
attempting to acquire a new connection. Even in high-throughput
environments, we are never bottlenecked on connection acquisition.

By defaulting to 1 partition, we reduce the number of bookkeeping
threads required. Each partition requires 5 bookkeeping threads, so by
reducing the partition count to 1 we eliminate 20 threads, and save
about 20M of resident memory on users systems.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
