### PR TITLE
Don't store classes or tags for catalogs

### DIFF
--- a/src/com/puppetlabs/puppetdb/catalog.clj
+++ b/src/com/puppetlabs/puppetdb/catalog.clj
@@ -16,8 +16,8 @@
 ;;    `Class[Foobar]`, as opposed to something like
 ;;    `{"type" "Class" "title" "Foobar"}`
 ;;
-;; 2. Tags and classes are represented as lists (and may contain
-;;    duplicates) instead of sets
+;; 2. Tags are represented as lists (and may contain duplicates)
+;;    instead of sets
 ;;
 ;; 3. Resources are represented as a list instead of a map, making
 ;;    operations that need to correlate against specific resources
@@ -80,8 +80,6 @@
 ;;     {:certname    "..."
 ;;      :api-version "..."
 ;;      :version     "..."
-;;      :classes     #("class1", "class2", ...)
-;;      :tags        #("tag1", "tag2", ...)
 ;;      :resources   {<resource-spec> <resource>
 ;;                    <resource-spec> <resource>
 ;;                    ...}
@@ -139,21 +137,12 @@
 ;; ## Misc normalization routines
 
 (defn transform-tags
-  "Turns an object's (either catalog or resource) list of tags into a set of
-  strings."
+  "Turns a resource's list of tags into a set of strings."
   [{:keys [tags] :as o}]
   {:pre [tags
          (every? string? tags)]
    :post [(set? (:tags %))]}
   (update-in o [:tags] set))
-
-(defn transform-classes
-  "Turns the catalog's list of classes into a set of strings."
-  [{:keys [classes] :as catalog}]
-  {:pre [classes
-         (every? string? classes)]
-   :post [(set? (:classes %))]}
-  (update-in catalog [:classes] set))
 
 ;; ## Resource normalization
 
@@ -263,14 +252,12 @@
   (comp
     transform-edges
     transform-resources
-    transform-classes
-    transform-tags
     transform-metadata
     collapse))
 
 (def validate
   "Applies every validation step to the catalog."
-  (comp validate-edges validate-resources validate-tags))
+  (comp validate-edges validate-resources))
 
 ;; ## Deserialization
 ;;

--- a/src/com/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/com/puppetlabs/puppetdb/scf/migrate.clj
@@ -183,6 +183,13 @@
         "CREATE INDEX idx_catalog_resources_tags_gin ON catalog_resources USING gin(tags)")
       (log/warn (format "Version %s of PostgreSQL is too old to support fast tag searches; skipping GIN index on tags. For reliability and performance reasons, consider upgrading to the latest stable version." (string/join "." (sql-current-connection-database-version)))))))
 
+(defn drop-classes-and-tags
+  "Removes the `classes` and `tags` tables, as this information can be derived
+  from resources."
+  []
+  (sql/drop-table :classes)
+  (sql/drop-table :tags))
+
 ;; The available migrations, as a map from migration version to migration
 ;; function.
 (def migrations
@@ -190,7 +197,8 @@
    2 allow-node-deactivation
    3 add-catalog-timestamps
    4 add-certname-facts-metadata-table
-   5 add-missing-indexes})
+   5 add-missing-indexes
+   6 drop-classes-and-tags})
 
 (defn schema-version
   "Returns the current version of the schema, or 0 if the schema

--- a/test/com/puppetlabs/puppetdb/test/catalog.clj
+++ b/test/com/puppetlabs/puppetdb/test/catalog.clj
@@ -176,8 +176,7 @@
 (deftest complete-transformation
   (catalog-before-and-after
     {:data
-     {:classes ["settings"],
-      :edges [{:relationship "contains",
+     {:edges [{:relationship "contains",
                :source {:title "main", :type "Class"},
                :target {:title "/tmp/foo", :type "File"}}
               {:relationship "contains",
@@ -254,7 +253,6 @@
                    :tags ["file" "class"],
                    :title "/tmp/quux",
                    :type "File"}],
-      :tags ["settings"],
       :version 1330995750},
      :document_type "Catalog",
      :metadata {:api_version 1}}
@@ -262,7 +260,6 @@
     {:certname "nick-lewis.puppetlabs.lan",
      :api-version 1,
      :puppetdb-version 1,
-     :classes #{"settings"},
      :edges #{{:source {:title "/tmp/baz", :type "File"},
                :target {:title "/tmp/bar", :type "File"},
                :relationship :required-by}
@@ -346,5 +343,4 @@
                   :tags #{"class" "file"},
                   :title "/tmp/quux",
                   :type "File"}},
-     :tags #{"settings"},
      :version "1330995750"}))

--- a/test/com/puppetlabs/puppetdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/storage.clj
@@ -167,14 +167,6 @@
         (is (= (query-to-vec ["SELECT cr.certname, c.api_version, c.catalog_version FROM catalogs c, certname_catalogs cr WHERE cr.catalog=c.hash"])
               [{:certname certname :api_version 1 :catalog_version "123456789"}])))
 
-      (testing "should contain a complete tags list"
-        (is (= (query-to-vec ["SELECT name FROM tags ORDER BY name"])
-              [{:name "class"} {:name "foobar"}])))
-
-      (testing "should contain a complete classes list"
-        (is (= (query-to-vec ["SELECT name FROM classes ORDER BY name"])
-              [{:name "baz"} {:name "foobar"}])))
-
       (testing "should contain a complete edges list"
         (is (= (query-to-vec [(str "SELECT r1.type as stype, r1.title as stitle, r2.type as ttype, r2.title as ttitle, e.type as etype "
                                 "FROM edges e, catalog_resources r1, catalog_resources r2 "
@@ -271,12 +263,6 @@
       (let [hash (add-catalog! catalog)]
         (delete-catalog! hash))
 
-      (is (= (query-to-vec ["SELECT * FROM tags"])
-            []))
-
-      (is (= (query-to-vec ["SELECT * FROM classes"])
-            []))
-
       (is (= (query-to-vec ["SELECT * FROM edges"])
             []))
 
@@ -311,18 +297,6 @@
       ;; anymore
       (is (= (query-to-vec ["SELECT certname FROM certname_catalogs ORDER BY certname"])
             [{:certname "myhost2.mydomain.com"}]))
-
-      ;; no tags for myhost
-      (is (= (query-to-vec [(str "SELECT t.name FROM tags t, certname_catalogs cc "
-                              "WHERE t.catalog=cc.catalog AND cc.certname=?")
-                            certname])
-            []))
-
-      ;; no classes for myhost
-      (is (= (query-to-vec [(str "SELECT c.name FROM classes c, certname_catalogs cc "
-                              "WHERE c.catalog=cc.catalog AND cc.certname=?")
-                            certname])
-            []))
 
       ;; no edges for myhost
       (is (= (query-to-vec [(str "SELECT COUNT(*) as c FROM edges e, certname_catalogs cc "


### PR DESCRIPTION
These are unnecessary, as they are simply the union of all classes/tags,
which can be computed based on the resources. They don't really seem to
have a use, anyway, and we never allowed anyone to query or retrieve
them.
