### PR TITLE
Increase timeout for waiting for puppetdb to start up

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -166,9 +166,10 @@ module PuppetDBExtensions
     # acceptance nodes (they run puppet master from the CLI).
     manifest = <<-EOS
     class { 'puppetdb::master::config':
-      puppetdb_server   => '#{database.node_name}',
-      puppetdb_version  => '#{version}',
-      restart_puppet    => false,
+      puppetdb_server           => '#{database.node_name}',
+      puppetdb_version          => '#{version}',
+      puppetdb_startup_timeout  => 120,
+      restart_puppet            => false,
     }
     EOS
     apply_manifest_on(host, manifest)


### PR DESCRIPTION
This is just a cherry-pick from the 1.0.x branch; it reduces the likelihood that we will see acceptance failures that are due to us not waiting long enough for puppetdb to start up.
