### PR TITLE
Configure embedded broker with KahaDB recovery opts

### DIFF
--- a/src/com/puppetlabs/mq.clj
+++ b/src/com/puppetlabs/mq.clj
@@ -97,6 +97,8 @@
                (set-store-usage! (:store-usage config))
                (set-temp-usage!  (:temp-usage config)))
           db (doto (.getPersistenceAdapter mq)
+               (.setIgnoreMissingJournalfiles true)
+               (.setArchiveCorruptedIndex true)
                (.setCheckForCorruptJournalFiles true)
                (.setChecksumJournalFiles true))]
       mq)))

--- a/test/com/puppetlabs/test/mq.clj
+++ b/test/com/puppetlabs/test/mq.clj
@@ -49,10 +49,12 @@
                       {:store-usage size-megs
                        :temp-usage  size-megs})]
       (is (instance? BrokerService broker))
-      (is (-> broker (.getPersistenceAdapter) (.isCheckForCorruptJournalFiles)))
-      (is (-> broker (.getPersistenceAdapter) (.isChecksumJournalFiles)))
-      (is (= size-bytes (-> broker (.getSystemUsage) (.getStoreUsage) (.getLimit))))
-      (is (= size-bytes (-> broker (.getSystemUsage) (.getTempUsage) (.getLimit)))))))
+      (is (.. broker (getPersistenceAdapter) (isIgnoreMissingJournalfiles)))
+      (is (.. broker (getPersistenceAdapter) (isArchiveCorruptedIndex)))
+      (is (.. broker (getPersistenceAdapter) (isCheckForCorruptJournalFiles)))
+      (is (.. broker (getPersistenceAdapter) (isChecksumJournalFiles)))
+      (is (= size-bytes (.. broker (getSystemUsage) (getStoreUsage) (getLimit))))
+      (is (= size-bytes (.. broker (getSystemUsage) (getTempUsage) (getLimit)))))))
 
 (deftest json-publish
   (testing "publish-json!"


### PR DESCRIPTION
The broker can automatically recover from corrupted journal files, but
only if a few additional options are enabled:

http://activemq.apache.org/kahadb.html

This patchset changes the broker defaults to supply the correct recovery
options.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
