### PR TITLE
Add update-server URL to check-for-updates error message

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -125,7 +125,7 @@
   (let [{:keys [version newer link]} (try
                                        (update-info update-server)
                                        (catch Throwable e
-                                         (log/debug e "Could not retrieve update information")))
+                                         (log/debug e (format "Could not retrieve update information (%s)" update-server))))
         link-str                     (if link
                                        (format "Visit %s for details." link)
                                        "")


### PR DESCRIPTION
I was running into an issue where, when my server was starting up,
it was failing to connect to the server on `check-for-updates`.
The error message that showed up in the logs wasn't entirely
intuitive; adding the URL to it makes it at least a bit more clear.
