### PR TITLE
(#17397) DB pool setup fails with numeric username/pw

### DIFF
--- a/src/com/puppetlabs/jdbc.clj
+++ b/src/com/puppetlabs/jdbc.clj
@@ -129,8 +129,8 @@
                           (.setJdbcUrl (str "jdbc:" subprotocol ":" subname))
                           (.setConnectionHook (connection-hook log-statements? log-slow-statements)))]
     ;; configurable without default
-    (when username (.setUsername config username))
-    (when password (.setPassword config password))
+    (when username (.setUsername config (str username)))
+    (when password (.setPassword config (str password)))
     (when log-statements? (.setLogStatementsEnabled config log-statements?))
     (when log-slow-statements
       (.setQueryExecuteTimeLimit config log-slow-statements (TimeUnit/SECONDS)))

--- a/test/com/puppetlabs/test/jdbc.clj
+++ b/test/com/puppetlabs/test/jdbc.clj
@@ -32,6 +32,14 @@
 
 (use-fixtures :each with-test-database)
 
+(deftest pool-construction
+  (testing "can construct pool with numeric usernames and passwords"
+    (let [pool (-> (test-db)
+                   (assoc :username 1234 :password 1234)
+                   (subject/pooled-datasource))]
+      (subject/with-transacted-connection pool
+        (sql/create-table :test [:foo "INT"]))
+      (.close (:datasource pool)))))
 
 (deftest query-to-vec
   (testing "query string only"


### PR DESCRIPTION
Our config file parsing code tries to be clever and automatically
convert things that look like numbers into proper numbers. That's never
been a problem. However, interop with Java requires specific types
(nothing is auto-coerced or converted).

This bug happens during `make-connection-pool`. If the username or
password is numeric, when parsing the configuration file they're turned
into numbers. Then when we interop with BoneCP, we get an error because
we're passing in numbers when strings are expected.

As these are the only 2 possible properties that may be auto-converted
to numbers, simply coercing them to the correct type is sufficient.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
