### PR TITLE
Add notes about the PuppetDB module to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,17 @@ greater flexibility and control over bandwidth and clients.
 
 ## Installation
 
+### Installing using the PuppetDB module
+
+You can install any combination of PuppetDB, PostgreSQL, and the PuppetDB
+terminuses for your Puppet master using the PuppetDB module from the forge:
+
+http://forge.puppetlabs.com/puppetlabs/puppetdb
+
+For notes on how to use the module, take a look at the [README_GETTING_STARTED.md](https://github.com/puppetlabs/puppetlabs-puppetdb/blob/master/README_GETTING_STARTED.md)
+file in the github repo.  The module also includes some sample manifests in
+the `tests` that show you the basic usage.
+
 ### Installing from system packages
 
 If installing from a distribution maintained package, such as those
@@ -245,7 +256,7 @@ Other useful commands:
 
 * `lein docs` to build docs in `docs/uberdoc.html`
 
-To use the Puppet module from source, add the Ruby code to $RUBYLIB.
+To use the PuppetDB terminuses from source, add the Ruby code to $RUBYLIB.
 
     $ export RUBYLIB=$RUBYLIB:`pwd`/puppet/lib
 


### PR DESCRIPTION
I was in the README for another issue, and figured I'd throw this
in while I was there.

Our installation docs did not include any mention of using the
forge module to install; this commit adds some brief notes and
links.
