### PR TITLE
Restrict "not" to only a single argument

### DIFF
--- a/spec/operators.md
+++ b/spec/operators.md
@@ -25,12 +25,10 @@ supplied regexp must follow are backend-dependent:
 
 ### Boolean operators
 
-Each of these operators accepts a list of expressions, and applies a logical
-operation to the results of those expressions.
-
-`and`: True if every expression returns true
-`or`: True if any expression returns true
-`not`: True if no expression returns true
+The `and` and `or` operators accept a list of expressions, and apply a logical
+operation to the results of those expressions. The `not` operator accepts a
+*single* expression, and negates its value (returning true if the expression is
+false, and vice versa).
 
 ### Subqueries
 

--- a/spec/resource.md
+++ b/spec/resource.md
@@ -18,10 +18,10 @@ Queries for resources must conform to the following format:
 
 The `query` parameter is described by the following grammar:
 
-    query: [ {type} {query}+ ] | [ {match} {field} {value} ]
+    query: [ {bool} {query}+ ] | [ "not" {query} ] | [ {match} {field} {value} ]
     field:  string | [ string+ ]
     value:  string
-    type:   "or" | "and" | "not"
+    bool:   "or" | "and"
     match:  "=" | "~"
 
 `field` may be any of:

--- a/test/com/puppetlabs/puppetdb/test/http/v1/resources.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v1/resources.clj
@@ -111,6 +111,14 @@ to the result of the form supplied to this method."
                                 ["=" ["node" "name"] "one.local"]
                                 ["=" "type" "File"]]
                                #{foo1}]
+                              [["or"
+                                ["=" ["node" "name"] "one.local"]
+                                ["=" "type" "File"]]
+                               #{foo1 bar1}]
+                              [["not"
+                                ["=" ["node" "name"] "one.local"]
+                                ["=" "type" "File"]]
+                               #{bar2}]
                               [["=" ["parameter" "ensure"] "file"] #{foo1 bar1}]
                               [["=" ["parameter" "owner"] "root"] #{foo1 bar1}]
                               [["=" ["parameter" "acl"] ["john:rwx" "fred:rwx"]] #{foo1 bar1}]]]

--- a/test/com/puppetlabs/puppetdb/test/http/v2/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v2/facts.clj
@@ -212,7 +212,13 @@
         (let [request (make-request "/v2/facts" {"query" (json/generate-string [])})
               {:keys [status body]} (*app* request)]
           (is (= status pl-http/status-bad-request))
-          (is (= body "[] is not well-formed: queries must contain at least one operator")))))))
+          (is (= body "[] is not well-formed: queries must contain at least one operator"))))
+
+      (testing "'not' with too many arguments"
+        (let [request (make-request "/v2/facts" {"query" (json/generate-string ["not" ["=" "name" "ipaddress"] ["=" "name" "operatingsystem"]])})
+              {:keys [status body]} (*app* request)]
+          (is (= status pl-http/status-bad-request))
+          (is (= body "'not' takes exactly one argument, but 2 were supplied")))))))
 
 (defn is-query-result
   [query results]

--- a/test/com/puppetlabs/puppetdb/test/query/resource.clj
+++ b/test/com/puppetlabs/puppetdb/test/query/resource.clj
@@ -184,7 +184,7 @@
                   ["=" ["parameter" "hash"] {"bar" 10}] []
                   ;; testing not operations
                   ["not" ["=" "type" "File"]] [foo2 foo3 bar3 foo5 bar5 foo6 foo7 foo8]
-                  ["not" ["=" "type" "File"] ["=" "type" "Notify"]] [foo6 foo7]
+                  ["not" ["=" "type" "Notify"]] [foo1 bar1 foo4 foo6 foo7]
                   ;; and, or
                   ["and" ["=" "type" "File"] ["=" "title" "/etc/passwd"]] [foo1 bar1]
                   ["and" ["=" "type" "File"] ["=" "type" "Notify"]] []
@@ -223,10 +223,20 @@
 
 (deftest query-resources-with-extra-FAIL
   (testing "combine terms without arguments"
-    (doseq [op ["and" "AND" "or" "OR" "AnD" "Or" "not" "NOT" "NoT"]]
+    (doseq [op ["and" "AND" "or" "OR" "AnD" "Or"]]
       (is (thrown-with-msg? IllegalArgumentException #"requires at least one term"
             (s/query-resources (s/v2-query->sql [op]))))
       (is (thrown-with-msg? IllegalArgumentException (re-pattern (str "(?i)" op))
+            (s/query-resources (s/v2-query->sql [op]))))))
+
+  (testing "'not' term without arguments in v1"
+    (doseq [op ["not" "NOT" "NoT"]]
+      (is (thrown-with-msg? IllegalArgumentException #"requires at least one term"
+            (s/query-resources (s/v1-query->sql [op]))))))
+
+  (testing "'not' term without arguments in v2"
+    (doseq [op ["not" "NOT" "NoT"]]
+      (is (thrown-with-msg? IllegalArgumentException #"'not' takes exactly one argument, but 0 were supplied"
             (s/query-resources (s/v2-query->sql [op]))))))
 
   (testing "bad query operators"


### PR DESCRIPTION
Multiple arguments to "not" is confusing and not particularly useful. So
now "not" will only take a single argument, and will negate its value
(for v2 only, v1 remains unchanged). The old behavior can still be
achieved through `["not" ["or" <query> <query> <query> ...]]`.
