### PR TITLE
Standardize node query

### DIFF
--- a/src/com/puppetlabs/puppetdb/http/v1/node.clj
+++ b/src/com/puppetlabs/puppetdb/http/v1/node.clj
@@ -45,7 +45,7 @@
     (with-transacted-connection db
       (let [query (if query (json/parse-string query true))
             sql   (node/query->sql query)
-            nodes (node/search sql)]
+            nodes (node/query-nodes sql)]
         (pl-http/json-response nodes)))
     (catch com.fasterxml.jackson.core.JsonParseException e
       (pl-http/error-response e))

--- a/src/com/puppetlabs/puppetdb/query.clj
+++ b/src/com/puppetlabs/puppetdb/query.clj
@@ -147,6 +147,8 @@
 
 (def resource-columns #{"certname" "catalog" "resource" "type" "title" "tags" "exported" "sourcefile" "sourceline"})
 
+(def node-columns #{"name" "deactivated"})
+
 (def selectable-columns
   {:resource resource-columns
    :fact fact-columns})
@@ -232,6 +234,15 @@
   (let [{:keys [where joins params]} (compile-term ops query)
         join-stmt (build-join-expr :fact joins)
         sql (format "SELECT %s FROM certname_facts %s WHERE %s" (string/join ", " (map #(str "certname_facts." %) fact-columns)) join-stmt where)]
+    (apply vector sql params)))
+
+(defn node-query->sql
+  "Compile a node query, returning a vector containing the SQL and parameters
+  for the query. All node columns are selected, and no order is applied."
+  [ops query]
+  {:post [valid-jdbc-query? %]}
+  (let [{:keys [where params]} (compile-term ops query)
+        sql (format "SELECT %s FROM certnames WHERE %s" (string/join ", " node-columns) where)]
     (apply vector sql params)))
 
 (defn compile-resource-equality-v2
@@ -365,6 +376,7 @@
 
            :else (throw (IllegalArgumentException.
                           (str path " is not a valid operand for regexp comparison"))))))
+
 (defn compile-fact-inequality
   "Compile a numeric inequality for a fact query (> < >= <=). The `value` for
   comparison must be either a number or the string representation of a number.
@@ -383,6 +395,37 @@
 
            :else (throw (IllegalArgumentException.
                          (str path " is not a queryable object for facts"))))
+    (throw (IllegalArgumentException.
+            (format "Value %s must be a number for %s comparison." value op)))))
+
+(defn compile-node-equality
+  "Compile an equality operator for nodes. This can either be for the value of
+  a specific fact, or based on node activeness."
+  [path value]
+  {:post [(map? %)
+          (string? (:where %))]}
+  (match [path]
+         [["fact" (name :when string?)]]
+         {:where  "certnames.name IN (SELECT cf.certname FROM certname_facts cf WHERE cf.name = ? AND cf.value = ?)"
+          :params [name (str value)]}
+         [["node" "active"]]
+         {:where (format "certnames.deactivated IS %s" (if value "NULL" "NOT NULL"))}
+
+         :else (throw (IllegalArgumentException.
+                        (str path " is not a queryable object for nodes")))))
+
+(defn compile-node-inequality
+  [op path value]
+  {:post [(map? %)
+          (string? (:where %))]}
+  (if-let [number (parse-number (str value))]
+    (match [path]
+           [["fact" (name :when string?)]]
+           {:where  (format "certnames.name IN (SELECT cf.certname FROM certname_facts cf WHERE cf.name = ? AND %s %s ?)" (sql-as-numeric "cf.value") op)
+            :params [name number]}
+
+           :else (throw (IllegalArgumentException.
+                         (str path " is not a queryable object for nodes"))))
     (throw (IllegalArgumentException.
             (format "Value %s must be a number for %s comparison." value op)))))
 
@@ -444,3 +487,15 @@
       ;; select-resources uses a different set of operators-v2, of course
       (= op "select-resources") (partial resource-query->sql resource-operators-v2)
       (= op "select-facts") (partial fact-query->sql fact-operators-v2))))
+
+(defn node-operators
+  "Maps v1 node query operators to the functions implementing them. Returns nil
+  if the operator isn't known."
+  [op]
+  (let [op (string/lower-case op)]
+    (cond
+      (= op "=") compile-node-equality
+      (#{">" "<" ">=" "<="} op) (partial compile-node-inequality op)
+      (= op "and") (partial compile-and node-operators)
+      (= op "or") (partial compile-or node-operators)
+      (= op "not") (partial compile-not-v1 node-operators))))

--- a/src/com/puppetlabs/puppetdb/query/node.clj
+++ b/src/com/puppetlabs/puppetdb/query/node.clj
@@ -9,25 +9,9 @@
   (:use clojureql.core
         [com.puppetlabs.puppetdb.scf.storage :only [db-serialize sql-array-query-string sql-as-numeric]]
         [clojure.core.match :only [match]]
+        [com.puppetlabs.puppetdb.query :only [node-query->sql node-operators]]
         [com.puppetlabs.jdbc :only [query-to-vec with-transacted-connection valid-jdbc-query?]]
         [com.puppetlabs.utils :only [parse-number]]))
-
-(defmulti compile-term
-  "Recursively compile a query into a structured map reflecting the terms of
-  the query."
-  (fn [query]
-    (let [operator (string/lower-case (first query))]
-      (cond
-       (#{">" "<" ">=" "<="} operator) :numeric-comparison
-       (#{"and" "or"} operator) :connective
-       :else operator))))
-
-(defn build-join-expr
-  "Builds an inner join expression between catalog_resources and the given
-  `table`. There aren't any actual possibilities for this currently, but the
-  function is left here to aid in possible unification of various query paths."
-  [table]
-  (condp = table))
 
 (defn query->sql
   "Converts a vector-structured `query` to a corresponding SQL query which will
@@ -35,95 +19,16 @@
   [query]
   {:pre  [((some-fn nil? sequential?) query)]
    :post [(valid-jdbc-query? %)]}
-  (if query
-    (let [{:keys [where joins params]} (compile-term query)
-          join-expr                    (->> joins
-                                            (map build-join-expr)
-                                            (string/join " "))]
-      (apply vector (format "%s WHERE %s" join-expr where) params))
-    [""]))
+  (let [[subselect & params] (if query
+                               (node-query->sql node-operators query)
+                               ["SELECT name, deactivated FROM certnames"])
+        sql (format "SELECT name AS certname FROM (%s) subquery1 ORDER BY name ASC" subselect)]
+    (apply vector sql params)))
 
-(defn search
+(defn query-nodes
   "Search for nodes satisfying the given SQL filter."
-  [[sql & params :as filter-expr]]
+  [filter-expr]
   {:pre  [(valid-jdbc-query? filter-expr)]
    :post [(vector? %)
           (every? string? %)]}
-  (let [query (format "SELECT name AS certname FROM certnames %s" sql)
-        nodes (apply query-to-vec query params)]
-    (-> (map :certname nodes)
-        (sort)
-        (vec))))
-
-(defn fetch-all
-  "Retrieves all nodes from the database."
-  []
-  (search [""]))
-
-(defmethod compile-term "="
-  [[op path value :as term]]
-  {:post [(map? %)
-          (string? (:where %))]}
-  (let [count (count term)]
-    (if (not= 3 count)
-      (throw (IllegalArgumentException.
-              (format "%s requires exactly two arguments, but we found %d" op (dec count))))))
-  (match [path]
-         [["fact" (name :when string?)]]
-         {:where  "certnames.name IN (SELECT cf.certname FROM certname_facts cf WHERE cf.name = ? AND cf.value = ?)"
-          :params [name (str value)]}
-         [["node" "active"]]
-         {:where (format "certnames.deactivated IS %s" (if value "NULL" "NOT NULL"))}
-
-         :else (throw (IllegalArgumentException.
-                       (str term " is not a valid query term")))))
-
-(defmethod compile-term :numeric-comparison
-  [[op path value :as term]]
-  {:post [(map? %)
-          (string? (:where %))]}
-  (let [count (count term)]
-    (if (not= 3 count)
-      (throw (IllegalArgumentException.
-              (format "%s requires exactly two arguments, but we found %d" op (dec count))))))
-  (if-let [number (parse-number (str value))]
-    (match [path]
-           [["fact" (name :when string?)]]
-           {:where  (format "certnames.name IN (SELECT cf.certname FROM certname_facts cf WHERE cf.name = ? AND %s %s ?)" (sql-as-numeric "cf.value") op)
-            :params [name number]}
-
-           :else (throw (IllegalArgumentException.
-                         (str term " is not a valid query term"))))
-    (throw (IllegalArgumentException.
-            (format "Value %s must be a number for %s comparison." value op)))))
-
-;; Join a set of predicates together with an 'and' relationship,
-;; performing an intersection (via natural join).
-(defmethod compile-term :connective
-  [[op & terms]]
-  {:pre  [(every? vector? terms)]
-   :post [(string? (:where %))]}
-  (when (empty? terms)
-    (throw (IllegalArgumentException. (str op " requires at least one term"))))
-  (let [terms  (map compile-term terms)
-        joins  (distinct (mapcat :joins terms))
-        params (mapcat :params terms)
-        query  (->> (map :where terms)
-                    (map #(format "(%s)" %))
-                    (string/join (format " %s " (string/upper-case op))))]
-    {:joins  joins
-     :where  query
-     :params params}))
-
-;; Join a set of predicates together with a 'not' relationship,
-;; performing a set difference. This will reject resources matching
-;; _any_ child predicate.
-(defmethod compile-term "not"
-  [[op & terms]]
-  {:pre  [(every? vector? terms)]
-   :post [(string? (:where %))]}
-  (when (empty? terms)
-    (throw (IllegalArgumentException. (str op " requires at least one term"))))
-  (let [term  (compile-term (cons "or" terms))
-        query (format "NOT (%s)" (:where term))]
-    (assoc term :where query)))
+  (mapv :certname (query-to-vec filter-expr)))

--- a/test/com/puppetlabs/puppetdb/test/query/node.clj
+++ b/test/com/puppetlabs/puppetdb/test/query/node.clj
@@ -10,26 +10,13 @@
 
 (use-fixtures :each with-test-db)
 
-(deftest fetch-all
-  (sql/insert-records
-   :certnames
-   {:name "foo"}
-   {:name "bar"}
-   {:name "baz"}
-   {:name "quux"}
-   {:name "something"})
-
-  (testing "should return all the certnames in the database"
-    (is (= (node/fetch-all)
-           ["bar" "baz" "foo" "quux" "something"])) ))
-
 (defn retrieve-nodes
   "Search for nodes based on an uncompiled query."
   [filter-expr]
   (let [query (node/query->sql filter-expr)]
-    (node/search query)))
+    (node/query-nodes query)))
 
-(deftest search
+(deftest query-nodes
   (let [names     #{"node_a" "node_b" "node_c" "node_d" "node_e"}
         timestamp (to-timestamp (now))]
     (doseq [name names]


### PR DESCRIPTION
This moves the node query operators into query.clj, and renames some things to make it more similar to the resource and facts query functions.
