### PR TITLE
Add HTTP endpoint for /facts/:name/:value

### DIFF
--- a/spec/facts.md
+++ b/spec/facts.md
@@ -64,6 +64,27 @@ name. There must be an `Accept` header containing `application/json`.
      {"certname": "b.example.com", "name": "operatingsystem", "value": "Redhat"},
      {"certname": "c.example.com", "name": "operatingsystem", "value": "Ubuntu"}]
 
+#### `GET /v2/facts/:name/:value`
+
+This will return all facts for all nodes with the indicated name and
+value. There must be an `Accept` header containing `application/json`.
+
+##### Parameters
+
+  `query`: Optional. A JSON array containing the query in prefix
+  notation. The syntax and semantics are identical to the `query`
+  parameter for the `/facts` route, mentioned above. When supplied,
+  the query is assumed to supply _additional_ criteria that can be
+  used to return a _subset_ of the information normally returned by
+  this route.
+
+##### Examples
+
+    curl -X GET -H 'Accept: application/json' http://puppetdb:8080/v2/facts/operatingsystem/Debian
+
+    [{"certname": "a.example.com", "name": "operatingsystem", "value": "Debian"},
+     {"certname": "b.example.com", "name": "operatingsystem", "value": "Debian}]
+
 ### Request
 
 All requests must accept `application/json`.

--- a/spec/node.md
+++ b/spec/node.md
@@ -62,6 +62,65 @@ not. There must be an `Accept` header containing `application/json`.
 The response is the same format as for the [/v2/status](status.md)
 endpoint.
 
+#### `GET /v2/nodes/:node/facts`
+
+This will return the facts for the given node. Facts from deactivated
+nodes aren't included in the response. There must be an `Accept`
+header containing `application/json`.
+
+##### Parameters
+
+  `query`: Optional. A JSON array containing the query in prefix
+  notation. The syntax and semantics are identical to the `query`
+  parameter for the `/v2/facts` route. When supplied, the query is
+  assumed to supply _additional_ criteria that can be used to return a
+  _subset_ of the information normally returned by this route.
+
+##### Response format
+
+The response is the same format as for the [/v2/facts](facts.md)
+endpoint.
+
+#### `GET /v2/nodes/:node/facts/:name`
+
+This will return facts with the given name for the given node. Facts
+from deactivated nodes aren't included in the response. There must be
+an `Accept` header containing `application/json`.
+
+##### Parameters
+
+  `query`: Optional. A JSON array containing the query in prefix
+  notation. The syntax and semantics are identical to the `query`
+  parameter for the `/v2/facts` route. When supplied, the query is
+  assumed to supply _additional_ criteria that can be used to return a
+  _subset_ of the information normally returned by this route.
+
+##### Response format
+
+The response is the same format as for the [/v2/facts](facts.md)
+endpoint.
+
+
+#### `GET /v2/nodes/:node/facts/:name/:value`
+
+This will return facts with the given name and value for the given
+node. Facts from deactivated nodes aren't included in the
+response. There must be an `Accept` header containing
+`application/json`.
+
+##### Parameters
+
+  `query`: Optional. A JSON array containing the query in prefix
+  notation. The syntax and semantics are identical to the `query`
+  parameter for the `/v2/facts` route. When supplied, the query is
+  assumed to supply _additional_ criteria that can be used to return a
+  _subset_ of the information normally returned by this route.
+
+##### Response format
+
+The response is the same format as for the [/v2/facts](facts.md)
+endpoint.
+
 #### `GET /v2/nodes/:node/resources`
 
 This will return the resources for the given node. Resources from

--- a/src/com/puppetlabs/puppetdb/http/query.clj
+++ b/src/com/puppetlabs/puppetdb/http/query.clj
@@ -45,7 +45,7 @@
                    ["=" ["node" "active"] true]]
                   req))
 
-(defn restrict-query-to-fact
+(defn restrict-fact-query-to-name
   "Restrict the query parameter of the supplied request so that it
   only returns facts with the given name"
   [fact req]
@@ -53,6 +53,16 @@
    :post [(are-queries-different? req %)]}
   (restrict-query ["and"
                    ["=" "name" fact]]
+                  req))
+
+(defn restrict-fact-query-to-value
+  "Restrict the query parameter of the supplied request so that it
+  only returns facts with the given name"
+  [value req]
+  {:pre  [(string? value)]
+   :post [(are-queries-different? req %)]}
+  (restrict-query ["and"
+                   ["=" "value" value]]
                   req))
 
 (defn restrict-resource-query-to-type

--- a/src/com/puppetlabs/puppetdb/http/v2/facts.clj
+++ b/src/com/puppetlabs/puppetdb/http/v2/facts.clj
@@ -39,5 +39,8 @@
        (verify-param-exists "query")
        (verify-accepts-json))
 
+   [fact value &]
+   (comp query-app (partial http-q/restrict-fact-query-to-name fact) (partial http-q/restrict-fact-query-to-value value))
+
    [fact &]
-   (comp query-app (partial http-q/restrict-query-to-fact fact))))
+   (comp query-app (partial http-q/restrict-fact-query-to-name fact))))

--- a/test/com/puppetlabs/puppetdb/test/http/experimental/explore.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/experimental/explore.clj
@@ -147,6 +147,13 @@
          (is (= (set (map :name facts)) #{"kernel"}))
          (is (= (count facts) 2))))
 
+      (testing "/facts/<fact>/<value> should return all instances of the given fact with the given value"
+        (check-json-response
+         facts response (get-response "facts/kernel/Linux")
+         (is (= (set (map :name facts)) #{"kernel"}))
+         (is (= (set (map :value facts)) #{"Linux"}))
+         (is (= (count facts) 2))))
+
       (testing "/facts/<fact> should return [] if the fact doesn't match anything"
         (check-json-response
          facts response (get-response "facts/blahblahblah")
@@ -167,4 +174,14 @@
            facts response (get-response (format "nodes/%s/facts/kernel" host))
            (is (= (get-in (treeify-facts facts) [host "kernel"]) "Linux"))
            (is (= (set (map :certname facts)) #{host}))
+           (is (= (count facts) 1)))))
+
+      (testing "/nodes/<node>/fact/<fact>/<value> should return the given fact with the matching value for that node"
+        (doseq [host ["host1" "host2"]]
+          (check-json-response
+           facts response (get-response (format "nodes/%s/facts/kernel/Linux" host))
+           (is (= (get-in (treeify-facts facts) [host "kernel"]) "Linux"))
+           (is (= (set (map :certname facts)) #{host}))
+           (is (= (set (map :name facts)) #{"kernel"}))
+           (is (= (set (map :value facts)) #{"Linux"}))
            (is (= (count facts) 1))))))))


### PR DESCRIPTION
This will let you collect all the facts across a population that have a
particular name and value, like "give me all the facts you know about
with a name of 'operatingsystem' and a value of 'Debian'". It's an easy
way to find all the hosts with that fact, without having to do a big
query.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
