### PR TITLE
Fix json parsing for auto-deactivation of nodes during db gc

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -54,6 +54,7 @@
             [clj-time.core :as time]
             [clojure.java.jdbc :as sql]
             [clojure.tools.logging :as log]
+            [cheshire.core :as json]
             [com.puppetlabs.puppetdb.http.server :as server])
   (:use [clojure.java.io :only [file]]
         [clojure.core.incubator :only (-?>)]
@@ -115,7 +116,7 @@
         (format "sweep of stale nodes (%s day threshold)" node-ttl-days)
         (with-transacted-connection db
           (doseq [node (scf-store/stale-nodes (time/ago (time/days node-ttl-days)))]
-            (send-command! "deactivate node" 1 node)))))
+            (send-command! "deactivate node" 1 (json/generate-string node))))))
 
      (sleep))))
 


### PR DESCRIPTION
The command submission for "deactivate node" in the database
garbage collection loop was not json-serializing the node
name quite as many times as all of the other uses of that
command, so it was failing.

This commit adds in the extra JSON serialization and should
get things working again.  We might at some point want to
remove all of these seemingly redundant serializations
from all of the uses of this command, but this seemed like
the lower-impact change for the time being.
