### PR TITLE
Acceptance: disable latest-version checks during acceptance tests

### DIFF
--- a/acceptance/setup/pre_suite/60_disable_update_check.rb
+++ b/acceptance/setup/pre_suite/60_disable_update_check.rb
@@ -1,0 +1,5 @@
+test_config = PuppetDBExtensions.config
+
+step "Create file on PuppetDB server to disable version checking" do
+  on(database, "mkdir -p /var/lib/puppetdb && touch /var/lib/puppetdb/DISABLE_VERSION_CHECK")
+end

--- a/src/com/puppetlabs/puppetdb/http/version.clj
+++ b/src/com/puppetlabs/puppetdb/http/version.clj
@@ -18,7 +18,7 @@
   `version` key with the version, as well as a `newer` key which is a boolean
   specifying whether the latest version is newer than the current version."
   [{:keys [globals]}]
-  {:pre [(:update-server globals)]}
+  {:pre [(contains? globals :update-server)]}
   (let [update-server (:update-server globals)]
     (try
       (if-let [update (update-info update-server (:scf-db globals))]


### PR DESCRIPTION
Prior to this commit, our acceptance tests were generating a lot
of traffic on our update / "latest available version" server.
This commit makes a small tweak to prevent them from attempting
to check in with that server.
