### PR TITLE
Drop the non-GIN index on catalog_resources(tags)

### DIFF
--- a/src/com/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/com/puppetlabs/puppetdb/scf/migrate.clj
@@ -163,6 +163,13 @@
         "CREATE INDEX idx_catalog_resources_tags_gin ON catalog_resources USING gin(tags)")
       (log/warn (format "Version %s of PostgreSQL is too old to support fast tag searches; skipping GIN index on tags. For reliability and performance reasons, consider upgrading to the latest stable version." (string/join "." (sql-current-connection-database-version)))))))
 
+(defn drop-old-tags-index
+  "Drops the non-GIN tags index, which is never used (because nobody
+  does equality comparisons against array columns)"
+  []
+  (sql/do-commands
+   "DROP INDEX idx_catalog_resources_tags"))
+
 ;; The available migrations, as a map from migration version to migration
 ;; function.
 (def migrations
@@ -170,7 +177,8 @@
    2 allow-node-deactivation
    3 add-catalog-timestamps
    4 add-certname-facts-metadata-table
-   5 add-missing-indexes})
+   5 add-missing-indexes
+   6 drop-old-tags-index})
 
 (defn schema-version
   "Returns the current version of the schema, or 0 if the schema


### PR DESCRIPTION
The non-GIN tags index is never actually used (because nobody ever does
equality comparions on ARRAY columns). That's why we added the GIN index
in the first place, because it massively sped up tag-based queries by
actually looking inside the ARRAY column for a match.

However, I wasn't smart enough to nuke the old, non-GIN index at the
same time...this patch corrects that.

This should save people some disk space and (slightly) improve catalog
storage performance. For larger installations, the space savings could
be considerable; one user reports that old index taking close to 10GB of
disk space!

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
