### PR TITLE
Fix type for configuration-version

### DIFF
--- a/src/com/puppetlabs/puppetdb/report.clj
+++ b/src/com/puppetlabs/puppetdb/report.clj
@@ -14,7 +14,7 @@
   {:certname                 :string
    :puppet-version           :string
    :report-format            :integer
-   :configuration-version    :datetime
+   :configuration-version    :string
    :start-time               :datetime
    :end-time                 :datetime
    :resource-events          :coll})

--- a/test/com/puppetlabs/puppetdb/examples/report.clj
+++ b/test/com/puppetlabs/puppetdb/examples/report.clj
@@ -6,7 +6,7 @@
    {:certname               "foo.local"
     :puppet-version         "3.0.1"
     :report-format          3
-    :configuration-version  "123456789"
+    :configuration-version  "a81jasj123"
     :start-time             "2011-01-01T12:00:00-03:00"
     :end-time               "2011-01-01T12:10:00-03:00"
     :resource-events


### PR DESCRIPTION
The configuration-version field on reports doesn't really have
any type requirements; any string should work.  There was a bug
where it was configured in the `Report` model to be of type
`datetime`; this appears to have been working so far because
all of the strings I've passed into it have been integers, which
the clojure time library must have been interpreting as
seconds-since-epoch or something, and thus they passed the
`datetime?` check.

This commit fixes it so that the model only validates that the
input is a `string`.  Also changes the examples to use a string
that would have failed the `datetime?` test, so that the tests
actually show this issue.
