### PR TITLE
Support non-string resource property values in events

### DIFF
--- a/src/com/puppetlabs/puppetdb/query/event.clj
+++ b/src/com/puppetlabs/puppetdb/query/event.clj
@@ -2,7 +2,8 @@
 
 (ns com.puppetlabs.puppetdb.query.event
   (:require [com.puppetlabs.utils :as utils]
-            [clojure.string :as string])
+            [clojure.string :as string]
+            [cheshire.core :as json])
   (:use [com.puppetlabs.jdbc :only [query-to-vec underscores->dashes valid-jdbc-query?]]))
 
 ;; ## Resource Event query functions
@@ -44,7 +45,9 @@
                                   FROM resource_events %s")
                         sql)
         results   (map
-                    #(utils/mapkeys underscores->dashes %)
+                    #(-> (utils/mapkeys underscores->dashes %)
+                         (update-in [:old-value] json/parse-string)
+                         (update-in [:new-value] json/parse-string))
                     (query-to-vec (apply vector query params)))]
     results))
 

--- a/src/com/puppetlabs/puppetdb/report.clj
+++ b/src/com/puppetlabs/puppetdb/report.clj
@@ -27,9 +27,9 @@
    :property           { :optional? true
                          :type      :string}
    :new-value          { :optional? true
-                         :type      :string}
+                         :type      :jsonable }
    :old-value          { :optional? true
-                         :type      :string}
+                         :type      :jsonable }
    :message            { :optional? true
                          :type      :string}})
 

--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -724,6 +724,8 @@ must be supplied as the value to be matched."
   (let [report-hash         (report-identity-string report)
         resource-event-rows (map #(-> %
                                      (update-in [:timestamp] to-timestamp)
+                                     (update-in [:old-value] db-serialize)
+                                     (update-in [:new-value] db-serialize)
                                      (assoc :report report-hash)
                                      ((partial utils/mapkeys dashes->underscores)))
                                   resource-events)]

--- a/src/com/puppetlabs/validation.clj
+++ b/src/com/puppetlabs/validation.clj
@@ -1,7 +1,8 @@
 (ns com.puppetlabs.validation
   (:require [com.puppetlabs.utils :as pl-utils]
             [clojure.string :as string]
-            [clojure.set :as set]))
+            [clojure.set :as set])
+  (:use [cheshire.custom :only [JSONable]]))
 
 (defmacro defmodel
   "Defines a 'model' which can be used for validating maps of data.  Here's an
@@ -58,7 +59,8 @@
                   :integer  integer?
                   :number   number?
                   :datetime pl-utils/datetime?
-                  :coll     coll? }
+                  :coll     coll?
+                  :jsonable #(satisfies? JSONable %)}
         type-errors (for [[field {:keys [optional? type]}] fields
                           :let [value (field obj)
                                 type-fn (type-fns type)]]

--- a/test/com/puppetlabs/puppetdb/examples/report.clj
+++ b/test/com/puppetlabs/puppetdb/examples/report.clj
@@ -16,7 +16,15 @@
           :resource-title   "notify, yo"
           :property         "message"
           :new-value        "notify, yo"
-          :old-value        "absent"
+          :old-value        ["what" "the" "woah"]
+          :message          "defined 'message' as 'notify, yo'"}
+         {:status           "success"
+          :timestamp        "2011-01-01T12:00:03-03:00"
+          :resource-type    "Notify"
+          :resource-title   "notify, yar"
+          :property         "message"
+          :new-value        {"absent" 5}
+          :old-value        {"absent" true}
           :message          "defined 'message' as 'notify, yo'"}
          {:status           "skipped"
           :timestamp        "2011-01-01T12:00:02-03:00"

--- a/test/com/puppetlabs/puppetdb/test/http/experimental/event.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/experimental/event.clj
@@ -4,6 +4,7 @@
             [com.puppetlabs.puppetdb.scf.storage :as scf-store]
             [cheshire.core :as json])
   (:use clojure.test
+        [clojure.walk :only [stringify-keys]]
         ring.mock.request
         com.puppetlabs.puppetdb.examples.report
         com.puppetlabs.puppetdb.fixtures
@@ -55,5 +56,6 @@
       (let [response (get-response ["=" "report" report-hash])
             expected (expected-resource-events-response
                         (:resource-events basic)
-                        report-hash)]
-        (response-equal? response expected)))))
+                        report-hash)
+            munge-event-values #(utils/maptrans {[:old-value :new-value] stringify-keys} %)]
+        (response-equal? response expected #(map munge-event-values %))))))


### PR DESCRIPTION
These were previously only allowed to be strings, which doesn't reflect
what the values might actually come in as, and also is different from
what resources support. Now we make sure to db-serialize them before
storage, and JSON parse them on the way back out. Also, added a
"jsonable" type class to the model validation code, which accepts, as
the name implies, any object satisfying the JSONable protocol. That type
class is now used to validate event property values.
