### PR TITLE
Stringify configuration version in report

### DIFF
--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -36,7 +36,7 @@ Puppet::Reports.register_report(:puppetdb) do
       "certname"                => host,
       "puppet-version"          => @puppet_version,
       "report-format"           => @report_format,
-      "configuration-version"   => configuration_version,
+      "configuration-version"   => configuration_version.to_s,
       "start-time"              => Puppet::Util::Puppetdb.to_wire_time(time),
       "end-time"                => Puppet::Util::Puppetdb.to_wire_time(time + run_duration),
       "resource-events"         =>

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -12,7 +12,7 @@ describe processor do
 
   subject {
     s = Puppet::Transaction::Report.new("foo").extend(processor)
-    s.configuration_version = "123456789"
+    s.configuration_version = 123456789
     s
   }
 
@@ -94,7 +94,7 @@ describe processor do
           # TODO: change these two to use accessors as soon as we get up to puppet 3.0
           result["puppet-version"].should == subject.instance_variable_get(:@puppet_version)
           result["report-format"].should == subject.instance_variable_get(:@report_format)
-          result["configuration-version"].should == subject.configuration_version
+          result["configuration-version"].should == subject.configuration_version.to_s
           result["resource-events"].should == []
         end
       end


### PR DESCRIPTION
This is required to be a string instead of a datetime now, but the
default from Puppet is for it to be a number. Now we will ensure it's
always a string, no matter what.
