### PR TITLE
Maint/1.0.x/pe packaging acceptance

### DIFF
--- a/ext/test/build_packages_rpm.sh
+++ b/ext/test/build_packages_rpm.sh
@@ -87,6 +87,13 @@ rm pkg/rpm/$NAME-*.src.rpm
 # Ship the rpms staged locally in yum.puppetlabs.com
 ship_rpms
 
+# This is a Puppet Enterprise rpm
+build_srpm "PE_BUILD=true"
+build_rpm "PKG=\$(ls pkg/rpm/pe-$NAME-*.src.rpm)"
+
+# Ship the PE rpms
+ship_rpms PE_BUILD=true
+
 # If this is a tagged version, we want to save the results for later promotion.
 if [ "$REF_TYPE" = "tag" ]; then
   scp -r el fedora neptune.puppetlabs.lan:$PENDING/$NAME-$VERSION


### PR DESCRIPTION
Add building of puppet enterprise puppetdb RPM packages in the acceptance script. This places the packages in the 'extras' subdirectory, mirroring the layout of yum.puppetlabs.com and yum-enterprise.puppetlabs.com. This does not affect the current debian package building, that will be in a separate pull.
