### PR TITLE
DONT MERGE YET: Deprecate Postgresql versions older then 8.4

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -332,6 +332,9 @@
     ;; Add a shutdown hook where we can handle any required cleanup
     (pl-utils/add-shutdown-hook! on-shutdown)
 
+    ;; Check for deprecated database versions
+    (scf-store/warn-on-db-deprecation! db)
+
     ;; Ensure the database is migrated to the latest version
     (sql/with-connection db
       (migrate!))

--- a/test/com/puppetlabs/puppetdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/storage.clj
@@ -521,6 +521,13 @@
             actual        (resource-events-query-result ["=" "report" report1-hash])]
         (is (= expected actual))))))
 
+(deftest db-deprecation?
+  (testing "should return true and a string if db is deprecated"
+    (let [[deprecated? message] (db-deprecated? "PostgreSQL" [8 1])]
+      (is deprecated?)
+      (is (string? message))))
 
-
-
+  (testing "should return false and nil if db is not deprecated"
+    (let [[deprecated? message] (db-deprecated? "PostgreSQL" [9 4])]
+      (is (not deprecated?))
+      (is (nil? message)))))


### PR DESCRIPTION
This patch adds a deprecation warning at PuppetDB startup if the user is using
a version of PostgreSQL older than 8.4.

Don't merge this yet, we're still waiting for confirmation from all concerned parties. This is just for code review for now.
