### PR TITLE
Add utils for capturing log output during testing

### DIFF
--- a/test/com/puppetlabs/puppetdb/test/command.clj
+++ b/test/com/puppetlabs/puppetdb/test/command.clj
@@ -10,6 +10,7 @@
         [com.puppetlabs.puppetdb.fixtures]
         [com.puppetlabs.jdbc :only [query-to-vec]]
         [com.puppetlabs.puppetdb.examples]
+        [com.puppetlabs.testutils.logging]
         [clj-time.coerce :only [to-timestamp]]
         [clojure.test]
         [clojure.tools.logging :only [*logger-factory*]]

--- a/test/com/puppetlabs/puppetdb/testutils.clj
+++ b/test/com/puppetlabs/puppetdb/testutils.clj
@@ -4,7 +4,6 @@
             [com.puppetlabs.http :as pl-http]
             [clojure.string :as string]
             [clojure.java.jdbc :as sql]
-            [clojure.tools.logging.impl :as impl]
             [cheshire.core :as json]
             [fs.core :as fs])
   (:use     [com.puppetlabs.puppetdb.scf.storage :only [sql-current-connection-table-names]]
@@ -131,16 +130,6 @@
   If passed `nil`, returns `nil`."
   [ex]
   (if ex (str (.getMessage ex) "\n" (string/join "\n" (.getStackTrace ex)))))
-
-(defn atom-logger [output-atom]
-  "A logger factory that logs output to the supplied atom"
-  (reify impl/LoggerFactory
-    (name [_] "test factory")
-    (get-logger [_ log-ns]
-      (reify impl/Logger
-        (enabled? [_ level] true)
-        (write! [_ lvl ex msg]
-          (swap! output-atom conj [(str log-ns) lvl ex msg]))))))
 
 (defmacro with-fixtures
   "Evaluates `body` wrapped by the `each` fixtures of the current namespace."

--- a/test/com/puppetlabs/testutils/logging.clj
+++ b/test/com/puppetlabs/testutils/logging.clj
@@ -1,0 +1,57 @@
+(ns com.puppetlabs.testutils.logging
+  (:require [clojure.tools.logging.impl :as impl]
+            [clojure.tools.logging :only [*logger-factory*]]))
+
+(defn- log-entry->map
+  [log-entry]
+  {:namespace (get log-entry 0)
+   :level     (get log-entry 1)
+   :exception (get log-entry 2)
+   :message   (get log-entry 3)})
+
+(defn logs-matching
+  "Given a regular expression pattern and a sequence of log messages (in the format
+  used by `clojure.tools.logging`, return only the logs whose message matches the
+  specified regular expression pattern.  (Intended to be used alongside
+  `with-log-output` for tests that are validating log output.)  The result is
+  a sequence of maps, each of which contains the following keys:
+  `:namespace`, `:level`, `:exception`, and `:message`."
+  [pattern logs]
+  {:pre  [(instance? java.util.regex.Pattern pattern)
+          (coll? logs)]}
+  ;; the logs are formatted as sequences, where the string at index 3 contains
+  ;; the actual log message.
+  (let [matches (filter #(re-find pattern (get % 3)) logs)]
+    (map log-entry->map matches)))
+
+
+(defn atom-logger [output-atom]
+  "A logger factory that logs output to the supplied atom"
+  (reify impl/LoggerFactory
+    (name [_] "test factory")
+    (get-logger [_ log-ns]
+      (reify impl/Logger
+        (enabled? [_ level] true)
+        (write! [_ lvl ex msg]
+          (swap! output-atom conj [(str log-ns) lvl ex msg]))))))
+
+
+(defmacro with-log-output
+  "Sets up a temporary logger to capture all log output to a sequence, and
+  evaluates `body` in this logging context.
+
+  `log-output-var` - Inside of `body`, the variable named `log-output-var`
+  is a clojure atom containing the sequence of log messages that have been logged
+  so far.  You can access the individual log messages by dereferencing this
+  variable (with either `deref` or `@`).
+
+  Example:
+
+      (with-log-output logs
+        (log/info \"Hello There\")
+        (is (= 1 (num-logs-matching #\"Hello There\" @logs))))
+  "
+  [log-output-var & body]
+  `(let [~log-output-var (atom [])]
+     (binding [clojure.tools.logging/*logger-factory* (atom-logger ~log-output-var)]
+       ~@body)))


### PR DESCRIPTION
This commit adds a macro and a couple of functions to the testutils
namespace.  The macro, `with-log-output`, simplifies the process
of temporarily redirecting and capturing logging output during
tests.  The utility functions `logs-matching` and `num-logs-matching`
provide a means for searching through the captured logs for log
entries whose log messages match a specified regular expression
pattern.  Because the log entries generated by `clojure.tools.logging`
are structured as sequences, these functions are useful because they
prevent you from needing to remember that the actual log messages are
at index 3 inside of these log entry sequences.
