### PR TITLE
Fix DB deprecation warnings when using HSQLDB

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -332,11 +332,12 @@
     ;; Add a shutdown hook where we can handle any required cleanup
     (pl-utils/add-shutdown-hook! on-shutdown)
 
-    ;; Check for deprecated database versions
-    (scf-store/warn-on-db-deprecation! db)
-
-    ;; Ensure the database is migrated to the latest version
+    ;; Ensure the database is migrated to the latest version, and warn if it's
+    ;; deprecated. We do this in a single connection because HSQLDB seems to
+    ;; get confused if the database doesn't exist but we open and close a
+    ;; connection without creating anything.
     (sql/with-connection db
+      (scf-store/warn-on-db-deprecation!)
       (migrate!))
 
     ;; Initialize database-dependent metrics

--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -770,13 +770,11 @@ must be supplied as the value to be matched."
   [false nil])
 
 (defn warn-on-db-deprecation!
-  "Connect to database, get metadata about it and warn if database we are using
-  is deprecated."
-  [db]
-  {:pre [(map? db)]}
-  (sql/with-connection db
-    (let [version    (sql-current-connection-database-version)
-          dbtype     (sql-current-connection-database-name)
-          [deprecated? message] (db-deprecated? dbtype version)]
-      (when deprecated?
-        (log/warn message)))))
+  "Get metadata about the current connection and warn if the database we are
+  using is deprecated."
+  []
+  (let [version    (sql-current-connection-database-version)
+        dbtype     (sql-current-connection-database-name)
+        [deprecated? message] (db-deprecated? dbtype version)]
+    (when deprecated?
+      (log/warn message))))


### PR DESCRIPTION
In the case of a non-existent database (for instance, during the first
run), we were opening a connection to retrieve the database info for the
deprecation warning, and then closing the connection without creating
anything. This seems to confuse the DB for reasons that aren't exactly
clear. When we then open another connection to migrate, it hangs.

Now the warn-on-db-deprecation! function expects to be called within an
open connection, rather than taking the db as a parameter and opening
the connection itself. This is more consistent with other functions like
it, and also lets us use the same connection for warn-on-db-deprecation!
and migrate!, which means there will always be something in the database
hwne we close our first connection.
