### PR TITLE
Rework debian, rpm versioning

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,12 @@ def get_debversion
   if @pe then
     return "#{(@version.include?("rc") ? @version.sub(/rc[0-9]+/, '-0.1\0') : @version + "-1")}puppet#{get_debrelease}"
   else
-    return "#{(@version.include?("rc") ? @version.sub(/rc[0-9]+/, '-0.1\0') : @version + "-1")}puppetlabs#{get_debrelease}"
+    version = @version.match(/\d\.\d\.\d/)[0]
+    if @version.include?('rc')
+      return version + '-0.1' + @version.match(/rc\d+/)[0] + 'puppetlabs' + get_debrelease
+    else
+      return version + '-1puppetlabs' + get_debrelease
+    end
   end
 end
 
@@ -42,12 +47,7 @@ def get_origversion
 end
 
 def get_rpmversion
-  rpmversion = @version.match(/^([0-9\.]+)/)[1]
-  if @version.include?('rc')
-    # If an rc, the match will include an extra dot we don't want, so we trim
-    rpmversion.chop!
-  end
-  rpmversion
+  rpmversion = @version.match(/^([0-9\.]+)/)[1].chomp('.')
 end
 
 def get_debrelease


### PR DESCRIPTION
This commit sanifies the rpm versioning to be a little more tactful in its
removal of the trailing dot from a version. Second, this commit modifies the
debian version to address an issue where an rc tag resulted in a dash followed
by a dot in the version. This only handles the case where we don't care about commits on top of the RC tag, that information is lost in this deb version iteration (though, it has always been lost, this just doesn't fix it yet).

Signed-off-by: Moses Mendoza moses@puppetlabs.com
