### PR TITLE
Exclude fuse-extra from project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -65,7 +65,7 @@
                  [clojureql "1.0.3"]
                  ;; MQ connectivity
                  [clamq/clamq-activemq "0.4" :exclusions [org.slf4j/slf4j-api]]
-                 [org.apache.activemq/activemq-core "5.6.0" :exclusions [org.slf4j/slf4j-api]]
+                 [org.apache.activemq/activemq-core "5.6.0" :exclusions [org.slf4j/slf4j-api org.fusesource.fuse-extra/fusemq-leveldb]]
                  ;; WebAPI support libraries.
                  [net.cgrand/moustache "1.1.0" :exclusions [ring/ring-core org.clojure/clojure]]
                  [clj-http "0.5.3"]


### PR DESCRIPTION
We just noticed that the latest version of activemq is dragging in
a new dependency: `org.fusesource.fuse-extra/fusemq-level`.
This new dependency doesn't seem to be used (need to test that theory!)
and adds 20MB of bloat to our uberjar.
