### PR TITLE
(#17178) Update rubylib on debian/ubuntu installs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -78,7 +78,7 @@ end
 
 case @osfamily
   when /debian/
-    @plibdir = @pe ? '/opt/puppet/lib/ruby/1.8' : ( @ruby_version == '1.8' ?  '/usr/lib/ruby/1.8' : '/usr/lib/ruby/vendor_ruby/1.9.1' )
+    @plibdir = @pe ? '/opt/puppet/lib/ruby/1.8' : '/usr/lib/ruby/vendor_ruby'
   when /redhat/
     @plibdir = @pe ? '/opt/puppet/lib/ruby/site_ruby/1.8' : ( @ruby_version == '1.8' ? '/usr/lib/ruby/site_ruby/1.8' : '/usr/share/ruby/vendor_ruby' )
   when /suse/


### PR DESCRIPTION
Previously the terminus would be installed to the 1.8 sitelibdir for ruby1.8 or
the 1.9.1 vendorlibdir on ruby1.9. The ruby1.9 code path was never used, so
platforms with ruby1.9 as the default (such as quantal and wheezy) would not be
able to load the terminus. Modern debian packages put version agnostic ruby
code in vendordir (/usr/lib/ruby/vendor_ruby), so this commit moves the
terminus install dir to be vendordir.
