### PR TITLE
Force a TTY when calling freight, to fix debian packaging

### DIFF
--- a/ext/test/build_packages_deb.sh
+++ b/ext/test/build_packages_deb.sh
@@ -94,7 +94,7 @@ FREIGHT_CONF
 
 scp ./freight.conf neptune:${FREIGHT_DIR}
 
-ssh neptune <<FREIGHT
+ssh neptune -t -t <<FREIGHT
 set -e
 set -x
 


### PR DESCRIPTION
The latest version of freight introduced a bug whereby it fails if it's
not running with a TTY. This change forces ssh to allocate a TTY, so
that freight will run correctly.
