### PR TITLE
Use fqdn with fallback to hostname in jetty.ini

### DIFF
--- a/ext/templates/puppetdb-ssl-setup
+++ b/ext/templates/puppetdb-ssl-setup
@@ -94,7 +94,7 @@ fi
 jettyfile="${puppetdb_confdir}/conf.d/jetty.ini"
 if [ -f "$jettyfile" ] ; then
   if grep "ssl-host" ${jettyfile} > /dev/null; then
-    sed -e 's/^ssl-host.*/ssl-host = '"`facter fqdn`"'/' ${jettyfile} > ${jettyfile}.tmp
+    sed -e 's/^ssl-host.*/ssl-host = '"$fqdn"'/' ${jettyfile} > ${jettyfile}.tmp
     mv ${jettyfile}.tmp ${jettyfile}
   else
     echo "$jettyfile exists, but could not find ssl-host setting. Please update that setting to the desired hostname that puppetdb should listen on (e.g.: '`facter fqdn`)."


### PR DESCRIPTION
Without this patch, [this line](https://github.com/Seldaek/puppetdb/blob/50c41116f8d0879e7de63350c6a4e80f2b1dc5b6/ext/templates/puppetdb-ssl-setup#L61) is not respected in the generated jetty.ini

I am not sure regarding contributions of such small patches whether I am supposed to create an issue or not in redmine first, but I hope not.
