### PR TITLE
Revert "Force a TTY when calling freight, to fix debian packaging"

### DIFF
--- a/ext/test/build_packages_deb.sh
+++ b/ext/test/build_packages_deb.sh
@@ -94,7 +94,7 @@ FREIGHT_CONF
 
 scp ./freight.conf neptune:${FREIGHT_DIR}
 
-ssh neptune -t -t <<FREIGHT
+ssh neptune <<FREIGHT
 set -e
 set -x
 


### PR DESCRIPTION
This reverts commit 138194a2f4b2a760ef1d836819b0b8669a712f08.

This was intended to work around a bug in freight, but seems to have
caused more issues with jenkins. We're instead choosing to pin to an
older version of freight until the bug is fixed, so this change is no
longer necessary.
