### PR TITLE
Acceptance: stop using deprecated parameter `manage_redhat_firewall`

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -152,7 +152,8 @@ module PuppetDBExtensions
     manifest = <<-EOS
     class { 'puppetdb':
       database               => '#{db}',
-      manage_redhat_firewall => false,
+      open_ssl_listen_port   => false,
+      open_postgres_port     => false,
       puppetdb_version       => '#{get_package_version(host, version)}',
     }
     EOS


### PR DESCRIPTION
The acceptance tests were using the deprecated parameter
`manage_redhat_firewall` from the puppetdb module.  This commit
just changes the call to the module so that it uses the new
replacement parameters.
