### PR TITLE
(#18879) Remove the environment key from v1 catalogs

### DIFF
--- a/src/com/puppetlabs/puppetdb/catalog.clj
+++ b/src/com/puppetlabs/puppetdb/catalog.clj
@@ -300,7 +300,7 @@
          (number? version)]
    :post [(map? %)]}
   (-> catalog
-      (update-in [:data] dissoc :classes :tags)
+      (update-in [:data] dissoc :classes :tags :environment)
       (parse-catalog (inc version))))
 
 (defmethod parse-catalog 2

--- a/test/com/puppetlabs/puppetdb/examples.clj
+++ b/test/com/puppetlabs/puppetdb/examples.clj
@@ -118,6 +118,7 @@
           :type       "Node"}]
         :tags        ["settings" "default" "node"]
         :classes     ["settings" "default"]
+        :environment "production"
         :version     1332533763}}}
 
    2 {:empty


### PR DESCRIPTION
In some versions of Puppet, this key may be present. This fixes an issue
where older versions of the terminus (or otherwise perfectly legal v1
catalogs) would submit a catalog with this unexpected, but still not
allowed key. Now we explicitly remove it, so that when we call the v2
parse-catalog function, the catalog is legal.
