### PR TITLE
Fix inventory service to return 'nil' when a node is not found

### DIFF
--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -21,6 +21,15 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
 
       if response.is_a? Net::HTTPSuccess
         result = PSON.parse(response.body)
+        # Note: the Inventory Service API appears to expect us to return nil here
+        # if the node isn't found.  However, PuppetDB returns an empty array in
+        # this case; for now we will just look for that condition and assume that
+        # it means that the node wasn't found, so we will return nil.  In the
+        # future we may want to improve the logic such that we can distinguish
+        # between the "node not found" and the "no facts for this node" cases.
+        if result.empty?
+          return nil
+        end
         facts = result.inject({}) do |a,h|
           a.merge(h['name'] => h['value'])
         end

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -85,7 +85,10 @@ describe Puppet::Node::Facts::Puppetdb do
     end
 
     it "should return nil if no facts are found" do
-      response = Net::HTTPNotFound.new('1.1', 404, 'Not Found')
+      body = [].to_pson
+
+      response = Net::HTTPOK.new('1.1', 200, 'OK')
+      response.stubs(:body).returns body
 
       subject.stubs(:http_get).returns response
 


### PR DESCRIPTION
The previous commit had a side effect of causing the facts
terminus' `find` method to return an empty array when the
requested node did not exist.  This commit changes the behavior
back to what it was previously--to return `nil` instead.
