### PR TITLE
Update docs to include info about setting dashboard host via module

### DIFF
--- a/documentation/install_via_module.markdown
+++ b/documentation/install_via_module.markdown
@@ -33,6 +33,12 @@ Using the normal methods for your site, assign the PuppetDB module's classes to 
 * If you want to run PuppetDB on its own server with a local PostgreSQL instance, assign the `puppetdb` class to it, and assign the `puppetdb::master::config` class to your puppet master. Make sure to set the class parameters as necessary.
 * If you want PuppetDB and PostgreSQL to each run on their own servers, assign the `puppetdb::server` class and the `puppetdb::database::postgresql` classes to different servers, and the `puppetdb::master::config` class to your puppet master. Make sure to set the class parameters as necessary.
 
+Note: by default the module sets up the PuppetDB dashboard to be accessible only via `localhost`.  If you'd like to allow access to the PuppetDB dashboard via an external network interface, you should set the `listen_address` parameter on either of the `puppetdb` or `puppetdb::server` classes.  e.g.:
+
+    class { 'puppetdb':
+        listen_address => 'example.foo.com'
+    }
+
 These classes automatically configure most aspects of PuppetDB. If you need to set additional settings (to change the `node_ttl`, for example), see [the "Playing Nice With the PuppetDB Module" section][config_with_module] of the "Configuring" page. 
 
 For full details on how to use the module, see the [README_GETTING_STARTED.md

--- a/documentation/maintain_and_tune.markdown
+++ b/documentation/maintain_and_tune.markdown
@@ -23,7 +23,7 @@ Once you have PuppetDB running, visit the following URL, substituting in the nam
 
 `http://puppetdb.example.com:8080/dashboard/index.html`
 
-> **Note:** You may need to [edit PuppetDB's HTTP configuration][configure_jetty] first, changing the `host` setting to the server's externally-accessible hostname. When you do this, you should also configure your firewall to control access to PuppetDB's cleartext HTTP port.
+> **Note:** You may need to [edit PuppetDB's HTTP configuration][configure_jetty] first, changing the `host` setting to the server's externally-accessible hostname.  If you've used the PuppetDB module to install, you'll need to [set the `listen_address` parameter](./install_via_module.html#assign_classes_to_nodes).  When you do this, you should also configure your firewall to control access to PuppetDB's cleartext HTTP port.
 
 PuppetDB uses this page to display a web-based dashboard with performance information and metrics, including its memory use, queue depth, command processing metrics, duplication rate, and query stats. It displays min/max/median of each metric over a configurable duration, as well as an animated SVG "sparkline" (a simple line chart that shows general variation). It also displays the current version of PuppetDB and checks for updates, showing a link to the latest package if your deployment is out of date.
 


### PR DESCRIPTION
The current documentation does not reflect the fact that the module
provides a parameter for setting the listen address for the PuppetDB
dashboard.  It mentions that you may need to override the setting
in jetty.ini, but if you do this after installing via the module,
the module will override your setting.  This commit takes a stab
at updating the docs to indicate how you'd accomplish this via
the module.

@nfagerlund: I presume you'll want to reword or entirely gut this
verbiage and work your magic on it, but I just wanted to submit this
as a starting point.
