### PR TITLE
Remove space between DESTDIR and value

### DIFF
--- a/ext/redhat/puppetdb.spec.erb
+++ b/ext/redhat/puppetdb.spec.erb
@@ -126,8 +126,8 @@ mkdir -p $RPM_BUILD_ROOT/%{_initddir}
 PATH=/opt/puppet/bin:$PATH rake install PARAMS_FILE= DESTDIR=$RPM_BUILD_ROOT PE_BUILD=true
 PATH=/opt/puppet/bin:$PATH rake terminus PARAMS_FILE= DESTDIR=$RPM_BUILD_ROOT PE_BUILD=true
 <% else -%>
-rake install PARAMS_FILE= DESTDIR= $RPM_BUILD_ROOT
-rake terminus PARAMS_FILE= DESTDIR= $RPM_BUILD_ROOT
+rake install PARAMS_FILE= DESTDIR=$RPM_BUILD_ROOT
+rake terminus PARAMS_FILE= DESTDIR=$RPM_BUILD_ROOT
 <% end -%>
 
 mkdir -p $RPM_BUILD_ROOT/%{_localstatedir}/log/%{name}


### PR DESCRIPTION
The space between DESTDIR= and $RPM_BUILD_ROOT in the rake call in the rpm spec
file means that DESTDIR gets set to nothing, which later means that puppetdb
and the terminus are installed at top level, which does not work in mock when
building as a non-root user (as it shouldn't). This commit removes the space so
that the DESTDIR is correctly set.
