### PR TITLE
Remove cows from top-level Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,6 @@ if @pe
     @lib_dir = "/opt/puppet/share/puppetdb"
     @name ="pe-puppetdb"
     @sbin_dir = "/opt/puppet/sbin"
-    @cows = 'lucid', 'squeeze', 'precise', 'wheezy'
     @pe_version = ENV['PE_VER'] || '2.8'
     @java_bin = "/opt/puppet/bin/java"
 else


### PR DESCRIPTION
We don't use this information any more now that puppetdb has switched to the
packaging repo. It was somehow added back in during the original PR merge
conflict resolution, so we need to remove it again.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
