### PR TITLE
Acceptance: Remove debugging output from version checking

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -182,18 +182,6 @@ module PuppetDBExtensions
             raise ArgumentError, "Unsupported OS family: '#{os}'"
         end
       expected_version = get_package_version(host)
-      puts "Expected version class, length, inspect, bytes:"
-      puts expected_version.class
-      puts expected_version.length
-      puts expected_version.inspect
-      expected_version.bytes.map { |b| puts b }
-      puts "-------------------"
-      puts "Installed version class, length, inspect, bytes:"
-      puts installed_version.class
-      puts installed_version.length
-      puts installed_version.inspect
-      installed_version.bytes.map { |b| puts b }
-      puts "-------------------"
 
       PuppetAcceptance::Log.notify "Expecting package version: '#{expected_version}', actual version: '#{installed_version}'"
       if installed_version != expected_version


### PR DESCRIPTION
We were experiencing a weird bug where the acceptance tests were
failing on Debian systems when they were attempting to validate
the version number of the installed package.  We'd added some
debug output to help us narrow down the root cause of the problem.

We've since discovered what the issue was and fixed it, so this
commit simply removes the debugging output.
