### PR TITLE
Generalize and improve our utility function for parsing CLI args

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/com/puppetlabs/puppetdb/cli/benchmark.clj
@@ -164,15 +164,21 @@
   [hostname report]
   (assoc report "certname" hostname))
 
+
+(def supported-cli-options
+  [["-c" "--config" "Path to config.ini (required)"]
+   ["-C" "--catalogs" "Path to a directory containing sample JSON catalogs (files must end with .json)"]
+   ["-R" "--reports" "Path to a directory containing sample JSON reports (files must end with .json)"]
+   ["-i" "--runinterval" "What runinterval (in minutes) to use during simulation"]
+   ["-n" "--numhosts" "How many hosts to use during simulation"]
+   ["-rp" "--rand-perc" "What percentage of submitted catalogs are tweaked (int between 0 and 100)"]])
+
+(def required-cli-options
+  [:config])
+
 (defn -main
   [& args]
-  (let [[options _]     (cli! args
-                              ["-C" "--catalogs" "Path to a directory containing sample JSON catalogs (files must end with .json)"]
-                              ["-R" "--reports" "Path to a directory containing sample JSON reports (files must end with .json)"]
-                              ["-i" "--runinterval" "What runinterval (in minutes) to use during simulation"]
-                              ["-n" "--numhosts" "How many hosts to use during simulation"]
-                              ["-rp" "--rand-perc" "What percentage of submitted catalogs are tweaked (int between 0 and 100)"])
-
+  (let [[options _]     (cli! args supported-cli-options required-cli-options)
         config          (-> (:config options)
                             (inis-to-map)
                             (configure-logging!))

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -326,9 +326,19 @@
   ;; nothing much to do here for now, but let's at least log that we're shutting down.
   (log/info "Shutdown request received; puppetdb exiting."))
 
+
+(def supported-cli-options
+  [["-c" "--config" "Path to config.ini (required)"]
+   ["-D" "--debug" "Enable debug mode" :default false :flag true]])
+
+(def required-cli-options
+  [:config])
+
 (defn -main
   [& args]
-  (let [[options _]                                (cli! args)
+  (let [[options _]                                (cli! args
+                                                      supported-cli-options
+                                                      required-cli-options)
         initial-config                             {:debug (:debug options)}
         {:keys [jetty database global command-processing]
             :as config}                            (parse-config! (:config options) initial-config)


### PR DESCRIPTION
At some point in time the clojure CLI library that we use to parse
stopped supporting a flag to indicate 'required' arguments.  Thus,
we were getting much farther into the code than we should have been
if you left off, e.g., the `--config` option to the `services`
program.  This also resulted in useless, unintuitive error messages.

Additionally, the function that we were providing in `utils` to
generalize our CLI argument handling for other PuppetDB command-line
tools included more arguments than would be applicable to some
tools.

This commit provides a more generalized `validate-cli-args!` function
in the utils namespace, which doesn't assume any arguments besides
`--help`.  It also adds support for checking for `required` arguments
and fails with a reasonable error message if you are missing any.
