### PR TITLE
(#19241) Bump ActiveMQ dependency to 5.8.0 to solve upstream KahaDB issues

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -56,8 +56,11 @@
                  [postgresql/postgresql "9.0-801.jdbc4"]
                  [clojureql "1.0.3"]
                  ;; MQ connectivity
-                 [clamq/clamq-activemq "0.4" :exclusions [org.slf4j/slf4j-api]]
-                 [org.apache.activemq/activemq-core "5.6.0" :exclusions [org.slf4j/slf4j-api org.fusesource.fuse-extra/fusemq-leveldb]]
+                 [clamq/clamq-activemq "0.4" :exclusions [org.slf4j/slf4j-api org.apache.activemq/activemq-core]]
+                 ;; ActiveMQ parts
+                 [org.apache.activemq/activemq-client "5.8.0"]
+                 [org.apache.activemq/activemq-broker "5.8.0"]
+                 [org.apache.activemq/activemq-kahadb-store "5.8.0"]
                  ;; WebAPI support libraries.
                  [net.cgrand/moustache "1.1.0" :exclusions [ring/ring-core org.clojure/clojure]]
                  [clj-http "0.5.3"]


### PR DESCRIPTION
Two KahaDB related bugs have been solved in 5.7.0 that we care about:
1. db.data steady growth due to BTreeIndex page leak:

https://issues.apache.org/jira/browse/AMQ-3956

I believe we may have had an incident of this with #19066 but its hard to tell,
as it could have been due to bad index archiving as well.
1. Lack of tracking for db.data in systemUsage constraints:

https://issues.apache.org/jira/browse/AMQ-3973

Without this db.data is not included in size calculations, so any 'store-usage'
setting would not have taken into account this file as part of its calculation.

While most of what we care about is in 5.7.0, some follow up bugs to the changes
in that release were released with 5.8.0.

With 5.8.0 the jar activemq-core was decomposed so people could pull in the
parts they need depending on their solution, so our dependencies have changed
to accomodate this new organisation by pulling in only the jars: client, broker
and kahadb-store.

Obviously there are lots of other changes in 5.7.0 and 5.8.0 also:

5.7: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12321258
5.8: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12323282

Signed-off-by: Ken Barber ken@bob.sh
