### PR TITLE
(#19239) Work around EOFException upon journal corruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Administration
 * [Configuring](./documentation/configure.markdown)
 * [Debugging with Remote REPL](./documentation/repl.markdown)
 
+Troubleshooting
+-----
+
+* [KahaDB Corruption](./documentation/trouble_kahadb_corruption.markdown)
+
 The PuppetDB API
 -----
 

--- a/documentation/puppetdb-faq.markdown
+++ b/documentation/puppetdb-faq.markdown
@@ -5,6 +5,8 @@ subtitle: "Basic Info and Troubleshooting Tips"
 canonical: "/puppetdb/1.1/puppetdb-faq.html"
 ---
 
+[trouble_kahadb]: ./trouble_kahadb_corruption.html
+
 ## PuppetDB is complaining about a truststore or keystore file. What do I do?
 
 There are several related causes for this, but it boils down to PuppetDB being
@@ -91,3 +93,16 @@ databases before settling on PostgreSQL. These included Neo4j, Riak, and MySQL
 with ActiveRecord in Ruby. We have no plans to support any other databases,
 including MySQL, which lacks important features such as array columns and
 recursive queries.
+
+## I may have a corrupt KahaDB store. What does this mean, what causes it and how can I recover?
+
+If PuppetDB throws an exception while the application starts or while receiving
+a command it may be due to KahaDB corruption. The exception generally has some
+mention of the KahaDB libraries (org.apache.activemq.store.kahadb), for example:
+
+    java.io.EOFException
+        at java.io.RandomAccessFile.readInt(RandomAccessFile.java:776)
+        at org.apache.activemq.store.kahadb.disk.journal.DataFileAccessor.readRecord(DataFileAccessor.java:81)
+
+You should consult the [Troubleshooting guide for Kahadb][trouble_kahadb] for
+details on how to rememdy this.

--- a/documentation/trouble_kahadb_corruption.markdown
+++ b/documentation/trouble_kahadb_corruption.markdown
@@ -1,0 +1,49 @@
+---
+title: "PuppetDB 1.1 » Troublshooting » KahaDB Corruption
+layout: default
+canonical: "/puppetdb/1.1/trouble_kahadb_corruption.html"
+---
+
+[configure_vardir]: ./configure.html#vardir
+[redmine]: http://projects.puppetlabs.com/projects/puppetdb
+
+What is KahaDB?
+-----
+
+Internally PuppetDB utilises ActiveMQ for queuing commands received via the API and sometimes initiated internally. The queue today utilises a technology built for ActiveMQ called 'KahaDB' which is a file based persistence database designed specifically for high performance queuing.  
+
+The KahaDB storage for PuppetDB is located in a sub-directory underneath your configured `vardir` (see [Configuration][configure_vardir] for more details). This sub-directory is generally, `mq/localhost/KahaDB`. For OSS PuppetDB the full path is usually `/var/lib/puppetdb/mq/localhost/KahaDB`.
+
+Why does corruption occur?
+-----
+
+In some cases this database may corrupt. Lots of things may cause this:
+
+* Your disk may fill up, so writes are not finalised within the journal or database index.
+* There might be a bug in the KahaDB code that the developers haven't catered for.
+
+How do I recover?
+-----
+
+During corruption, the simplest way to recover is to simply move the KahaDB directory out of the way and restart PuppetDB:
+
+    $ service puppetdb stop
+    $ cd /var/lib/puppetdb/mq/localhost
+    $ mv KahaDB KahaDB.old
+    $ service puppetdb start
+
+(*Note:* it is very important for us that you preserve the old KahaDB directory. If the problem turns out to be something our Engineers haven't seen before we'll need that directory to replicate the problem, so make sure you preserve it.)
+
+In most cases this is enough, however this means that any data that was not processed may be lost. This is usually only transient queue data however, and is not the persisted data that is stored in your PostgreSQL or HSQLDB database, so in most cases it is not a major concern. For most cases re-running puppet on your nodes will resubmit these lost commands for processing.
+
+If these is going to be too destructive, then there is a few things you can do. But first of all, backup your KahaDB directory before doing anything so you can revert it after each attempt at the techniques listed below:
+
+* You can try clearing your `db.data` file and recreating it. The `db.data` file represents your index, and clearing it may force it to be recreated from the logs.
+* You can try clearing your `db-*.log` files. These files contain the journal and while KahaDB is usually good at finding pin-point corruption and ignoring these today (in fact much better since PuppetDB 1.1.0) there are still edge cases.  Clearing them may let you skip over these bad blocks. It might be that only 1 of these files are corrupted, and the remainder are good so you could attempt clearing one at a time (newest first) to find the culprit.
+
+How do I bring my corruption to the attention of developers?
+-----
+
+In almost all cases though we want to hear about your corruption so we can improve the ways we deal with these problems. We would appreciate if you have these issues to look at our [Bug Tracker][redmine] for the term `kahadb` to see if you're problem is already known, and adding a comment if you see it yourself, including the version of PuppetDB you are using.
+
+If the problem is unknown or new, make sure you log a new ticket including your `puppetdb.log` file, or at least the pertinent exception including the version of PuppetDB you are using and the potential cause of the corruption if you are aware of it. In all cases, make sure you preserve any backups of the `KahaDB` directory in its original corrupted state, this may be helpful to our Software Engineers to replicate the problem later.

--- a/src/com/puppetlabs/mq.clj
+++ b/src/com/puppetlabs/mq.clj
@@ -119,6 +119,18 @@
   (.stop broker)
   (.waitUntilStopped broker))
 
+(defn build-and-start-broker!
+  "Builds ands starts a broker in one go, attempts restart upon known exceptions"
+  [brokername dir config]
+  (try
+    (start-broker! (build-embedded-broker brokername dir config))
+    (catch java.io.EOFException e
+      (log/warn
+        (str "Caught EOFException on broker startup, trying to restart it "
+             "again to see if that solves it. This is probably due to "
+             "KahaDB corruption."))
+      (start-broker! (build-embedded-broker brokername dir config)))))
+
 (defn connect!
   "Connect to the specified broker URI."
   [uri]

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -400,11 +400,15 @@
     (pop/initialize-metrics db)
 
     (let [error         (promise)
-          broker        (do
+          broker        (try
                           (log/info "Starting broker")
-                          (mq/start-broker!
-                            (mq/build-embedded-broker
-                              "localhost" mq-dir command-processing)))
+                          (mq/build-and-start-broker! "localhost" mq-dir command-processing)
+                          (catch java.io.EOFException e
+                            (log/error
+                              "EOF Exception caught during broker start, this "
+                              "might be due to KahaDB corruption. Consult the "
+                              "PuppetDB troubleshooting guide.")
+                            (throw e)))
           command-procs (let [nthreads (command-processing :threads)]
                           (log/info (format "Starting %d command processor threads" nthreads))
                           (vec (for [n (range nthreads)]


### PR DESCRIPTION
We discovered a bug in KahaDB that when the journal is corrupted there might be
a stray EOFException that is not caught by the KahaDB store, however upon
broker restart it corrects itself.

This patch will automatically restart the broker when that state is detected,
avoiding the need for an administrator to intervene.

Signed-off-by: Ken Barber ken@bob.sh
