### PR TITLE
[packaging] Update PE package building for new workflow

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -86,7 +86,7 @@ end
 
 desc "Get rid of build artifacts including clojure (lein) builds"
 task :clobber => [ :clean ] do
-  rm_rf FileList["puppetdb*jar"]
+  rm_rf FileList["target/puppetdb*jar"]
 end
 
 task :version do


### PR DESCRIPTION
This PR contains two bugfixes for building packages. One addresses an issue for the Release Team's new jenkins-based build workflow, and the other updates the clobber task to reflect lein 2's target directory.
