### PR TITLE
(maint) Add f18 mocks to build_defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -9,7 +9,7 @@ gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-fedora-16-i386 pl-fedora-17-i386'
+final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-fedora-16-i386 pl-fedora-17-i386 pl-fedora-18-i386'
 yum_host: 'burji.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE


### PR DESCRIPTION
Fedora 18 has been released to the world, so we should build packages for it.
This commit adds the fedora 18 mocks to the build_defaults so we can easily
supply fedora 18 packages.
