### PR TITLE
(#17842) Return meaningful errors with invalid resource references

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -184,7 +184,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
                 "#{other_ref} doesn't seem to be in the correct format. " +
                 "Resource references should be formatted as: " +
                 "Classname['title'] or Modulename::Classname['title'] (take " +
-                "careful note of the capitilization)."
+                "careful note of the capitalization)."
             end
 
             # This is an unfortunate hack.  Puppet does some weird things w/rt
@@ -207,7 +207,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
             # and try that
             other_resource = find_resource(hash['resources'], other_hash) || find_resource(hash['resources'], aliases[other_array])
 
-            raise "Invalid relationship: #{edge_to_s(resource_hash_to_ref(resource_hash), other_ref, param)}, because #{other_ref} doesn't seem to be in the catalog" unless other_resource
+            raise Puppet::Error, "Invalid relationship: #{edge_to_s(resource_hash_to_ref(resource_hash), other_ref, param)}, because #{other_ref} doesn't seem to be in the catalog" unless other_resource
 
             # As above, virtual exported resources will eventually be removed,
             # so if a real resource refers to one, it's wrong. Non-virtual
@@ -217,7 +217,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
             # suffices to check for virtual.
             if other_real_resource = catalog.resource(other_resource['type'], other_resource['title'])
               if other_real_resource.virtual?
-                raise "Invalid relationship: #{edge_to_s(resource_hash_to_ref(resource_hash), other_ref, param)}, because #{other_ref} is exported but not collected"
+                raise Puppet::Error, "Invalid relationship: #{edge_to_s(resource_hash_to_ref(resource_hash), other_ref, param)}, because #{other_ref} is exported but not collected"
               end
             end
 

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -383,7 +383,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
 
           expect do
             subject.munge_catalog(catalog)
-          end.to raise_error("Invalid relationship: Notify[source] { before => Notify[target] }, because Notify[target] is exported but not collected")
+          end.to raise_error(Puppet::Error, "Invalid relationship: Notify[source] { before => Notify[target] }, because Notify[target] is exported but not collected")
         end
 
         it "should not add edges defined on an uncollected exported resource" do
@@ -485,7 +485,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
 
           expect do
             subject.munge_catalog(catalog)
-          end.to raise_error("Invalid relationship: Notify[source] { before => Notify[target] }, because Notify[target] doesn't seem to be in the catalog")
+          end.to raise_error(Puppet::Error, "Invalid relationship: Notify[source] { before => Notify[target] }, because Notify[target] doesn't seem to be in the catalog")
         end
 
         it "should not add edges defined on an uncollected virtual resource" do
@@ -526,7 +526,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         hash = subject.add_parameters_if_missing(catalog_data_hash)
         expect {
           subject.synthesize_edges(hash, catalog)
-        }.to raise_error("Invalid relationship: Notify[anyone] { before => Notify[non-existent] }, because Notify[non-existent] doesn't seem to be in the catalog")
+        }.to raise_error(Puppet::Error, "Invalid relationship: Notify[anyone] { before => Notify[non-existent] }, because Notify[non-existent] doesn't seem to be in the catalog")
       end
 
       it "should produce a reasonable error message for a missing 'required-by' relationship" do
@@ -534,7 +534,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         hash = subject.add_parameters_if_missing(catalog_data_hash)
         expect {
           subject.synthesize_edges(hash, catalog)
-        }.to raise_error("Invalid relationship: Notify[anyone] { require => Notify[non-existent] }, because Notify[non-existent] doesn't seem to be in the catalog")
+        }.to raise_error(Puppet::Error, "Invalid relationship: Notify[anyone] { require => Notify[non-existent] }, because Notify[non-existent] doesn't seem to be in the catalog")
       end
 
       it "should produce a reasonable error message for a missing 'notifies' relationship" do
@@ -543,7 +543,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         hash = subject.add_parameters_if_missing(catalog_data_hash)
         expect {
           subject.synthesize_edges(hash, catalog)
-        }.to raise_error("Invalid relationship: Notify[anyone] { notify => Notify[non-existent] }, because Notify[non-existent] doesn't seem to be in the catalog")
+        }.to raise_error(Puppet::Error, "Invalid relationship: Notify[anyone] { notify => Notify[non-existent] }, because Notify[non-existent] doesn't seem to be in the catalog")
       end
 
       it "should produce a reasonable error message for a missing 'subscription-of' relationship" do
@@ -552,7 +552,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         hash = subject.add_parameters_if_missing(catalog_data_hash)
         expect {
           subject.synthesize_edges(hash, catalog)
-        }.to raise_error("Invalid relationship: Notify[anyone] { subscribe => Notify[non-existent] }, because Notify[non-existent] doesn't seem to be in the catalog")
+        }.to raise_error(Puppet::Error, "Invalid relationship: Notify[anyone] { subscribe => Notify[non-existent] }, because Notify[non-existent] doesn't seem to be in the catalog")
       end
 
       it "should produce a reasonable error message for an invalid resourceref" do
@@ -561,7 +561,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         hash = subject.add_parameters_if_missing(catalog_data_hash)
         expect {
           subject.synthesize_edges(hash, catalog)
-        }.to raise_error("Invalid relationship: Notify[anyone] { subscribe => Foobar::baz[name] }, because Foobar::baz[name] doesn't seem to be in the correct format. Resource references should be formatted as: Classname['title'] or Modulename::Classname['title'] (take careful note of the capitilization).")
+        }.to raise_error(Puppet::Error, "Invalid relationship: Notify[anyone] { subscribe => Foobar::baz[name] }, because Foobar::baz[name] doesn't seem to be in the correct format. Resource references should be formatted as: Classname['title'] or Modulename::Classname['title'] (take careful note of the capitilization).")
       end
     end
 


### PR DESCRIPTION
Normally this kind of thing isn't allowed:

```
file { '/tmp/foo':
  ensure => present,
  require => Mymodule::foo['bar'],
}
```

However puppet lets it slip by when someone uses create resources:

```
create_resources('file', { '/usr/local/homeaway/api-favorites-ustst1-jdk/java' => { ensure => present, require => "Mymodule::foo[bar]" }})
```

With the puppetdb terminus, our relationship checks fail when this kind of
delcaration is used, however in the compiler terminus it slips through because
I believe the comparison is done all in capitals.

Since the parser stops it, it shouldn't be allowed. However, our behaviour is
confusing to the user. This patch adds a more meaningful error message to this
kind of failure, instead of stating that it is a relationship error we stop
earlier with an error about the format.

Signed-off-by: Ken Barber ken@bob.sh
