### PR TITLE
Define postgres settings using environment vars

### DIFF
--- a/test-resources/config/default.clj
+++ b/test-resources/config/default.clj
@@ -7,11 +7,25 @@
 (defn test-db-config
   "Return a map of connection attrs for the test database"
   []
-  {:classname   "org.hsqldb.jdbcDriver"
-   :subprotocol "hsqldb"
-   :subname     (str "mem:"
-                  (java.util.UUID/randomUUID)
-                  ";shutdown=true;hsqldb.tx=mvcc;sql.syntax_pgs=true")})
+  (let [dbtype     (System/getenv "PUPPETDB_DBTYPE")
+        dbsubname  (System/getenv "PUPPETDB_DBSUBNAME")
+        dbuser     (System/getenv "PUPPETDB_DBUSER")
+        dbpassword (System/getenv "PUPPETDB_DBPASSWORD")]
+    (if (= dbtype "postgres")
+      (if (some nil? [dbsubname dbuser dbpassword])
+        (do
+          (println "Ensure environment variables PUPPETDB_DBSUBNAME, PUPPETDB_DBUSER and PUPPETDB_DBPASSWORD are set")
+          (System/exit 1))
+        {:classname   "org.postgresql.Driver"
+         :subprotocol "postgresql"
+         :subname     dbsubname
+         :user        dbuser
+         :password    dbpassword})
+      {:classname   "org.hsqldb.jdbcDriver"
+       :subprotocol "hsqldb"
+       :subname     (str "mem:"
+                      (java.util.UUID/randomUUID)
+                      ";shutdown=true;hsqldb.tx=mvcc;sql.syntax_pgs=true")})))
 
 ;; here is a sample test-db-config function for use with postgres
 ;(defn test-db-config


### PR DESCRIPTION
In the past we were copying a magic from from tb-driver: local.clj that
contained all the information needed to connect to our test Postgres
database. tb-driver is being decommissioned, and its felt we need a better
way to manage this going forward.

This patch allows us to parameterize database tests, in particular the postgres
specific settings using environment variables. This way we can pass the
settings in from Jenkins using its special 'passwords as environment vars'
feature.

The default HSQLDB behaviour is kept if DBTEST_TYPE is not set, and local.clj
support is kept.

Signed-off-by: Ken Barber ken@bob.sh
