### PR TITLE
Revert "(#19241) Bump ActiveMQ dependency to 5.8.0 to solve upstream KahaDB issues"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -56,11 +56,8 @@
                  [postgresql/postgresql "9.0-801.jdbc4"]
                  [clojureql "1.0.3"]
                  ;; MQ connectivity
-                 [clamq/clamq-activemq "0.4" :exclusions [org.slf4j/slf4j-api org.apache.activemq/activemq-core]]
-                 ;; ActiveMQ parts
-                 [org.apache.activemq/activemq-client "5.8.0"]
-                 [org.apache.activemq/activemq-broker "5.8.0"]
-                 [org.apache.activemq/activemq-kahadb-store "5.8.0"]
+                 [clamq/clamq-activemq "0.4" :exclusions [org.slf4j/slf4j-api]]
+                 [org.apache.activemq/activemq-core "5.6.0" :exclusions [org.slf4j/slf4j-api org.fusesource.fuse-extra/fusemq-leveldb]]
                  ;; WebAPI support libraries.
                  [net.cgrand/moustache "1.1.0" :exclusions [ring/ring-core org.clojure/clojure]]
                  [clj-http "0.5.3"]


### PR DESCRIPTION
This removes this patch, as it changed the metrics we expose via the 'metrics'
api end-point. Reverting until we come up with a better solution.

This reverts commit e36e5084dfb80f0c6383e939fc4307e61921044c.
