### PR TITLE
WIP: Define our own Centos-Base.repo during pre_suite setup

### DIFF
--- a/acceptance/setup/pre_suite/15_setup_package_repos.rb
+++ b/acceptance/setup/pre_suite/15_setup_package_repos.rb
@@ -1,0 +1,64 @@
+test_config = PuppetDBExtensions.config
+
+def setup_package_repos_on_host(host, os)
+  case os
+  when :debian
+  when :redhat
+    create_remote_file host, '/etc/yum.repos.d/CentOS-Base.repo', <<-REPO.gsub(' '*8, '')
+[base]
+name=CentOS-$releasever - Base
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os
+baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever
+
+[contrib]
+name=CentOS-$releasever - Contrib
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib
+baseurl=http://mirror.centos.org/centos/$releasever/contrib/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever
+
+[centosplus]
+name=CentOS-$releasever - Plus
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
+baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever
+
+[extras]
+name=CentOS-$releasever - Extras
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
+baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever
+
+[updates]
+name=CentOS-$releasever - Updates
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates
+baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever
+    REPO
+
+    create_remote_file host, '/etc/yum.repos.d/epel.repo', <<-REPO
+[epel]
+name=Extra Packages for Enterprise Linux $releasever - $basearch
+baseurl=http://download.fedoraproject.org/pub/epel/$releasever/$basearch
+mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch
+failovermethod=priority
+enabled=1
+gpgcheck=0
+    REPO
+  else
+    raise ArgumentError, "Unsupported OS '#{os}'"
+  end
+end
+
+step "Setup package repos" do
+  os_families = test_config[:os_families]
+  hosts.each do |host|
+    setup_package_repos_on_host(host, os_families[host.name])
+  end
+end
+

--- a/acceptance/setup/pre_suite/20_install_puppet.rb
+++ b/acceptance/setup/pre_suite/20_install_puppet.rb
@@ -24,17 +24,6 @@ gpgkey=http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
 enabled=1
 gpgcheck=1
     REPO
-
-    create_remote_file host, '/etc/yum.repos.d/epel.repo', <<-REPO
-[epel]
-name=Extra Packages for Enterprise Linux $releasever - $basearch
-baseurl=http://download.fedoraproject.org/pub/epel/$releasever/$basearch
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch
-failovermethod=priority
-enabled=1
-gpgcheck=0
-    REPO
-
   else
     raise ArgumentError, "Unsupported OS '#{os}'"
   end


### PR DESCRIPTION
This patch provides a known Centos-Base.repo that will override the system
one to ensure Centos-Base.repo is using our preferred settings.

In particular this provides a fix for our current Centos 5 image
(ami-4433bf74) which only had 1 mirror defined. By providing the endorsed
Centos mirrorlist and baseurl we should avoid transient errors due to mirror
failures.

Signed-off-by: Ken Barber ken@bob.sh
