### PR TITLE
Bug/master/excessive database connections during export

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/export.clj
+++ b/src/com/puppetlabs/puppetdb/cli/export.clj
@@ -93,7 +93,7 @@
         (json/generate-string export-metadata {:pretty true}))
       ;; we can use a pmap call to retrieve the catalogs in parallel, so long
       ;; as we only touch the tar stream from a single thread.
-      (doseq [{:keys [node catalog]} (pmap get-catalog-fn nodes)]
+      (doseq [{:keys [node catalog]} (map get-catalog-fn nodes)]
         (println (format "Writing catalog for node '%s'" node))
         (archive/add-entry tar-writer
           (.getPath (io/file export-root-dir "catalogs" (format "%s.json" node)))


### PR DESCRIPTION
Change `pmap` back to `map` in export tool

Because clojure's `pmap` attempts to evaluate lazy sequences in
chunks of 32, the existing code for the export tool could cause
us to run out of Postgres connections because of too many
simultaneous catalog requests.  This commit simply changes the
code back to using a regular `map`, which is slower but safer
for now.  I may submit another pull request with another implementation
of parallelization if I can put together something simple without
spending too much time on it, but for now, it's best for us to
just make sure that we're safe and stable since performance isn't
a hugely pressing concern for this tool.
