### PR TITLE
Update config.ini template to reference etc_dir

### DIFF
--- a/ext/templates/config.ini.erb
+++ b/ext/templates/config.ini.erb
@@ -6,7 +6,7 @@
 vardir = <%= @lib_dir -%>
 
 # Use an external log4j config file
-logging-config = <%= @config_dir -%>/../log4j.properties
+logging-config = <%= @etc_dir -%>/log4j.properties
 
 # Maximum number of results that a resource query may return
 resource-query-limit = 20000


### PR DESCRIPTION
Previously the config.ini template referenced the @config_dir and then ascended
a directory to its parent, which is @etc_dir. This commit updates the template
to use @etc_dir, as that is clearer and less confusing, while equivalent in
functionality.
