### PR TITLE
Add a `bounded-pmap` function, and use it in the export tool

### DIFF
--- a/src/com/puppetlabs/concurrent.clj
+++ b/src/com/puppetlabs/concurrent.clj
@@ -1,0 +1,33 @@
+;; ## Concurrency-related Utility Functions
+;;
+;; This namespace contains some utility functions for multi-thread operations.
+;; In most cases these will simply be thin wrappers around clojure concurrency
+;; functions and/or structures from `java.util.concurrent`.
+
+(ns com.puppetlabs.concurrent
+  (:import  [java.util.concurrent Semaphore]))
+
+(defn bound-via-semaphore
+  "Given a semaphore `sem` function `f`, return a new function which simply
+  acquires the semaphore, executes `f`, and then releases the semaphore.  This
+  is mostly intended to be a helper function for use by `bounded-pmap`."
+  [sem f]
+  {:pre [(instance? Semaphore sem)
+         (ifn? f)]
+   :post [(ifn? %)]}
+  (fn [& args]
+    (.acquire sem)
+    (try
+      (apply f args)
+      (finally (.release sem)))))
+
+(defn bounded-pmap
+  "Similar to clojure's built-in `pmap`, but prevents concurrent evaluation of
+  more than `max-threads` number of items in the resulting sequence."
+  [max-threads f coll]
+  {:pre [(integer? max-threads)
+         (ifn? f)
+         (coll? coll)]}
+  (let [sem         (Semaphore. max-threads)
+        bounded-fn  (bound-via-semaphore sem f)]
+    (pmap bounded-fn coll)))

--- a/src/com/puppetlabs/puppetdb/cli/export.clj
+++ b/src/com/puppetlabs/puppetdb/cli/export.clj
@@ -10,7 +10,8 @@
 (ns com.puppetlabs.puppetdb.cli.export
   (:use [com.puppetlabs.utils :only (cli!)]
         [clj-time.core :only [now]]
-        [clj-time.coerce :only [to-string]])
+        [clj-time.coerce :only [to-string]]
+        [com.puppetlabs.concurrent :only [bounded-pmap]])
   (:require [cheshire.core :as json]
             [fs.core :as fs]
             [clojure.java.io :as io]
@@ -92,8 +93,11 @@
         (.getPath (io/file export-root-dir export-metadata-file-name))
         (json/generate-string export-metadata {:pretty true}))
       ;; we can use a pmap call to retrieve the catalogs in parallel, so long
-      ;; as we only touch the tar stream from a single thread.
-      (doseq [{:keys [node catalog]} (map get-catalog-fn nodes)]
+      ;; as we only touch the tar stream from a single thread.  However, we need
+      ;; to bound the pmap so that it doesn't overwhelm the server with requests
+      ;; and use up all of the db connections.  Allowing 5 concurrent requests
+      ;; seems to give us close to optimal performance w/o using too much memory.
+      (doseq [{:keys [node catalog]} (bounded-pmap 5 get-catalog-fn nodes)]
         (println (format "Writing catalog for node '%s'" node))
         (archive/add-entry tar-writer
           (.getPath (io/file export-root-dir "catalogs" (format "%s.json" node)))

--- a/test/com/puppetlabs/test/concurrent.clj
+++ b/test/com/puppetlabs/test/concurrent.clj
@@ -1,0 +1,70 @@
+(ns com.puppetlabs.test.concurrent
+  (:use [com.puppetlabs.concurrent]
+        [clojure.test])
+  (:require [clojure.tools.logging :as log])
+  (:import [java.util.concurrent Semaphore]))
+
+(defn- create-futures
+  "Helper function to create a sequence of `n` futures that simply apply function
+  `f` to `args`."
+  [n f & args]
+  (doall (for [i (range n)] (future (apply f args)))))
+
+(defn- increment-count
+  "Test helper function: increments the `:current` counter, and if the new value
+  exceeds the `:max` counter, update the `:max` counter to the new max value."
+  [counts]
+  {:pre [(map? counts)
+         (contains? counts :current)
+         (contains? counts :max)]}
+  (let [updated (update-in counts [:current] inc)]
+    (assoc updated :max (max (:max updated) (:current updated)))))
+
+(defn- decrement-count
+  "Test helper function: decrements the `:current` counter."
+  [counts]
+  {:pre [(map? counts)
+         (contains? counts :current)
+         (contains? counts :max)]}
+  (update-in counts [:current] dec))
+
+(defn- update-counts
+  "Test helper function: calls `swap!` on the `counts` atom to increment
+  the counters, sleeps for a very short period to make sure other threads have
+  a change to run, and then calls `swap!` again to decrement the counters."
+  [counts]
+  {:pre [(instance? clojure.lang.Atom counts)]}
+  (swap! counts increment-count)
+  (Thread/sleep 5)
+  (swap! counts decrement-count))
+
+(defn- update-counts-and-inc
+  "Test helper function: calls `update-counts` to exercise the counter/semaphore
+  code, then simply calls `inc` on `item` (to allow testing results of the `map`
+  operation."
+  [counts item]
+  {:pre [(instance? clojure.lang.Atom counts)
+         (number? item)]}
+  (update-counts counts)
+  (inc item))
+
+
+(deftest test-bound-via-semaphore
+  (doseq [bound [1 2 5]]
+    (testing (format "Testing bound-via-semaphore with semaphore size %s" bound)
+      (let [sem     (Semaphore. bound)
+            counts  (atom {:current 0 :max 0})
+            futures (create-futures 10
+                      (bound-via-semaphore sem update-counts) counts)]
+      (doseq [fut futures]
+        ;; deref all of the futures to make sure we've waited for them to complete
+        @fut)
+      (is (= {:current 0 :max bound} @counts))))))
+
+(deftest test-bounded-pmap
+  (doseq [bound [1 2 5]]
+    (testing (format "Testing bounded-pmap with bound %s" bound)
+      (let [counts  (atom {:current 0 :max 0})
+            results (doall (bounded-pmap bound (partial update-counts-and-inc counts) (range 20)))]
+        (is (= {:current 0 :max bound} @counts))
+        (is (= (set (map inc (range 20))) (set results)))))))


### PR DESCRIPTION
This commit adds a new namespace called `concurrent`, intended to
contain some utility functions relating to concurrency.  (I expect
that in most cases these will simply be thin wrappers around
clojure concurrency functions in combination with structures from
`java.util.concurrent`.)

The first major function in this namespace is `bounded-pmap`, which
is just like clojure's `pmap`, but allows you to pass in an integer
value `max-threads` and prevents concurrent evaluation of more than
`max-threads` items in the resulting sequence.

Also ports the `export` command-line tool over to use `bounded-pmap`,
which improves performance by about 3x and drastically reduces
memory consumption.
