### PR TITLE
Docs: Change canonical links to "latest" instead of 1.1

### DIFF
--- a/documentation/api/commands.markdown
+++ b/documentation/api/commands.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » Commands"
 layout: default
-canonical: "/puppetdb/1.1/api/commands.html"
+canonical: "/puppetdb/latest/api/commands.html"
 ---
 
 [facts]: ./wire_format/facts_format.html

--- a/documentation/api/index.markdown
+++ b/documentation/api/index.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » Overview"
 layout: default
-canonical: "/puppetdb/1.1/api/index.html"
+canonical: "/puppetdb/latest/api/index.html"
 ---
 
 [commands]: ./commands.html

--- a/documentation/api/query/curl.markdown
+++ b/documentation/api/query/curl.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "PuppetDB 1.1 » API » Query » Curl Tips"
-canonical: "/puppetdb/1.1/api/query/curl.html"
+canonical: "/puppetdb/latest/api/query/curl.html"
 ---
 
 [Facts]: ./v2/facts.html

--- a/documentation/api/query/experimental/event.markdown
+++ b/documentation/api/query/experimental/event.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » Experimental » Querying Events"
 layout: default
-canonical: "/puppetdb/1.1/api/query/experimental/event.html"
+canonical: "/puppetdb/latest/api/query/experimental/event.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp

--- a/documentation/api/query/experimental/report.markdown
+++ b/documentation/api/query/experimental/report.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » Experimental » Querying Reports"
 layout: default
-canonical: "/puppetdb/1.1/api/query/experimental/report.html"
+canonical: "/puppetdb/latest/api/query/experimental/report.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp

--- a/documentation/api/query/tutorial.markdown
+++ b/documentation/api/query/tutorial.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » Query Tutorial"
 layout: default
-canonical: "/puppetdb/1.1/api/query/tutorial.html"
+canonical: "/puppetdb/latest/api/query/tutorial.html"
 ---
 
 This page is a walkthrough for constructing several types of PuppetDB queries. It uses the **version 2 API** in all of its examples; however, most of the general principles are also applicable to the version 1 API. 

--- a/documentation/api/query/v1/facts.markdown
+++ b/documentation/api/query/v1/facts.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » v1 » Querying Facts"
 layout: default
-canonical: "/puppetdb/1.1/api/query/v1/facts.html"
+canonical: "/puppetdb/latest/api/query/v1/facts.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp

--- a/documentation/api/query/v1/metrics.markdown
+++ b/documentation/api/query/v1/metrics.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » v1 » Querying Metrics"
 layout: default
-canonical: "/puppetdb/1.1/api/query/v1/metrics.html"
+canonical: "/puppetdb/latest/api/query/v1/metrics.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp

--- a/documentation/api/query/v1/nodes.markdown
+++ b/documentation/api/query/v1/nodes.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » v1 » Querying Nodes"
 layout: default
-canonical: "/puppetdb/1.1/api/query/v1/nodes.html"
+canonical: "/puppetdb/latest/api/query/v1/nodes.html"
 ---
 
 [resource]: ./resources.html

--- a/documentation/api/query/v1/resources.markdown
+++ b/documentation/api/query/v1/resources.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » v1 » Querying Resources"
 layout: default
-canonical: "/puppetdb/1.1/api/query/v1/resources.html"
+canonical: "/puppetdb/latest/api/query/v1/resources.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp

--- a/documentation/api/query/v1/status.markdown
+++ b/documentation/api/query/v1/status.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » v1 » Querying Status"
 layout: default
-canonical: "/puppetdb/1.1/api/query/v1/status.html"
+canonical: "/puppetdb/latest/api/query/v1/status.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp

--- a/documentation/api/query/v2/fact-names.markdown
+++ b/documentation/api/query/v2/fact-names.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » v2 » Querying Fact Names"
 layout: default
-canonical: "/puppetdb/1.1/api/query/v2/fact-names.html"
+canonical: "/puppetdb/latest/api/query/v2/fact-names.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp

--- a/documentation/api/query/v2/facts.markdown
+++ b/documentation/api/query/v2/facts.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » v2 » Querying Facts"
 layout: default
-canonical: "/puppetdb/1.1/api/query/v2/facts.html"
+canonical: "/puppetdb/latest/api/query/v2/facts.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp

--- a/documentation/api/query/v2/metrics.markdown
+++ b/documentation/api/query/v2/metrics.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » v2 » Querying Metrics"
 layout: default
-canonical: "/puppetdb/1.1/api/query/v2/metrics.html"
+canonical: "/puppetdb/latest/api/query/v2/metrics.html"
 ---
 
 > **Note:** The v2 metrics endpoint is currently exactly the same as the [v1 endpoint](../v1/metrics.html).

--- a/documentation/api/query/v2/nodes.markdown
+++ b/documentation/api/query/v2/nodes.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » v2 » Querying Nodes"
 layout: default
-canonical: "/puppetdb/1.1/api/query/v2/nodes.html"
+canonical: "/puppetdb/latest/api/query/v2/nodes.html"
 ---
 
 [resource]: ./resources.html

--- a/documentation/api/query/v2/operators.markdown
+++ b/documentation/api/query/v2/operators.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » v2 » Query Operators"
 layout: default
-canonical: "/puppetdb/1.1/api/query/v2/operators.html"
+canonical: "/puppetdb/latest/api/query/v2/operators.html"
 ---
 
 [resources]: ./resources.html

--- a/documentation/api/query/v2/query.markdown
+++ b/documentation/api/query/v2/query.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » v2 » Query Structure"
 layout: default
-canonical: "/puppetdb/1.1/api/query/v2/query.html"
+canonical: "/puppetdb/latest/api/query/v2/query.html"
 ---
 
 [prefix]: http://en.wikipedia.org/wiki/Polish_notation

--- a/documentation/api/query/v2/resources.markdown
+++ b/documentation/api/query/v2/resources.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » v2 » Querying Resources"
 layout: default
-canonical: "/puppetdb/1.1/api/query/v2/resources.html"
+canonical: "/puppetdb/latest/api/query/v2/resources.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp

--- a/documentation/api/wire_format/catalog_format.markdown
+++ b/documentation/api/wire_format/catalog_format.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » Catalog Wire Format, Version 1"
 layout: default
-canonical: "/puppetdb/1.1/api/wire_format/catalog_format.html"
+canonical: "/puppetdb/latest/api/wire_format/catalog_format.html"
 ---
 
 [containment]: /puppet/2.7/reference/lang_containment.html

--- a/documentation/api/wire_format/facts_format.markdown
+++ b/documentation/api/wire_format/facts_format.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » Facts Wire Format"
 layout: default
-canonical: "/puppetdb/1.1/api/wire_format/facts_format.html"
+canonical: "/puppetdb/latest/api/wire_format/facts_format.html"
 ---
 
 

--- a/documentation/api/wire_format/report_format.markdown
+++ b/documentation/api/wire_format/report_format.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » API » Experimental » Report Wire Format, Version 1"
 layout: default
-canonical: "/puppetdb/1.1/api/wire_format/report_format.html"
+canonical: "/puppetdb/latest/api/wire_format/report_format.html"
 ---
 
 [api]: ../index.html

--- a/documentation/community_add_ons.markdown
+++ b/documentation/community_add_ons.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Community Projects and Add-ons"
 layout: default
-canonical: "/puppetdb/1.1/community_add_ons.html"
+canonical: "/puppetdb/latest/community_add_ons.html"
 ---
 
 

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Configuration"
 layout: default
-canonical: "/puppetdb/1.1/configure.html"
+canonical: "/puppetdb/latest/configure.html"
 ---
 
 [log4j]: http://logging.apache.org/log4j/1.2/manual.html

--- a/documentation/connect_puppet_apply.markdown
+++ b/documentation/connect_puppet_apply.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Connecting Standalone Puppet Nodes to PuppetDB"
 layout: default
-canonical: "/puppetdb/1.1/connect_puppet_apply.html"
+canonical: "/puppetdb/latest/connect_puppet_apply.html"
 ---
 
 [exported]: /puppet/2.7/reference/lang_exported.html

--- a/documentation/connect_puppet_master.markdown
+++ b/documentation/connect_puppet_master.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Connecting Puppet Masters to PuppetDB"
 layout: default
-canonical: "/puppetdb/1.1/connect_puppet_master.html"
+canonical: "/puppetdb/latest/connect_puppet_master.html"
 ---
 
 [puppetdb_download]: http://downloads.puppetlabs.com/puppetdb

--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Overview"
 layout: default
-canonical: "/puppetdb/1.1/index.html"
+canonical: "/puppetdb/latest/index.html"
 ---
 
 [exported]: /puppet/2.7/reference/lang_exported.html

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Installing PuppetDB From Packages"
 layout: default
-canonical: "/puppetdb/1.1/install_from_packages.html"
+canonical: "/puppetdb/latest/install_from_packages.html"
 ---
 
 [connect_master]: ./connect_puppet_master.html

--- a/documentation/install_from_source.markdown
+++ b/documentation/install_from_source.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Installing PuppetDB from Source"
 layout: default
-canonical: "/puppetdb/1.1/install_from_source.html"
+canonical: "/puppetdb/latest/install_from_source.html"
 ---
 
 [perf_dashboard]: ./maintain_and_tune.html#monitor-the-performance-dashboard

--- a/documentation/install_via_module.markdown
+++ b/documentation/install_via_module.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "PuppetDB 1.1 » Installing PuppetDB Via Module"
-canonical: "/puppetdb/1.1/install_via_module.html"
+canonical: "/puppetdb/latest/install_via_module.html"
 ---
 
 [module]: http://forge.puppetlabs.com/puppetlabs/puppetdb

--- a/documentation/known_issues.markdown
+++ b/documentation/known_issues.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Known Issues"
 layout: default
-canonical: "/puppetdb/1.1/known_issues.html"
+canonical: "/puppetdb/latest/known_issues.html"
 ---
 
 

--- a/documentation/maintain_and_tune.markdown
+++ b/documentation/maintain_and_tune.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Maintaining and Tuning"
 layout: default
-canonical: "/puppetdb/1.1/maintain_and_tune.html"
+canonical: "/puppetdb/latest/maintain_and_tune.html"
 ---
 
 [configure_jetty]: ./configure.html#jetty-http-settings

--- a/documentation/migrate.markdown
+++ b/documentation/migrate.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.2 » Migrating Data"
 layout: default
-canonical: "/puppetdb/1.2/migrate.html"
+canonical: "/puppetdb/latest/migrate.html"
 ---
 
 Migrating from ActiveRecord storeconfigs

--- a/documentation/postgres_ssl.markdown
+++ b/documentation/postgres_ssl.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Configuration » Using SSL with PostgreSQL"
 layout: default
-canonical: "/puppetdb/1.1/postgres_ssl.html"
+canonical: "/puppetdb/latest/postgres_ssl.html"
 ---
 
 ## Talking to PostgreSQL using SSL/TLS

--- a/documentation/puppetdb-faq.markdown
+++ b/documentation/puppetdb-faq.markdown
@@ -2,7 +2,7 @@
 layout: default
 title: "PuppetDB 1.1 FAQ"
 subtitle: "Frequently Asked Questions"
-canonical: "/puppetdb/1.1/puppetdb-faq.html"
+canonical: "/puppetdb/latest/puppetdb-faq.html"
 ---
 
 [trouble_kahadb]: ./trouble_kahadb_corruption.html

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Release Notes"
 layout: default
-canonical: "/puppetdb/1.1/release_notes.html"
+canonical: "/puppetdb/latest/release_notes.html"
 ---
 
 1.1.1

--- a/documentation/repl.markdown
+++ b/documentation/repl.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Debugging with the Remote REPL"
 layout: default
-canonical: "/puppetdb/1.1/repl.html"
+canonical: "/puppetdb/latest/repl.html"
 ---
 
 PuppetDB includes a remote REPL interface, which is disabled by default.

--- a/documentation/scaling_recommendations.markdown
+++ b/documentation/scaling_recommendations.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Scaling Recommendations"
 layout: default
-canonical: "/puppetdb/1.1/scaling_recommendations.html"
+canonical: "/puppetdb/latest/scaling_recommendations.html"
 ---
 
 [configure_heap]: ./configure.html#configuring-the-java-heap-size

--- a/documentation/trouble_kahadb_corruption.markdown
+++ b/documentation/trouble_kahadb_corruption.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Troubleshooting » KahaDB Corruption"
 layout: default
-canonical: "/puppetdb/1.1/trouble_kahadb_corruption.html"
+canonical: "/puppetdb/latest/trouble_kahadb_corruption.html"
 ---
 
 [configure_vardir]: ./configure.html#vardir

--- a/documentation/upgrade.markdown
+++ b/documentation/upgrade.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Upgrading PuppetDB"
 layout: default
-canonical: "/puppetdb/1.1/upgrade.html"
+canonical: "/puppetdb/latest/upgrade.html"
 ---
 
 

--- a/documentation/using.markdown
+++ b/documentation/using.markdown
@@ -1,7 +1,7 @@
 ---
 title: "PuppetDB 1.1 » Using PuppetDB"
 layout: default
-canonical: "/puppetdb/1.1/using.html"
+canonical: "/puppetdb/latest/using.html"
 ---
 
 [exported]: /puppet/2.7/reference/lang_exported.html


### PR DESCRIPTION
This should save some time when pushing new versions. I knew that "latest"
shortcut would come in handy.

In our implementation, "latest" points at the newest numeric version, never at
named versions like "master." (Versions, of course, are created in
puppet-docs/source/_config.yml. Apologies as ever for this toolchain, but
anyway.)

The one funky bit in this commit is that I changed one canonical link from 1.2
to latest, which is a bunk URL until we release the 1.2 docs. I am fine with
that, and Google will figure it out until then.
