### PR TITLE
WIP: (#19884) puppetdb-ssl-setup should be choosey when it changes things

### DIFF
--- a/ext/templates/jetty.ini.erb
+++ b/ext/templates/jetty.ini.erb
@@ -3,13 +3,16 @@
 #host = localhost
 # Port to listen on for clear-text HTTP.
 port = 8080
-<%# placeholder string for ssl-host; will be overwritten by the
+
+<%# placeholder configuration for ssl setup will be overridden by
         puppetdb-ssl-setup script %>
-ssl-host = `facter fqdn`
-ssl-port = 8081
-keystore = <%= @etc_dir -%>/ssl/keystore.jks
-truststore = <%= @etc_dir -%>/ssl/truststore.jks
-<%# these are placeholder passwords, will be overwritten by the
-        puppetdb-ssl-setup script %>
-key-password = PASSWORD
-trust-password = PASSWORD
+# The following are SSL specific settings. They can be configured
+# automatically with the tool puppetdb-ssl-setup, which is normally
+# ran during package installation.
+#
+# ssl-host = <HOST>
+# ssl-port = <PORT>
+# keystore = <PATH>
+# truststore = <PATH>
+# key-password = <PASSWORD>
+# trust-password = <PASSWORD>

--- a/ext/templates/puppetdb-ssl-setup
+++ b/ext/templates/puppetdb-ssl-setup
@@ -1,17 +1,23 @@
 #!/bin/bash
 
+function sedeasy {
+  tmp=$3.tmp.`date +%s`
+  sed "s/$1/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g" $3 > $tmp
+  mv $tmp $3
+}
 
-#TODO Move this into the init script and ensure it only runs when something is wrong with configuraiton
-
-while getopts "i" opt;
+while getopts "if" opt;
 do
     case $opt in
         i)
-            interactive=true
+            interactive=true ;;
+        f)
+            force=true ;;
     esac
 done
 
 ${interactive:=false}
+${force:=false}
 
 if $interactive
 then
@@ -93,21 +99,43 @@ fi
 
 jettyfile="${puppetdb_confdir}/conf.d/jetty.ini"
 if [ -f "$jettyfile" ] ; then
-  if grep "ssl-host" ${jettyfile} > /dev/null; then
-    sed -e 's/^ssl-host.*/ssl-host = '"$fqdn"'/' ${jettyfile} > ${jettyfile}.tmp
-    mv ${jettyfile}.tmp ${jettyfile}
-  else
-    echo "$jettyfile exists, but could not find ssl-host setting. Please update that setting to the desired hostname that puppetdb should listen on (e.g.: '`facter fqdn`)."
-  fi
+  jettyfile_bak="${jettyfile}.bak.`date +%s`"
+  cp -p $jettyfile $jettyfile_bak
+  echo "Backing up ${jettyfile} to ${jettyfile_bak} before making changes"
 
-  if grep "key-password" ${jettyfile} >/dev/null && grep "trust-password" ${jettyfile} >/dev/null; then
-    sed -e 's/^key-password.*/key-password = '"$password"'/' ${jettyfile} > ${tmpdir}/tmp.jetty
-    sed -e 's/^trust-password.*/trust-password = '"$password"'/' ${tmpdir}/tmp.jetty > ${jettyfile}
-  else
-    echo "$jettyfile exists, but could not find key-password and trust-password settings. Please update those settings to the password contained in ${puppetdb_confdir}/ssl/puppetdb_keystore_pw.txt"
-  fi
+  settings=('ssl-host' 'ssl-port' 'key-password' 'trust-password' 'keystore' 'truststore')
+  values=($fqdn 8081 $password $password "${puppetdb_confdir}/ssl/keystore.jks" "${puppetdb_confdir}/ssl/truststore.jks")
+
+  for (( i=0; i<${#settings[@]}; i++ )); do
+    if grep -e "^${settings[$i]}" ${jettyfile} > /dev/null; then
+      if grep -e "^${settings[$i]} = ${values[$i]}$" ${jettyfile} > /dev/null; then
+        echo "Setting ${settings[$i]} in ${jettyfile} already correct."
+      else
+        if $force; then
+          sedeasy "^${settings[$i]}.*" "${settings[$i]} = ${values[$i]}" ${jettyfile}
+          echo "Updated setting ${settings[$i]} in ${jettyfile}."
+        else
+          echo "Setting ${settings[$i]} in ${jettyfile} doesn't seem to be correct. This can be remedied with $0 -f."
+        fi
+      fi
+    else
+      if grep -E "^# ${settings[$i]} = <[A-Z]+>$" ${jettyfile} > /dev/null; then
+        sedeasy "^# ${settings[$i]}.*" "${settings[$i]} = ${values[$i]}" ${jettyfile}
+        echo "Updated default settings from package installation for ${settings[$i]} in ${jettyfile}."
+      else
+        if $force; then
+          cat ${jettyfile} > ${jettyfile}.tmp
+          echo "${settings[$i]} = ${values[$i]}" >> ${jettyfile}.tmp
+          mv ${jettyfile}.tmp ${jettyfile}
+          echo "Added setting ${settings[$i]} to ${jettyfile}."
+        else
+          echo "$jettyfile exists, but could not find active ${settings[$i]} setting. Include that setting yourself manually. Or force with $0 -f."
+        fi
+      fi
+    fi
+  done
 else
-  echo "Please update your key-password and trust-password settings to the password contained in ${puppetdb_confdir}/ssl/puppetdb_keystore_pw.txt"
+  echo "Unable to find PuppetDB Jetty configuration at ${jettyfile}. Unable to provide automatic configuration for that file."
 fi
 
 chmod 600 ${puppetdb_confdir}/ssl/*


### PR DESCRIPTION
This patch modifies puppetdb-ssl-setup so it is more choosey when it changes
items in jetty.ini. In the past it would simply overwrite all settings, but
now you need to supply -f if you want to do this. This means that during
package upgrade we are passive for settings that have already been set, but
we do return warnings to the console so users can make these changes
themselves if they so desire.

However, there are cases where this kind of thing is required - esp. during
first installation so the tool now looks for factory default settings and
modifies those if it finds them. These are in the form:

```
# setting = <FOO>
```

Our tool looks for these especially, assuming they are package defaults and
_will_ modify them regardless of the -f setting. Once they are modified it
shouldn't do it again. This makes sure the 'initial installation' case does
the write thing.

The original jetty.ini file that is laid down now has all the SSL settings
commented out and in the format the tool requires. The fact they are commented
means that if the tool bombs out PuppetDB should still work but with no SSL
settings.

I've made the script more wordy about what it is doing which might help, and
also made sure we backup the old jetty.ini before doing anything. The backup
itself is timestamped, so subsequent runs on a faulty jetty.ini do not
override somethings settings no matter how often it runs. Generally I hate it
when tools don't do this, so I don't want to inflict it on our users.

The scriptage around change settings has been made more generalised so we can
stretch this pattern out to a number of settings if required now.

Signed-off-by: Ken Barber ken@bob.sh
