### PR TITLE
Install sqlite3 from gems on EL during acceptance testing

### DIFF
--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -36,15 +36,19 @@ step "Install other dependencies on database" do
   end
 end
 
-step "Install sqlite3 on master" do
+step "Install rubygems and sqlite3 on master" do
   os = test_config[:os_families][master.name]
 
   case os
   when :redhat
-    on database, "yum install -y ruby-sqlite3"
+    on master, "yum install -y rubygems sqlite-devel"
+    on master, "gem install sqlite3"
   when :debian
-    on database, "apt-get install -y libsqlite3-ruby rubygems"
+    on master, "apt-get install -y rubygems libsqlite3-ruby"
   else
     raise ArgumentError, "Unsupported OS '#{os}'"
   end
+
+  # Make sure there isn't a gemrc file, because that could ruin our day.
+  on master, "rm ~/.gemrc"
 end

--- a/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
+++ b/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
@@ -18,14 +18,8 @@ test_name "storeconfigs export and import" do
     on master, "chmod -R 777 #{db_path}"
   end
 
-  step "install activerecord on the master" do
-    # EL5 doesn't have the activerecord gem, because it's Ruby 1.8.5. So we
-    # have to use our own package of it.
-    if master['platform'].include? 'el-5'
-      on master, "yum install -y rubygem-activerecord"
-    else
-      on master, "gem install activerecord -v 2.3.17 --no-ri --no-rdoc"
-    end
+  step "install activerecord and sqlite3 on the master" do
+    on master, "gem install activerecord -v 2.3.17 --no-ri --no-rdoc"
   end
 
   step "run each agent once to populate the database" do
@@ -70,10 +64,6 @@ test_name "storeconfigs export and import" do
   end
 
   teardown do
-    if master['platform'].include? 'el-5'
-      on master, "yum -y remove rubygem-activerecord rubygem-activesupport"
-    else
-      on master, "gem uninstall activerecord activesupport"
-    end
+    on master, "gem uninstall activerecord activesupport"
   end
 end


### PR DESCRIPTION
When installing Puppet 3.x in acceptance tests, the centos5 machine has
1.8.7 installed as a dependency. This means the ruby-sqlite3 package
doesn't work correctly, as it's meant for use with Ruby 1.8.5. Now we
just install the devel package, and install sqlite3 as a gem.

We also always install rubygems, as it was missing on certain platforms.
