### PR TITLE
Fix typo in kahadb troubleshooting doc and change title of FAQ

### DIFF
--- a/documentation/puppetdb-faq.markdown
+++ b/documentation/puppetdb-faq.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "PuppetDB 1.1 FAQ"
-subtitle: "Basic Info and Troubleshooting Tips"
+subtitle: "Frequently Asked Questions"
 canonical: "/puppetdb/1.1/puppetdb-faq.html"
 ---
 

--- a/documentation/trouble_kahadb_corruption.markdown
+++ b/documentation/trouble_kahadb_corruption.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 1.1 » Troublshooting » KahaDB Corruption"
+title: "PuppetDB 1.1 » Troubleshooting » KahaDB Corruption"
 layout: default
 canonical: "/puppetdb/1.1/trouble_kahadb_corruption.html"
 ---


### PR DESCRIPTION
This patch fixes a title in the KahaDB docs, it also changes the title of the
FAQ to 'Frequently Asked Questions' to reflect its real purpose now that we
are attempting to create a more precise troubleshooting area.

Signed-off-by: Ken Barber ken@bob.sh
