### PR TITLE
lein shouldn't fail when "rake version" fails

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,11 +11,9 @@
        (s/trim (slurp "version"))
        (let [command                ["rake" "version" "-s"]
              {:keys [exit out err]} (apply sh command)]
-         (when-not (zero? exit)
-           (println (format "Non-zero exit status during version check:\n%s\n%s\n%s\n%s"
-                            command exit out err))
-           (System/exit 1))
-       (s/trim out))))))
+         (if (zero? exit)
+           (s/trim out)
+           "0.0-dev-build"))))))
 
 (defproject puppetdb (version-string)
   :description "Puppet-integrated catalog and fact storage"
@@ -71,7 +69,6 @@
                    :dependencies [[ring-mock "0.1.1"]]}}
 
   :jar-exclusions [#"leiningen/"]
-  :manifest {"Build-Version" ~(version-string)}
 
   :aot [com.puppetlabs.puppetdb.core]
   :main com.puppetlabs.puppetdb.core


### PR DESCRIPTION
The current use of "rake version" in the project.clj breaks all use of
leiningen, even for non-packaging tasks, if you don't have all the
packaging machinery installed.

There are a few problems with this:

1) There is no documentation in our repo about how to actually do
development on the clj code now. I updated to master, and couldn't run
anything and had no idea how to proceed. New contributors or people
building from source (of which there are definitely a few) would have
even more trouble. I just gave 2 public talks on PuppetDB, and now any
people checking out our stuff will have a bad time. :(

2) It's a suboptimal experience for developers. To do anything with the
project, like run "lein test", "lein compile", "lein repl", or even
"lein help" you now need to have rake & facter installed, and have run
the packaging tasks. This is all for packaging machinery that has no
relation to the actual task the developer was trying to complete in many
cases, which is somewhat confusing.

3) It makes integration into IDEs and editors that manage the use of
lein for you considerably more difficult. For one, you now have to bake
into all of those tools the knowledge of how to launch rake, where the
facter libs are, etc (difficult if you're using, say, rvm). Some tools
like drip don't even give you the option.

This fix is pretty basic; if "rake version" fails for whatever reason,
we default to a hard-coded version string that indicates that this is a
development build. This allows developers to interact with the clojure
codebase as they normally would, while still allowing us to do much more
interesting stuff for formal packaging purposes.
