### PR TITLE
Docs formatting: in release notes, make 1.2.0 header a header

### DIFF
--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -5,6 +5,7 @@ canonical: "/puppetdb/latest/release_notes.html"
 ---
 
 1.2.0
+-----
 
 Many thanks to following people who contributed patches to this
 release:


### PR DESCRIPTION
This commit needs to be cherry-picked back to 1.2.x. 
