### PR TITLE
Remove unused namespace

### DIFF
--- a/src/com/puppetlabs/puppetdb/http/v2/catalog.clj
+++ b/src/com/puppetlabs/puppetdb/http/v2/catalog.clj
@@ -1,5 +1,0 @@
-(ns com.puppetlabs.puppetdb.http.v2.catalog
-  (:require  [com.puppetlabs.puppetdb.http.v1.catalog :as v1-catalog]))
-
-(def catalog-app
-  v1-catalog/catalog-app)


### PR DESCRIPTION
In fact, the file doesn't even compile as it references a namespace
(v1.catalog) that doesn't exist!
