### PR TITLE
Change which rake task reports the version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
      []
      (if (.exists (file "version"))
        (s/trim (slurp "version"))
-       (let [command                ["rake" "version" "-s"]
+       (let [command                ["rake" "package:version" "-s"]
              {:keys [exit out err]} (apply sh command)]
          (if (zero? exit)
            (s/trim out)


### PR DESCRIPTION
We currently use "rake version -s" to produce the version number of the
project. However, if someone has rake installed but hasn't run rake
package:bootstrap, then rake will retun nothing, but still exit with a
0.

This changes which task we execute to the more specific rake
package:version; that does the exact same thing as rake version, but
will be a hard failure if the packaging shims haven't been put in place.
