### PR TITLE
Change default value of `report-ttl` to 14 days

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -285,7 +285,7 @@ You may specify the time as a string using any of the suffixes described in the
 Outdated reports will be deleted during the database garbage collection, which
 runs every `gc-interval` minutes.
 
-If unset, the default value is 7 days.
+If unset, the default value is 14 days.
 
 ### `log-slow-statements`
 

--- a/documentation/maintain_and_tune.markdown
+++ b/documentation/maintain_and_tune.markdown
@@ -54,7 +54,7 @@ Although deactivated nodes will be excluded from storeconfigs queries, their dat
 
 ## Clean Up Old Reports
 
-When the [PuppetDB report processor][puppetdb_report_processor] is enabled on your Puppet master, PuppetDB will retain reports for each node for a fixed amount of time.  This defaults to seven days, but you can alter this to suit your needs using the [`report-ttl` setting][report_ttl].  The larger the value you provide for this setting, the more history you will retain; however, your database size will grow accordingly.
+When the [PuppetDB report processor][puppetdb_report_processor] is enabled on your Puppet master, PuppetDB will retain reports for each node for a fixed amount of time.  This defaults to 14 days, but you can alter this to suit your needs using the [`report-ttl` setting][report_ttl].  The larger the value you provide for this setting, the more history you will retain; however, your database size will grow accordingly.
 
 ## View the Log
 

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -241,7 +241,7 @@
         ;; same
         node-ttl-default (secs 0)
         node-purge-ttl-default (secs 0)
-        report-ttl-default (days 7)
+        report-ttl-default (days 14)
         parsed-commandproc (update-in command-processing [:dlo-compression-threshold] #(or (maybe-parse-period %) dlo-compression-default))
         parsed-database (-> database
                             (update-in [:gc-interval] #(or (maybe-minutes %) gc-interval-default))

--- a/test/com/puppetlabs/puppetdb/test/cli/services.clj
+++ b/test/com/puppetlabs/puppetdb/test/cli/services.clj
@@ -90,10 +90,10 @@
       (let [{:keys [report-ttl]} (:database (configure-gc-params { :database { :report-ttl "10d" }}))]
         (is (period? report-ttl))
         (is (= (days 10) (days (to-days report-ttl))))))
-    (testing "should default to 7 days"
+    (testing "should default to 14 days"
       (let [{:keys [report-ttl]} (:database (configure-gc-params {}))]
         (is (period? report-ttl))
-        (is (= (days 7) (days (to-days report-ttl))))))))
+        (is (= (days 14) (days (to-days report-ttl))))))))
 
 (deftest http-configuration
   (testing "should enable need-client-auth"


### PR DESCRIPTION
Most of our current UI mockups for future versions of PE guis
assume that we will have at least 14 days of report data around,
so we have decided to tweak the default value of this setting
accordingly.
