### PR TITLE
Improvements to report exp/imp tests

### DIFF
--- a/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
+++ b/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
@@ -59,8 +59,8 @@ test_name "storeconfigs export and import" do
     scp_from(database, db_new_export_file, ".")
   end
 
-  step "verify legacy export data matches new export data" do
-    compare_export_data(driver_legacy_export_file, driver_new_export_file)
+  step "verify legacy export data matches new export data - catalog data only" do
+    compare_export_data(driver_legacy_export_file, driver_new_export_file, :metadata => false, :reports => false)
   end
 
   teardown do


### PR DESCRIPTION
With the new reports import/export additions some minor errors were made to
correcting the stored config based export/import tests. In particular we were
inserting store-report => 1 into the metadata to make a test pass.

Instead of doing that, I've modified the compare_export_data test to allow
us to control what exactly gets compared, so we can exclude the metadata
comparison if required.

I've also refactored compare_export_data a tad as previously it didn't have
its own compare_report method or report munging facility - it was using the
metadata one instead.

Signed-off-by: Ken Barber ken@bob.sh
