### PR TITLE
Remove certnames from exported reports

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -384,6 +384,7 @@ module PuppetDBExtensions
     #  be inside of the jenkins workspace, which I'm hoping means that it will
     #  be cleaned up regularly if we accidentally leave anything lying around
     tmpdir = "./puppetdb_export_test_tmp"
+    FileUtils.rm_rf(tmpdir)
     export_dir1 = File.join(tmpdir, "export1", File.basename(export_file1, ".tar.gz"))
     export_dir2 = File.join(tmpdir, "export2", File.basename(export_file2, ".tar.gz"))
     FileUtils.mkdir_p(export_dir1)

--- a/acceptance/tests/import_export/import_export.rb
+++ b/acceptance/tests/import_export/import_export.rb
@@ -39,41 +39,4 @@ test_name "storeconfigs export and import" do
     compare_export_data(export_file1, export_file2)
   end
 
-
-  #
-  #driver_legacy_export_file = "./legacy_storeconfigs_export.tar.gz"
-  #driver_new_export_file    = "./puppetdb-export.tar.gz"
-  #
-  #step "export the storeconfigs data" do
-  #  result = on master, "puppet storeconfigs export #{args}"
-  #  regex = /Exported storeconfigs data to (.*)/
-  #  assert_match regex, result.output
-  #  legacy_export_file = regex.match(result.output)[1]
-  #
-  #  scp_from(master, legacy_export_file, ".")
-  #  File.rename(File.join(".", File.basename(legacy_export_file)), driver_legacy_export_file)
-  #end
-  #
-  #clear_and_restart_puppetdb(database)
-  #
-  #step "import data into puppetdb" do
-  #  db_legacy_export_dir  = "."
-  #  db_legacy_export_file = File.join(db_legacy_export_dir, "legacy_storeconfigs_export.tar.gz")
-  #  scp_to(database, driver_legacy_export_file, db_legacy_export_dir)
-  #  on database, "puppetdb-import --infile #{db_legacy_export_file}"
-  #end
-  #
-  #step "export data from puppetdb" do
-  #  db_new_export_file = "./puppetdb-export.tar.gz"
-  #  on database, "puppetdb-export --outfile #{db_new_export_file}"
-  #  scp_from(database, db_new_export_file, ".")
-  #end
-  #
-  #step "verify legacy export data matches new export data" do
-  #  compare_export_data(driver_legacy_export_file, driver_new_export_file)
-  #end
-  #
-  #teardown do
-  #  on master, "gem uninstall activerecord activesupport"
-  #end
 end

--- a/src/com/puppetlabs/puppetdb/cli/export.clj
+++ b/src/com/puppetlabs/puppetdb/cli/export.clj
@@ -54,7 +54,7 @@
       (sort-by
         #(mapv % [:timestamp :resource-type :resource-title :property])
         (map
-          #(dissoc % :report)
+          #(dissoc % :report :certname)
           (json/parse-string body true))))))
 
 (defn reports-for-node


### PR DESCRIPTION
As a side effect of a recent merge, I introduced a bug in the
report export functionality.  Report submissions should not
contain the 'certname' field on individual resource events,
but that field does come back in query results now.  This commit
simply removes it from the export data so that we don't try to
send it back up on imports.
