### PR TITLE
Ignore extra files in export comparison

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -417,6 +417,12 @@ module PuppetDBExtensions
     export2_files = Set.new(
       Dir.glob("#{export_dir2}/**/*").map { |f| f.sub(/^#{Regexp.escape(export_dir2)}\//, "") })
     diff = export2_files - export1_files
+    unless opts[:catalogs]
+      diff = diff.select { |f| !(f =~ /^puppetdb_bak\/catalogs/) }
+    end
+    unless opts[:reports]
+      diff = diff.select { |f| !(f =~ /^puppetdb_bak\/reports/) }
+    end
 
     assert(diff.empty?, "Export file '#{export_file2}' contains extra file entries: '#{diff.to_a.join("', '")}'")
 


### PR DESCRIPTION
The export tool now exports reports.  However, the legacy storeconfigs
export tool does not.  Therefore, when we are comparing the legacy
export data against a fresh export, we should be ignoring extra
files that we specifically said we didn't want to compare in the
test code.
