### PR TITLE
Fix #clear_database helper path for embedded

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -350,7 +350,7 @@ module PuppetDBExtensions
         on host, 'su postgres -c "dropdb puppetdb"'
         install_postgres(host)
       when :embedded
-        on host, "rm -rf /etc/puppetdb/conf/db/*"
+        on host, "rm -rf /usr/share/puppetdb/db/*"
       else
         raise ArgumentError, "Unsupported database: '#{PuppetDBExtensions.config[:database]}'"
     end


### PR DESCRIPTION
Previously we were clearing the wrong path, this patch corrects that.

Signed-off-by: Ken Barber ken@bob.sh
