### PR TITLE
Remove need for starting master in apply test

### DIFF
--- a/acceptance/tests/apply/fact_storage.rb
+++ b/acceptance/tests/apply/fact_storage.rb
@@ -1,33 +1,31 @@
 require 'json'
 
 test_name "facts should be available through facts terminus when using apply" do
-
-  with_master_running_on master, "--autosign true", :preserve_ssl => true do
-
-    create_remote_file(master, '/tmp/routes-apply.yaml', <<-EOS)
+  create_remote_file(master, '/tmp/routes-apply.yaml', <<-EOS)
 apply:
   facts:
     terminus: facter
     cache: puppetdb_apply
-    EOS
+  EOS
 
-    step "Run apply on host to populate database" do
-      result = on(master, "FACTER_foo='testfoo' puppet apply --route_file /tmp/routes-apply.yaml -e 'notice($foo)'")
-      assert_match(/testfoo/, result.output)
-    end
+  step "Run apply on host to populate database" do
+    result = on(master, "FACTER_foo='testfoo' puppet apply --route_file /tmp/routes-apply.yaml -e 'notice($foo)'")
+    assert_match(/testfoo/, result.output)
+  end
 
-    step "Run again to ensure we aren't using puppetdb for the answer" do
-      result = on(master, "FACTER_foo='second test' puppet apply --route_file /tmp/routes-apply.yaml -e 'notice($foo)'")
-      assert_match(/second test/, result.output)
-    end
+  step "Run again to ensure we aren't using puppetdb for the answer" do
+    result = on(master, "FACTER_foo='second test' puppet apply --route_file /tmp/routes-apply.yaml -e 'notice($foo)'")
+    assert_match(/second test/, result.output)
+  end
 
-    # Wait until all the commands have been processed
-    sleep_until_queue_empty database
+  # Wait until all the commands have been processed
+  sleep_until_queue_empty database
 
-    step "Run facts face to find facts for master" do
-      result = on master, "puppet facts find #{master.node_name} --terminus puppetdb"
+  step "Run facts face to find facts for each node" do
+    hosts.each do |host|
+      result = on master, "puppet facts find #{host.node_name} --terminus puppetdb"
       facts = JSON.parse(result.stdout.strip)
-      assert_equal('second test', facts['values']['foo'], "Failed to retrieve facts for '#{master.node_name}' via inventory service!")
+      assert_equal('second test', facts['values']['foo'], "Failed to retrieve facts for '#{host.node_name}' via inventory service!")
     end
   end
 end


### PR DESCRIPTION
Starting the master during the apply test was unnecessary. It may be that this
also causes an ordering issue on some platforms, that has been hard to
reproduce.

Signed-off-by: Ken Barber ken@bob.sh
