### PR TITLE
Increase the length of the `puppet_version` column

### DIFF
--- a/src/com/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/com/puppetlabs/puppetdb/scf/migrate.clj
@@ -303,6 +303,18 @@
   (sql/do-commands
     "CREATE INDEX idx_resource_events_status ON resource_events(status)"))
 
+(defn increase-puppet-version-field-length
+  "Increase the length of the puppet_version field in the reports table, as we've
+  encountered some version strings that are longer than 40 chars."
+  []
+  (sql/do-commands
+    (condp = (sql-current-connection-database-name)
+      "PostgreSQL" "ALTER TABLE reports ALTER puppet_version TYPE VARCHAR(255)"
+      "HSQL Database Engine" "ALTER TABLE reports ALTER puppet_version VARCHAR(255)"
+      (throw (IllegalArgumentException.
+               (format "Unsupported database engine '%s'"
+                 (sql-current-connection-database-name)))))))
+
 ;; The available migrations, as a map from migration version to migration
 ;; function.
 (def migrations
@@ -315,7 +327,8 @@
    7 drop-classes-and-tags
    8 rename-fact-column
    9 add-reports-tables
-   10 add-event-status-index})
+   10 add-event-status-index
+   11 increase-puppet-version-field-length})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/test/com/puppetlabs/puppetdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/storage.clj
@@ -508,7 +508,14 @@
             [{:certname (:certname report)}]))
 
       (is (= (query-to-vec ["SELECT hash FROM reports"])
-            [{:hash report-hash}]))))
+            [{:hash report-hash}])))
+
+    (testing "should store report with long puppet version string"
+      (store-example-report!
+        (assoc report
+          :puppet-version "3.2.1 (Puppet Enterprise 3.0.0-preview0-168-g32c839e)") timestamp)))
+
+
 
   (deftest report-cleanup
     (testing "should delete reports older than the specified age"


### PR DESCRIPTION
Previously it had a max length of 40 chars, but dev versions of PE
send a version string that is longer than that.
