### PR TITLE
(PE-618) Don't suggest 'postgres' for pe-puppetdb on debian

### DIFF
--- a/ext/templates/deb/control.erb
+++ b/ext/templates/deb/control.erb
@@ -16,8 +16,8 @@ Architecture: all
 Depends: ${misc:Depends}, pe-java, adduser, pe-puppet
 <% else -%>
 Depends: ${misc:Depends},  java6-runtime-headless, adduser, puppet (>= 2.7.12)
-<% end -%>
 Suggests: postgresql
+<% end -%>
 Description:PuppetDB Centralized Storage.
 
 Package: <%= @name %>-terminus


### PR DESCRIPTION
We're going to be installing pe-postgresql whenever we need to in PE, so we
shouldn't suggest to the user that they also install postgres.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
