### PR TITLE
Fixing the puppetdb init script

### DIFF
--- a/ext/templates/init_debian.erb
+++ b/ext/templates/init_debian.erb
@@ -119,7 +119,7 @@ case "$1" in
     esac
     ;;
   status)
-       status_of_proc "$JAVA_BIN" "$NAME" && exit 0 || exit $?
+       status_of_proc -p $PIDFILE "$JAVA_BIN" "$NAME" && exit 0 || exit $?
        ;;
   #reload|force-reload)
     #


### PR DESCRIPTION
The puppetdb init script was returning running anytime a java process was running since no PID was specified. This fixes that.
