### PR TITLE
Revert "(maint) Fix PE PuppetDB Accp Tests"

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -19,7 +19,7 @@ module PuppetDBExtensions
     base_dir = File.join(File.dirname(__FILE__), '..')
 
     install_type =
-        get_option_value(options[:type], [:git, :manual, :pe], "install type")
+        get_option_value(options[:type], [:git, :manual], "install type")
 
     install_mode =
         get_option_value(options[:puppetdb_install_mode],
@@ -124,29 +124,9 @@ module PuppetDBExtensions
     end
   end
 
-  def puppetdb_sharedir(host)
-    if host.is_pe?
-      "/opt/puppet/share/puppetdb"
-    else
-      "/usr/share/puppetdb"
-    end
-  end
-
-  def puppetdb_sbin_dir(host)
-    if host.is_pe?
-      "/opt/puppet/sbin"
-    else
-      "/usr/sbin"
-    end
-  end
-
   def start_puppetdb(host)
     step "Starting PuppetDB" do
-      if host.is_pe?
-        on host, "service pe-puppetdb start"
-      else
-        on host, "service puppetdb start"
-      end
+      on host, "service puppetdb start"
       sleep_until_started(host)
     end
   end
@@ -224,8 +204,6 @@ module PuppetDBExtensions
       puppetdb_server           => '#{database.node_name}',
       puppetdb_version          => '#{get_package_version(host, version)}',
       puppetdb_startup_timeout  => 120,
-      manage_report_processor   => true,
-      enable_reports            => true,
       restart_puppet            => false,
     }
     EOS
@@ -250,60 +228,11 @@ module PuppetDBExtensions
   def install_postgres(host)
     PuppetAcceptance::Log.notify "Installing postgres on #{host}"
 
-
-    ############################################################################
-    # NOTE: A lot of the differences between the PE and FOSS manifests here is 
-    #   only necessary because the puppetdb::database::postgresql module
-    #   doesn't parameterize things like the service name. It would be nice
-    #   to simplify this once we've added more paramters to the module.
-    ############################################################################
-
-    if host.is_pe?
-      service_name = "pe-postgresql"
-      db_name = "pe-puppetdb"
-      db_user = "pe-puppetdb"
-      db_pass = "pe-puppetdb"
-      manifest = <<-EOS
-      # get the pg server up and running
-      $version = '9.2'
-      class { 'postgresql':
-        client_package_name => 'pe-postgresql',
-        server_package_name => 'pe-postgresql-server',
-        devel_package_name  => 'pe-postgresql-devel',
-        java_package_name   => 'pe-postgresql-jdbc',
-        datadir             => "/opt/puppet/var/lib/pgsql/${version}/data",
-        confdir             => "/opt/puppet/var/lib/pgsql/${version}/data",
-        bindir              => '/opt/puppet/bin',
-        service_name        => 'pe-postgresql',
-        user                => 'pe-postgres',
-        group               => 'pe-postgres',
-        locale              => 'en_US.UTF8',
-        charset             => 'UTF8',
-        run_initdb          => true,
-        version             => $version
-      } ->
-      class { '::postgresql::server':
-        service_name => #{service_name},
-        config_hash => {
-          # TODO: make this stuff configurable
-          'ip_mask_allow_all_users' => '0.0.0.0/0',
-          'manage_redhat_firewall'  => false,
-        },
-      }
-      # create the puppetdb database
-      class { 'puppetdb::database::postgresql_db': 
-        database_name     => #{db_name},
-        database_username => #{db_user},
-        database_password => #{db_pass},
-      }
-      EOS
-    else
-      manifest = <<-EOS
-      class { 'puppetdb::database::postgresql':
-        manage_redhat_firewall => false,
-      }
-      EOS
-    end
+    manifest = <<-EOS
+    class { 'puppetdb::database::postgresql':
+      manage_redhat_firewall => false,
+    }
+    EOS
     apply_manifest_on(host, manifest)
   end
 
@@ -359,11 +288,7 @@ module PuppetDBExtensions
 
 
   def stop_puppetdb(host)
-    if host.is_pe?
-      on host, "service pe-puppetdb stop"
-    else
-      on host, "service puppetdb stop"
-    end
+    on host, "service puppetdb stop"
     sleep_until_stopped(host)
   end
 
@@ -422,14 +347,10 @@ module PuppetDBExtensions
   def clear_database(host)
     case PuppetDBExtensions.config[:database]
       when :postgres
-        if host.is_pe?
-          on host, 'su pe-postgres -c "/opt/puppet/bin/dropdb pe-puppetdb"'
-        else
-          on host, 'su postgres -c "dropdb puppetdb"'
-        end
+        on host, 'su postgres -c "dropdb puppetdb"'
         install_postgres(host)
       when :embedded
-        on host, "rm -rf #{puppetdb_sharedir(host)}/db/*"
+        on host, "rm -rf /usr/share/puppetdb/db/*"
       else
         raise ArgumentError, "Unsupported database: '#{PuppetDBExtensions.config[:database]}'"
     end
@@ -564,141 +485,12 @@ module PuppetDBExtensions
     meta = JSON.parse(File.read(cat_path))
     munged_resources = meta["data"]["resources"].map { |resource| munge_resource_for_comparison(resource) }
     meta["data"]["resources"] = Set.new(munged_resources)
-    meta["data"]["edges"] = Set.new(meta["data"]["edges"])
     meta
   end
 
   def munge_report_for_comparison(cat_path)
     JSON.parse(File.read(cat_path))
   end
-
-
-  ############################################################################
-  # NOTE: This code should be merged into the harness before long, and when
-  #   that happens, we should get rid of this and use their version.
-  #
-  #   Temp copy of Justins new Puppet Master Methods
-  ############################################################################
-
-  class IniFile
-    attr_accessor :contents
-    def initialize file_as_string
-      @contents = parse( file_as_string )
-      @contents['main'] ||= {}
-      @contents['master'] ||= {}
-      @contents['agent'] ||= {}
-    end
-
-    def method_missing( meth, *args )
-      if @contents.respond_to? meth
-        @contents.send( meth, *args )
-      else
-        super
-      end
-    end
-
-    def parse file_as_string
-      accumulator = Hash.new
-      accumulator[:global] = Hash.new
-      section = :global
-      file_as_string.each_line do |line|
-        case line
-        when /^\s*\[\S+\]/
-          # We've got a section header
-          match = line.match(/^\s*\[(\S+)\].*/)
-          section = match[1]
-          accumulator[section] = Hash.new
-        when /^\s*\S+\s*=\s*\S/
-          # add a key value pair to the current section
-          # will add it to the :global section if before a section header
-          # note: in line comments are not support in puppet.conf
-          raw_key, raw_value = line.split( '=' )
-          key = raw_key.strip
-          value = raw_value.strip
-          accumulator[section][key] = value
-        end
-        # comments, whitespace and lines without an '=' pass through
-      end
-
-      return accumulator
-    end
-
-    def to_s
-      string = ''
-      @contents.each_pair do |header, values|
-        if header == :global
-          values.each_pair do |key, value|
-            next if value.nil?
-            string << "#{key} = #{value}\n"
-          end
-          string << "\n"
-        else
-          string << "[#{header}]\n"
-          values.each_pair do |key, value|
-            next if value.nil?
-            string << " #{key} = #{value}\n"
-          end
-          string << "\n"
-        end
-      end
-      return string
-    end
-  end
-
-  def puppet_conf_for host
-    puppetconf = on( host, "cat #{host['puppetpath']}/puppet.conf" ).stdout
-    IniFile.new( puppetconf )
-  end
-
-  def with_puppet_running_on host, conf_opts, testdir = host.tmpdir(File.basename(@path)), &block
-    new_conf = puppet_conf_for( host )
-    new_conf.contents.each_key do |key|
-      new_conf.contents[key].merge!( conf_opts.delete( key ) ) if conf_opts[key]
-    end
-    new_conf.contents.merge!( conf_opts )
-    create_remote_file host, "#{testdir}/puppet.conf", new_conf.to_s
-    # puts "#########################"
-    # puts "New conf = #{new_conf.to_s}"
-
-    begin
-      on host, "cp #{host['puppetpath']}/puppet.conf #{host['puppetpath']}/puppet.conf.bak"
-      on host, "cat #{testdir}/puppet.conf > #{host['puppetpath']}/puppet.conf", :silent => true
-      on host, "cat #{host['puppetpath']}/puppet.conf"
-      if host.is_pe?
-        on host, '/etc/init.d/pe-httpd restart' # we work with PE yo!
-      else
-        on host, puppet( 'master' ) # maybe we even work with FOSS?!?!??
-        require 'socket'
-        inc = 0
-        logger.debug 'Waiting for the puppet master to start'
-        begin
-          TCPSocket.new(host.to_s, 8140).close
-        rescue Errno::ECONNREFUSED
-          sleep 1
-          inc += 1
-          retry unless inc >= 9
-          raise 'Puppet master did not start in a timely fashion'
-        end
-      end
-
-      yield self if block_given?
-    ensure
-      on host, "if [ -f #{host['puppetpath']}/puppet.conf.bak ]; then " +
-                 "cat #{host['puppetpath']}/puppet.conf.bak > " +
-                 "#{host['puppetpath']}/puppet.conf; " +
-                 "rm -rf #{host['puppetpath']}/puppet.conf.bak; " +
-               "fi"
-      if host.is_pe?
-        on host, '/etc/init.d/pe-httpd restart'
-      else
-        on host, 'kill $(cat `puppet master --configprint pidfile`)'
-      end
-    end
-  end
-
-  ##############################################################################
-  # END_OF Temp Copy of Justins new Puppet Master Methods
-  ##############################################################################
 
   ##############################################################################
   # Object diff functions

--- a/acceptance/setup/pre_suite/20_install_puppet.rb
+++ b/acceptance/setup/pre_suite/20_install_puppet.rb
@@ -72,7 +72,7 @@ step "Install Puppet" do
   when :package
     install_puppet_from_package(test_config[:os_families])
   end
-  # If our :install_type is :git or :pe, then the harness has already installed
+  # If our :install_type is :git, then the harness has already installed
   # puppet.
 end
 

--- a/acceptance/tests/db_garbage_collection/node_ttl.rb
+++ b/acceptance/tests/db_garbage_collection/node_ttl.rb
@@ -15,10 +15,7 @@ end
 
 test_name "validate that nodes are deactivated and deleted based on ttl settings" do
 
-  with_puppet_running_on master, {
-    'master' => {
-      'autosign' => 'true'
-    }} do
+  with_master_running_on master, "--autosign true", :preserve_ssl => true do
     step "Run agents once to activate nodes" do
       run_agent_on agents, "--test --server #{master}"
     end
@@ -35,9 +32,9 @@ test_name "validate that nodes are deactivated and deleted based on ttl settings
   end
 
   step "Back up the database.ini file and create a temp one with a node-purge-ttl" do
-    on database, "cp -p #{puppetdb_confdir(database)}/conf.d/database.ini #{puppetdb_confdir(database)}/conf.d/database.ini.bak"
+    on database, "cp -p /etc/puppetdb/conf.d/database.ini /etc/puppetdb/conf.d/database.ini.bak"
     # TODO: this could/should be done via the module once we support it
-    on database, "echo 'node-purge-ttl = 1s' >> #{puppetdb_confdir(database)}/conf.d/database.ini"
+    on database, "echo 'node-purge-ttl = 1s' >> /etc/puppetdb/conf.d/database.ini"
   end
 
   restart_to_gc database
@@ -49,8 +46,8 @@ test_name "validate that nodes are deactivated and deleted based on ttl settings
   end
 
   step "Restore the original database.ini and add a node-ttl" do
-    on database, "cp -p #{puppetdb_confdir(database)}/conf.d/database.ini.bak #{puppetdb_confdir(database)}/conf.d/database.ini"
-    on database, "echo 'node-ttl = 1s' >> #{puppetdb_confdir(database)}/conf.d/database.ini"
+    on database, "cp -p /etc/puppetdb/conf.d/database.ini.bak /etc/puppetdb/conf.d/database.ini"
+    on database, "echo 'node-ttl = 1s' >> /etc/puppetdb/conf.d/database.ini"
   end
 
   restart_to_gc database
@@ -74,7 +71,7 @@ test_name "validate that nodes are deactivated and deleted based on ttl settings
   end
 
   step "Add a purge ttl to the database.ini file" do
-    on database, "echo 'node-purge-ttl = 1s' >> #{puppetdb_confdir(database)}/conf.d/database.ini"
+    on database, "echo 'node-purge-ttl = 1s' >> /etc/puppetdb/conf.d/database.ini"
   end
 
   # In case there are any catalogs/facts/reports waiting to be processed, let
@@ -114,7 +111,7 @@ test_name "validate that nodes are deactivated and deleted based on ttl settings
   end
 
   step "Restore the original database.ini file and restart puppetdb" do
-    on database, "mv #{puppetdb_confdir(database)}/conf.d/database.ini.bak #{puppetdb_confdir(database)}/conf.d/database.ini"
+    on database, "mv /etc/puppetdb/conf.d/database.ini.bak /etc/puppetdb/conf.d/database.ini"
     restart_puppetdb database
   end
 

--- a/acceptance/tests/db_garbage_collection/report_ttl.rb
+++ b/acceptance/tests/db_garbage_collection/report_ttl.rb
@@ -1,12 +1,8 @@
 require 'json'
-  confd = "#{puppetdb_confdir(database)}/conf.d"
 
 test_name "validate that reports are deleted based on report-ttl setting" do
 
-  with_puppet_running_on master, {
-    'master' => {
-      'autosign' => 'true'
-    }} do
+  with_master_running_on master, "--reports=store,puppetdb --autosign true", :preserve_ssl => true do
     step "Run agents once to generate reports" do
       run_agent_on agents, "--test --server #{master}"
     end
@@ -30,9 +26,9 @@ test_name "validate that reports are deleted based on report-ttl setting" do
 
 
   step "Back up the database.ini file and create a temp one with a ttl" do
-    on database, "cp #{confd}/database.ini #{confd}/database.ini.bak"
+    on database, "cp /etc/puppetdb/conf.d/database.ini /etc/puppetdb/conf.d/database.ini.bak"
     # TODO: this could/should be done via the module once we support it
-    on database, "echo 'report-ttl = 1s' >> #{confd}/database.ini"
+    on database, "echo 'report-ttl = 1s' >> /etc/puppetdb/conf.d/database.ini"
   end
 
 
@@ -57,11 +53,7 @@ test_name "validate that reports are deleted based on report-ttl setting" do
   end
 
   step "Restore the original database.ini file and restart puppetdb" do
-    if database.is_pe?
-      on database, "mv #{confd}/database.ini.bak #{confd}/database.ini ; chown pe-puppetdb:pe-puppetdb #{confd}/database.ini"
-    else
-      on database, "mv #{confd}/database.ini.bak #{confd}/database.ini ; chown puppetdb:puppetdb #{confd}/database.ini"
-    end
+    on database, "mv /etc/puppetdb/conf.d/database.ini.bak /etc/puppetdb/conf.d/database.ini ; chown puppetdb:puppetdb /etc/puppetdb/conf.d/database.ini"
     restart_puppetdb database
   end
 

--- a/acceptance/tests/import_export/import_export.rb
+++ b/acceptance/tests/import_export/import_export.rb
@@ -1,5 +1,4 @@
 test_name "storeconfigs export and import" do
-  sbin_loc = puppetdb_sbin_dir(database)
 
   step "clear puppetdb database so that we can control exactly what we will eventually be exporting" do
     clear_and_restart_puppetdb(database)
@@ -7,12 +6,7 @@ test_name "storeconfigs export and import" do
 
   step "run each agent once to populate the database" do
     # dbadapter, dblocation, storeconfigs_backend, routefile
-    with_puppet_running_on master, {
-      'master' => {
-        'autosign' => 'true',
-        'report' => 'true',
-      }} do
-
+    with_master_running_on master, "--autosign true --report true --reports=store,puppetdb", :preserve_ssl => true do
       hosts.each do |host|
         run_agent_on host, "--test --server #{master}", :acceptable_exit_codes => [0,2]
       end
@@ -23,7 +17,7 @@ test_name "storeconfigs export and import" do
   export_file2 = "./puppetdb-export2.tar.gz"
 
   step "export data from puppetdb" do
-    on database, "#{sbin_loc}/puppetdb-export --outfile #{export_file1}"
+    on database, "puppetdb-export --outfile #{export_file1}"
     scp_from(database, export_file1, ".")
   end
 
@@ -32,12 +26,12 @@ test_name "storeconfigs export and import" do
   end
 
   step "import data into puppetdb" do
-    on database, "#{sbin_loc}/puppetdb-import --infile #{export_file1}"
+    on database, "puppetdb-import --infile #{export_file1}"
     sleep_until_queue_empty(database)
   end
 
   step "export data from puppetdb again" do
-    on database, "#{sbin_loc}/puppetdb-export --outfile #{export_file2}"
+    on database, "puppetdb-export --outfile #{export_file2}"
     scp_from(database, export_file2, ".")
   end
 

--- a/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
+++ b/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
@@ -1,6 +1,4 @@
 test_name "storeconfigs export and import" do
-  skip_test "Skipping test for PE because slqite3 isn't available" if master.is_pe?
-
   db_path = master.tmpfile('storeconfigs.sqlite3')
   manifest_path = master.tmpfile('storeconfigs.pp')
   args = "--dbadapter sqlite3 --dblocation #{db_path} --storeconfigs_backend active_record --debug"
@@ -26,15 +24,7 @@ test_name "storeconfigs export and import" do
 
   step "run each agent once to populate the database" do
     # dbadapter, dblocation, storeconfigs_backend, routefile
-    with_puppet_running_on master, {
-      'master' => {
-        'dbadapter' => 'sqlite3',
-        'dblocation' => db_path,
-        'storeconfigs_backend' => 'active_record',
-        'debug' => 'true',
-        'manifest' => manifest_path,
-        'autosign' => 'true'
-      }} do
+    with_master_running_on master, "#{args} --manifest #{manifest_path} --autosign true", :preserve_ssl => true do
       hosts.each do |host|
         run_agent_on host, "--test --server #{master}", :acceptable_exit_codes => [0,2]
       end

--- a/acceptance/tests/inventory/basic_fact_retrieval.rb
+++ b/acceptance/tests/inventory/basic_fact_retrieval.rb
@@ -2,10 +2,7 @@ require 'json'
 
 test_name "facts should be available through facts terminus" do
 
-  with_puppet_running_on master, {
-    'master' => {
-      'autosign' => 'true',
-    }} do
+  with_master_running_on master, "--autosign true", :preserve_ssl => true do
 
     step "Run agent once to populate database" do
       run_agent_on hosts, "--test --server #{master}", :acceptable_exit_codes => [0,2]

--- a/acceptance/tests/reports/basic_event_query.rb
+++ b/acceptance/tests/reports/basic_event_query.rb
@@ -29,14 +29,7 @@ MANIFEST
 
   # TODO: the module should be setting up the report processors so that we don't
   # have to add it on the CLI here
-  with_puppet_running_on master, {
-    'master' => {
-      'storeconfigs' => 'true',
-      'store_configs_backend' => 'puppetdb',
-      'autosign' => 'true',
-      'manifest' => manifest_file
-    }} do
-
+  with_master_running_on master, "--storeconfigs --storeconfigs_backend puppetdb --reports=store,puppetdb --autosign true --manifest #{manifest_file}", :preserve_ssl => true do
       step "Run agents once to submit reports" do
         run_agent_on agents, "--test --server #{master}", :acceptable_exit_codes => [0,2]
       end

--- a/acceptance/tests/reports/report_query_by_timestamp.rb
+++ b/acceptance/tests/reports/report_query_by_timestamp.rb
@@ -16,12 +16,7 @@ test_name "basic validation of puppet report query by timestamp" do
 
   # TODO: the module should be setting up the report processors so that we don't
   # have to add it on the CLI here
-  with_puppet_running_on master, {
-    'master' => {
-      'storeconfigs' => 'true',
-      'store_configs_backend' => 'puppetdb',
-      'autosign' => 'true'
-    }} do
+  with_master_running_on master, "--storeconfigs --storeconfigs_backend puppetdb --reports=store,puppetdb --autosign true", :preserve_ssl => true do
 
       step "Run agents once to submit reports" do
         run_agent_on agents, "--test --server #{master}", :acceptable_exit_codes => [0,2]

--- a/acceptance/tests/reports/report_storage.rb
+++ b/acceptance/tests/reports/report_storage.rb
@@ -19,13 +19,7 @@ MANIFEST
 
   # TODO: the module should be setting up the report processors so that we don't
   # have to add it on the CLI here
-  with_puppet_running_on master, {
-    'master' => {
-      'storeconfigs' => 'true',
-      'store_configs_backend' => 'puppetdb',
-      'autosign' => 'true',
-      'manifest' => manifest_file
-    }} do
+  with_master_running_on master, "--storeconfigs --storeconfigs_backend puppetdb --reports=store,puppetdb --autosign true --manifest #{manifest_file}", :preserve_ssl => true do
 
       step "Run agents once to submit reports" do
         run_agent_on agents, "--test --server #{master}", :acceptable_exit_codes => [0,2]

--- a/acceptance/tests/security/puppetdb-ssl-setup.rb
+++ b/acceptance/tests/security/puppetdb-ssl-setup.rb
@@ -1,6 +1,5 @@
 test_name "puppetdb-ssl-setup" do
   confd = "#{puppetdb_confdir(database)}/conf.d"
-  sbin_loc = "#{puppetdb_sbin_dir(database)}"
 
   step "backup jetty.ini and setup template" do
     on database, "cp #{confd}/jetty.ini #{confd}/jetty.ini.bak.ssl_setup_tests"
@@ -13,19 +12,19 @@ test_name "puppetdb-ssl-setup" do
   end
 
   step "run puppetdb-ssl-setup again to make sure it is idempotent" do
-    on database, "#{sbin_loc}/puppetdb-ssl-setup"
+    on database, "puppetdb-ssl-setup"
     on database, "diff #{confd}/jetty.ini #{confd}/jetty.ini.bak.ssl_setup_tests"
   end
 
   step "purposely modify jetty.ini ssl-host and make sure puppetdb-ssl-setup does not touch it" do
     on database, "sed -i 's/^ssl-host = .*/ssl-host = foobarbaz/' #{confd}/jetty.ini"
-    on database, "#{sbin_loc}/puppetdb-ssl-setup"
+    on database, "puppetdb-ssl-setup"
     on database, "grep -e '^ssl-host = foobarbaz' #{confd}/jetty.ini"
   end
 
   step "purposely modify jetty.ini ssl-host and make sure puppetdb-ssl-setup -f fixes it" do
     on database, "sed -i 's/^ssl-host = .*/ssl-host = foobarbaz/' #{confd}/jetty.ini"
-    on database, "#{sbin_loc}/puppetdb-ssl-setup -f"
+    on database, "puppetdb-ssl-setup -f"
     on database, "grep -e '^ssl-host = foobarbaz' #{confd}/jetty.ini", :acceptable_exit_codes => [1]
   end
 

--- a/acceptance/tests/storeconfigs/basic_collection.rb
+++ b/acceptance/tests/storeconfigs/basic_collection.rb
@@ -21,11 +21,7 @@ node "#{name}" {
 
   on master, "chmod -R +rX #{tmpdir}"
 
-  with_puppet_running_on master, {
-    'master' => {
-      'autosign' => 'true',
-      'manifest' => manifest_file
-    }} do
+  with_master_running_on master, "--autosign true --manifest #{manifest_file}", :preserve_ssl => true do
 
     step "Run agent once to populate database" do
       run_agent_on hosts, "--test --server #{master}", :acceptable_exit_codes => [0,2]

--- a/acceptance/tests/storeconfigs/collections_with_queries.rb
+++ b/acceptance/tests/storeconfigs/collections_with_queries.rb
@@ -74,11 +74,7 @@ MANIFEST
 
   on master, "chmod -R +rX #{tmpdir}"
 
-  with_puppet_running_on master, {
-    'master' => {
-      'autosign' => 'true',
-      'manifest' => manifest_file
-    }} do
+  with_master_running_on master, "--autosign true --manifest #{manifest_file}", :preserve_ssl => true do
 
     step "Run exporter to populate the database" do
       run_agent_on exporter, "--test --server #{master}", :acceptable_exit_codes => [0,2]

--- a/acceptance/tests/storeconfigs/deactivated_nodes.rb
+++ b/acceptance/tests/storeconfigs/deactivated_nodes.rb
@@ -49,11 +49,7 @@ MANIFEST
 
   on master, "chmod -R +rX #{tmpdir}"
 
-  with_puppet_running_on master, {
-    'master' => {
-      'autosign' => 'true',
-      'manifest' => manifest_file
-    }} do
+  with_master_running_on master, "--autosign true --manifest #{manifest_file}", :preserve_ssl => true do
 
     step "Run exporter to populate the database" do
       run_agent_on exporter, "--test --server #{master}", :acceptable_exit_codes => [0,2]

--- a/acceptance/tests/storeconfigs/dup_collected_resources.rb
+++ b/acceptance/tests/storeconfigs/dup_collected_resources.rb
@@ -28,11 +28,7 @@ MANIFEST
 
   on master, "chmod -R +rX #{tmpdir}"
 
-  with_puppet_running_on master, {
-    'master' => {
-      'autosign' => 'true',
-      'manifest' => manifest_file
-    }} do
+  with_master_running_on master, "--autosign true --manifest #{manifest_file}", :preserve_ssl => true do
 
     step "Run exporters to populate the database" do
       run_agent_on exporter1, "--test --server #{master}", :acceptable_exit_codes => [0,2]

--- a/acceptance/tests/storeconfigs/non_parameter_queries.rb
+++ b/acceptance/tests/storeconfigs/non_parameter_queries.rb
@@ -72,11 +72,7 @@ MANIFEST
 
   on master, "chmod -R +rX #{tmpdir}"
 
-  with_puppet_running_on master, {
-    'master' => {
-      'autosign' => 'true',
-      'manifest' => manifest_file
-    }} do
+  with_master_running_on master, "--autosign true --manifest #{manifest_file}", :preserve_ssl => true do
 
     step "Run exporter to populate the database" do
       run_agent_on exporter, "--test --server #{master}", :acceptable_exit_codes => [0,2]


### PR DESCRIPTION
This reverts commit 618d1d99ece56cc9d987bee0cd2b124617b13f86.

We are reverting this change temporarily because there have been
upstream changes that make the tests incompatible with PE.
