### PR TITLE
(#21321) Disable support for SSLv2Hello protocol

### DIFF
--- a/src/com/puppetlabs/jetty.clj
+++ b/src/com/puppetlabs/jetty.clj
@@ -52,6 +52,12 @@
           "SSL_RSA_WITH_3DES_EDE_CBC_SHA"
           "SSL_RSA_WITH_RC4_128_MD5"]))))
 
+;; Which SecureSocket protocols we should explicitly disallow
+(def excluded-protocols
+  [;; http://tools.ietf.org/html/rfc4346#appendix-E
+   "SSLv2Hello"
+   ])
+
 ;; Monkey-patched version of `create-server` that will only create a
 ;; non-SSL connector if the options specifically dictate it.
 
@@ -78,7 +84,8 @@
                         (acceptable-ciphers))]
         (when ciphers
           (doto (.getSslContextFactory connector)
-            (.setIncludeCipherSuites (into-array ciphers))))
+            (.setIncludeCipherSuites (into-array ciphers))
+            (.setExcludeProtocols (into-array excluded-protocols))))
         (.addConnector server connector)))
     server))
 


### PR DESCRIPTION
By default, the JVM allows for SSLv2 client "hello" messages for all
secure sockets. Note that this isn't the full SSLv2 protocol, but rather
just a backwards-compatible "hello" message:

http://tools.ietf.org/html/rfc4346#appendix-E

Still, the general recommendation is to disable use of that.
