### PR TITLE
(packaging) Use the packaging loader for tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,10 @@ JAR_FILE = 'puppetdb.jar'
 RAKE_ROOT = File.dirname(__FILE__)
 
 # Load tasks and variables for packaging automation
-Dir[ File.join(RAKE_ROOT, 'ext', 'packaging', 'tasks', '*.rake') ].sort.each { |t| load t }
+begin
+  load File.join(RAKE_ROOT, 'ext', 'packaging', 'packaging.rake')
+rescue LoadError
+end
 
 def ln_sfT(src, dest)
   sh "ln -sfT #{src} #{dest}"


### PR DESCRIPTION
The packaging repo now uses an explicit loader which handles loading the
various rake tasks in packaging. This commit updates the puppetdb Rakefile to use
the loader instead of a blind glob of the ext/packaging/tasks directory. We
move this load into the rescue LoadError block because the packaging repo won't
always be there.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
