### PR TITLE
Coerce -p values for export/import cli to Integer

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/export.clj
+++ b/src/com/puppetlabs/puppetdb/cli/export.clj
@@ -140,7 +140,7 @@
   [& args]
   (let [specs          [["-o" "--outfile" "Path to backup file (required)"]
                         ["-H" "--host" "Hostname of PuppetDB server" :default "localhost"]
-                        ["-p" "--port" "Port to connect to PuppetDB server" :default 8080]]
+                        ["-p" "--port" "Port to connect to PuppetDB server" :parse-fn #(Integer. %) :default 8080]]
         required       [:outfile]
         [{:keys [outfile host port]} _] (cli! args specs required)
         nodes          (get-active-node-names host port)

--- a/src/com/puppetlabs/puppetdb/cli/import.clj
+++ b/src/com/puppetlabs/puppetdb/cli/import.clj
@@ -96,7 +96,7 @@
   [& args]
   (let [specs       [["-i" "--infile" "Path to backup file (required)"]
                      ["-H" "--host" "Hostname of PuppetDB server" :default "localhost"]
-                     ["-p" "--port" "Port to connect to PuppetDB server" :default 8080]]
+                     ["-p" "--port" "Port to connect to PuppetDB server" :parse-fn #(Integer. %) :default 8080]]
         required    [:infile]
         [{:keys [infile host port]} _] (cli! args specs required)
         metadata    (parse-metadata infile)]


### PR DESCRIPTION
The -p option when used was throwing an assertion error, due to it being passed
to downstream functions as a string. This patch coerces these values to an
Integer at the clojure.tools.cli level.

Extra tests have been added to test setting -p and -H explicitly also.

Signed-off-by: Ken Barber ken@bob.sh
