### PR TITLE
query parameter is optional in nodes endpoint

### DIFF
--- a/documentation/api/query/v2/nodes.markdown
+++ b/documentation/api/query/v2/nodes.markdown
@@ -21,7 +21,7 @@ aren't included in the response. There must be an `Accept` header matching
 
 #### Parameters
 
-* `query`: Required. A JSON array of query predicates, in prefix form,
+* `query`: Optional. A JSON array of query predicates, in prefix form,
   conforming to the format described below.
 
 The `query` parameter is a similar format to [resource queries][resource].


### PR DESCRIPTION
small documentation fix
