### PR TITLE
Reports return a hash key not id

### DIFF
--- a/documentation/api/query/experimental/event.markdown
+++ b/documentation/api/query/experimental/event.markdown
@@ -31,7 +31,7 @@ The `query` parameter is described by the following grammar:
     match:          "=" | "~"
     inequality:     ">" | ">=" | "<" | "<="
 
-For example, for all events in the report with id
+For example, for all events in the report with hash
 '38ff2aef3ffb7800fe85b322280ade2b867c8d27', the JSON query structure would be:
 
     ["=", "report", "38ff2aef3ffb7800fe85b322280ade2b867c8d27"]

--- a/documentation/api/query/experimental/report.markdown
+++ b/documentation/api/query/experimental/report.markdown
@@ -44,7 +44,7 @@ the completion time of the report, in descending order:
         "receive-time": "2012-10-29T18:38:04.238Z",
         "configuration-version": "1351535883",
         "start-time": "2012-10-29T18:38:00.000Z",
-        "id": "d4bcb35a-fb7b-45da-84e0-fceb7a1df713",
+        "hash": "bd899b1ee825ec1d2c671fe5541b5c8f4a783472",
         "certname": "foo.local",
         "report-format": 3
         },
@@ -54,7 +54,7 @@ the completion time of the report, in descending order:
         "receive-time": "2012-10-26T22:39:35.305Z",
         "configuration-version": "1351291174",
         "start-time": "2012-10-26T22:39:31.000Z",
-        "id": "5ec13ff5-c6fd-43fb-b5b1-59a00ec8e1f1",
+        "hash": "cd4e5fd8846bac26d15d151664a40e0f2fa600b0",
         "certname": "foo.local",
         "report-format": 3
         }

--- a/src/com/puppetlabs/puppetdb/http/experimental/report.clj
+++ b/src/com/puppetlabs/puppetdb/http/experimental/report.clj
@@ -30,7 +30,7 @@
 ;;    "receive-time": "2012-10-29T18:38:04.238Z",
 ;;    "configuration-version": "1351535883",
 ;;    "start-time": "2012-10-29T18:38:00.000Z",
-;;    "id": "d4bcb35a-fb7b-45da-84e0-fceb7a1df713",
+;;    "hash": "df1c772155ee25593dd83a54ffb6ccc780e50c90",
 ;;    "certname": "foo.local",
 ;;    "report-format": 3
 ;;    },
@@ -40,7 +40,7 @@
 ;;    "receive-time": "2012-10-26T22:39:35.305Z",
 ;;    "configuration-version": "1351291174",
 ;;    "start-time": "2012-10-26T22:39:31.000Z",
-;;    "id": "5ec13ff5-c6fd-43fb-b5b1-59a00ec8e1f1",
+;;    "hash": "bd899b1ee825ec1d2c671fe5541b5c8f4a783472",
 ;;    "certname": "foo.local",
 ;;    "report-format": 3
 ;;    }


### PR DESCRIPTION
Note: When merged, this needs cherry-picking for branches 1.1.x, 1.2.x and 1.3.x as well I believe.

This patch fixes the documentation and some inline comments to reflect that
a report returns a "hash" key not an "id" and that the type is a hash, not
a uuid in this instance.

Signed-off-by: Ken Barber ken@bob.sh
