### PR TITLE
Initial systemd service files

### DIFF
--- a/ext/systemd/puppetdb.service
+++ b/ext/systemd/puppetdb.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Puppetdb Daemon
+After=syslog.target network.target
+
+[Service]
+Type=simple
+User=puppetdb
+EnvironmentFile=/etc/conf.d/puppetdb
+PIDFile=/var/run/puppetdb.pid
+ExecStart=/usr/bin/java \
+          $JAVA_ARGS \
+          -jar /usr/share/puppetdb/puppetdb.jar \
+          services -c $CONFIG $@
+  
+ExecStop=/bin/kill $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/ext/systemd/puppetdb.systemd.params
+++ b/ext/systemd/puppetdb.systemd.params
@@ -1,0 +1,9 @@
+##
+## Parameters to be passed to puppetdb.service
+##
+## Default data
+JAVA_ARGS=-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/puppetdb/puppetdb-oom.hprof
+JAVA_BIN=/usr/bin/java
+INSTALL_DIR=/usr/share/puppetdb
+JARFILE=puppetdb.jar
+CONFIG=/etc/puppetdb/conf.d


### PR DESCRIPTION
If you want to use this, please copy and rename puppetdb.systemd.params
to "/etc/conf.d/puppetdb". puppetdb.service expects this file there.
