### PR TITLE
(#21611) Allow rake commands to be ran on Ruby 2.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,9 +69,8 @@ end
 
 # We only need the ruby major, minor versions
 @ruby_version = (ENV['RUBY_VER'] || Facter.value(:rubyversion))[0..2]
-unless @ruby_version == '1.8' or @ruby_version == '1.9'
-  STDERR.puts "RUBY_VER needs to be 1.8 or 1.9"
-  exit 1
+unless ['1.8','1.9'].include?(@ruby_version)
+  STDERR.puts "Warning: Existing rake commands are untested on #{@ruby_version} currently supported rubies include 1.8 or 1.9"
 end
 
 PATH = ENV['PATH']


### PR DESCRIPTION
This allows rake commands to be ran on Ruby 2.0, for building on Fedora 19
to be made possible.

Signed-off-by: Ken Barber ken@bob.sh
