### PR TITLE
Change createdb docs example to use UTF8 encoding

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -222,7 +222,7 @@ Before using the PostgreSQL backend, you must set up a PostgreSQL server, ensure
 
     $ sudo -u postgres sh
     $ createuser -DRSP puppetdb
-    $ createdb -O puppetdb puppetdb
+    $ createdb -E UTF8 -O puppetdb puppetdb
     $ exit
 
 Ensure you can log in by running:


### PR DESCRIPTION
This needs cherry picking back to: 1.1.x, 1.2.x & 1.3.x.

Signed-off-by: Ken Barber ken@bob.sh
