### PR TITLE
(maint) Fix typo in puppetdb.spec

### DIFF
--- a/ext/redhat/puppetdb.spec.erb
+++ b/ext/redhat/puppetdb.spec.erb
@@ -37,7 +37,7 @@
 %global  _sharedstatedir /var/lib
 %global  _realsysconfdir /etc
 %if 0%{?suse_version}
-%global  _initdir    %{_realsysconfdir}/init.d
+%global  _initddir    %{_realsysconfdir}/init.d
 %else
 %global  _initddir   %{_realsysconfdir}/rc.d/init.d
 %endif


### PR DESCRIPTION
_initdir is not the same as _initddir.
