### PR TITLE
(maint) Move suse specific java requirements into the open_jdk macro

### DIFF
--- a/ext/redhat/puppetdb.spec.erb
+++ b/ext/redhat/puppetdb.spec.erb
@@ -6,13 +6,17 @@
 %global open_jdk          pe-java
 <% else -%>
 # Fedora 17 ships with openjdk 1.7.0
-%if 0%{?fedora} >= 17
+%if 0%{?fedora} >= 17 || ( 0%{?suse_version} >= 1200 && %{undefined sles_version} )
 %global open_jdk          java-1.7.0-openjdk
 %else
-%if 0%{?suse_version}
+%if 0%{?sles_version}
 %global open_jdk          java-1_6_0-ibm
 %else
+%if 0%{?suse_version}
+%global open_jdk          java-1_6_0-openjdk
+%else
 %global open_jdk          java-1.6.0-openjdk
+%endif
 %endif
 %endif
 <% end -%>
@@ -103,14 +107,12 @@ BuildRequires: sles-release
 Requires:      aaa_base
 Requires:      pwdutils
 Requires:      logrotate
-BuildRequires: java-devel
-Requires:      java
 %else
 BuildRequires: /usr/sbin/useradd
+%endif
 Requires:      chkconfig
 BuildRequires: %{open_jdk}
 Requires:      %{open_jdk}
-%endif
 
 %description
 Puppet Centralized Storage.


### PR DESCRIPTION
There is an open_jdk macro defined at the top of the spec file to specify the
java requirements for puppetdb. This commit moves the sles/suse specific java
logic into that macro section. This supplies the os standard java for opensuse
11,12 and sles. java-devel should not be required for puppetdb build or
installation, so this commit also removes that dependency.
