### PR TITLE
Fix usage information for -c to indicate a conf.d directory can be used

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/com/puppetlabs/puppetdb/cli/benchmark.clj
@@ -166,7 +166,7 @@
 
 
 (def supported-cli-options
-  [["-c" "--config" "Path to config.ini (required)"]
+  [["-c" "--config" "Path to config.ini or conf.d directory (required)"]
    ["-C" "--catalogs" "Path to a directory containing sample JSON catalogs (files must end with .json)"]
    ["-R" "--reports" "Path to a directory containing sample JSON reports (files must end with .json)"]
    ["-i" "--runinterval" "What runinterval (in minutes) to use during simulation"]

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -343,7 +343,7 @@
 
 
 (def supported-cli-options
-  [["-c" "--config" "Path to config.ini (required)"]
+  [["-c" "--config" "Path to config.ini or conf.d directory (required)"]
    ["-D" "--debug" "Enable debug mode" :default false :flag true]])
 
 (def required-cli-options


### PR DESCRIPTION
Since puppetdb can accept a directory of configuration, the current usage
information for the -c switch is not completely accurate. This patch
changes the usage information to indicate a directory can be used for
both the 'services' and 'benchmark' sub-commands.

Signed-off-by: Ken Barber ken@bob.sh
