### PR TITLE
Don't template nonexistent init script for suse

### DIFF
--- a/tasks/template.rake
+++ b/tasks/template.rake
@@ -38,7 +38,6 @@ task :template => [ :clean ] do
    # files for rpm
    erb "ext/templates/logrotate.erb", "ext/files/puppetdb.logrotate"
    erb "ext/templates/init_redhat.erb", "ext/files/puppetdb.redhat.init"
-   erb "ext/templates/init_suse.erb", "ext/files/puppetdb.suse.init"
    erb "ext/templates/puppetdb_default.erb", "ext/files/puppetdb.default"
 
    # developer utility files for redhat


### PR DESCRIPTION
The init script for suse was removed in a8683ac, but is still
templated by the template task. This commit removes it.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
