### PR TITLE
Fix spec tests to be compatible with puppet 3.3

### DIFF
--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -45,14 +45,14 @@ describe processor do
 
   context "#report_to_hash" do
     let (:resource) {
-      resource = mock "resource"
-      resource.stubs(:path).returns("foo")
-      resource.stubs(:file).returns("foo")
-      resource.stubs(:line).returns("foo")
-      resource.stubs(:tags).returns([])
-      resource.stubs(:title).returns("foo")
-      resource.stubs(:type).returns("foo")
-      resource
+      stub("resource",
+        { :pathbuilder => ["foo", "bar", "baz"],
+          :path => "foo",
+          :file => "foo",
+          :line => "foo",
+          :tags => [],
+          :title => "foo",
+          :type => "foo" })
     }
 
     let (:status) {


### PR DESCRIPTION
One of our spec tests mocks an object from the puppet object model.
In the latest version of puppet this object had a small API change;
our mock object was not set up to handle this correctly.  This
commit should make the tests compatible with all versions of Puppet
from 2.7.x, 3.0.x, 3.1.x, 3.2.x, and 3.3.x.
