### PR TITLE
(#19174) Change query parameter to optional for facts & resources

### DIFF
--- a/documentation/api/query/v2/facts.markdown
+++ b/documentation/api/query/v2/facts.markdown
@@ -20,7 +20,8 @@ deactivated nodes are not included in the response. There must be an
 
 #### URL Parameters
 
-* `query`: Required. A JSON array containing the query in prefix notation.
+* `query`: Optional. A JSON array containing the query in prefix notation. If
+  not provided, all results will be returned.
 
 #### Available Fields
 

--- a/documentation/api/query/v2/resources.markdown
+++ b/documentation/api/query/v2/resources.markdown
@@ -20,8 +20,9 @@ deactivated nodes are not included in the response. There must be an
 
 #### Parameters
 
-* `query`: Required. A JSON array of query predicates, in prefix form,
-  conforming to the format described below.
+* `query`: Optional. A JSON array of query predicates, in prefix form,
+  conforming to the format described below. If not provided, all results will
+  be returned.
 
 The `query` parameter is described by the following grammar:
 

--- a/src/com/puppetlabs/puppetdb/http/v2/facts.clj
+++ b/src/com/puppetlabs/puppetdb/http/v2/facts.clj
@@ -35,9 +35,7 @@
 (def facts-app
   (app
    []
-   (-> query-app
-       (verify-param-exists "query")
-       (verify-accepts-json))
+   (verify-accepts-json query-app)
 
    [fact value &]
    (comp query-app (partial http-q/restrict-fact-query-to-name fact) (partial http-q/restrict-fact-query-to-value value))

--- a/src/com/puppetlabs/puppetdb/http/v2/resources.clj
+++ b/src/com/puppetlabs/puppetdb/http/v2/resources.clj
@@ -40,9 +40,7 @@
 (def resources-app
   (app
    []
-   (-> query-app
-       (verify-param-exists "query")
-       (verify-accepts-json))
+   (verify-accepts-json query-app)
 
    [type title &]
    (comp query-app (partial http-q/restrict-resource-query-to-type type) (partial http-q/restrict-resource-query-to-title title))

--- a/test/com/puppetlabs/puppetdb/test/http/experimental/explore.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/experimental/explore.clj
@@ -107,10 +107,9 @@
          (is (= (set (map :title resources)) #{"/etc/foobar"}))
          (is (= (count resources) 1)))))
 
-    (testing "/resources without a query should fail"
+    (testing "/resources without a query should not fail"
        (let [response (get-response "resources")]
-         (is (= 400 (:status response)))
-         (is (= "missing query" (:body response)))))
+         (is (= 200 (:status response)))))
 
     (testing "/resources/<type> should return all resources matching the supplied type"
       (check-json-response
@@ -141,10 +140,9 @@
                           ;; Create a tree-structure for facts: node -> name -> value
                           (reduce #(assoc-in %1 [(:certname %2) (:name %2)] (:value %2)) {} facts))]
 
-      (testing "/facts without a query should fail"
+      (testing "/facts without a query should not fail"
         (let [response (get-response "facts")]
-          (is (= 400 (:status response)))
-          (is (= "missing query" (:body response)))))
+          (is (= 200 (:status response)))))
 
       (testing "/facts/<fact> should return all instances of the given fact"
         (check-json-response

--- a/test/com/puppetlabs/puppetdb/test/http/v2/resources.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v2/resources.clj
@@ -120,11 +120,10 @@ to the result of the form supplied to this method."
               :sourceline nil
               :parameters {}}]
 
-    (testing "query without filter"
+    (testing "query without filter should not fail"
       (let [response (get-response)
             body     (get response :body "null")]
-        (is (= (:status response) pl-http/status-bad-request))
-        (is (re-find #"missing query" body))))
+        (is (= 200 (:status response)))))
 
     (testing "query with filter"
       (doseq [[query result] [[["=" "type" "File"] #{foo1 bar1}]


### PR DESCRIPTION
Previously for the /v2/facts and /v2/resources end-point we had documented that
the query parameter was required, however a blank query parameter could be used
to return _all_ data, so this assertion wasn't quite accurate. However one
could never really drop the query parameter as it was considered mandatory and
without it you would get an error.

To align with the need to return all results at times, and the fact that
making a query like '/v2/facts?query=' to do such a thing is wasteful, we have
decided to drop the mandatory need for the 'query' parameter.

This patch allows 'query' to be an optional parameter for /v2/facts & resources
by removing the validation check and updating the documentation to reflect this
this new behaviour.

Signed-off-by: Ken Barber ken@bob.sh
