### PR TITLE
Add NOTICE.txt to comply with ASLv2 instructions

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,17 @@
+PuppetDB - Centralized Puppet Storage
+Copyright 2011-2013 Puppet Labs Inc
+
+This product includes software developed at
+Puppet Labs Inc (http://puppetlabs.com/).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this software except in compliance with the License.
+You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
According to the Apache website for ASLv2:

  http://www.apache.org/dev/apply-license.html#new

Which states "In addition, a correct NOTICE file MUST be included in the same
directory as the LICENSE file.". This patch adds such a file.

Signed-off-by: Ken Barber ken@bob.sh
