### PR TITLE
Fix failing import/export test for anonymize full

### DIFF
--- a/src/com/puppetlabs/puppetdb/anonymizer.clj
+++ b/src/com/puppetlabs/puppetdb/anonymizer.clj
@@ -334,7 +334,9 @@
   [events context config]
   {:pre  [(coll? events)]
    :post [(coll? %)]}
-  (map #(anonymize-resource-event % context config) events))
+  (sort-by
+    #(mapv % ["timestamp" "resource-type" "resource-title" "property"])
+    (map #(anonymize-resource-event % context config) events)))
 
 ;; Primary entry points, for anonymizing catalogs and reports
 

--- a/src/com/puppetlabs/puppetdb/cli/anonymize.clj
+++ b/src/com/puppetlabs/puppetdb/cli/anonymize.clj
@@ -148,7 +148,7 @@
 
     ;; Process reports
     (when (re-find (re-pattern report-pattern) path)
-      (let [[_ hostname starttime confversion] (re-matches #".+\/(.+)-(.+)-(.+)\.json" path)
+      (let [[_ hostname starttime confversion] (re-matches #".+\/(.+?)-(\d.+Z)-(.+)\.json" path)
             newpath     (.getPath (io/file export-root-dir "reports" (format "%s-%s-%s.json" (anon/anonymize-leaf hostname :node {:node hostname} config) starttime confversion)))]
         (println (format "Anonymizing report from archive entry '%s' to '%s'" path newpath))
         (archive/add-entry tar-writer "UTF-8" newpath


### PR DESCRIPTION
Previously a regex was failing to dileneate the hostname from the rest of the
metadata from a report filename. In particular, it failed to take into account
extra hyphens in hostnames and times.

This patch fixes the regex so it is able to dileneate the hostname better.

We also order the event reports the same way as puppetdb-export does now, to
ensure we can compare them - and that both tools exhibit the same behaviour
by returning export dumps in the same shape.

This patch fixes the immediate issue, but does bring to light how bad parsing
the file names of reports in export dumps is. I raised a separate issue to fix the
issue properly here: http://projects.puppetlabs.com/issues/21956.

Signed-off-by: Ken Barber ken@bob.sh
