### PR TITLE
Improve regexp for report name matching

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/anonymize.clj
+++ b/src/com/puppetlabs/puppetdb/cli/anonymize.clj
@@ -148,7 +148,7 @@
 
     ;; Process reports
     (when (re-find (re-pattern report-pattern) path)
-      (let [[_ hostname starttime confversion] (re-matches #".+\/(.+?)-(\d.+Z)-(.+)\.json" path)
+      (let [[_ hostname starttime confversion] (re-matches #".+\/(.+?)-(\d{4}\-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)-(.+)\.json" path)
             newpath     (.getPath (io/file export-root-dir "reports" (format "%s-%s-%s.json" (anon/anonymize-leaf hostname :node {:node hostname} config) starttime confversion)))]
         (println (format "Anonymizing report from archive entry '%s' to '%s'" path newpath))
         (archive/add-entry tar-writer "UTF-8" newpath


### PR DESCRIPTION
This provides a very precise match to pick up the iso8601 timestamp in the
report file name, to avoid even more failures.

Signed-off-by: Ken Barber ken@bob.sh
