### PR TITLE
Add conn-lifetime setting to DB pool

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -339,7 +339,7 @@ If not supplied, we default to 60 minutes.
 
 This sets the time (in minutes), for a connection to remain idle before sending a test query to the DB. This is useful to prevent a DB from timing out connections on its end.
 
-If not supplied, we default to 240 minutes.
+If not supplied, we default to 45 minutes.
 
 ### `conn-lifetime`
 

--- a/src/com/puppetlabs/jdbc.clj
+++ b/src/com/puppetlabs/jdbc.clj
@@ -155,7 +155,7 @@
            log-statements      "true"
            log-slow-statements 10
            conn-max-age        60
-           conn-keep-alive     240}
+           conn-keep-alive     45}
     :as   db}]
   ;; Load the database driver class
   (Class/forName classname)


### PR DESCRIPTION
This will allow connections to be cycled at a set interval on a busy puppetdb server. Otherwise extra connections always remain open because the open connections are used in a round-robin fashion, and never trigger the idle connection timeout.
