### PR TITLE
(maint) puppetdb-ssl-setup returns 1 with legacy setup

### DIFF
--- a/acceptance/tests/security/puppetdb-ssl-setup.rb
+++ b/acceptance/tests/security/puppetdb-ssl-setup.rb
@@ -22,7 +22,7 @@ test_name "puppetdb-ssl-setup" do
     end
 
     step "run puppetdb-ssl-setup again to make sure it is idempotent" do
-      on database, "#{sbin_loc}/puppetdb-ssl-setup"
+      on database, "#{sbin_loc}/puppetdb-ssl-setup", :acceptable_exit_codes => [1]
       on database, "diff #{confd}/jetty.ini #{confd}/jetty.ini.bak.ssl_setup_tests"
     end
 


### PR DESCRIPTION
This fixes acceptance test failures that were bombing out due to
puppetdb-ssl-setup return an exit code of 1 when legacy setup was in place.

Signed-off-by: Ken Barber ken@bob.sh
