### PR TITLE
Remove unused settings relating to queued commands

### DIFF
--- a/puppet/lib/puppet/util/puppetdb/config.rb
+++ b/puppet/lib/puppet/util/puppetdb/config.rb
@@ -9,7 +9,6 @@ class Config
   def self.load(config_file = nil)
     defaults = { :server              => "puppetdb",
                  :port                => 8081,
-                 :max_queued_commands => 1000,
     }
 
     config_file ||= File.join(Puppet[:confdir], "puppetdb.conf")
@@ -49,12 +48,11 @@ class Config
     main_section = main_section.inject({}) {|h, (k,v)| h[k.to_sym] = v ; h}
     # merge with defaults but filter out anything except the legal settings
     config_hash = defaults.merge(main_section).reject do |k, v|
-      !([:server, :port, :max_queued_commands].include?(k))
+      !([:server, :port].include?(k))
     end
 
     config_hash[:server] = config_hash[:server].strip
     config_hash[:port] = config_hash[:port].to_i
-    config_hash[:max_queued_commands] = config_hash[:max_queued_commands].to_i
 
     self.new(config_hash)
   rescue => detail
@@ -75,10 +73,6 @@ class Config
 
   def port
     config[:port]
-  end
-
-  def max_queued_commands
-    config[:max_queued_commands]
   end
 
   # Private instance methods

--- a/puppet/spec/spec_helper.rb
+++ b/puppet/spec/spec_helper.rb
@@ -5,6 +5,7 @@ $LOAD_PATH.unshift File.join(dir, "../lib")
 $LOAD_PATH.push File.join(dir, "../../../puppetlabs_spec_helper")
 
 require 'rspec'
+require 'rspec/expectations'
 require 'puppetlabs_spec_helper/puppet_spec_helper'
 require 'tmpdir'
 require 'fileutils'

--- a/puppet/spec/unit/util/puppetdb/config_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/config_spec.rb
@@ -31,7 +31,6 @@ describe Puppet::Util::Puppetdb::Config do
         config = described_class.load
         config.server.should == 'puppetdb'
         config.port.should == 8081
-        config.max_queued_commands.should == 1000
       end
 
     end
@@ -60,12 +59,10 @@ CONF
 [main]
 server = main_server
 port = 1234
-max_queued_commands = 0
 CONF
         config = described_class.load
         config.server.should == 'main_server'
         config.port.should == 1234
-        config.max_queued_commands.should == 0
       end
 
       it "should use the default if no value is specified" do


### PR DESCRIPTION
Some time ago, we did some investigatory work around the possibility
of queueing failed commands to disk on the master and trying to
re-send them to puppetdb later.  This work ended up being scrapped
due to complications relating to the unpredictable threading/process
model for the environments that the puppet master might be
deployed in.  However, it appears that we failed to remove one of
the configuration settings that had been added in support of that.
