### PR TITLE
Bug/burgundy/pe 957 spec assumed array order

### DIFF
--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -210,15 +210,14 @@ describe processor do
             config.stubs(:ignore_blacklisted_events?).returns(false)
             result = subject.send(:report_to_hash)
             result["resource-events"].length.should == 3
-            foo_event = result["resource-events"][0]
-            schedule_event = result["resource-events"][1]
-            notify_event = result["resource-events"][2]
-            foo_event["resource-type"].should == "Foo"
-            foo_event["resource-title"].should == "foo"
-            schedule_event["resource-type"].should == "Schedule"
-            schedule_event["resource-title"].should == "weekly"
-            notify_event["resource-type"].should == "Notify"
-            notify_event["resource-title"].should == "Hello there"
+            [["Foo", "foo"],
+             ["Schedule", "weekly"],
+             ["Notify", "Hello there"]].each do |type, title|
+              matches = result["resource-events"].select do |e|
+                  e["resource-type"] == type and e["resource-title"] == title
+              end
+              matches.length.should be(1), "Expected to find an event with type '#{type}' and title '#{title}'"
+            end
           end
         end
       end


### PR DESCRIPTION
(PE-957) Fix spec so that it doesn't assume array order

One of the tests for filtering blacklisted events was
    assuming that the array of events returned by `report_to_hash`
    would always be in the same order; in fact, the order
    differed between ruby 1.8.7 and ruby 1.9.3.  This commit
    changes the test so that it doesn't assume a specific order,
    since the order doesn't really have anything to do with
    what we're testing.
