### PR TITLE
(#22168) Adjust max-threads based on cpu

### DIFF
--- a/test/com/puppetlabs/puppetdb/test/cli/services.clj
+++ b/test/com/puppetlabs/puppetdb/test/cli/services.clj
@@ -95,10 +95,28 @@
         (is (period? report-ttl))
         (is (= (days 14) (days (to-days report-ttl))))))))
 
+(deftest jetty7-minimum-threads-test
+  (testing "should return the same number when higher than num-cpus"
+    (is (= 500 (jetty7-minimum-threads 500 1))))
+  (testing "should set the number to min threads when it is higher and return a warning"
+    (with-log-output logs
+      (is (= 4 (jetty7-minimum-threads 1 4)))
+      (is (= 1 (count (logs-matching #"max-threads = 1 is less than the minium allowed on this system for Jetty 7 to operate." @logs)))))))
+
 (deftest http-configuration
   (testing "should enable need-client-auth"
     (let [config (configure-web-server {:jetty {:client-auth false}})]
-      (is (= (get-in config [:jetty :client-auth]) :need)))))
+      (is (= (get-in config [:jetty :client-auth]) :need))))
+  (testing "should set max-threads"
+    (let [config (configure-web-server {:jetty {}})]
+      (is (contains? (:jetty config) :max-threads))))
+  (testing "should merge configuration with initial-configs correctly"
+    (let [user-config {:jetty {:truststore "foo"}}
+          config      (configure-web-server user-config)]
+      (is (= config {:jetty {:truststore "foo" :max-threads 50 :client-auth :need}})))
+    (let [user-config {:jetty {:max-threads 500 :truststore "foo"}}
+          config      (configure-web-server user-config)]
+      (is (= config {:jetty {:truststore "foo" :max-threads 500 :client-auth :need}})))))
 
 (deftest product-name-validation
   (doseq [product-name ["puppetdb" "pe-puppetdb"]]


### PR DESCRIPTION
This patch fixes a weird behaviour in Jetty 7 whereby if you attempt to set the
max-threads to something lower then the number of CPU's on your system, it will
simply stop with the warning:

  insufficient threads configured for SslSelectChannelConnector@0.0.0.0:8081

At this point it will simply not serve any HTTP request at all, effectively
breaking PuppetDB.

This also applies to the default setting of 50. So users with greater then 50
cpus will always see this error, and may not know how to resolve it themselves.

This patch adjusts the behaviour so we automatically adjust the # of
max-threads to a safe level if below num-cpus, and we log a warning telling the
user of this fact.

Signed-off-by: Ken Barber ken@bob.sh
