### PR TITLE
(Bug #22165) rm hardcoded hostname dependencies

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -10,11 +10,12 @@ gpg_key: '4BD6EC30'
 sign_tar: FALSE
 # a space separated list of mock configs
 final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-fedora-17-i386 pl-fedora-18-i386 pl-fedora-19-i386'
-yum_host: 'burji.puppetlabs.com'
+yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE
 build_dmg: FALSE
 build_ips: FALSE
-apt_host: 'burji.puppetlabs.com'
+apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'
 apt_repo_path: '/opt/repository/incoming'
+tar_host: 'downloads.puppetlabs.com'


### PR DESCRIPTION
Prior to this commit, we had hardcoded burji.puppetlabs.com in the
build_defaults file. We've come to the conclusion that this isn't the
best way thing to do. This commit takes out those hardcoded hostnames,
in favor of cnames that point to the right place, and will be easier to
update next time we change things up.
