### PR TITLE
(maint) Change :use's to :require/:refer's

### DIFF
--- a/src/com/puppetlabs/archive.clj
+++ b/src/com/puppetlabs/archive.clj
@@ -7,9 +7,9 @@
   (:import [java.io Closeable File OutputStream FileOutputStream IOException InputStream FileInputStream]
            [org.apache.commons.compress.archivers.tar TarArchiveEntry TarArchiveOutputStream TarArchiveInputStream]
            [org.apache.commons.compress.compressors.gzip GzipCompressorOutputStream GzipCompressorInputStream])
-  (:use [clojure.java.io]
-        [clj-time.core :only [now]]
-        [clj-time.coerce :only [to-date]]))
+  (:require [clojure.java.io :refer :all]
+            [clj-time.core :refer [now]]
+            [clj-time.coerce :refer [to-date]]))
 
 ;; A simple type for writing tar/gz streams
 (defrecord TarGzWriter [tar-stream tar-writer gzip-stream]

--- a/src/com/puppetlabs/jdbc.clj
+++ b/src/com/puppetlabs/jdbc.clj
@@ -6,9 +6,8 @@
   (:require [clojure.java.jdbc :as sql]
             [clojure.string :as string]
             [clojure.tools.logging :as log]
-            [com.puppetlabs.utils :as utils])
-  (:use com.puppetlabs.jdbc.internal))
-
+            [com.puppetlabs.utils :as utils]
+            [com.puppetlabs.jdbc.internal :refer :all]))
 
 (defn valid-jdbc-query?
   "Most SQL queries generated in the PuppetDB code base are represented internally

--- a/src/com/puppetlabs/jdbc/internal.clj
+++ b/src/com/puppetlabs/jdbc/internal.clj
@@ -4,10 +4,10 @@
 ;; *subject to change without notice.*
 
 (ns com.puppetlabs.jdbc.internal
-  (:use [clojure.string :only (join)])
   (:import (com.jolbox.bonecp.hooks AbstractConnectionHook))
   (:require [clojure.java.jdbc :as sql]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log]
+            [clojure.string :refer [join]]))
 
 (defn query-param->str
   "Helper method for converting a single parameter from a prepared statement

--- a/src/com/puppetlabs/jetty.clj
+++ b/src/com/puppetlabs/jetty.clj
@@ -3,10 +3,10 @@
 (ns com.puppetlabs.jetty
   (:import (org.eclipse.jetty.server Server)
            (org.eclipse.jetty.server.nio SelectChannelConnector))
-  (:require [ring.adapter.jetty :as jetty])
-  (:use [clojure.tools.logging :as log]
-        [clojure.string :only (split trim)]
-        [com.puppetlabs.utils :only (compare-jvm-versions)]))
+  (:require [ring.adapter.jetty :as jetty]
+            [clojure.tools.logging :as log]
+            [clojure.string :refer [split trim]]
+            [com.puppetlabs.utils :refer [compare-jvm-versions]]))
 
 ;; We need to monkey-patch `add-ssl-connector!` in order to set the
 ;; appropriate options for Client Certificate Authentication, and use

--- a/src/com/puppetlabs/middleware.clj
+++ b/src/com/puppetlabs/middleware.clj
@@ -5,9 +5,9 @@
             [com.puppetlabs.http :as pl-http]
             [ring.util.response :as rr]
             [clojure.string :as s]
-            [clojure.tools.logging :as log])
-  (:use [metrics.timers :only (timer time!)]
-        [metrics.meters :only (meter mark!)]))
+            [clojure.tools.logging :as log]
+            [metrics.timers :refer [timer time!]]
+            [metrics.meters :refer [meter mark!]]))
 
 (defn wrap-with-debug-logging
   "Ring middleware that logs incoming HTTP request URIs (at DEBUG level) as

--- a/src/com/puppetlabs/mq.clj
+++ b/src/com/puppetlabs/mq.clj
@@ -10,8 +10,8 @@
             [clamq.protocol.consumer :as mq-consumer]
             [clamq.protocol.seqable :as mq-seq]
             [clamq.protocol.producer :as mq-producer]
-            [clojure.tools.logging :as log])
-  (:use [cheshire.custom :only (JSONable)]))
+            [clojure.tools.logging :as log]
+            [cheshire.custom :refer [JSONable]]))
 
 (defn- set-usage!*
   "Internal helper function for setting `SystemUsage` values on a `BrokerService`

--- a/src/com/puppetlabs/puppetdb/anonymizer.clj
+++ b/src/com/puppetlabs/puppetdb/anonymizer.clj
@@ -1,11 +1,11 @@
 (ns com.puppetlabs.puppetdb.anonymizer
   (:require [com.puppetlabs.puppetdb.catalog :as catalog]
             [com.puppetlabs.puppetdb.report :as report]
-            [clojure.string :as string])
-  (:use [com.puppetlabs.concurrent :only (bounded-pmap)]
-        [com.puppetlabs.utils :only (regexp? boolean?)]
-        [clojure.walk :only (keywordize-keys)]
-        [com.puppetlabs.random]))
+            [clojure.string :as string]
+            [com.puppetlabs.concurrent :refer [bounded-pmap]]
+            [com.puppetlabs.utils :refer [regexp? boolean?]]
+            [clojure.walk :refer [keywordize-keys]]
+            [com.puppetlabs.random :refer :all]))
 
 ;; Validation functions, for use within pre/post conditions
 

--- a/src/com/puppetlabs/puppetdb/catalog.clj
+++ b/src/com/puppetlabs/puppetdb/catalog.clj
@@ -93,8 +93,8 @@
             [clojure.set :as set]
             [cheshire.core :as json]
             [digest]
-            [com.puppetlabs.utils :as pl-utils])
-  (:use [clojure.core.match :only [match]]))
+            [com.puppetlabs.utils :as pl-utils]
+            [clojure.core.match :refer [match]]))
 
 (def ^:const catalog-version
   ^{:doc "Constant representing the version number of the PuppetDB

--- a/src/com/puppetlabs/puppetdb/catalog/utils.clj
+++ b/src/com/puppetlabs/puppetdb/catalog/utils.clj
@@ -5,8 +5,8 @@
 
 (ns com.puppetlabs.puppetdb.catalog.utils
   (:require [clojure.string :as string]
-            [com.puppetlabs.puppetdb.catalog :as cat])
-  (:use [com.puppetlabs.random :only [random-resource random-kw-resource random-parameters]]))
+            [com.puppetlabs.puppetdb.catalog :as cat]
+            [com.puppetlabs.random :refer [random-resource random-kw-resource random-parameters]]))
 
 (defn add-random-resource-to-wire-catalog
   "Adds a random resource to the given wire-format catalog"

--- a/src/com/puppetlabs/puppetdb/cli/anonymize.clj
+++ b/src/com/puppetlabs/puppetdb/cli/anonymize.clj
@@ -1,14 +1,14 @@
 (ns com.puppetlabs.puppetdb.cli.anonymize
-  (:use [com.puppetlabs.utils :only (cli!)]
-        [com.puppetlabs.puppetdb.cli.export :only [export-root-dir export-metadata-file-name]]
-        [com.puppetlabs.puppetdb.cli.import :only [parse-metadata]])
   (:import  [com.puppetlabs.archive TarGzReader TarGzWriter]
             [org.apache.commons.compress.archivers.tar TarArchiveEntry])
   (:require [cheshire.core :as json]
             [clojure.java.io :as io]
             [clojure.string :as string]
             [com.puppetlabs.archive :as archive]
-            [com.puppetlabs.puppetdb.anonymizer :as anon]))
+            [com.puppetlabs.puppetdb.anonymizer :as anon]
+            [com.puppetlabs.utils :refer [cli!]]
+            [com.puppetlabs.puppetdb.cli.export :refer [export-root-dir export-metadata-file-name]]
+            [com.puppetlabs.puppetdb.cli.import :refer [parse-metadata]]))
 
 (def cli-description "Anonymize puppetdb dump files")
 

--- a/src/com/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/com/puppetlabs/puppetdb/cli/benchmark.clj
@@ -46,9 +46,9 @@
             [cheshire.core :as json]
             [clj-http.client :as client]
             [clj-http.util :as util]
-            [fs.core :as fs])
-  (:use [com.puppetlabs.utils :only (cli! inis-to-map configure-logging! utf8-string->sha1)]
-        [com.puppetlabs.puppetdb.scf.migrate :only [migrate!]]))
+            [fs.core :as fs]
+            [com.puppetlabs.utils :refer [cli! inis-to-map configure-logging! utf8-string->sha1]]
+            [com.puppetlabs.puppetdb.scf.migrate :refer [migrate!]]))
 
 (def cli-description "Development-only benchmarking tool")
 

--- a/src/com/puppetlabs/puppetdb/cli/export.clj
+++ b/src/com/puppetlabs/puppetdb/cli/export.clj
@@ -8,16 +8,16 @@
 ;; database.
 
 (ns com.puppetlabs.puppetdb.cli.export
-  (:use [com.puppetlabs.utils :only (cli!)]
-        [clj-time.core :only [now]]
-        [clj-time.coerce :only [to-string]]
-        [com.puppetlabs.concurrent :only [bounded-pmap]]
-        [clj-http.util :only [url-encode]])
   (:require [cheshire.core :as json]
             [fs.core :as fs]
             [clojure.java.io :as io]
             [clj-http.client :as client]
-            [com.puppetlabs.archive :as archive]))
+            [com.puppetlabs.archive :as archive]
+            [com.puppetlabs.utils :refer [cli!]]
+            [clj-time.core :refer [now]]
+            [clj-time.coerce :refer [to-string]]
+            [com.puppetlabs.concurrent :refer [bounded-pmap]]
+            [clj-http.util :refer [url-encode]]))
 
 (def cli-description "Export all PuppetDB catalog data to a backup file")
 

--- a/src/com/puppetlabs/puppetdb/cli/import.clj
+++ b/src/com/puppetlabs/puppetdb/cli/import.clj
@@ -10,11 +10,11 @@
             [com.puppetlabs.http :as pl-http]
             [com.puppetlabs.archive :as archive]
             [cheshire.core :as json]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [com.puppetlabs.utils :refer [cli!]]
+            [com.puppetlabs.puppetdb.cli.export :refer [export-root-dir export-metadata-file-name]])
   (:import  [com.puppetlabs.archive TarGzReader]
-            [org.apache.commons.compress.archivers.tar TarArchiveEntry])
-  (:use [com.puppetlabs.utils :only (cli!)]
-        [com.puppetlabs.puppetdb.cli.export :only [export-root-dir export-metadata-file-name]]))
+            [org.apache.commons.compress.archivers.tar TarArchiveEntry]))
 
 (def cli-description "Import PuppetDB catalog data from a backup file")
 

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -57,16 +57,16 @@
             [clojure.tools.logging :as log]
             [cheshire.core :as json]
             [com.puppetlabs.puppetdb.http.server :as server]
-            [com.puppetlabs.ssl :as ssl])
-  (:use [clojure.java.io :only [file]]
-        [clj-time.core :only [ago secs minutes days]]
-        [overtone.at-at :only (mk-pool interspaced)]
-        [com.puppetlabs.time :only [to-secs to-millis parse-period format-period period?]]
-        [com.puppetlabs.jdbc :only (with-transacted-connection)]
-        [com.puppetlabs.utils :only (cli! configure-logging! inis-to-map with-error-delivery missing?)]
-        [com.puppetlabs.repl :only (start-repl)]
-        [com.puppetlabs.puppetdb.scf.migrate :only [migrate!]]
-        [com.puppetlabs.puppetdb.version :only [version update-info]]))
+            [com.puppetlabs.ssl :as ssl]
+            [clojure.java.io :refer [file]]
+            [clj-time.core :refer [ago secs minutes days]]
+            [overtone.at-at :refer [mk-pool interspaced]]
+            [com.puppetlabs.time :refer [to-secs to-millis parse-period format-period period?]]
+            [com.puppetlabs.jdbc :refer [with-transacted-connection]]
+            [com.puppetlabs.utils :refer [cli! configure-logging! inis-to-map with-error-delivery missing?]]
+            [com.puppetlabs.repl :refer [start-repl]]
+            [com.puppetlabs.puppetdb.scf.migrate :refer [migrate!]]
+            [com.puppetlabs.puppetdb.version :refer [version update-info]]))
 
 (def cli-description "Main PuppetDB daemon")
 

--- a/src/com/puppetlabs/puppetdb/cli/version.clj
+++ b/src/com/puppetlabs/puppetdb/cli/version.clj
@@ -10,9 +10,9 @@
 ;; by the property value.
 
 (ns com.puppetlabs.puppetdb.cli.version
-  (:require [cheshire.core :as json])
-  (:use [com.puppetlabs.puppetdb.version :only [version]]
-        [com.puppetlabs.puppetdb.scf.migrate :only [desired-schema-version]]))
+  (:require [cheshire.core :as json]
+            [com.puppetlabs.puppetdb.version :refer [version]]
+            [com.puppetlabs.puppetdb.scf.migrate :refer [desired-schema-version]]))
 
 (def cli-description "Print info about the current version of PuppetDB")
 

--- a/src/com/puppetlabs/puppetdb/command.clj
+++ b/src/com/puppetlabs/puppetdb/command.clj
@@ -68,14 +68,14 @@
             [cheshire.core :as json]
             [clamq.protocol.consumer :as mq-cons]
             [clamq.protocol.producer :as mq-producer]
-            [clamq.protocol.connection :as mq-conn])
-  (:use [slingshot.slingshot :only [try+ throw+]]
-        [cheshire.custom :only (JSONable)]
-        [clj-http.util :only [url-encode]]
-        [com.puppetlabs.jdbc :only (with-transacted-connection)]
-        [metrics.meters :only (meter mark!)]
-        [metrics.histograms :only (histogram update!)]
-        [metrics.timers :only (timer time!)]))
+            [clamq.protocol.connection :as mq-conn]
+            [slingshot.slingshot :refer [try+ throw+]]
+            [cheshire.custom :refer [JSONable]]
+            [clj-http.util :refer [url-encode]]
+            [com.puppetlabs.jdbc :refer [with-transacted-connection]]
+            [metrics.meters :refer [meter mark!]]
+            [metrics.histograms :refer [histogram update!]]
+            [metrics.timers :refer [timer time!]]))
 
 ;; ## Performance counters
 

--- a/src/com/puppetlabs/puppetdb/command/dlo.clj
+++ b/src/com/puppetlabs/puppetdb/command/dlo.clj
@@ -5,13 +5,13 @@
             [com.puppetlabs.utils :as pl-utils]
             [clj-time.format :as time-format]
             [cheshire.core :as json]
-            [fs.core :as fs])
-  (:use [clojure.java.io :only [file make-parents]]
-        [clj-time.core :only [ago after?]]
-        [metrics.gauges :only [gauge]]
-        [metrics.meters :only [meter mark!]]
-        [metrics.timers :only [timer time!]]
-        [com.puppetlabs.time :only [period?]]))
+            [fs.core :as fs]
+            [clojure.java.io :refer [file make-parents]]
+            [clj-time.core :refer [ago after?]]
+            [metrics.gauges :refer [gauge]]
+            [metrics.meters :refer [meter mark!]]
+            [metrics.timers :refer [timer time!]]
+            [com.puppetlabs.time :refer [period?]]))
 
 (def ns-str (str *ns*))
 

--- a/src/com/puppetlabs/puppetdb/core.clj
+++ b/src/com/puppetlabs/puppetdb/core.clj
@@ -13,8 +13,8 @@
 
 (ns com.puppetlabs.puppetdb.core
   (:require [com.puppetlabs.utils :as utils]
-            [clojure.tools.namespace :as ns])
-  (:use [clojure.string :only (split)])
+            [clojure.tools.namespace :as ns]
+            [clojure.string :refer [split]])
   (:gen-class))
 
 (def ns-prefix "com.puppetlabs.puppetdb.cli.")

--- a/src/com/puppetlabs/puppetdb/query.clj
+++ b/src/com/puppetlabs/puppetdb/query.clj
@@ -60,11 +60,11 @@
 ;; applying ordering constraints.
 ;;
 (ns com.puppetlabs.puppetdb.query
-  (:require [clojure.string :as string])
-  (:use [com.puppetlabs.utils :only [parse-number keyset]]
-        [com.puppetlabs.puppetdb.scf.storage :only [db-serialize sql-as-numeric sql-array-query-string sql-regexp-match sql-regexp-array-match]]
-        [com.puppetlabs.jdbc :only [valid-jdbc-query?]]
-        [clojure.core.match :only [match]]))
+  (:require [clojure.string :as string]
+            [com.puppetlabs.utils :refer [parse-number keyset]]
+            [com.puppetlabs.puppetdb.scf.storage :refer [db-serialize sql-as-numeric sql-array-query-string sql-regexp-match sql-regexp-array-match]]
+            [com.puppetlabs.jdbc :refer [valid-jdbc-query?]]
+            [clojure.core.match :refer [match]]))
 
 (defn compile-term
   "Compile a single query term, using `ops` as the set of legal operators. This

--- a/src/com/puppetlabs/puppetdb/query/catalog.clj
+++ b/src/com/puppetlabs/puppetdb/query/catalog.clj
@@ -5,9 +5,9 @@
 ;;
 
 (ns com.puppetlabs.puppetdb.query.catalog
-  (:require [com.puppetlabs.puppetdb.query.resource :as r])
-  (:use [com.puppetlabs.jdbc :only [query-to-vec]]
-        [com.puppetlabs.utils :only [dissoc-if-nil]]))
+  (:require [com.puppetlabs.puppetdb.query.resource :as r]
+            [com.puppetlabs.jdbc :refer [query-to-vec]]
+            [com.puppetlabs.utils :refer [dissoc-if-nil]]))
 
 (defn get-catalog-version
   "Given a node name, returns the Puppet catalog version string for the most

--- a/src/com/puppetlabs/puppetdb/report.clj
+++ b/src/com/puppetlabs/puppetdb/report.clj
@@ -4,11 +4,11 @@
 ;; internal PuppetDB format, including validation.
 
 (ns com.puppetlabs.puppetdb.report
-  (:use [clj-time.coerce :only [to-timestamp]]
-        [com.puppetlabs.validation :only [defmodel validate-against-model!]])
   (:require [cheshire.core :as json]
             [com.puppetlabs.utils :as utils]
-            [clojure.string :as s]))
+            [clojure.string :as s]
+            [clj-time.coerce :refer [to-timestamp]]
+            [com.puppetlabs.validation :refer [defmodel validate-against-model!]]))
 
 (defmodel Report
   {:certname                 :string

--- a/src/com/puppetlabs/puppetdb/report/utils.clj
+++ b/src/com/puppetlabs/puppetdb/report/utils.clj
@@ -4,9 +4,9 @@
 ;; randomly modifying existing reports
 
 (ns com.puppetlabs.puppetdb.report.utils
-  (:require [clojure.string :as string])
-  (:use [clojure.walk :only [keywordize-keys]]
-        [com.puppetlabs.random :only [random-string random-resource-event]]))
+  (:require [clojure.string :as string]
+            [clojure.walk :refer [keywordize-keys]]
+            [com.puppetlabs.random :refer [random-string random-resource-event]]))
 
 (defn add-random-event-to-report
   "Add a randomly-generated event to an existing report."

--- a/src/com/puppetlabs/random.clj
+++ b/src/com/puppetlabs/random.clj
@@ -1,7 +1,7 @@
 (ns com.puppetlabs.random
-  (:require [clojure.string :as string])
-  (:use [clojure.walk :only [keywordize-keys]]
-        [com.puppetlabs.utils :only [boolean?]]))
+  (:require [clojure.string :as string]
+            [clojure.walk :refer [keywordize-keys]]
+            [com.puppetlabs.utils :refer [boolean?]]))
 
 (def ^{:doc "Convenience for java.util.Random"}
   random (java.util.Random.))

--- a/src/com/puppetlabs/ssl.clj
+++ b/src/com/puppetlabs/ssl.clj
@@ -3,8 +3,8 @@
            (java.security.cert X509Certificate)
            (org.bouncycastle.openssl PEMReader PEMWriter)
            (org.bouncycastle.jce.provider BouncyCastleProvider))
-  (:use [clojure.tools.logging :as log]
-        [clojure.java.io :only (reader writer)]))
+  (:require [clojure.tools.logging :as log]
+            [clojure.java.io :refer [reader writer]]))
 
 ;; Need to make sure that the provider is initialized
 (Security/addProvider (BouncyCastleProvider.))

--- a/src/com/puppetlabs/utils.clj
+++ b/src/com/puppetlabs/utils.clj
@@ -17,16 +17,16 @@
             [clojure.string :as string]
             [clojure.tools.cli :as cli]
             [digest]
-            [fs.core :as fs])
-  (:use [clojure.java.io :only (reader)]
-        [clojure.set :only (difference union)]
-        [clojure.string :only (split)]
-        [clojure.stacktrace :only (print-cause-trace)]
-        [clj-time.core :only [now]]
-        [clj-time.coerce :only [ICoerce to-date-time]]
-        [clj-time.format :only [formatters unparse]]
-        [metrics.timers :only [time! timer]]
-        [slingshot.slingshot :only (try+ throw+)]))
+            [fs.core :as fs]
+            [clojure.java.io :refer [reader]]
+            [clojure.set :refer [difference union]]
+            [clojure.string :refer [split]]
+            [clojure.stacktrace :refer [print-cause-trace]]
+            [clj-time.core :refer [now]]
+            [clj-time.coerce :refer [ICoerce to-date-time]]
+            [clj-time.format :refer [formatters unparse]]
+            [metrics.timers :refer [time! timer]]
+            [slingshot.slingshot :refer [try+ throw+]]))
 
 ;; ## Type checking
 

--- a/src/com/puppetlabs/validation.clj
+++ b/src/com/puppetlabs/validation.clj
@@ -1,8 +1,8 @@
 (ns com.puppetlabs.validation
   (:require [com.puppetlabs.utils :as pl-utils]
             [clojure.string :as string]
-            [clojure.set :as set])
-  (:use [cheshire.custom :only [JSONable]]))
+            [clojure.set :as set]
+            [cheshire.custom :refer [JSONable]]))
 
 (defmacro defmodel
   "Defines a 'model' which can be used for validating maps of data.  Here's an


### PR DESCRIPTION
Prior to this commit the namespace declarations in puppetdb did not
align with clojure best practices where there were cases of
:use/:only's. This commit moves many of these :use's to the :require's.
