### PR TITLE
(#21520) Provide option for soft failure during terminus writes when PuppetDB is unavailable

### DIFF
--- a/acceptance/tests/soft_fail/soft_write_fail.rb
+++ b/acceptance/tests/soft_fail/soft_write_fail.rb
@@ -1,0 +1,83 @@
+test_name "soft write failure" do
+  on master, "puppet master --configprint confdir"
+  confdir = stdout.chomp
+  puppetdb_conf = "#{confdir}/puppetdb.conf"
+
+  step "backup puppetdb.conf and prepare with new setting" do
+    on master, "rm -f #{puppetdb_conf}.soft_write_fail"
+    on master, "cp -p #{puppetdb_conf} #{puppetdb_conf}.soft_write_fail"
+    on master, "echo 'soft_write_failure = true' >> #{puppetdb_conf}"
+  end
+
+  teardown do
+    # Restore original puppetdb.conf
+    on master, "rm -f #{puppetdb_conf}"
+    on master, "mv #{puppetdb_conf}.soft_write_fail #{puppetdb_conf}"
+
+    start_puppetdb(database)
+  end
+
+  names = hosts.map(&:name)
+  tmpdir = master.tmpdir('storeconfigs')
+
+  manifest_file_export = manifest_file_collect = nil
+
+  step "prepare sample content" do
+    manifest_export = names.map do |name|
+      <<-PIECE
+node "#{name}" {
+  @@notify { "Hello from #{name}": }
+}
+      PIECE
+    end.join("\n")
+
+    manifest_file_export = File.join(tmpdir, 'site-export.pp')
+    create_remote_file(master, manifest_file_export, manifest_export)
+
+    manifest_collect = names.map do |name|
+      <<-PIECE
+node "#{name}" {
+  @@notify { "Hello from #{name}": }
+  Notify <<||>>
+}
+      PIECE
+    end.join("\n")
+
+    manifest_file_collect = File.join(tmpdir, 'site-collect.pp')
+    create_remote_file(master, manifest_file_collect, manifest_collect)
+
+    on master, "chmod -R +rX #{tmpdir}"
+  end
+
+  step "Run agent with collection and puppetdb stopped making sure it fails" do
+    with_puppet_running_on master, {
+      'master' => {
+        'autosign' => 'true',
+        'manifest' => manifest_file_collect,
+      }} do
+
+      stop_puppetdb(database)
+
+      run_agent_on hosts, "--test --server #{master}", :acceptable_exit_codes => [1]
+
+      start_puppetdb(database)
+    end
+  end
+
+  step "Run agent with no collection and puppetdb stopped making sure it completes" do
+    with_puppet_running_on master, {
+      'master' => {
+        'autosign' => 'true',
+        'manifest' => manifest_file_export,
+      }} do
+
+      stop_puppetdb(database)
+
+      on hosts, 'puppet master --configprint storeconfigs'
+
+      run_agent_on hosts, "--test --verbose --trace --server #{master}"
+
+      start_puppetdb(database)
+    end
+  end
+end

--- a/documentation/connect_puppet_apply.markdown
+++ b/documentation/connect_puppet_apply.markdown
@@ -98,13 +98,15 @@ You can specify the contents of [puppetdb.conf][puppetdb_conf] directly in your 
     server = puppetdb.example.com
     port = 8081
 
-* PuppetDB's port for secure traffic defaults to 8081.
-* Puppet _requires_ use of PuppetDB's secure, HTTPS port. You cannot use the unencrypted, plain HTTP port.
+PuppetDB's port for secure traffic defaults to 8081. Puppet _requires_ use of PuppetDB's secure, HTTPS port. You cannot use the unencrypted, plain HTTP port.
+
+For availability reasons there is a setting named `soft_write_failure` that will cause the PuppetDB terminus to fail in a soft-manner if PuppetDB is not accessable for command submission. This will mean that users who are either not using storeconfigs, or only exporting resources will still have their catalogs compile during a PuppetDB outage.
 
 If no puppetdb.conf file exists, the following default values will be used:
 
     server = puppetdb
     port = 8081
+    soft_write_failure = false
 
 ### Manage puppet.conf
 

--- a/puppet/spec/unit/util/puppetdb/config_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/config_spec.rb
@@ -61,11 +61,13 @@ CONF
 server = main_server
 port = 1234
 ignore_blacklisted_events = false
+soft_write_failure = true
 CONF
         config = described_class.load
         config.server.should == 'main_server'
         config.port.should == 1234
         config.ignore_blacklisted_events?.should == false
+        config.soft_write_failure.should be_true
       end
 
       it "should use the default if no value is specified" do
@@ -75,6 +77,7 @@ CONF
         config.server.should == 'puppetdb'
         config.port.should == 8081
         config.ignore_blacklisted_events?.should == true
+        config.soft_write_failure.should be_false
       end
 
       it "should be insensitive to whitespace" do


### PR DESCRIPTION
This patch adds a new option 'soft_write_failure' for puppetdb.conf to change
the terminus behaviour so that if a command or write fails, instead of
throwing an exception and causing the agent to stop it will simply log an
error to the puppet master log.

Signed-off-by: Ken Barber ken@bob.sh
