### PR TITLE
Maint/burgundy/introduce query v3

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -406,7 +406,7 @@ module PuppetDBExtensions
     begin
       Timeout.timeout(timeout) do
         until queue_size == 0
-          result = on host, %Q(curl http://localhost:8080/v2/metrics/mbean/#{CGI.escape(metric)} 2> /dev/null |awk -F"," '{for (i = 1; i <= NF; i++) { print $i } }' |grep QueueSize |awk -F ":" '{ print $2 }')
+          result = on host, %Q(curl http://localhost:8080/v3/metrics/mbean/#{CGI.escape(metric)} 2> /dev/null |awk -F"," '{for (i = 1; i <= NF; i++) { print $i } }' |grep QueueSize |awk -F ":" '{ print $2 }')
           queue_size = Integer(result.stdout.chomp)
         end
       end

--- a/acceptance/tests/db_garbage_collection/node_ttl.rb
+++ b/acceptance/tests/db_garbage_collection/node_ttl.rb
@@ -25,7 +25,7 @@ test_name "validate that nodes are deactivated and deleted based on ttl settings
   end
 
   step "Verify that the number of active nodes is what we expect" do
-    result = on database, %Q|curl -G http://localhost:8080/v2/nodes|
+    result = on database, %Q|curl -G http://localhost:8080/v3/nodes|
     result_node_statuses = JSON.parse(result.stdout)
     assert_equal(agents.length, result_node_statuses.length, "Expected query to return '#{agents.length}' active nodes; returned '#{result_node_statuses.length}'")
   end
@@ -43,7 +43,7 @@ test_name "validate that nodes are deactivated and deleted based on ttl settings
   restart_to_gc database
 
   step "Verify that the nodes are still there and still active" do
-    result = on database, %Q|curl -G http://localhost:8080/v2/nodes|
+    result = on database, %Q|curl -G http://localhost:8080/v3/nodes|
     result_node_statuses = JSON.parse(result.stdout)
     assert_equal(agents.length, result_node_statuses.length, "Expected query to return '#{agents.length}' active nodes; returned '#{result_node_statuses.length}'")
   end
@@ -56,12 +56,12 @@ test_name "validate that nodes are deactivated and deleted based on ttl settings
   restart_to_gc database
 
   step "Verify that the nodes were deactivated but not deleted" do
-    result = on database, %Q|curl -G http://localhost:8080/v2/nodes|
+    result = on database, %Q|curl -G http://localhost:8080/v3/nodes|
     result_node_statuses = JSON.parse(result.stdout)
     assert_equal(0, result_node_statuses.length, "Expected query to return '0' active nodes; returned '#{result_node_statuses.length}'")
 
     agents.each do |agent|
-      result = on database, %Q|curl -G http://localhost:8080/v2/nodes/#{agent.node_name}|
+      result = on database, %Q|curl -G http://localhost:8080/v3/nodes/#{agent.node_name}|
       result_node_status = JSON.parse(result.stdout)
 
       assert_equal(agent.node_name, result_node_status['name'], "Didn't get a node back for #{agent.node_name}")
@@ -85,7 +85,7 @@ test_name "validate that nodes are deactivated and deleted based on ttl settings
 
   step "Verify that the nodes were all deleted" do
     agents.each do |agent|
-      result = on database, %Q|curl -G http://localhost:8080/v2/nodes/#{agent.node_name}|
+      result = on database, %Q|curl -G http://localhost:8080/v3/nodes/#{agent.node_name}|
       result_node_status = JSON.parse(result.stdout)
 
       assert_equal({"error" => "No information is known about #{agent.node_name}"}, result_node_status, "Got a result back for #{agent.node_name} when it shouldn't exist")
@@ -93,13 +93,13 @@ test_name "validate that nodes are deactivated and deleted based on ttl settings
   end
 
   step "Verify that all associated data was deleted" do
-    result = on database, "curl -G http://localhost:8080/v2/facts/operatingsystem"
+    result = on database, "curl -G http://localhost:8080/v3/facts/operatingsystem"
     facts = JSON.parse(result.stdout)
 
     assert_equal([], facts, "Got facts when they should all have been deleted")
 
     # We have to supply a query for resources, so use one that will always match
-    result = on database, %q|curl -G http://localhost:8080/v2/resources --data 'query=["=","exported",false]'|
+    result = on database, %q|curl -G http://localhost:8080/v3/resources --data 'query=["=","exported",false]'|
     resources = JSON.parse(result.stdout)
 
     assert_equal([], resources, "Got resources when they should all have been deleted")

--- a/acceptance/tests/security/cert_whitelist.rb
+++ b/acceptance/tests/security/cert_whitelist.rb
@@ -21,7 +21,7 @@ test_name "certificate whitelisting" do
                  "--cacert #{ssldir}/certs/ca.pem " +
                  "--cert #{ssldir}/certs/#{dbname}.pem " +
                  "--key #{ssldir}/private_keys/#{dbname}.pem "+
-                 "https://#{dbname}:8081/v2/metrics/mbeans " +
+                 "https://#{dbname}:8081/v3/metrics/mbeans " +
                  "-o /dev/null"
     actual_status_code = stdout.chomp
     assert_equal expected_status_code.to_s, actual_status_code, "Reqs from #{dbname} with whitelist '#{whitelist}' should return #{expected_status_code}, not #{actual_status_code}"

--- a/acceptance/tests/storeconfigs/file_with_binary_template.rb
+++ b/acceptance/tests/storeconfigs/file_with_binary_template.rb
@@ -54,7 +54,7 @@ file { "/tmp/myfile":
 
   sleep_until_queue_empty database
 
-  on database, %Q|curl -G -H 'Accept: application/json' http://localhost:8080/v2/resources --data 'query=["=",%20"tag",%20"binary_file"]' > binary_file.json|
+  on database, %Q|curl -G -H 'Accept: application/json' http://localhost:8080/v3/resources --data 'query=["=",%20"tag",%20"binary_file"]' > binary_file.json|
   # We redirected this output to a file because if the invalid binary data was printed to the log from 
   # the curl statement, then Jenkins would try to parse it at the end of the run and fail.
   scp_from(database, "binary_file.json", ".")

--- a/src/com/puppetlabs/puppetdb/http/v3.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3.clj
@@ -1,0 +1,32 @@
+(ns com.puppetlabs.puppetdb.http.v3
+  (:use [com.puppetlabs.puppetdb.http.v3.command :only (command-app)]
+        [com.puppetlabs.puppetdb.http.v3.facts :only (facts-app)]
+        [com.puppetlabs.puppetdb.http.v3.fact-names :only (fact-names-app)]
+        [com.puppetlabs.puppetdb.http.v3.node :only (node-app)]
+        [com.puppetlabs.puppetdb.http.v3.resources :only (resources-app)]
+        [com.puppetlabs.puppetdb.http.v3.metrics :only (metrics-app)]
+        [com.puppetlabs.puppetdb.http.v3.version :only (version-app)]
+        [net.cgrand.moustache :only (app)]))
+
+(def v3-app
+  (app
+    ["commands" &]
+    {:any command-app}
+
+    ["facts" &]
+    {:any facts-app}
+
+    ["fact-names" &]
+    {:any fact-names-app}
+
+    ["nodes" &]
+    {:any node-app}
+
+    ["resources" &]
+    {:any resources-app}
+
+    ["metrics" &]
+    {:any metrics-app}
+
+    ["version" &]
+    {:any version-app}))

--- a/src/com/puppetlabs/puppetdb/http/v3/command.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/command.clj
@@ -1,0 +1,5 @@
+(ns com.puppetlabs.puppetdb.http.v3.command
+  (:require [com.puppetlabs.puppetdb.http.v2.command :as v2-command]))
+
+(def command-app
+  v2-command/command-app)

--- a/src/com/puppetlabs/puppetdb/http/v3/fact_names.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/fact_names.clj
@@ -1,0 +1,5 @@
+(ns com.puppetlabs.puppetdb.http.v3.fact-names
+  (:require [com.puppetlabs.puppetdb.http.v3.fact-names :as v2-fact-names]))
+
+(def fact-names-app
+  v2-fact-names/fact-names-app)

--- a/src/com/puppetlabs/puppetdb/http/v3/facts.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/facts.clj
@@ -1,0 +1,5 @@
+(ns com.puppetlabs.puppetdb.http.v3.facts
+  (:require [com.puppetlabs.puppetdb.http.v2.facts :as v2-facts]))
+
+(def facts-app
+  v2-facts/facts-app)

--- a/src/com/puppetlabs/puppetdb/http/v3/metrics.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/metrics.clj
@@ -1,0 +1,5 @@
+(ns com.puppetlabs.puppetdb.http.v3.metrics
+  (:require  [com.puppetlabs.puppetdb.http.v2.metrics :as v2-metrics]))
+
+(def metrics-app
+  v2-metrics/metrics-app)

--- a/src/com/puppetlabs/puppetdb/http/v3/node.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/node.clj
@@ -1,0 +1,5 @@
+(ns com.puppetlabs.puppetdb.http.v3.node
+  (:require [com.puppetlabs.puppetdb.http.v2.node :as v2-node]))
+
+(def node-app
+  v2-node/node-app)

--- a/src/com/puppetlabs/puppetdb/http/v3/resources.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/resources.clj
@@ -1,0 +1,5 @@
+(ns com.puppetlabs.puppetdb.http.v3.resources
+  (:require [com.puppetlabs.puppetdb.http.v2.resources :as v2-resources]))
+
+(def resources-app
+  v2-resources/resources-app)

--- a/src/com/puppetlabs/puppetdb/http/v3/version.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/version.clj
@@ -1,0 +1,5 @@
+(ns com.puppetlabs.puppetdb.http.v3.version
+  (:require  [com.puppetlabs.puppetdb.http.v2.version :as v2-version]))
+
+(def version-app
+  v2-version/version-app)

--- a/test/com/puppetlabs/puppetdb/test/http/experimental/explore.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/experimental/explore.clj
@@ -21,7 +21,7 @@
     (update-in request [:headers] assoc "Accept" c-t)))
 
 (defn get-response
-  ([route] (*app* (get-request (str "/v2/" route)))))
+  ([route] (*app* (get-request (str "/v3/" route)))))
 
 (defmacro check-json-response
   "Test if the HTTP request is a success, and if the result is equal

--- a/test/com/puppetlabs/puppetdb/test/http/server.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/server.clj
@@ -11,10 +11,10 @@
 
 (deftest method-not-allowed
   (testing "provides a useful error message"
-    (let [request (header (request :post "/v2/nodes") "Accept" c-t)
+    (let [request (header (request :post "/v3/nodes") "Accept" c-t)
           {:keys [status body]} (*app* request)]
       (is (= status pl-http/status-bad-method))
-      (is (= body "The POST method is not allowed for /v2/nodes")))))
+      (is (= body "The POST method is not allowed for /v3/nodes")))))
 
 (deftest resource-requests
   (testing "/ redirects to the dashboard"

--- a/test/com/puppetlabs/puppetdb/test/http/v1/deprecation.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v1/deprecation.clj
@@ -1,0 +1,40 @@
+(ns com.puppetlabs.puppetdb.test.http.v1.deprecation
+  (:require [ring.mock.request :as mock]
+            [cheshire.core :as json]
+            [com.puppetlabs.http :as pl-http])
+  (:use     [clojure.test]
+            [com.puppetlabs.puppetdb.fixtures]
+            [com.puppetlabs.testutils.logging]))
+
+
+
+(use-fixtures :each with-http-app)
+
+(def c-t pl-http/json-response-content-type)
+
+(defn get-request
+  [path]
+  (let [request (mock/request :get path)
+        headers (:headers request)]
+    (assoc request :headers (assoc headers "Accept" c-t))))
+
+(defn get-response
+  ([url] (*app* (get-request url))))
+
+(deftest test-v1-deprecation
+  (testing "URLs with no version are deprecated"
+    (with-log-output logs
+      (let [response (get-response "/version")
+            msg      #"Use of unversioned APIs is deprecated"]
+        (is (= 1 (count (logs-matching msg @logs))))
+        (let [dep-header ((response :headers) "X-Deprecation")]
+          (is dep-header)
+          (is (re-find msg dep-header))))))
+  (testing "URLs with /v1 are deprecated"
+    (with-log-output logs
+      (let [response  (get-response "/v1/version")
+            msg       #"v1 query API is deprecated and will be removed in an upcoming release"]
+        (is (= 1 (count (logs-matching msg @logs))))
+        (let [dep-header ((response :headers) "X-Deprecation")]
+          (is dep-header)
+          (is (re-find msg dep-header)))))))

--- a/test/com/puppetlabs/puppetdb/test/http/v1/version.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v1/version.clj
@@ -27,7 +27,7 @@
                          "link" "http://docs.puppetlabs.com/puppetdb/100.0/release_notes.html"
                          "version" "100.0.0"})
                       version/version (constantly "99.0.0")]
-          (json/parse-string (:body (*app* (get-request "/v2/version/latest")))))))))
+          (json/parse-string (:body (*app* (get-request "/v3/version/latest")))))))))
 
 (deftest latest-version-response
   (testing "should return 'newer'->true if product is not specified"


### PR DESCRIPTION
```
Introduce v3 query API endpoints

This commit introduces the v3 query endpoints.  For now, they are
all simply routing directly to the v2 endpoints; this commit is
merely scaffolding.

It also deprecates the v1 endpoints and introduces tests to
validate the deprecation warnings, and updates all acceptance tests
to use the new v3 endpoints.
```
