### PR TITLE
Use a faster query to retrieve report_timestamp

### DIFF
--- a/src/com/puppetlabs/puppetdb/query/node.clj
+++ b/src/com/puppetlabs/puppetdb/query/node.clj
@@ -26,12 +26,11 @@
                      subquery1.deactivated,
                      certname_catalogs.timestamp AS catalog_timestamp,
                      certname_facts_metadata.timestamp AS facts_timestamp,
-                     (SELECT end_time FROM reports
-                       WHERE certname = subquery1.name
-                       ORDER BY end_time DESC LIMIT 1) AS report_timestamp
+                     reports.end_time AS report_timestamp
                      FROM (%s) subquery1
                        LEFT OUTER JOIN certname_catalogs ON subquery1.name = certname_catalogs.certname
                        LEFT OUTER JOIN certname_facts_metadata ON subquery1.name = certname_facts_metadata.certname
+                       LEFT OUTER JOIN reports ON subquery1.name = reports.certname AND reports.hash IN (SELECT report FROM latest_reports)
                      ORDER BY subquery1.name ASC"
                     subselect)]
     (apply vector sql params)))


### PR DESCRIPTION
This was performing a correlated subquery with an ORDER BY clause on reports
in order to retrieve the latest report for each node, which is slow and runs
many times. Now we take advantage of the latest_reports table to make fetching
the latest report inexpensive. In testing, the round trip time for /v2/nodes
with 179 nodes went from ~700ms to ~33ms.
