### PR TITLE
WIP: Streaming fact queries

### DIFF
--- a/src/com/puppetlabs/http.clj
+++ b/src/com/puppetlabs/http.clj
@@ -101,6 +101,20 @@
           (rr/response)
           (rr/status status-not-acceptable)))))
 
+(defn json-response*
+  "Returns a Ring response object with the supplied `body`, response
+  `code`, and a JSON content type and charset. `body` is assumed to
+  alredy be JSON-ified. To auto-serialize body to JSON, look at
+  `json-response`."
+  ([body]
+     (json-response* body status-ok))
+  ([body code]
+     (-> body
+         (rr/response)
+         (rr/header "Content-Type" "application/json")
+         (rr/charset "utf-8")
+         (rr/status code))))
+
 (defn json-response
   "Returns a Ring response object with the supplied `body` and response `code`,
   and a JSON content type. If unspecified, `code` will default to 200."
@@ -109,10 +123,7 @@
   ([body code]
      (-> body
          (json/generate-string {:date-format "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" :pretty true})
-         (rr/response)
-         (rr/header "Content-Type" "application/json")
-         (rr/charset "utf-8")
-         (rr/status code))))
+         (json-response* code))))
 
 (def json-response-content-type "application/json; charset=utf-8")
 

--- a/src/com/puppetlabs/puppetdb/http/v2/resources.clj
+++ b/src/com/puppetlabs/puppetdb/http/v2/resources.clj
@@ -19,15 +19,10 @@
                            (-> query
                                (json/parse-string true)
                                (query->sql)))]
-
-      (-> (pl-http/streamed-response buffer
-            (with-transacted-connection db
-              (r/with-queried-resources sql params #(pl-http/stream-json % buffer))))
-          (rr/response)
-          (rr/header "Content-Type" "application/json")
-          (rr/charset "utf-8")
-          (rr/status pl-http/status-ok)))
-
+      (pl-http/json-response*
+       (pl-http/streamed-response buffer
+        (with-transacted-connection db
+          (r/with-queried-resources sql params #(pl-http/stream-json % buffer))))))
     (catch IllegalArgumentException e
       ;; Query compilation error
       (pl-http/error-response e))

--- a/src/com/puppetlabs/puppetdb/query/facts.clj
+++ b/src/com/puppetlabs/puppetdb/query/facts.clj
@@ -56,7 +56,19 @@
       (apply vector sql params))
     ["SELECT certname, name, value FROM certname_facts ORDER BY certname, name, value"]))
 
+(defn with-queried-facts
+  "Execute `func` against the rows returned from fact query `query`
+  with query parameters `params`."
+  [query params func]
+  {:pre [(string? query)
+         (or (coll? params) (nil? params))
+         (fn? func)]}
+  (sql/with-query-results-cursor query params rs
+    (func rs)))
+
 (defn query-facts
   [[sql & params]]
   {:pre [(string? sql)]}
-  (apply sql/query-to-vec sql params))
+  (let [results (atom [])]
+    (with-queried-facts sql params #(reset! results (vec %)))
+    @results))

--- a/test/com/puppetlabs/puppetdb/test/http/v2/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v2/facts.clj
@@ -185,7 +185,7 @@
                 {:keys [status body headers]} (*app* request)]
             (is (= status pl-http/status-ok))
             (is (= (headers "Content-Type") c-t))
-            (is (= result (json/parse-string body true))
+            (is (= result (json/parse-string (slurp body) true))
                 (pr-str query)))))
 
       (testing "malformed, yo"
@@ -206,7 +206,7 @@
         {:keys [status body]} (*app* request)]
     (is (= status pl-http/status-ok))
     (is (= (try
-             (json/parse-string body true)
+             (json/parse-string (slurp body) true)
              (catch Throwable e
                body)) results) query)))
 


### PR DESCRIPTION
This extends the benefits of streamed resource queries to facts. This is
especially helpful for users with a large number of nodes and/or very
large custom facts; previously, a query for all facts would blow out the
heap and take down PuppetDB.
