### PR TITLE
Upgrade to latest core.match

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
   :description "Puppet-integrated catalog and fact storage"
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [cheshire "5.2.0"]
-                 [org.clojure/core.match "0.2.0-alpha9"]
+                 [org.clojure/core.match "0.2.0-rc5"]
                  [org.clojure/math.combinatorics "0.0.4"]
                  [org.clojure/tools.logging "0.2.6"]
                  [org.clojure/tools.cli "0.2.2"]

--- a/src/com/puppetlabs/puppetdb/catalog.clj
+++ b/src/com/puppetlabs/puppetdb/catalog.clj
@@ -272,13 +272,13 @@
   returning a PuppetDB-suitable representation."
   (fn [catalog version]
     (match [catalog version]
-           [(_ :when string?) _]
+           [(_ :guard string?) _]
            String
 
-           [(_ :when map?) (_ :when number?)]
+           [(_ :guard map?) (_ :guard number?)]
            version
 
-           [(_ :when map?) (_ :when (complement number?))]
+           [(_ :guard map?) (_ :guard (complement number?))]
            (throw (IllegalArgumentException. (format "Catalog version '%s' is not a legal version number" version)))
 
            ;; At this point, catalog can't be a string or a map (regardless of

--- a/src/com/puppetlabs/puppetdb/query.clj
+++ b/src/com/puppetlabs/puppetdb/query.clj
@@ -260,12 +260,12 @@
            :where (format "certname_catalogs.certname IN (SELECT name FROM certnames WHERE deactivated IS %s)" (if value "NULL" "NOT NULL"))}
 
          ;; param joins.
-         [["parameter" (name :when string?)]]
+         [["parameter" (name :guard string?)]]
          {:where  "catalog_resources.resource IN (SELECT rp.resource FROM resource_params rp WHERE rp.name = ? AND rp.value = ?)"
           :params [name (db-serialize value)]}
 
          ;; metadata match.
-         [(metadata :when #{"catalog" "resource" "type" "title" "tags" "exported" "sourcefile" "sourceline"})]
+         [(metadata :guard #{"catalog" "resource" "type" "title" "tags" "exported" "sourcefile" "sourceline"})]
            {:where  (format "catalog_resources.%s = ?" metadata)
             :params [value]}
 
@@ -309,7 +309,7 @@
           :params [pattern]}
 
          ;; metadata match.
-         [(metadata :when #{"catalog" "resource" "type" "title" "exported" "sourcefile" "sourceline"})]
+         [(metadata :guard #{"catalog" "resource" "type" "title" "exported" "sourcefile" "sourceline"})]
          {:where  (sql-regexp-match (format "catalog_resources.%s" metadata))
           :params [pattern]}
 
@@ -393,7 +393,7 @@
   {:post [(map? %)
           (string? (:where %))]}
   (match [path]
-         [["fact" (name :when string?)]]
+         [["fact" (name :guard string?)]]
          {:where  "certnames.name IN (SELECT cf.certname FROM certname_facts cf WHERE cf.name = ? AND cf.value = ?)"
           :params [name (str value)]}
          [["node" "active"]]
@@ -412,7 +412,7 @@
          ["name"]
          {:where "certnames.name = ?"
           :params [value]}
-         [["fact" (name :when string?)]]
+         [["fact" (name :guard string?)]]
          {:where  "certnames.name IN (SELECT cf.certname FROM certname_facts cf WHERE cf.name = ? AND cf.value = ?)"
           :params [name (str value)]}
          [["node" "active"]]
@@ -435,7 +435,7 @@
            {:where (sql-regexp-match "certnames.name")
             :params [pattern]}
 
-           [["fact" (name :when string?)]]
+           [["fact" (name :guard string?)]]
            {:where (format "certnames.name IN (SELECT cf.certname FROM certname_facts cf WHERE cf.name = ? AND %s)" (sql-regexp-match "cf.value"))
             :params [name pattern]}
 
@@ -448,7 +448,7 @@
           (string? (:where %))]}
   (if-let [number (parse-number (str value))]
     (match [path]
-           [["fact" (name :when string?)]]
+           [["fact" (name :guard string?)]]
            {:where  (format "certnames.name IN (SELECT cf.certname FROM certname_facts cf WHERE cf.name = ? AND %s %s ?)" (sql-as-numeric "cf.value") op)
             :params [name number]}
 

--- a/src/com/puppetlabs/puppetdb/query/event.clj
+++ b/src/com/puppetlabs/puppetdb/query/event.clj
@@ -47,20 +47,20 @@
       {:where (format "reports.certname = ?")
        :params [value]}
 
-      [(field :when #{"report" "resource_type" "resource_title" "status"})]
+      [(field :guard #{"report" "resource_type" "resource_title" "status"})]
       {:where (format "resource_events.%s = ?" field)
        :params [value] }
 
       ;; these fields allow NULL, which causes a change in semantics when
       ;; wrapped in a NOT(...) clause, so we have to be very explicit
       ;; about the NULL case.
-      [(field :when #{"property" "message" "file" "line"})]
+      [(field :guard #{"property" "message" "file" "line"})]
       {:where (format "resource_events.%s = ? AND resource_events.%s IS NOT NULL" field field)
        :params [value] }
 
       ;; these fields require special treatment for NULL (as described above),
       ;; plus a serialization step since the values can be complex data types
-      [(field :when #{"old_value" "new_value"})]
+      [(field :guard #{"old_value" "new_value"})]
       {:where (format "resource_events.%s = ? AND resource_events.%s IS NOT NULL" field field)
        :params [(db-serialize value)] }
 
@@ -81,14 +81,14 @@
         {:where (sql-regexp-match "reports.certname")
          :params [pattern]}
 
-        [(field :when #{"report" "resource_type" "resource_title" "status"})]
+        [(field :guard #{"report" "resource_type" "resource_title" "status"})]
         {:where  (sql-regexp-match (format "resource_events.%s" field))
          :params [pattern] }
 
         ;; these fields allow NULL, which causes a change in semantics when
         ;; wrapped in a NOT(...) clause, so we have to be very explicit
         ;; about the NULL case.
-        [(field :when #{"property" "message" "file" "line"})]
+        [(field :guard #{"property" "message" "file" "line"})]
         {:where (format "%s AND resource_events.%s IS NOT NULL"
                     (sql-regexp-match (format "resource_events.%s" field))
                     field)


### PR DESCRIPTION
The newer releases switch to using :guard to denote predicates inside a
match clause.
