### PR TITLE
(#21558) Add support for status in reports

### DIFF
--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -38,6 +38,7 @@ Puppet::Reports.register_report(:puppetdb) do
       "puppet-version"          => @puppet_version,
       "report-format"           => @report_format,
       "configuration-version"   => configuration_version.to_s,
+      "status"                  => status,
       "start-time"              => Puppet::Util::Puppetdb.to_wire_time(time),
       "end-time"                => Puppet::Util::Puppetdb.to_wire_time(time + run_duration),
       "resource-events"         => build_events_list

--- a/src/com/puppetlabs/puppetdb/query/report.clj
+++ b/src/com/puppetlabs/puppetdb/query/report.clj
@@ -38,6 +38,7 @@
                                       report_format,
                                       configuration_version,
                                       start_time,
+                                      status,
                                       end_time,
                                       receive_time
                                   FROM reports %s ORDER BY start_time DESC")

--- a/src/com/puppetlabs/puppetdb/report.clj
+++ b/src/com/puppetlabs/puppetdb/report.clj
@@ -16,6 +16,7 @@
    :puppet-version           :string
    :report-format            :integer
    :configuration-version    :string
+   :status                   :string
    :start-time               :datetime
    :end-time                 :datetime
    :resource-events          :coll})

--- a/src/com/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/com/puppetlabs/puppetdb/scf/migrate.clj
@@ -354,6 +354,12 @@
                (format "Unsupported database engine '%s'"
                  (sql-current-connection-database-name)))))))
 
+(defn add-report-status
+  "Add 'status' column to the report table."
+  []
+  (sql/do-commands
+    "ALTER TABLE reports ADD COLUMN status VARCHAR(20) DEFAULT NULL"))
+
 (defn add-file-line-columns-to-events-table
   "Add 'file' and 'line' columns to the event table."
   []
@@ -396,7 +402,8 @@
    11 increase-puppet-version-field-length
    12 add-file-line-columns-to-events-table
    13 add-latest-reports-table
-   14 add-parameter-cache})
+   14 add-parameter-cache
+   15 add-report-status})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -715,7 +715,7 @@ must be supplied as the value to be matched."
   configuration version, timestamps, events).
   "
   [{:keys [certname puppet-version report-format configuration-version
-           start-time end-time resource-events] :as report}]
+           status start-time end-time resource-events] :as report}]
   (-> (sorted-map)
     (assoc :certname certname)
     (assoc :puppet-version puppet-version)
@@ -723,6 +723,7 @@ must be supplied as the value to be matched."
     (assoc :configuration-version configuration-version)
     (assoc :start-time start-time)
     (assoc :end-time end-time)
+    (assoc :status status)
     (assoc :resource-events (sort (map resource-event-identity-string resource-events)))
     (pr-str)
     (utils/utf8-string->sha1)))
@@ -749,7 +750,7 @@ must be supplied as the value to be matched."
   the transaction.  This should always be set to `true`, except during some very specific testing
   scenarios."
   [{:keys [puppet-version certname report-format configuration-version
-           start-time end-time resource-events]
+           status start-time end-time resource-events]
     :as report}
    timestamp update-latest-report?]
   {:pre [(map? report)
@@ -771,6 +772,7 @@ must be supplied as the value to be matched."
             :certname               certname
             :report_format          report-format
             :configuration_version  configuration-version
+            :status                 status
             :start_time             (to-timestamp start-time)
             :end_time               (to-timestamp end-time)
             :receive_time           (to-timestamp timestamp)})


### PR DESCRIPTION
In Puppet::Transaction::Report contains a 'status' field
(changed, unchanged,failed).  This commit allows puppetdb to
consume that value and store it, allowing for a quick view on
the outcome of a report.
