### PR TITLE
Bug/burgundy/pe 1246 counts shouldnt be nil

### DIFF
--- a/src/com/puppetlabs/puppetdb/query/aggregate_event_counts.clj
+++ b/src/com/puppetlabs/puppetdb/query/aggregate_event_counts.clj
@@ -1,6 +1,7 @@
 (ns com.puppetlabs.puppetdb.query.aggregate-event-counts
   (:require [com.puppetlabs.puppetdb.query.event-counts :as event-counts])
-  (:use [com.puppetlabs.jdbc :only [valid-jdbc-query? query-to-vec]]))
+  (:use [com.puppetlabs.jdbc :only [valid-jdbc-query? query-to-vec]]
+        [com.puppetlabs.utils :only [mapvals]]))
 
 (defn- get-aggregate-sql
   "Given the `event-count-sql`, return a SQL string that will aggregate the results."
@@ -41,5 +42,7 @@
   [[sql & params :as query-and-params]]
   {:pre  [(string? sql)]
    :post [(map? %)]}
-  (first (perform-query query-and-params)))
+  (->> (perform-query query-and-params)
+    first
+    (mapvals #(if (nil? %) 0 %))))
 

--- a/test/com/puppetlabs/puppetdb/test/query/aggregate_event_counts.clj
+++ b/test/com/puppetlabs/puppetdb/test/query/aggregate_event_counts.clj
@@ -121,4 +121,14 @@
                        :skips 1
                        :total 1}
             actual    (aggregate-counts-query-result ["=" "certname" "foo.local"] "node" {:count-by "node"})]
-        (is (= actual expected))))))
+        (is (= actual expected)))))
+
+  (testing "when nothing matches, should return zeroes rather than nils"
+    (let [expected  {:successes 0
+                      :failures 0
+                      :noops 0
+                      :skips 0
+                      :total 0}
+
+          actual    (aggregate-counts-query-result ["<" "timestamp" 0] "resource")]
+      (is (= actual expected)))))


### PR DESCRIPTION
Prior to this commit, if the aggregate event count queries don't return any events, then the results will come back with 'nil' values for the various fields ('successes', 'failures', etc.).  This commit fixes things so that we're returning zeroes instead.
