### PR TITLE
Maint/burgundy/pe 1345 move endpoints out of experimental

### DIFF
--- a/documentation/api/index.markdown
+++ b/documentation/api/index.markdown
@@ -39,9 +39,23 @@ The available query endpoints are documented in the pages linked below.
 
 ### Query Endpoints
 
+#### Version 3
+
+Version 3 of the query API adds new endpoints, and introduces paging and sorting operations.  The following endpoints will continue to work for the foreseeable future.
+
+* [Facts Endpoint](./query/v2/facts.html)
+* [Resources Endpoint](./query/v2/resources.html)
+* [Nodes Endpoint](./query/v2/nodes.html)
+* [Fact-Names Endpoint](./query/v2/fact-names.html)
+* [Metrics Endpoint](./query/v2/metrics.html)
+* [Reports Endpoint](./query/v3/report.html)
+* [Events Endpoint](./query/v3/event.html)
+* [Event Counts Endpoint](./query/v3/event-counts.html)
+* [Aggregate Event Counts Endpoint](./query/v3/aggregate-event-counts.html)
+
 #### Version 2
 
-Version 2 of the query API adds new endpoints, and introduces subqueries and regular expression operators for more efficient requests and better insight into your data. The following endpoints will continue to work for the foreseeable future. 
+Version 2 of the query API adds new endpoints, and introduces subqueries and regular expression operators for more efficient requests and better insight into your data.  It isn't deprecated, but we encourage you to use version 3 if possible.
 
 * [Facts Endpoint](./query/v2/facts.html)
 * [Resources Endpoint](./query/v2/resources.html)
@@ -49,9 +63,9 @@ Version 2 of the query API adds new endpoints, and introduces subqueries and reg
 * [Fact-Names Endpoint](./query/v2/fact-names.html)
 * [Metrics Endpoint](./query/v2/metrics.html)
 
-#### Version 1
+#### Version 1 (DEPRECATED)
 
-Version 1 of the query API works with PuppetDB 1.1 and 1.0. It isn't deprecated, but we encourage you to use version 2 if you can.
+Version 1 of the query API works with PuppetDB 1.1 and 1.0. It is deprecated and will be removed in a future release.
 
 In PuppetDB 1.0, you could access the version 1 endpoints without the `/v1/` prefix. This still works but **is now deprecated,** and we currently plan to remove support in PuppetDB 2.0. Please change your version 1 applications to use the `/v1/` prefix.
 
@@ -60,13 +74,6 @@ In PuppetDB 1.0, you could access the version 1 endpoints without the `/v1/` pre
 * [Nodes Endpoint](./query/v1/nodes.html)
 * [Status Endpoint](./query/v1/status.html)
 * [Metrics Endpoint](./query/v1/metrics.html)
-
-#### Experimental
-
-These endpoints are not yet set in stone, and their behavior may change at any time without regard for normal versioning rules. We invite you to play with them, but you should be ready to adjust your application on your next upgrade. 
-
-* [Report Endpoint](./query/experimental/report.html)
-* [Event Endpoint](./query/experimental/event.html)
 
 Commands
 -----

--- a/documentation/api/query/v3/event.markdown
+++ b/documentation/api/query/v3/event.markdown
@@ -1,7 +1,7 @@
 ---
-title: "PuppetDB 1.4 » API » Experimental » Querying Events"
+title: "PuppetDB 1.4 » API » v3 » Querying Events"
 layout: default
-canonical: "/puppetdb/latest/api/query/experimental/event.html"
+canonical: "/puppetdb/latest/api/query/v3/event.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
@@ -12,7 +12,7 @@ canonical: "/puppetdb/latest/api/query/experimental/event.html"
 
 ## Routes
 
-### `GET /experimental/events`
+### `GET /v3/events`
 
 This will return all resource events matching the given query.  (Resource events
 are generated from Puppet reports.)  There must be an `Accept` header matching
@@ -180,4 +180,4 @@ on [paging][paging].
 
 [You can use `curl`][curl] to query information about events like so:
 
-    curl -G 'http://localhost:8080/experimental/events' --data-urlencode 'query=["=", "report", "38ff2aef3ffb7800fe85b322280ade2b867c8d27"]' --data-urlencode 'limit=1000'
+    curl -G 'http://localhost:8080/v3/events' --data-urlencode 'query=["=", "report", "38ff2aef3ffb7800fe85b322280ade2b867c8d27"]' --data-urlencode 'limit=1000'

--- a/documentation/api/query/v3/report.markdown
+++ b/documentation/api/query/v3/report.markdown
@@ -1,7 +1,7 @@
 ---
-title: "PuppetDB 1.4 » API » Experimental » Querying Reports"
+title: "PuppetDB 1.4 » API » v3 » Querying Reports"
 layout: default
-canonical: "/puppetdb/latest/api/query/experimental/report.html"
+canonical: "/puppetdb/latest/api/query/v3/report.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
@@ -14,7 +14,7 @@ endpoint.
 
 ## Routes
 
-### `GET /experimental/reports`
+### `GET /v3/reports`
 
 #### Parameters
 
@@ -82,4 +82,4 @@ on [paging][paging].
 
 [You can use `curl`][curl] to query information about reports like so:
 
-    curl -G 'http://localhost:8080/experimental/reports' --data-urlencode 'query=["=", "certname", "example.local"]'
+    curl -G 'http://localhost:8080/v3/reports' --data-urlencode 'query=["=", "certname", "example.local"]'

--- a/src/com/puppetlabs/puppetdb/http/experimental.clj
+++ b/src/com/puppetlabs/puppetdb/http/experimental.clj
@@ -1,32 +1,12 @@
 (ns com.puppetlabs.puppetdb.http.experimental
-  (:use [com.puppetlabs.puppetdb.http.experimental.catalog :only (catalog-app)]
-        [com.puppetlabs.puppetdb.http.experimental.planetarium-catalog :only (planetarium-catalog-app)]
+  (:use [com.puppetlabs.puppetdb.http.experimental.planetarium-catalog :only (planetarium-catalog-app)]
         [com.puppetlabs.puppetdb.http.experimental.population :only (population-app)]
-        [com.puppetlabs.puppetdb.http.experimental.event :only (events-app)]
-        [com.puppetlabs.puppetdb.http.experimental.event-counts :only (event-counts-app)]
-        [com.puppetlabs.puppetdb.http.experimental.aggregate-event-counts :only (aggregate-event-counts-app)]
-        [com.puppetlabs.puppetdb.http.experimental.report :only (reports-app)]
         [net.cgrand.moustache :only (app)]))
 
 (def experimental-app
   (app
-    ["catalog" &]
-    {:any catalog-app}
-
     ["planetarium-catalog" &]
     {:any planetarium-catalog-app}
 
     ["population" &]
-    {:any population-app}
-
-    ["events" &]
-    {:any events-app}
-
-    ["event-counts" &]
-    {:any event-counts-app}
-
-    ["aggregate-event-counts" &]
-    {:any aggregate-event-counts-app}
-
-    ["reports" &]
-    {:any reports-app}))
+    {:any population-app}))

--- a/src/com/puppetlabs/puppetdb/http/v3.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3.clj
@@ -6,6 +6,11 @@
         [com.puppetlabs.puppetdb.http.v3.resources :only (resources-app)]
         [com.puppetlabs.puppetdb.http.v3.metrics :only (metrics-app)]
         [com.puppetlabs.puppetdb.http.v3.version :only (version-app)]
+        [com.puppetlabs.puppetdb.http.v3.catalog :only (catalog-app)]
+        [com.puppetlabs.puppetdb.http.v3.event :only (events-app)]
+        [com.puppetlabs.puppetdb.http.v3.report :only (reports-app)]
+        [com.puppetlabs.puppetdb.http.v3.event-counts :only (event-counts-app)]
+        [com.puppetlabs.puppetdb.http.v3.aggregate-event-counts :only (aggregate-event-counts-app)]
         [net.cgrand.moustache :only (app)]))
 
 (def v3-app
@@ -29,4 +34,19 @@
     {:any metrics-app}
 
     ["version" &]
-    {:any version-app}))
+    {:any version-app}
+
+    ["catalog" &]
+    {:any catalog-app}
+
+    ["events" &]
+    {:any events-app}
+
+    ["event-counts" &]
+    {:any event-counts-app}
+
+    ["aggregate-event-counts" &]
+    {:any aggregate-event-counts-app}
+
+    ["reports" &]
+    {:any reports-app}))

--- a/src/com/puppetlabs/puppetdb/http/v3/aggregate_event_counts.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/aggregate_event_counts.clj
@@ -1,5 +1,5 @@
 ;; TODO docs
-(ns com.puppetlabs.puppetdb.http.experimental.aggregate-event-counts
+(ns com.puppetlabs.puppetdb.http.v3.aggregate-event-counts
   (:require [com.puppetlabs.http :as pl-http]
             [com.puppetlabs.puppetdb.query.aggregate-event-counts :as aggregate-event-counts]
             [cheshire.core :as json])

--- a/src/com/puppetlabs/puppetdb/http/v3/catalog.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/catalog.clj
@@ -1,4 +1,4 @@
-(ns com.puppetlabs.puppetdb.http.experimental.catalog
+(ns com.puppetlabs.puppetdb.http.v3.catalog
   (:require [cheshire.core :as json]
             [com.puppetlabs.http :as pl-http]
             [com.puppetlabs.puppetdb.query.catalog :as c]

--- a/src/com/puppetlabs/puppetdb/http/v3/event.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/event.clj
@@ -45,7 +45,7 @@
 ;;    }
 ;;  ]`
 
-(ns com.puppetlabs.puppetdb.http.experimental.event
+(ns com.puppetlabs.puppetdb.http.v3.event
   (:require [com.puppetlabs.http :as pl-http]
             [com.puppetlabs.utils :as pl-utils]
             [com.puppetlabs.puppetdb.query.event :as query]

--- a/src/com/puppetlabs/puppetdb/http/v3/event_counts.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/event_counts.clj
@@ -1,5 +1,5 @@
 ;; TODO docs
-(ns com.puppetlabs.puppetdb.http.experimental.event-counts
+(ns com.puppetlabs.puppetdb.http.v3.event-counts
   (:require [com.puppetlabs.http :as pl-http]
             [com.puppetlabs.puppetdb.query.event-counts :as event-counts]
             [cheshire.core :as json]

--- a/src/com/puppetlabs/puppetdb/http/v3/report.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/report.clj
@@ -46,7 +46,7 @@
 ;;    }
 ;;]`
 
-(ns com.puppetlabs.puppetdb.http.experimental.report
+(ns com.puppetlabs.puppetdb.http.v3.report
   (:require [com.puppetlabs.http :as pl-http]
             [com.puppetlabs.puppetdb.query.report :as query]
             [ring.util.response :as rr]

--- a/test/com/puppetlabs/puppetdb/test/http/v3/aggregate_event_counts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v3/aggregate_event_counts.clj
@@ -1,4 +1,4 @@
-(ns com.puppetlabs.puppetdb.test.http.experimental.aggregate-event-counts
+(ns com.puppetlabs.puppetdb.test.http.v3.aggregate-event-counts
   (:require [com.puppetlabs.http :as pl-http]
             [cheshire.core :as json])
   (:use clojure.test
@@ -14,7 +14,7 @@
   (store-example-report! (:basic reports) (now))
 
   (testing "summarize-by rejects unsupported values"
-    (let [response  (get-response "/experimental/aggregate-event-counts"
+    (let [response  (get-response "/v3/aggregate-event-counts"
                                   ["=" "certname" "foo.local"]
                                   "illegal-summarize-by"
                                   {} true)
@@ -23,7 +23,7 @@
       (is (re-find #"Unsupported value for 'summarize-by': 'illegal-summarize-by'" body))))
 
   (testing "count-by rejects unsupported values"
-    (let [response  (get-response "/experimental/aggregate-event-counts"
+    (let [response  (get-response "/v3/aggregate-event-counts"
                                   ["=" "certname" "foo.local"]
                                   "node"
                                   {"count-by" "illegal-count-by"} true)
@@ -37,7 +37,7 @@
                      :noops 0
                      :skips 1
                      :total 1}
-          response  (get-response "/experimental/aggregate-event-counts"
+          response  (get-response "/v3/aggregate-event-counts"
                                   ["or" ["=" "status" "success"] ["=" "status" "skipped"]]
                                    "containing-class"
                                    {"count-by"      "node"

--- a/test/com/puppetlabs/puppetdb/test/http/v3/catalog.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v3/catalog.clj
@@ -1,4 +1,4 @@
-(ns com.puppetlabs.puppetdb.test.http.experimental.catalog
+(ns com.puppetlabs.puppetdb.test.http.v3.catalog
   (:require [cheshire.core :as json]
             [com.puppetlabs.puppetdb.testutils.catalog :as testcat])
   (:use  [clojure.java.io :only [resource]]
@@ -18,7 +18,7 @@
 
 (defn get-response
   ([]      (get-response nil))
-  ([node] (*app* (get-request (str "/experimental/catalog/" node)))))
+  ([node] (*app* (get-request (str "/v3/catalog/" node)))))
 
 
 (deftest catalog-retrieval

--- a/test/com/puppetlabs/puppetdb/test/http/v3/event.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v3/event.clj
@@ -1,4 +1,4 @@
-(ns com.puppetlabs.puppetdb.test.http.experimental.event
+(ns com.puppetlabs.puppetdb.test.http.v3.event
   (:require [com.puppetlabs.puppetdb.report :as report]
             [com.puppetlabs.utils :as utils]
             [com.puppetlabs.http :as pl-http]
@@ -22,7 +22,7 @@
   ([query]
     (get-response query {}))
   ([query extra-query-params]
-    (*app* (get-request "/experimental/events" query extra-query-params))))
+    (*app* (get-request "/v3/events" query extra-query-params))))
 
 (defn munge-event-values
   "Munge the event values that we get back from the web to a format suitable
@@ -131,7 +131,7 @@
       (testing (str "should support paging through events " label " counts")
         (let [results (paged-results
                         {:app-fn  *app*
-                         :path    "/experimental/events"
+                         :path    "/v3/events"
                          :query   ["=" "report" report-hash]
                          :limit   1
                          :total   (count (:resource-events basic))

--- a/test/com/puppetlabs/puppetdb/test/http/v3/event_counts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v3/event_counts.clj
@@ -1,4 +1,4 @@
-(ns com.puppetlabs.puppetdb.test.http.experimental.event-counts
+(ns com.puppetlabs.puppetdb.test.http.v3.event-counts
   (:require [com.puppetlabs.http :as pl-http]
             [cheshire.core :as json])
   (:use clojure.test
@@ -15,14 +15,14 @@
   (store-example-report! (:basic reports) (now))
 
   (testing "summarize-by rejects unsupported values"
-    (let [response  (get-response "/experimental/event-counts"
+    (let [response  (get-response "/v3/event-counts"
                                   ["=" "certname" "foo.local"] "illegal-summarize-by" {} true)
           body      (get response :body "null")]
       (is (= (:status response) pl-http/status-bad-request))
       (is (re-find #"Unsupported value for 'summarize-by': 'illegal-summarize-by'" body))))
 
   (testing "count-by rejects unsupported values"
-    (let [response  (get-response "/experimental/event-counts"
+    (let [response  (get-response "/v3/event-counts"
                                   ["=" "certname" "foo.local"] "node"
                                   {"count-by" "illegal-count-by"} true)
           body      (get response :body "null")]
@@ -36,7 +36,7 @@
                        :successes 0
                        :noops 0
                        :skips 1}}
-          response  (get-response "/experimental/event-counts"
+          response  (get-response "/v3/event-counts"
                                   ["or" ["=" "status" "success"] ["=" "status" "skipped"]]
                                   "containing-class"
                                   {"count-by"      "node"
@@ -66,7 +66,7 @@
                          :skips           1}}
             results (paged-results
                       {:app-fn  *app*
-                       :path    "/experimental/event-counts"
+                       :path    "/v3/event-counts"
                        :query   [">" "timestamp" 0]
                        :params  {:summarize-by "resource"}
                        :limit   1

--- a/test/com/puppetlabs/puppetdb/test/http/v3/report.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v3/report.clj
@@ -1,4 +1,4 @@
-(ns com.puppetlabs.puppetdb.test.http.experimental.report
+(ns com.puppetlabs.puppetdb.test.http.v3.report
   (:require [cheshire.core :as json]
             [com.puppetlabs.puppetdb.scf.storage :as scf-store]
             [com.puppetlabs.puppetdb.report :as report]
@@ -16,7 +16,7 @@
 (use-fixtures :each with-test-db with-http-app)
 
 (defn get-response
-  [query] (*app* (get-request "/experimental/reports" query)))
+  [query] (*app* (get-request "/v3/reports" query)))
 
 (defn report-response
   [report]
@@ -69,7 +69,7 @@
       (testing (str "should support paging through reports " label " counts")
         (let [results       (paged-results
                               {:app-fn  *app*
-                               :path    "/experimental/reports"
+                               :path    "/v3/reports"
                                :query   ["=" "certname" (:certname basic1)]
                                :limit   1
                                :total   2


### PR DESCRIPTION
Several of the http endpoints are moving from `experimental` to v3.  This pull request, well, moves them.
