### PR TITLE
tests: add ruby tests to travis-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml
 /pkg/
 test-resources/config/local.clj
 ext/packaging/*
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: clojure
 lein: lein2
-jdk:
-  - oraclejdk6
-  - oraclejdk7
-  - openjdk6
-  - openjdk7
-install: bundle install
-script: lein2 test
+env:
+  - T_TEST=java:oraclejdk7
+  - T_TEST=java:openjdk6
+  - T_TEST=java:openjdk7
+  - T_TEST=ruby:default
+script: ./ext/travisci/test.sh
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,11 @@
 source 'https://rubygems.org'
 
 gem 'facter'
+
+group :test do
+  # Pinning to work-around an incompatiblity with 2.14 in puppetlabs_spec_helper
+  gem 'rspec', '2.13.0'
+  gem 'puppetlabs_spec_helper', '0.4.1', :require => false
+
+  gem 'puppet', :require => false
+end

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+T_LANG="${T_TEST%%:*}"
+T_VERSION="${T_TEST#*:}"
+
+echo "Running tests in language: ${T_LANG} version: ${T_VERSION}"
+
+if [ $T_LANG == "ruby" ]; then
+  # Using `rvm use` in travis-ci needs a lot more work, so just accepting
+  # the default version for now.
+  ruby -v
+  bundle install
+  cd puppet
+  bundle exec rspec spec/
+else
+  if [ $T_LANG == "java" ]; then
+    jdk_switcher use $T_VERSION
+    java -version
+    lein2 test
+  else
+    echo "Invalid language ${T_LANG}"
+    exit 1
+  fi
+fi


### PR DESCRIPTION
This switches the TravisCI matrix to support different languages so we can do
tests for Clojure and for our ruby terminus as well for PR's.

For now this just supports the default version of Ruby that travis-ci provides
due to hassles trying to use 'rvm use' in a script. Later on we'll extend the
tooling to support this but for now having at least the default (1.9.3) tested
is going to get us further then where we are now.

Signed-off-by: Ken Barber ken@bob.sh
