### PR TITLE
Updated documentation for PostgreSQL configuration to reflect changing

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -218,7 +218,9 @@ Before using the PostgreSQL backend, you must set up a PostgreSQL server, ensure
     $ createdb -E UTF8 -O puppetdb puppetdb
     $ exit
 
-Next you will most likely need to modify the `pg_hba.conf` file to allow for md5 authentication from at least localhost logins.  The following example `pg_hba.conf` file sets md5 authentication for localhost, IPv4, and IPv6 connections:
+Next you will most likely need to modify the `pg_hba.conf` file to allow for md5 authentication from at least localhost logins.  To locate the file you can either issue a `locate pg_hba.conf` command (if your distribution supports it) or consult your distribution's documentation for the `confdir`.
+
+The following example `pg_hba.conf` file sets md5 authentication for localhost, IPv4, and IPv6 connections:
 
     # TYPE  DATABASE   USER   CIDR-ADDRESS  METHOD
     local      all      all                  md5


### PR DESCRIPTION
Hello, I've been doing the PuppetDB installation from source per the instructions and discovered that for new PostgreSQL users that the default authentication to the database is set to "ident" instead of "md5" which will not work by default with the current instructions.  I've added language to leave the default case currently alone but go on to explain that if it does not work how to change PostgreSQL to md5 from ident, how to restart the database, and retest login.  These directions worked for my install on CentOS 6 and should work for other users.
