### PR TITLE
Bug/burgundy/pe1572 dashes not underscores

### DIFF
--- a/src/com/puppetlabs/jdbc.clj
+++ b/src/com/puppetlabs/jdbc.clj
@@ -128,10 +128,11 @@
   return the SQL string representing this term for use in an ORDER BY clause."
   [{:keys [field order]}]
   {:pre [(string? field)
-         (re-find #"^[\w_]+$" field)
+         (re-find #"^[\w\-]+$" field)
          ((some-fn string? nil?) order)]
    :post [(string? %)]}
-  (let [order (string/lower-case (or order "asc"))]
+  (let [field (dashes->underscores field)
+        order (string/lower-case (or order "asc"))]
     (when-not (#{"asc" "desc"} order)
       (throw (IllegalArgumentException.
                (str "Unsupported value " order

--- a/test/com/puppetlabs/puppetdb/test/http/v3/events.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v3/events.clj
@@ -141,4 +141,17 @@
           (is (= (expected-resource-events-response
                    (:resource-events basic)
                    report-hash conf-version)
-                (set (munge-event-values results)))))))))
+                (set (munge-event-values results)))))))
+
+    (testing "order-by field names"
+      (testing "should accept dashes"
+        (let [expected  (expected-resource-events-response (:resource-events basic) report-hash conf-version)
+              response  (get-response [">", "timestamp", 0] {:order-by (json/generate-string [{:field "resource-title"}])})]
+          (is (= (:status response) pl-http/status-ok))
+          (response-equal? response expected munge-event-values)))
+
+      (testing "should reject underscores"
+        (let [response  (get-response [">", "timestamp", 0] {:order-by (json/generate-string [{:field "resource_title"}])})
+              body      (get response :body "null")]
+          (is (= (:status response) pl-http/status-bad-request))
+          (is (re-find #"Unrecognized column 'resource_title' specified in :order-by" body)))))))


### PR DESCRIPTION
'order-by' should expect dashes in field names rather than underscores.
This commit makes that so.
