### PR TITLE
Report processor code was truncating microseconds

### DIFF
--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -45,7 +45,7 @@ module Puppet::Util::Puppetdb
     # The current implementation simply calls iso8601, but having this method
     # allows us to change that in the future if needed w/o being forced to
     # update all of the date objects elsewhere in the code.
-    time.iso8601
+    time.iso8601(9)
   end
 
   # Convert a value (usually a string) to a boolean


### PR DESCRIPTION
```
Because we were not specifying a precision when we called
`Time.iso8601`, the report processor was truncating
microseconds from the timestamps of everything in the
reports.

This commit adds an explicit precision so that we don't
lose the microseconds.
```
