### PR TITLE
 Add ability to filter out multiple events on the same resource

### DIFF
--- a/src/com/puppetlabs/http.clj
+++ b/src/com/puppetlabs/http.clj
@@ -154,3 +154,22 @@
                         [segs'
                          (conj strs (str delimiter (s/join delimiter segs')))]))]
        (second (reduce f [[] []] segments)))))
+
+(defn parse-boolean-query-param
+  "Utility method for parsing a query parameter whose value is expected to be
+  a boolean.  In the case where the HTTP request contains the query parameter but
+  not a value for it (e.g. `http://foo.com?mybool`), assumes the user intended
+  to use the parameter as a flag, and thus return `true`.  If the key doesn't
+  exist in the params map, return `false`.  In all other cases, attempt
+  to parse the value of the param as a Boolean, and return the result."
+  [params k]
+  (if (contains? params k)
+    (let [val (params k)]
+      (cond
+        ;; If the original query string contains the query param w/o a
+        ;; a value, it will show up here as nil.  We assume that in that
+        ;; case, the caller intended to use it as a flag.
+        (= val nil)                  true
+        (Boolean/parseBoolean val)   true
+        :else                        false))
+    false))

--- a/src/com/puppetlabs/puppetdb/http/v3/aggregate_event_counts.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/aggregate_event_counts.clj
@@ -18,11 +18,14 @@
          ((some-fn nil? string?) counts-filter)
          ((some-fn nil? string?) count-by)]}
   (try
-    (let [query         (json/parse-string query true)
-          counts-filter (if counts-filter (json/parse-string counts-filter true))]
+    (let [query               (json/parse-string query true)
+          counts-filter       (if counts-filter (json/parse-string counts-filter true))
+          distinct-resources? (pl-http/parse-boolean-query-param query-params "distinct-resources")]
       (with-transacted-connection db
         (-> query
-            (aggregate-event-counts/query->sql summarize-by {:counts-filter counts-filter :count-by count-by})
+            (aggregate-event-counts/query->sql summarize-by
+              {:counts-filter counts-filter :count-by count-by
+               :distinct-resources? distinct-resources?})
             (aggregate-event-counts/query-aggregate-event-counts)
             (pl-http/json-response))))
     (catch com.fasterxml.jackson.core.JsonParseException e
@@ -43,4 +46,4 @@
   (-> routes
       verify-accepts-json
       (validate-query-params {:required ["query" "summarize-by"]
-                              :optional ["counts-filter" "count-by"]})))
+                              :optional ["counts-filter" "count-by" "distinct-resources"]})))

--- a/src/com/puppetlabs/puppetdb/http/v3/events.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/events.clj
@@ -8,6 +8,7 @@
   (:use [net.cgrand.moustache :only [app]]
         com.puppetlabs.middleware
         [com.puppetlabs.jdbc :only (with-transacted-connection)]
+        [com.puppetlabs.http :only (parse-boolean-query-param)]
         [com.puppetlabs.puppetdb.http :only (query-result-response)]))
 
 (defn produce-body
@@ -18,13 +19,13 @@
 
   If the query would return more than `limit` results, `status-internal-error`
   is returned."
-  [limit query paging-options db]
+  [limit query query-options paging-options db]
   {:pre [(and (integer? limit) (>= limit 0))]}
   (try
     (with-transacted-connection db
       (-> query
           (json/parse-string true)
-          (query/query->sql)
+          ((partial query/query->sql query-options))
           ((partial query/limited-query-resource-events limit paging-options))
           (query-result-response)))
     (catch com.fasterxml.jackson.core.JsonParseException e
@@ -34,17 +35,30 @@
     (catch IllegalStateException e
       (pl-http/error-response e pl-http/status-internal-error))))
 
+(defn get-query-options
+  "Given a map of query params, build up a list of the legal query options
+  support by the event counts query."
+  [params]
+  ;; For now, the only supported query option is `:distinct-resources?`
+  {:distinct-resources? (parse-boolean-query-param params "distinct-resources")})
+
 (def routes
   (app
     [""]
     {:get (fn [{:keys [params globals paging-options]}]
-            (let [limit (:event-query-limit globals)]
-              (produce-body limit (params "query") paging-options (:scf-db globals))))}))
+            (let [limit         (:event-query-limit globals)
+                  query-options (get-query-options params)]
+              (produce-body
+                limit
+                (params "query")
+                query-options
+                paging-options
+                (:scf-db globals))))}))
 
 (def events-app
   "Ring app for querying events"
   (-> routes
     verify-accepts-json
     (validate-query-params {:required ["query"]
-                            :optional paging/query-params})
+                            :optional (cons "distinct-resources" paging/query-params)})
     wrap-with-paging-options))

--- a/src/com/puppetlabs/puppetdb/query/aggregate_event_counts.clj
+++ b/src/com/puppetlabs/puppetdb/query/aggregate_event_counts.clj
@@ -20,12 +20,12 @@
   Since all inputs are forwarded to `event-counts/query->sql`, look there for proper documentation."
   ([query summarize-by]
    (query->sql query summarize-by {}))
-  ([query summarize-by extra-query-params]
+  ([query summarize-by query-options]
    {:pre  [(sequential? query)
            (string? summarize-by)
-           (map? extra-query-params)]
+           (map? query-options)]
     :post [(valid-jdbc-query? %)]}
-   (let [[count-sql & params] (event-counts/query->sql query summarize-by extra-query-params)
+   (let [[count-sql & params] (event-counts/query->sql query summarize-by query-options)
          aggregate-sql        (get-aggregate-sql count-sql)]
      (apply vector aggregate-sql params))))
 

--- a/src/com/puppetlabs/puppetdb/query/event_counts.clj
+++ b/src/com/puppetlabs/puppetdb/query/event_counts.clj
@@ -166,7 +166,7 @@
   the value to `count-by` may also be specified (defaults to `resource`)."
   ([query summarize-by]
     (query->sql query summarize-by {}))
-  ([query summarize-by {:keys [counts-filter count-by]}]
+  ([query summarize-by {:keys [counts-filter count-by] :as query-options}]
     {:pre  [(sequential? query)
             (string? summarize-by)
             ((some-fn nil? sequential?) counts-filter)
@@ -176,7 +176,9 @@
           group-by                        (get-group-by summarize-by)
           {counts-filter-where  :where
            counts-filter-params :params}  (get-counts-filter-where-clause counts-filter)
-          [event-sql & event-params]      (events/query->sql query)
+          [event-sql & event-params]      (events/query->sql
+                                            (select-keys query-options [:distinct-resources?])
+                                            query)
           count-by-sql                    (get-count-by-sql event-sql count-by group-by)
           event-count-sql                 (get-event-count-sql count-by-sql group-by)
           filtered-sql                    (get-filtered-sql event-count-sql counts-filter-where)]

--- a/src/com/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/com/puppetlabs/puppetdb/scf/migrate.clj
@@ -322,7 +322,8 @@
     - A column for the resource's containment path in the resource_events table
     - A column for the transaction uuid in the reports & catalogs tables
     - Renames the `sourcefile` and `sourceline` columns on the `catalog_resources`
-      table to `file` and `line` for consistency."
+      table to `file` and `line` for consistency.
+    - Add index to 'property' column in resource_events table"
   []
   (sql/do-commands
     "ALTER TABLE resource_events ADD COLUMN file VARCHAR(1024) DEFAULT NULL"
@@ -330,7 +331,8 @@
   (sql/do-commands
     (format "ALTER TABLE resource_events ADD containment_path %s" (sql-array-type-string "TEXT"))
     "ALTER TABLE resource_events ADD containing_class VARCHAR(255)"
-    "CREATE INDEX idx_resource_events_containing_class ON resource_events(containing_class)")
+    "CREATE INDEX idx_resource_events_containing_class ON resource_events(containing_class)"
+    "CREATE INDEX idx_resource_events_property ON resource_events(property)")
   (sql/do-commands
     ;; It would be nice to change the transaction UUID column to NOT NULL in the future
     ;; once we stop supporting older versions of Puppet that don't have this field.

--- a/test/com/puppetlabs/puppetdb/examples/reports.clj
+++ b/test/com/puppetlabs/puppetdb/examples/reports.clj
@@ -116,4 +116,64 @@
           :file             "/Users/foo/workspace/puppetlabs/conf/puppet/master/conf/manifests/site.pp"
           :line             11
           :containment-path ["Foo" "" "Bar[Baz]"]
-          :containing-class "Foo"}]}})
+          :containing-class "Foo"}]}
+
+   :basic3
+   {:certname               "foo.local"
+    :puppet-version         "3.0.1"
+    :report-format          3
+    :transaction-uuid       "e1e561ba-212f-11e3-9d58-60a44c233a9d"
+    :configuration-version  "a81jasj123"
+    :start-time             "2011-01-02T12:00:00-03:00"
+    :end-time               "2011-01-02T12:10:00-03:00"
+    :resource-events
+    ;; NOTE: this is a bit wonky because resource events should *not* contain
+    ;;  a certname or containment-class on input, but they will have one on output
+    ;;  To make it easier to test output, we're included them here.  We also include
+    ;;  a `:test-id` field to make it easier to reference individual events during
+    ;;  testing.  All of these are munged out by the testutils `store-example-report!`
+    ;;  function before the report is submitted to the test database.
+    [{:test-id          7
+      :certname         "foo.local"
+      :status           "success"
+      :timestamp        "2011-01-02T12:00:00-03:00"
+      :resource-type    "Notify"
+      :resource-title   "notify, yo"
+      :property         "message"
+      :new-value        "notify, yo"
+      :old-value        ["what" "the" "woah"]
+      :message          "defined 'message' as 'notify, yo'"
+      :file             "foo.pp"
+      :line             1
+      :containment-path nil
+      :containing-class nil}
+     {:test-id          8
+      :certname         "foo.local"
+      :status           "failure"
+      :timestamp        "2011-01-02T12:00:00-03:00"
+      :resource-type    "Notify"
+      :resource-title   "notify, yar"
+      :property         "message"
+      :new-value        {"absent" 5}
+      :old-value        {"absent" true}
+      :message          "defined 'message' as 'notify, yo'"
+      :file             nil
+      :line             nil
+      :containment-path []
+      :containing-class nil}
+     {:test-id          9
+      :certname         "foo.local"
+      :status           "skipped"
+      :timestamp        "2011-01-02T12:00:00-03:00"
+      :resource-type    "Notify"
+      :resource-title   "hi"
+      :property         nil
+      :new-value        nil
+      :old-value        nil
+      :message          nil
+      :file             "bar"
+      :line             2
+      :containment-path ["Foo" "" "Bar[Baz]"]
+      :containing-class "Foo"}]}
+
+   })

--- a/test/com/puppetlabs/puppetdb/test/http/v3/events.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v3/events.clj
@@ -155,3 +155,19 @@
               body      (get response :body "null")]
           (is (= (:status response) pl-http/status-bad-request))
           (is (re-find #"Unrecognized column 'resource_title' specified in :order-by" body)))))))
+
+(deftest query-distinct-resources
+  (let [basic         (:basic reports)
+        report-hash   (store-example-report! basic (now))
+        conf-version  (:configuration-version basic)
+        basic-events  (get-events-map basic)
+
+        basic3        (:basic3 reports)
+        report-hash3  (store-example-report! basic3 (now))
+        conf-version3 (:configuration-version basic3)
+        basic-events3 (get-events-map basic3)]
+    (testing "should return only one event for a given resource"
+      (let [expected  (expected-resource-events-response (:resource-events basic3) report-hash3 conf-version3)
+            response  (get-response ["=", "certname", "foo.local"] {:distinct-resources true})]
+        (assert-success! response)
+        (response-equal? response expected munge-event-values)))))

--- a/test/com/puppetlabs/puppetdb/test/query/events.clj
+++ b/test/com/puppetlabs/puppetdb/test/query/events.clj
@@ -352,3 +352,20 @@
                                                       ["and" ["=" "status" "skipped"] ["=" "latest-report?" false]]
                                                       ["and" ["=" "message" "created"] ["=" "latest-report?" true]]])]
         (is (= actual expected))))))
+
+
+(deftest distinct-resource-event-queries
+  (let [basic1        (:basic reports)
+        events1       (get-events-map basic1)
+        report-hash1  (store-example-report! basic1 (now))
+        conf-version1 (:configuration-version basic1)
+
+        basic3        (:basic3 reports)
+        events3       (get-events-map basic3)
+        report-hash3  (store-example-report! basic3 (now))
+        conf-version3 (:configuration-version basic3)]
+    (testing "retrieval of events for distinct resources only"
+      (let [expected  (expected-resource-events (:resource-events basic3) report-hash3 conf-version3)
+            actual    (resource-events-query-result ["=" "certname" "foo.local"] {} {:distinct-resources? true})]
+        (is (= (count events3) (count actual)))
+        (is (= actual expected))))))

--- a/test/com/puppetlabs/puppetdb/testutils/events.clj
+++ b/test/com/puppetlabs/puppetdb/testutils/events.clj
@@ -60,8 +60,9 @@
   "Utility function that executes a resource events query and returns a set of
   results for use in test comparisons."
   ([query] (resource-events-query-result query nil))
-  ([query paging-options]
-    (->> (query/query->sql query)
+  ([query paging-options] (resource-events-query-result query paging-options nil))
+  ([query paging-options query-options]
+    (->> (query/query->sql query-options query)
          (query/query-resource-events paging-options)
          (:result)
          (set))))
@@ -71,7 +72,7 @@
   a set of results for use in test comparisons."
   ([limit query] (resource-events-limited-query-result limit query nil))
   ([limit query paging-options]
-    (->> (query/query->sql query)
+    (->> (query/query->sql nil query)
          (query/limited-query-resource-events limit paging-options)
          (:result)
          (set))))


### PR DESCRIPTION
```
Because of Burgundy UI requirements, we need a way to issue
an event query that only returns a single (most recent) event for
any given resource that also satisfies all of the other constraints
specified in the query (including timestamp filtering).

Because of the timestamp filtering, we cannot rely on the
`latest-reports` table to optimize and simplify the query; if the
user specifies a query that is bounded by timestamps that are
earlier than the latest report, and also specifies the `latest-report`
flag, then no events would be returned.

This commit introduces a new query parameter for the `event-counts`
endpoint: 'distinct-resources'.  If this parameter is set to `true`,
then we use a more complicated SQL query that JOINS on a subselect
in order to filter out duplicate events on a given resource (besides
the event with the MAX timestamp in the result set).
```
