### PR TITLE
Dev/burgundy/blacklist refactor

### DIFF
--- a/puppet/lib/puppet/util/puppetdb/blacklist.rb
+++ b/puppet/lib/puppet/util/puppetdb/blacklist.rb
@@ -1,0 +1,35 @@
+module Puppet::Util::Puppetdb
+  class Blacklist
+
+    BlacklistedEvent = Struct.new(:resource_type, :resource_title, :status, :property)
+
+    # Initialize our blacklist of events to filter out of reports.  This is needed
+    # because older versions of puppet always generate a swath of (meaningless)
+    # 'skipped' Schedule events on every agent run.  As of puppet 3.3, these
+    # events should no longer be generated, but this is here for backward compat.
+    BlacklistedEvents =
+        [BlacklistedEvent.new("Schedule", "never", "skipped", nil),
+         BlacklistedEvent.new("Schedule", "puppet", "skipped", nil),
+         BlacklistedEvent.new("Schedule", "hourly", "skipped", nil),
+         BlacklistedEvent.new("Schedule", "daily", "skipped", nil),
+         BlacklistedEvent.new("Schedule", "weekly", "skipped", nil),
+         BlacklistedEvent.new("Schedule", "monthly", "skipped", nil)]
+
+    def initialize(events)
+      @events = events.reduce({}) do |m, e|
+        m[e.resource_type] ||= {}
+        m[e.resource_type][e.resource_title] ||= {}
+        m[e.resource_type][e.resource_title][e.status] ||= {}
+        m[e.resource_type][e.resource_title][e.status][e.property] = true
+        m
+      end
+    end
+
+    def is_event_blacklisted?(event)
+      @events.fetch(event["resource-type"], {}).
+        fetch(event["resource-title"], {}).
+        fetch(event["status"], {}).
+        fetch(event["property"], false)
+    end
+  end
+end

--- a/puppet/lib/puppet/util/puppetdb/config.rb
+++ b/puppet/lib/puppet/util/puppetdb/config.rb
@@ -1,22 +1,9 @@
 require 'puppet/util/puppetdb/command_names'
+require 'puppet/util/puppetdb/blacklist'
 
 module Puppet::Util::Puppetdb
 class Config
   include Puppet::Util::Puppetdb::CommandNames
-
-  BlacklistedEvent = Struct.new(:resource_type, :resource_title, :status, :property)
-
-  # Initialize our blacklist of events to filter out of reports.  This is needed
-  # because older versions of puppet always generate a swath of (meaningless)
-  # 'skipped' Schedule events on every agent run.  As of puppet 3.3, these
-  # events should no longer be generated, but this is here for backward compat.
-  BlacklistedEvents =
-      [BlacklistedEvent.new("Schedule", "never", "skipped", nil),
-       BlacklistedEvent.new("Schedule", "puppet", "skipped", nil),
-       BlacklistedEvent.new("Schedule", "hourly", "skipped", nil),
-       BlacklistedEvent.new("Schedule", "daily", "skipped", nil),
-       BlacklistedEvent.new("Schedule", "weekly", "skipped", nil),
-       BlacklistedEvent.new("Schedule", "monthly", "skipped", nil)]
 
   # Public class methods
 
@@ -102,10 +89,7 @@ class Config
   end
 
   def is_event_blacklisted?(event)
-    blacklisted_events.fetch(event["resource-type"], {}).
-      fetch(event["resource-title"], {}).
-      fetch(event["status"], {}).
-      fetch(event["property"], false)
+   @blacklist.is_event_blacklisted? event
   end
 
   def soft_write_failure
@@ -116,17 +100,11 @@ class Config
   private
 
   attr_reader :config
-  attr_reader :blacklisted_events
 
-  def initialize_blacklisted_events(events = BlacklistedEvents)
-    @blacklisted_events = events.reduce({}) do |m, e|
-      m[e.resource_type] ||= {}
-      m[e.resource_type][e.resource_title] ||= {}
-      m[e.resource_type][e.resource_title][e.status] ||= {}
-      m[e.resource_type][e.resource_title][e.status][e.property] = true
-      m
-    end
+  Blacklist = Puppet::Util::Puppetdb::Blacklist
+
+  def initialize_blacklisted_events(events = Blacklist::BlacklistedEvents)
+    @blacklist = Blacklist.new(events)
   end
-
 end
 end

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -11,8 +11,6 @@ processor = Puppet::Reports.report(:puppetdb)
 
 describe processor do
 
-  BlacklistedEvent = Puppet::Util::Puppetdb::Config::BlacklistedEvent
-
   subject {
     s = Puppet::Transaction::Report.new("foo").extend(processor)
     s.configuration_version = 123456789
@@ -216,6 +214,8 @@ describe processor do
       end
 
       context "blacklisted events" do
+        BlacklistedEvent = Puppet::Util::Puppetdb::Blacklist::BlacklistedEvent
+
         let (:config) {
           Puppet::Util::Puppetdb.config
         }


### PR DESCRIPTION
This commit extracts the blacklist code from `config` into its own dedicated class.
This was done to make it easier to benchmark test the performance impact of blacklist filtering,
but it's a worthwhile refactor in general.
