### PR TITLE
(PE-1258) Refactored blacklist code into class

### DIFF
--- a/puppet/lib/puppet/util/puppetdb/blacklist.rb
+++ b/puppet/lib/puppet/util/puppetdb/blacklist.rb
@@ -1,0 +1,35 @@
+module Puppet::Util::Puppetdb
+  class Blacklist
+
+    BlacklistedEvent = Struct.new(:resource_type, :resource_title, :status, :property)
+
+    # Initialize our blacklist of events to filter out of reports.  This is needed
+    # because older versions of puppet always generate a swath of (meaningless)
+    # 'skipped' Schedule events on every agent run.  As of puppet 3.3, these
+    # events should no longer be generated, but this is here for backward compat.
+    BlacklistedEvents =
+        [BlacklistedEvent.new("Schedule", "never", "skipped", nil),
+         BlacklistedEvent.new("Schedule", "puppet", "skipped", nil),
+         BlacklistedEvent.new("Schedule", "hourly", "skipped", nil),
+         BlacklistedEvent.new("Schedule", "daily", "skipped", nil),
+         BlacklistedEvent.new("Schedule", "weekly", "skipped", nil),
+         BlacklistedEvent.new("Schedule", "monthly", "skipped", nil)]
+
+    def initialize(events)
+      @events = events.reduce({}) do |m, e|
+        m[e.resource_type] ||= {}
+        m[e.resource_type][e.resource_title] ||= {}
+        m[e.resource_type][e.resource_title][e.status] ||= {}
+        m[e.resource_type][e.resource_title][e.status][e.property] = true
+        m
+      end
+    end
+
+    def is_event_blacklisted?(event)
+      @events.fetch(event["resource-type"], {}).
+        fetch(event["resource-title"], {}).
+        fetch(event["status"], {}).
+        fetch(event["property"], false)
+    end
+  end
+end

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -11,8 +11,6 @@ processor = Puppet::Reports.report(:puppetdb)
 
 describe processor do
 
-  BlacklistedEvent = Puppet::Util::Puppetdb::Config::BlacklistedEvent
-
   subject {
     s = Puppet::Transaction::Report.new("foo").extend(processor)
     s.configuration_version = 123456789
@@ -187,6 +185,8 @@ describe processor do
       end
 
       context "blacklisted events" do
+        BlacklistedEvent = Puppet::Util::Puppetdb::Blacklist::BlacklistedEvent
+
         let (:config) {
           Puppet::Util::Puppetdb.config
         }


### PR DESCRIPTION
This commit extracts the blacklist code from config into its own dedicated class.
This was done to make it easier to benchmark test the performance impact of blacklist filtering,
but it's a worthwhile refactor in general.
