### PR TITLE
(PE-1673) Properly handle malformed order-by input

### DIFF
--- a/src/com/puppetlabs/puppetdb/query/paging.clj
+++ b/src/com/puppetlabs/puppetdb/query/paging.clj
@@ -20,7 +20,10 @@
   error response with a useful error message if there was a parse failure."
   [order-by]
   (try
-    (json/parse-string order-by true)
+    ;; If we don't force realization of parse-string right here, then
+    ;; we will return a lazy sequence, which upon realization later
+    ;; might throw an uncaught JsonParseException.
+    (doall (json/parse-string order-by true))
     (catch JsonParseException e
       (throw (IllegalArgumentException.
         (str "Illegal value '" order-by "' for :order-by; expected "

--- a/test/com/puppetlabs/puppetdb/test/http/paging.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/paging.clj
@@ -1,0 +1,22 @@
+(ns com.puppetlabs.puppetdb.test.http.paging
+  (:require [com.puppetlabs.http :as pl-http])
+  (:use clojure.test
+        com.puppetlabs.puppetdb.fixtures
+        [com.puppetlabs.puppetdb.testutils :only [get-request]]))
+
+(use-fixtures :each with-http-app)
+
+(deftest paging-options
+  (doseq [endpoint ["/v3/events"
+                    "/v3/event-counts"
+                    "/v3/fact-names"
+                    "/v3/facts"
+                    "/v3/nodes"
+                    "/v3/reports"
+                    "/v3/resources"]]
+    (testing (str endpoint " order-by should properly handle malformed JSON input")
+      (let [malformed-JSON  "[{\"field\":\"status\" \"order\":\"DESC\"}]"
+            response        (*app* (get-request endpoint ["these" "are" "unused"] {:order-by malformed-JSON}))
+            body            (get response :body "null")]
+        (is (= (:status response) pl-http/status-bad-request))
+        (is (re-find #"Illegal value '.*' for :order-by" body))))))


### PR DESCRIPTION
Prior to this commit, an invalid JSON input for the
'order-by' query paging parameter was causing an
exception to be thrown and an incorrect response to
be returned. This commit adds proper error handling.
