### PR TITLE
Resubmitted against 1.3.x instead of master.

### DIFF
--- a/ext/templates/log4j.properties.erb
+++ b/ext/templates/log4j.properties.erb
@@ -8,7 +8,7 @@ log4j.appender.A1.layout.ConversionPattern=%d %-5p [%t] [%c{2}] %m%n
 
 # Appender that logs to a file
 log4j.appender.F1=org.apache.log4j.FileAppender
-log4j.appender.F1.File=<%= @log_dir || "/var/log/puppetdb" -%>/puppetdb.log
+log4j.appender.F1.File=<%= @log_dir || "/var/log/puppetdb" -%>/<%= @name -%>.log
 
 log4j.appender.F1.layout=org.apache.log4j.PatternLayout
 log4j.appender.F1.layout.ConversionPattern=%d %-5p [%t] [%c{2}] %m%n


### PR DESCRIPTION
log4j logfile name was hardcoded to puppetdb. This broke logrotation
which used @name and so was pe-puppetdb on pe installations.
