### PR TITLE
Fix the libexec syntax in base.install and remove backquotes from echo

### DIFF
--- a/ext/templates/deb/base.install.erb
+++ b/ext/templates/deb/base.install.erb
@@ -3,7 +3,7 @@
 <%= @log_dir.gsub(/^\//, '') %>
 <%= @install_dir.gsub(/^\//, '') %>
 <%= @lib_dir.gsub(/^\//, '') %>
-<%= @libexec_dir.gsub(/^//, '') %>
+<%= @libexec_dir.gsub(/^\//, '') %>
 <%= @sbin_dir.gsub(/^\//, '') %>
 <% if @pe == false -%>
 <%= @link.gsub(/^\//, '') -%>

--- a/ext/templates/puppetdb-ssl-setup
+++ b/ext/templates/puppetdb-ssl-setup
@@ -297,7 +297,7 @@ if ! ${force}; then
       echo "  Your configuration indicates you may have a legacy keystore based setup,"
       echo "  and if we modify this on our own we may break things. Especially if"
       echo "  there has been specialized setup in the past, for example"
-      echo "  the keystores may have been created without `puppetdb ssl-setup`."
+      echo "  the keystores may have been created without 'puppetdb ssl-setup'."
       echo
       echo "  Your can however force this tool to overwrite your existing"
       echo "  configuration with the newer PEM based configuration with:"


### PR DESCRIPTION
Without these two things:
- The template parsing returns a syntax error
- echo will try to run puppetdb ssl-setup which is bad

Respectively.

Signed-off-by: Ken Barber ken@bob.sh
