### PR TITLE
Docs: Update puppet apply instructions to not break puppet resource

### DIFF
--- a/documentation/connect_puppet_apply.markdown
+++ b/documentation/connect_puppet_apply.markdown
@@ -24,6 +24,7 @@ PuppetDB can also be used with standalone Puppet deployments where each node run
 * Send the node's catalog to PuppetDB
 * Query PuppetDB when compiling catalogs that collect [exported resources][exported]
 * Store facts in PuppetDB
+* Send reports to PuppetDB (optional)
 
 You will need to take the following steps to configure your standalone nodes to connect to PuppetDB. Note that since you must change Puppet's configuration on every managed node, **we strongly recommend that you do so with Puppet itself.**
 
@@ -113,6 +114,9 @@ You will need to create a template for puppet.conf based on your existing config
     [main]
       storeconfigs = true
       storeconfigs_backend = puppetdb
+      # Optional settings to submit reports to PuppetDB:
+      report = true
+      reports = puppetdb
 
 > Note: The `thin_storeconfigs` and `async_storeconfigs` settings should be absent or set to `false`.
 


### PR DESCRIPTION
**This should be merged forward into 1.5.x and master.**

Setting the storeconfigs settings in puppet.conf without modifying routes.yaml
will cause puppet resource to break on puppet apply nodes.
