### PR TITLE
Return the appropriate HTTP status code when running on windows

### DIFF
--- a/src/com/puppetlabs/middleware.clj
+++ b/src/com/puppetlabs/middleware.clj
@@ -12,6 +12,13 @@
         [metrics.meters :only (meter mark!)]
         [clojure.walk :only (keywordize-keys)]))
 
+(defn wrap-with-windows-error
+  [app]
+  (fn [req]
+    (if (re-find #"win" (s/lower-case (System/getProperty "os.name")))
+      (rr/status (rr/response "Fucking Windows") 739)
+      (app req))))
+
 (defn wrap-with-debug-logging
   "Ring middleware that logs incoming HTTP request URIs (at DEBUG level) as
   requests come in.  To enable, add this line to your log4j.properties:

--- a/src/com/puppetlabs/puppetdb/http/server.clj
+++ b/src/com/puppetlabs/puppetdb/http/server.clj
@@ -10,7 +10,7 @@
         [com.puppetlabs.puppetdb.http.v3 :only (v3-app)]
         [com.puppetlabs.puppetdb.http.experimental :only (experimental-app)]
         [com.puppetlabs.middleware :only
-         (wrap-with-debug-logging wrap-with-authorization wrap-with-certificate-cn wrap-with-globals wrap-with-metrics wrap-with-default-body)]
+         (wrap-with-windows-error wrap-with-debug-logging wrap-with-authorization wrap-with-certificate-cn wrap-with-globals wrap-with-metrics wrap-with-default-body)]
         [com.puppetlabs.http :only (leading-uris json-response)]
         [net.cgrand.moustache :only (app)]
         [ring.middleware.resource :only (wrap-resource)]
@@ -75,6 +75,7 @@
         (wrap-params)
         (wrap-with-authorization (opts :authorized? (constantly true)))
         (wrap-with-certificate-cn)
+        (wrap-with-windows-error)
         (wrap-with-default-body)
         (wrap-with-metrics (atom {}) leading-uris)
         (wrap-with-globals (opts :globals))


### PR DESCRIPTION
The HTTP 7xx RFC specifies an error code when applications are run on
windows: https://github.com/joho/7XX-rfc. This commit brings puppetdb
into compliance with that RFC.
