### PR TITLE
Add missing docs for soft_write_failure for master/agent setup

### DIFF
--- a/documentation/connect_puppet_master.markdown
+++ b/documentation/connect_puppet_master.markdown
@@ -61,13 +61,15 @@ The [puppetdb.conf][puppetdb_conf] file will probably not exist yet. Create it, 
     server = puppetdb.example.com
     port = 8081
 
-* PuppetDB's port for secure traffic defaults to 8081.
-* Puppet _requires_ use of PuppetDB's secure HTTPS port. You cannot use the unencrypted, plain HTTP port.
+PuppetDB's port for secure traffic defaults to 8081. Puppet _requires_ use of PuppetDB's secure, HTTPS port. You cannot use the unencrypted, plain HTTP port.
+
+For availability reasons there is a setting named `soft_write_failure` that will cause the PuppetDB terminus to fail in a soft-manner if PuppetDB is not accessable for command submission. This will mean that users who are either not using storeconfigs, or only exporting resources will still have their catalogs compile during a PuppetDB outage.
 
 If no puppetdb.conf file exists, the following default values will be used:
 
     server = puppetdb
     port = 8081
+    soft_write_failure = false
 
 ### 2. Edit puppet.conf
 


### PR DESCRIPTION
We had added the feature for soft_write_failure in 1.5.x, but the documentation
was only updated for puppet apply cases. This patches updates the documentation
for puppet master/agent setups as well.

Signed-off-by: Ken Barber ken@bob.sh
