### PR TITLE
Change the log4j.properties file in test-resources to reduce unit test noise

### DIFF
--- a/test-resources/log4j.properties
+++ b/test-resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=INFO, A1
+log4j.rootLogger=ERROR, A1
 log4j.appender.A1=org.apache.log4j.ConsoleAppender
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d %-5p [%c{2}] %m%n
@@ -7,6 +7,4 @@ log4j.appender.A1.layout.ConversionPattern=%d %-5p [%c{2}] %m%n
 log4j.logger.org.apache.activemq=WARN
 log4j.logger.org.springframework.jms.connection=WARN
 log4j.logger.org.eclipse.jetty.server=WARN
-log4j.logger.com.puppetlabs.puppetdb.scf.migrate=ERROR
-log4j.logger.org.apache.activemq.broker=ERROR
 log4j.logger.org.apache.kahadb.journal=WARN


### PR DESCRIPTION
Just changed the default logging level to ERROR, removed the lines that were already set to error.  This removes most of the noisy output, when running lein test.
