### PR TITLE
Stringify the facts in the facts terminus test

### DIFF
--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -29,6 +29,7 @@ describe Puppet::Node::Facts::Puppetdb do
     end
 
     it "should POST the facts command as a URL-encoded PSON string" do
+      facts.stringify
       payload = {
         :command => CommandReplaceFacts,
         :version => 1,


### PR DESCRIPTION
Prior to this commit, when we were testing the pson serialization
of facts, we were not calling 'stringify' first; in the actual
terminus code, we _do_ call stringify.

A recent change in the `master` branch of Puppet started causing
this test to fail due to subtle differences in the pson code path
based on whether you have called stringify or not.

This commit simply makes the test consistent with the actual
terminus code.
