### PR TITLE
Added a skip for the read database acceptance test when running the embedded db

### DIFF
--- a/acceptance/tests/reports/event_query_with_read_db.rb
+++ b/acceptance/tests/reports/event_query_with_read_db.rb
@@ -4,7 +4,7 @@ require 'cgi'
 
 test_name "validation of basic PuppetDB resource event queries" do
 
-  skip_test "Skpping read-db test for HyperSQL.  This feature is only available for Postgres" if test_config[:database] == :embedded
+  skip_test "Skipping read-db test for HyperSQL.  This feature is only available for Postgres" if test_config[:database] == :embedded
 
   step "Create second database as a read-only database" do
 


### PR DESCRIPTION
Avoids the hypersql acceptance test build failures
