### PR TITLE
(#22882) Use v3 resources/facts queryies for /v3/nodes/*/resources|facts

### DIFF
--- a/src/com/puppetlabs/puppetdb/http/v3/nodes.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/nodes.clj
@@ -2,8 +2,8 @@
   (:require [com.puppetlabs.puppetdb.query.paging :as paging]
             [cheshire.core :as json]
             [com.puppetlabs.puppetdb.query.nodes :as node]
-            [com.puppetlabs.puppetdb.http.v2.facts :as f]
-            [com.puppetlabs.puppetdb.http.v2.resources :as r]
+            [com.puppetlabs.puppetdb.http.v3.facts :as f]
+            [com.puppetlabs.puppetdb.http.v3.resources :as r]
             [com.puppetlabs.puppetdb.http.query :as http-q]
             [com.puppetlabs.http :as pl-http])
   (:use [net.cgrand.moustache :only (app)]


### PR DESCRIPTION
Currently the /v3/nodes/*/resources|facts end-point uses the V2 version
internally, this patch ammends the end-point to use the v3 end-point.

In particular the sourcefile/sourceline attributes have been changed to
file line which makes the resources sub-end-point inconsistent with its
root-level equivalent. It also means the returned data is not compatible
with the catalog wireformat.

Signed-off-by: Ken Barber ken@bob.sh
