### PR TITLE
Fix `nodes` REST API to use correct version of wrapped queries

### DIFF
--- a/src/com/puppetlabs/puppetdb/http/v2/node.clj
+++ b/src/com/puppetlabs/puppetdb/http/v2/node.clj
@@ -1,8 +1,59 @@
 (ns com.puppetlabs.puppetdb.http.v2.node
-  (:require [com.puppetlabs.puppetdb.http.v3.nodes :as v3-node])
-  (:use [com.puppetlabs.middleware :only (verify-accepts-json validate-query-params)]))
+  (:require [cheshire.core :as json]
+            [com.puppetlabs.puppetdb.query.nodes :as node]
+            [com.puppetlabs.puppetdb.http.v2.facts :as f]
+            [com.puppetlabs.puppetdb.http.v2.resources :as r]
+            [com.puppetlabs.puppetdb.http.query :as http-q]
+            [com.puppetlabs.http :as pl-http])
+  (:use [net.cgrand.moustache :only (app)]
+        [com.puppetlabs.middleware :only (verify-accepts-json validate-query-params)]
+        [com.puppetlabs.jdbc :only (with-transacted-connection)]
+        [com.puppetlabs.puppetdb.http :only (query-result-response)]))
+
+(defn search-nodes
+  "Produce a response body for a request to search for nodes based on
+  `query`. If no `query` is supplied, all nodes will be returned."
+  [query db]
+  (try
+    (with-transacted-connection db
+      (let [query (if query (json/parse-string query true))
+            sql   (node/v2-query->sql query)
+            nodes (node/query-nodes sql)]
+        (query-result-response nodes)))
+    (catch com.fasterxml.jackson.core.JsonParseException e
+      (pl-http/error-response e))
+    (catch IllegalArgumentException e
+      (pl-http/error-response e))))
+
+(defn node-status
+  "Produce a response body for a request to obtain status information
+  for the given node."
+  [node db]
+  (if-let [status (with-transacted-connection db
+                    (node/status node))]
+    (pl-http/json-response status)
+    (pl-http/json-response {:error (str "No information is known about " node)} pl-http/status-not-found)))
+
+(def routes
+  (app
+    []
+    {:get (comp
+            (fn [{:keys [params globals]}]
+              (search-nodes (params "query") (:scf-db globals)))
+            http-q/restrict-query-to-active-nodes)}
+
+    [node]
+    {:get (fn [{:keys [globals]}]
+            (node-status node (:scf-db globals)))}
+
+    [node "facts" &]
+    (comp f/facts-app (partial http-q/restrict-query-to-node node))
+
+    [node "resources" &]
+    (comp r/resources-app (partial http-q/restrict-query-to-node node))))
 
 (def node-app
-  (-> v3-node/routes
-      verify-accepts-json
-      (validate-query-params {:optional ["query"]})))
+  (-> routes
+    verify-accepts-json
+    (validate-query-params {:optional ["query"]})))
+

--- a/src/com/puppetlabs/puppetdb/http/v3/nodes.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/nodes.clj
@@ -2,8 +2,8 @@
   (:require [com.puppetlabs.puppetdb.query.paging :as paging]
             [cheshire.core :as json]
             [com.puppetlabs.puppetdb.query.nodes :as node]
-            [com.puppetlabs.puppetdb.http.v2.facts :as f]
-            [com.puppetlabs.puppetdb.http.v2.resources :as r]
+            [com.puppetlabs.puppetdb.http.v3.facts :as f]
+            [com.puppetlabs.puppetdb.http.v3.resources :as r]
             [com.puppetlabs.puppetdb.http.query :as http-q]
             [com.puppetlabs.http :as pl-http])
   (:use [net.cgrand.moustache :only (app)]

--- a/test/com/puppetlabs/puppetdb/test/http/v2/explore.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v2/explore.clj
@@ -22,7 +22,7 @@
     (update-in request [:headers] assoc "Accept" c-t)))
 
 (defn get-response
-  ([route] (*app* (get-request (str "/v3/" route)))))
+  ([route] (*app* (get-request (str "/v2/" route)))))
 
 (defmacro check-json-response
   "Test if the HTTP request is a success, and if the result is equal
@@ -106,6 +106,8 @@
          (is (= (set (map :certname resources)) #{host}))
          (is (= (set (map :type resources)) #{"File"}))
          (is (= (set (map :title resources)) #{"/etc/foobar"}))
+         (is (= (set (map :sourcefile resources)) #{"/tmp/foo"}))
+         (is (= (set (map :sourceline resources)) #{10}))
          (is (= (count resources) 1)))))
 
     (testing "/resources without a query should not fail"

--- a/test/com/puppetlabs/puppetdb/test/http/v3/explore.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v3/explore.clj
@@ -106,6 +106,8 @@
          (is (= (set (map :certname resources)) #{host}))
          (is (= (set (map :type resources)) #{"File"}))
          (is (= (set (map :title resources)) #{"/etc/foobar"}))
+         (is (= (set (map :file resources)) #{"/tmp/foo"}))
+         (is (= (set (map :line resources)) #{10}))
          (is (= (count resources) 1)))))
 
     (testing "/resources without a query should not fail"


### PR DESCRIPTION
```
When the `v2/nodes` endpoint was being used
to wrap facts/resources queries, it was inadvertently using
v3 of those.  This PR separates the code and tests out so that
they each have their own explicit codepath, and adds tests
that cover this issue (relating to `sourcefile` vs `file`, etc.,
on the wrapped `resources` query).
```
