### PR TITLE
Extend travis testing to test against postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: clojure
 lein: lein2
 env:
-  - T_TEST=java:oraclejdk7
-  - T_TEST=java:openjdk6
-  - T_TEST=java:openjdk7
-  - T_TEST=ruby:default
+  - T_TEST=java:oraclejdk7:embedded
+  - T_TEST=java:openjdk6:embedded
+  - T_TEST=java:openjdk7:embedded
+  - T_TEST=java:oraclejdk7:postgres
+  - T_TEST=java:openjdk6:postgres
+  - T_TEST=java:openjdk7:postgres
+  - T_TEST=ruby:default:none
 script: ./ext/travisci/test.sh
 notifications:
   email: false
+services: postgresql

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-T_LANG="${T_TEST%%:*}"
-T_VERSION="${T_TEST#*:}"
+T_TEST_ARRAY=(${T_TEST//:/ })
+
+T_LANG=${T_TEST_ARRAY[0]}
+T_VERSION=${T_TEST_ARRAY[1]}
+T_DB=${T_TEST_ARRAY[2]}
 
 echo "Running tests in language: ${T_LANG} version: ${T_VERSION}"
 
@@ -16,7 +19,22 @@ else
   if [ $T_LANG == "java" ]; then
     jdk_switcher use $T_VERSION
     java -version
-    lein2 test
+    if [ $T_DB == "postgres" ]; then
+      psql -c 'create database puppetdbtest;' -U postgres
+      PUPPETDB_DBTYPE=$T_DB \
+      PUPPETDB_DBUSER=postgres \
+      PUPPETDB_DBSUBNAME=//127.0.0.1:5432/puppetdbtest \
+      PUPPETDB_DBPASSWORD= \
+      lein2 test
+    else
+      if [ $T_DB == "embedded" ]; then
+        PUPPETDB_DBTYPE=$T_DB \
+        lein2 test
+      else
+        echo "Invalid database ${T_DB}"
+        exit 1
+      fi
+    fi
   else
     echo "Invalid language ${T_LANG}"
     exit 1


### PR DESCRIPTION
This expands the test.sh script to accept a third element in T_TEST that
represents the database to test against.

We now launch a database (from travis services) and create a postgres db
when required.

Signed-off-by: Ken Barber ken@bob.sh
