### PR TITLE
Fix for the current unit test hanging issue.

### DIFF
--- a/test/com/puppetlabs/puppetdb/test/http/v2/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v2/facts.clj
@@ -63,6 +63,7 @@
     (testing "query without param should not fail"
       (let [response (get-response)
             body     (get response :body "null")]
+        (slurp body)
         (is (= 200 (:status response)))))
 
     (testing "fact queries"


### PR DESCRIPTION
The current code won't close the database connection until the HTTP response has been fully consumed. One of the tests wasn't actually consuming the response, causing the DB connection to stay open and then hang on the dropping of the DB table.
