### PR TITLE
(PDB-9) Improve report query syntax error handling

### DIFF
--- a/test/com/puppetlabs/puppetdb/test/http/v3/reports.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v3/reports.clj
@@ -79,3 +79,11 @@
                     [(assoc basic1 :hash basic1-hash)
                      (assoc basic2 :hash basic2-hash)])
                 (set (remove-receive-times results)))))))))
+
+(deftest invalid-queries
+  (let [response (get-response ["<" "timestamp" 0])]
+    (is (re-matches #".*query operator '<' is unknown" (:body response)))
+    (is (= 400 (:status response))))
+  (let [response (get-response ["=" "timestamp" 0])]
+    (is (= "'timestamp' is not a valid query term" (:body response)))
+    (is (= 400 (:status response)))))

--- a/test/com/puppetlabs/puppetdb/test/query/reports.clj
+++ b/test/com/puppetlabs/puppetdb/test/query/reports.clj
@@ -36,13 +36,13 @@
 
 (deftest test-compile-report-term
   (testing "should successfully compile a valid equality query"
-    (is (= (query/compile-report-term ["=" "certname" "foo.local"])
+    (is (= (query/compile-equals-term "certname" "foo.local")
            {:where   "reports.certname = ?"
             :params  ["foo.local"]})))
   (testing "should fail with an invalid equality query"
     (is (thrown-with-msg?
           IllegalArgumentException #"is not a valid query term"
-          (query/compile-report-term ["=" "foo" "foo"])))))
+          (query/compile-equals-term "foo" "foo")))))
 
 (deftest reports-retrieval
   (let [basic         (:basic reports)


### PR DESCRIPTION
Return better error messages when the user queries with bad operators or attributes
