### PR TITLE
Fix report tests to utilise postgresql 3.0.0 syntax

### DIFF
--- a/acceptance/tests/reports/event_query_with_read_db.rb
+++ b/acceptance/tests/reports/event_query_with_read_db.rb
@@ -10,12 +10,12 @@ test_name "validation of basic PuppetDB resource event queries" do
 
     second_db_manifest = <<MANIFEST
 include postgresql::server
-postgresql::db{ "puppetdb2":
-    user     => 'puppetdb2',
-    password => 'puppetdb2',
-    grant    => 'all',
-    require  => Class['::postgresql::server'],
-  }
+postgresql::server::db{ 'puppetdb2':
+  user     => 'puppetdb2',
+  password => 'puppetdb2',
+  grant    => 'all',
+  require  => Class['::postgresql::server'],
+}
 MANIFEST
   
     apply_manifest_on(database, second_db_manifest)


### PR DESCRIPTION
The syntax for creating a database was still using PostgreSQL 2.5.x syntax
and causing our tests to fail.

Signed-off-by: Ken Barber ken@bob.sh
