### PR TITLE
testing: Improve git fetch handling to support refspec

### DIFF
--- a/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
+++ b/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
@@ -16,7 +16,8 @@ step "Install development build of PuppetDB on the PuppetDB server" do
 
     on database, "rm -rf #{GitReposDir}/puppetdb"
     repo = extract_repo_info_from(test_config[:repo_puppetdb].to_s)
-    install_from_git database, GitReposDir, repo
+    install_from_git database, GitReposDir, repo,
+      :refspec => '+refs/pull/*:refs/remotes/origin/pr/*'
 
     if (test_config[:database] == :postgres)
       install_postgres(database)


### PR DESCRIPTION
For PR testing we need to download quite a different refspec, this patch
provides a better refspec for PR handling.

Signed-off-by: Ken Barber ken@bob.sh
