### PR TITLE
Clojure cleanup in string-contains?, add/extend tests for string-contains? and dissoc-if-nil.

### DIFF
--- a/src/com/puppetlabs/utils.clj
+++ b/src/com/puppetlabs/utils.clj
@@ -59,10 +59,11 @@
 ;; ## String utilities
 
 (defn string-contains?
-  "Returns true if `s` has the `substring` in it"
+  "Returns true if `s` contains `substring`"
   [substring s]
   {:pre [(string? s)
-         (string? substring)]}
+         (string? substring)]
+   :post [(boolean? %)]}
   (.contains s substring))
 
 ;; ## I/O

--- a/test/com/puppetlabs/test/utils.clj
+++ b/test/com/puppetlabs/test/utils.clj
@@ -54,9 +54,10 @@
 (deftest string-contains?-test
   (testing "should return true if substring is in string"
     (is (string-contains? "foo" "foobar")))
+  (testing "should return false if substring is not in string"
+    (is (false? (string-contains? "bar" "foo"))))
   (testing "should return true for an empty substring"
-    (is (string-contains? "" "foobar")))
-  )
+    (is (string-contains? "" "foobar"))))
 
 (deftest quotient-test
   (testing "quotient"


### PR DESCRIPTION
- Rewrote `string-contains?` to use the more straightforward java.lang.String.contains
- Added `string-contains?-test`
- Added  another test case for `dissoc-if-nil` to cover multiple keys at a time
