### PR TITLE
PDB-84 Update to latest version of PostgreSQL JDBC driver

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,7 @@
                  [org.slf4j/slf4j-log4j12 "1.7.5"]
                  [org.clojure/java.jdbc "0.1.1"]
                  [org.hsqldb/hsqldb "2.2.8"]
-                 [postgresql/postgresql "9.1-901-1.jdbc4"]
+                 [org.postgresql/postgresql "9.2-1003-jdbc4"]
                  [clojureql "1.0.3"]
                  ;; MQ connectivity
                  [clamq/clamq-activemq "0.4" :exclusions [org.slf4j/slf4j-api]]


### PR DESCRIPTION
The PostgreSQL upstream finally has uploaded a new revision of their JDBC
driver, but to a new organisation name on maven it seems:

```
http://mvnrepository.com/artifact/org.postgresql/postgresql
```

As linked from their download site:

```
http://jdbc.postgresql.org/download.html
```

Signed-off-by: Ken Barber ken@bob.sh
