### PR TITLE
Fix cli with no argument handling

### DIFF
--- a/acceptance/tests/commands/args-handling.rb
+++ b/acceptance/tests/commands/args-handling.rb
@@ -1,0 +1,15 @@
+test_name "argument handling" do
+  ["ssl-setup", "import", "export", "anonymize"].each do |k|
+    step "running puppetdb-#{k} -h should not error out" do
+      on database, "/usr/sbin/puppetdb-#{k} -h"
+    end
+
+    # We don't test ssl-setup here, because its actions without any arguments
+    # are tested elsewhere.
+    next if k == 'ssl-setup'
+    step "running puppetdb-#{k} with no arguments should not error out" do
+      on database, "/usr/sbin/puppetdb-#{k}", :acceptable_exit_codes => [1]
+      assert_match(/Missing required argument/, stdout)
+    end
+  end
+end

--- a/src/com/puppetlabs/utils.clj
+++ b/src/com/puppetlabs/utils.clj
@@ -564,13 +564,12 @@
     (when (:help options)
       (println banner)
       (System/exit 0))
-    (let [required-pairs (select-keys options required-args)]
-      (when-let [missing-field (some #(if (nil? (val %)) (key %)) required-pairs)]
-        (println)
-        (println (format "Missing required argument '--%s'!" (name missing-field)))
-        (println)
-        (println banner)
-        (System/exit 1)))
+    (when-let [missing-field (some #(if (not (contains? options %)) %) required-args)]
+      (println)
+      (println (format "Missing required argument '--%s'!" (name missing-field)))
+      (println)
+      (println banner)
+      (System/exit 1))
     [options extras]))
 
 


### PR DESCRIPTION
Seems the cli.tools 0.2.2 library had a bug and was returning completely
different data causing our command line tools with no arguments to return
ugly exceptions. This patch fixes this, and adds acceptance tests to
ensure we don't regress.

Signed-off-by: Ken Barber ken@bob.sh
