### PR TITLE
PDB-85 Fix report export format

### DIFF
--- a/acceptance/tests/anonymize/anonymize_profile.rb
+++ b/acceptance/tests/anonymize/anonymize_profile.rb
@@ -5,17 +5,15 @@ test_name "anonymize tool - with profile anonymization" do
     clear_and_restart_puppetdb(database)
   end
 
-  step "run each agent once to populate the database" do
-    with_puppet_running_on master, {
-      'master' => {
-        'autosign' => 'true',
-        'report' => 'true',
-      }} do
+  step "setup a test manifest for the master and perform agent runs" do
+    manifest = <<-MANIFEST
+      node default {
+        @@notify { "exported_resource": }
+        notify { "non_exported_resource": }
+     }
+    MANIFEST
 
-      hosts.each do |host|
-        run_agent_on host, "--test --server #{master}", :acceptable_exit_codes => [0,2]
-      end
-    end
+    run_agents_with_new_site_pp(master, manifest)
   end
 
   export_file1 = "./puppetdb-export1.tar.gz"

--- a/acceptance/tests/import_export/import_export.rb
+++ b/acceptance/tests/import_export/import_export.rb
@@ -5,18 +5,15 @@ test_name "export and import tools" do
     clear_and_restart_puppetdb(database)
   end
 
-  step "run each agent once to populate the database" do
-    # dbadapter, dblocation, storeconfigs_backend, routefile
-    with_puppet_running_on master, {
-      'master' => {
-        'autosign' => 'true',
-        'report' => 'true',
-      }} do
+  step "setup a test manifest for the master and perform agent runs" do
+    manifest = <<-MANIFEST
+      node default {
+        @@notify { "exported_resource": }
+        notify { "non_exported_resource": }
+     }
+    MANIFEST
 
-      hosts.each do |host|
-        run_agent_on host, "--test --server #{master}", :acceptable_exit_codes => [0,2]
-      end
-    end
+    run_agents_with_new_site_pp(master, manifest)
   end
 
   export_file1 = "./puppetdb-export1.tar.gz"

--- a/acceptance/tests/reports/report_storage.rb
+++ b/acceptance/tests/reports/report_storage.rb
@@ -2,38 +2,18 @@ require 'json'
 
 test_name "basic validation of puppet report submission" do
 
-  Log.notify "Setting up manifest file"
-  manifest = <<MANIFEST
-notify { "hi":
-  message => "Hi ${::clientcert}"
-}
-MANIFEST
+  step "setup a test manifest for the master and perform agent runs" do
+    manifest = <<-MANIFEST
+      notify { "hi":
+        message => "Hi ${::clientcert}"
+      }
+    MANIFEST
 
-  tmpdir = master.tmpdir('report_storage')
-
-  manifest_file = File.join(tmpdir, 'site.pp')
-
-  create_remote_file(master, manifest_file, manifest)
-
-  on master, "chmod -R +rX #{tmpdir}"
-
-  # TODO: the module should be setting up the report processors so that we don't
-  # have to add it on the CLI here
-  with_puppet_running_on master, {
-    'master' => {
-      'storeconfigs' => 'true',
-      'storeconfigs_backend' => 'puppetdb',
-      'autosign' => 'true',
-      'manifest' => manifest_file
-    }} do
-    step "Run agents once to submit reports" do
-      run_agent_on agents, "--test --server #{master}", :acceptable_exit_codes => [0,2]
-    end
+    run_agents_with_new_site_pp(master, manifest)
   end
 
   # Wait until all the commands have been processed
   sleep_until_queue_empty database
-
 
   agents.each do |agent|
     # Query for all of the reports for this node:

--- a/acceptance/tests/reports/transaction_uuid.rb
+++ b/acceptance/tests/reports/transaction_uuid.rb
@@ -1,17 +1,15 @@
 require 'json'
 
 test_name "validate matching transaction UUIDs in agent report and catalog" do
-  # TODO: the module should be setting up the report processors so that we don't have to add it on the CLI here
-  with_puppet_running_on master, {
-    'master' => {
-      'storeconfigs' => 'true',
-      'store_configs_backend' => 'puppetdb',
-      'autosign' => 'true',
-    }} do
+  step "setup a test manifest for the master and perform agent runs" do
+    manifest = <<-MANIFEST
+      node default {
+        @@notify { "exported_resource": }
+        notify { "non_exported_resource": }
+     }
+    MANIFEST
 
-      step "Run agents once to submit reports" do
-        run_agent_on agents, "--test --server #{master}", :acceptable_exit_codes => [0,2]
-      end
+    run_agents_with_new_site_pp(master, manifest)
   end
 
   # Wait until all the commands have been processed

--- a/src/com/puppetlabs/puppetdb/cli/export.clj
+++ b/src/com/puppetlabs/puppetdb/cli/export.clj
@@ -55,7 +55,7 @@
       (sort-by
         #(mapv % [:timestamp :resource-type :resource-title :property])
         (map
-          #(dissoc % :report :certname :configuration-version :containing-class)
+          #(dissoc % :report :certname :configuration-version :containing-class :run-start-time :run-end-time :report-receive-time)
           (json/parse-string body true))))))
 
 (defn reports-for-node


### PR DESCRIPTION
Three new parameters were added to the events end-point that were really
derived from the report of the event, and so aren't necessary for later
injection via import.

This was blocking anonymization and import from working as expected. This patch
ensures those parameters are stripped from the export correctly.

This bug wasn't seen because our tests do not always generate events, so
the invalid parameters never surfaced. As a safety guard for future
generations I've made sure that all the places that look like they could
do with some report events, I've ensured these exist now - even if they
probably haven't got any issues it seems like the correct thing to do
here.

To aid in this endeavour I've backported Ryan Seniors' two methods:
- run_agents_with_new_site_pp
- create_remote_site_pp

Since this setup was becoming quite common, this helped cleanup some of
our existing code as well.

Signed-off-by: Ken Barber ken@bob.sh
