### PR TITLE
PDB-109 Ensure basic_collection tests work on a clean database

### DIFF
--- a/acceptance/tests/storeconfigs/basic_collection.rb
+++ b/acceptance/tests/storeconfigs/basic_collection.rb
@@ -1,4 +1,7 @@
 test_name "general collection should get all exported resources except the host's" do
+  step "clear puppetdb database" do
+    clear_and_restart_puppetdb(database)
+  end
 
   names = hosts.map(&:name)
 


### PR DESCRIPTION
Some of the data from previous tests was being leaked. This patch adds a clear
and restart action to the start of the test to ensure there is no existing
data before these tests run.

Signed-off-by: Ken Barber ken@bob.sh
