### PR TITLE
Fix reference to configure-logging! function

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/com/puppetlabs/puppetdb/cli/benchmark.clj
@@ -41,13 +41,14 @@
   (:require [clojure.tools.logging :as log]
             [com.puppetlabs.puppetdb.catalogs :as cat]
             [com.puppetlabs.puppetdb.catalog.utils :as catutils]
+            [com.puppetlabs.utils.logging :as logutils]
             [com.puppetlabs.puppetdb.command :as command]
             [com.puppetlabs.http :as pl-http]
             [com.puppetlabs.cheshire :as json]
             [clj-http.client :as client]
             [clj-http.util :as util]
             [fs.core :as fs])
-  (:use [puppetlabs.kitchensink.core :only (cli! inis-to-map configure-logging! utf8-string->sha1)]
+  (:use [puppetlabs.kitchensink.core :only (cli! inis-to-map utf8-string->sha1)]
         [com.puppetlabs.puppetdb.scf.migrate :only [migrate!]]
         [com.puppetlabs.puppetdb.command.constants :only [command-names]]))
 
@@ -185,7 +186,7 @@
   (let [[options _]     (cli! args supported-cli-options required-cli-options)
         config          (-> (:config options)
                             (inis-to-map)
-                            (configure-logging!))
+                            (logutils/configure-logging!))
 
         catalogs        (if (:catalogs options) (load-sample-data (:catalogs options)))
         reports         (if (:reports options) (load-sample-data (:reports options)))


### PR DESCRIPTION
This was broken during the kitchensink move, this patch puts it back
from the com.puppetlabs.utils.logging now. Without this patch users
of the `benchmark` sub-command will receive an exception.

Signed-off-by: Ken Barber ken@bob.sh
