### PR TITLE
Run gem install of activerecord with greater verbosity

### DIFF
--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -48,7 +48,7 @@ step "Install rubygems and sqlite3 on master" do
   when :debian
     on master, "apt-get install -y rubygems libsqlite3-ruby"
     # this is to work around the absense of a decent package in lucid
-    on master, "gem install activerecord -v 2.3.17 --no-ri --no-rdoc"
+    on master, "gem install activerecord -v 2.3.17 --no-ri --no-rdoc -V --backtrace"
   else
     raise ArgumentError, "Unsupported OS '#{os}'"
   end


### PR DESCRIPTION
We keep getting activerecord gem installation problems, this patch changes
the verbosity of that installation so we can possibly see what is going
wrong. As this is intermittent its hard to test it in an isolated way, so
leaving this modification in source until it happens again seems a reasonable
approach.

Signed-off-by: Ken Barber ken@bob.sh
