### PR TITLE
Set a default timeout for sleep_until_queue_empty

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -432,7 +432,7 @@ module PuppetDBExtensions
     start_puppetdb(host)
   end
 
-  def sleep_until_queue_empty(host, timeout=nil)
+  def sleep_until_queue_empty(host, timeout=60)
     metric = "org.apache.activemq:BrokerName=localhost,Type=Queue,Destination=com.puppetlabs.puppetdb.commands"
     queue_size = nil
 


### PR DESCRIPTION
During acceptance test writing, this method may spin forever if the queue
doesn't clear properly (due to a fault often in the authors code most
probably).

To stop this from happening, we should set a reasonable default for this,
as we should constrain all tests from infinitely looping if we can. While
the parameter can be overriden at usage time, having a default will mean
infinite loops don't occur by accidental misusage.

Signed-off-by: Ken Barber ken@bob.sh
