### PR TITLE
Always ensure we ntp synchronise our test vms

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -140,6 +140,7 @@ namespace :test do
 
     beaker = "beaker " +
        "-c '#{RAKE_ROOT}/acceptance/config/#{config}.cfg' " +
+       "--ntp " +
        "--type #{type} " +
        "--debug " +
        "--tests " + args[:test_files] + " " +


### PR DESCRIPTION
Before this we weren't synchronising our virtual machines before running our
tests. This patch turns on the beaker option by default to use ntpdate every
time.

Signed-off-by: Ken Barber ken@bob.sh
