### PR TITLE
(PDB-81) - Adding a JDK 1.6 deprecation warning message

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -56,7 +56,8 @@
             [clojure.tools.logging :as log]
             [com.puppetlabs.cheshire :as json]
             [com.puppetlabs.puppetdb.http.server :as server]
-            [com.puppetlabs.puppetdb.config :as conf])
+            [com.puppetlabs.puppetdb.config :as conf]
+            [com.puppetlabs.puppetdb.utils :as utils])
   (:use [clojure.java.io :only [file]]
         [clj-time.core :only [ago secs minutes days]]
         [overtone.at-at :only (mk-pool interspaced)]
@@ -269,6 +270,7 @@
                                                     :product-name         product-name}]
 
 
+    (utils/log-deprecated-jdk)
 
     (when (version)
       (log/info (format "PuppetDB version %s" (version))))

--- a/src/com/puppetlabs/puppetdb/core.clj
+++ b/src/com/puppetlabs/puppetdb/core.clj
@@ -14,7 +14,9 @@
 (ns com.puppetlabs.puppetdb.core
   (:require [puppetlabs.kitchensink.core :as kitchensink]
             [com.puppetlabs.utils.logging :as logging-utils]
-            [clojure.tools.namespace :as ns])
+            [clojure.tools.namespace :as ns]
+            [clojure.tools.logging :as log]
+            [com.puppetlabs.puppetdb.utils :as utils])
   (:use [clojure.string :only (split)])
   (:gen-class))
 
@@ -62,22 +64,32 @@
       (println subcommand "\t" (or description "")))
     (println "\nFor help on a given subcommand, invoke it with -h")))
 
-(defn -main
-  [& args]
+(defn run-command
+  "Does the real work of invoking a command by attempting to result it and
+   passing in args. `success-fn` is a no-arg function that is called when the
+   command successfully executes.  `fail-fn` is called when a bad command is given
+   or a failure executing a command."
+  [success-fn fail-fn args]
   (let [subcommand (first args)
         allowed?   (available-subcommands)]
+
+    (utils/alert-deprecated-jdk)
 
     ;; Bad invokation
     (when-not (allowed? subcommand)
       (usage)
-      (System/exit 1))
+      (fail-fn))
 
     (let [module (str ns-prefix subcommand)
           args   (rest args)]
       (try
         (require (symbol module))
         (apply (resolve (symbol module "-main")) args)
-        (System/exit 0)
+        (success-fn)
         (catch Throwable e
           (logging-utils/catch-all-logger e)
-          (System/exit 1))))))
+          (fail-fn))))))
+
+(defn -main
+  [& args]
+  (run-command #(System/exit 0) #(System/exit 1) args))

--- a/src/com/puppetlabs/puppetdb/utils.clj
+++ b/src/com/puppetlabs/puppetdb/utils.clj
@@ -1,0 +1,44 @@
+(ns com.puppetlabs.puppetdb.utils
+  (:require [puppetlabs.kitchensink.core :as kitchensink]
+            [clojure.tools.logging :as log]))
+
+(defn jdk6?
+  "Returns true when the current JDK version is 1.6"
+  []
+  (.startsWith kitchensink/java-version "1.6"))
+
+(defn attention-warning-msg
+  "Wraps `msg` in lots of * to draw attention to the warning"
+  [msg]
+  (str "********************\n"
+       "*\n"
+       "* " msg "\n"
+       "* \n"
+       "********************"))
+
+(defn jdk-deprecation-message
+  "Returns warning message instructing the user to switch to JDK 1.7"
+  []
+  (attention-warning-msg
+   (format "Warning - Support for JDK 1.6 has been deprecated. PuppetDB requires JDK 1.7+, currently running: %s" kitchensink/java-version)))
+
+(defn println-err
+  "Redirects output to standard error before invoking println"
+  [& args]
+  (binding [*out* *err*]
+    (apply println args)))
+
+(defn log-deprecated-jdk
+  "Checks the current JDK version, logs a deprecation message if it's 1.6"
+  []
+  (when (jdk6?)
+    (let [attn-msg (jdk-deprecation-message)]
+      (log/error attn-msg))))
+
+(defn alert-deprecated-jdk
+  "Similar to log-deprecated-jdk, but also prints the deprecation message to standard error"
+  []
+  (when (jdk6?)
+    (let [attn-msg (jdk-deprecation-message)]
+      (println-err attn-msg)
+      (log/error attn-msg))))

--- a/test/com/puppetlabs/puppetdb/test/core.clj
+++ b/test/com/puppetlabs/puppetdb/test/core.clj
@@ -1,4 +1,91 @@
 (ns com.puppetlabs.puppetdb.test.core
-  (:use [com.puppetlabs.puppetdb.core])
-  (:use [clojure.test]))
+  (:require [com.puppetlabs.puppetdb.core :refer :all]
+            [clojure.test :refer :all]
+            [com.puppetlabs.testutils.logging :as pllog]
+            [puppetlabs.kitchensink.core :as kitchensink]
+            [com.puppetlabs.puppetdb.testutils :as tu]
+            [com.puppetlabs.puppetdb.test.utils :refer [jdk-1-6-version
+                                                        jdk-1-7-version
+                                                        deprecation-regex]]))
+
+(defn ignore-exception [f]
+  (try
+    (f)
+    (catch Exception _
+        ;;do nothing
+      )))
+
+(defn invoke-and-throw [ex-msg]
+  (let [called? (atom false)]
+    [called?
+     (fn []
+       (reset! called? true)
+       (throw (ex-info ex-msg {})))]))
+
+(deftest usage-message
+  (let [success? (atom false)
+        [fail? fail-fn] (invoke-and-throw "fail-fn called")]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"fail-fn called"
+                          (with-out-str
+                            (run-command #(reset! success? true) fail-fn ["something-random"]))))
+    (is (false? @success?))
+    (is (true? @fail?))
+    (is (re-find #"For help on a given subcommand.*"
+                 (with-out-str
+                   (ignore-exception
+                    (fn []
+                      (run-command (constantly nil) fail-fn ["something-random"]))))))))
+
+(deftest successful-command-invocation
+  (let [success? (atom false)
+        fail? (atom false)]
+    (with-out-str
+      (run-command #(reset! success? true)
+                   #(reset! fail? true)
+                   ["version"]))
+    (is (true? @success?))
+    (is (false? @fail?))))
+
+(defn valid-deprecation-pred [regex]
+  (fn [[category level _ msg :as foo]]
+    (and (= "com.puppetlabs.puppetdb.utils"
+            category)
+         (= :error
+            level)
+         (re-find regex msg))))
+
+(deftest deprecation-message
+  (testing "No deprecation message when using 1.7"
+    (let [success? (atom false)
+          fail? (atom false)
+          jdk-version  jdk-1-7-version]
+      (with-redefs [kitchensink/java-version jdk-version]
+        (pllog/with-log-output log
+          (is (nil?
+               (re-find deprecation-regex
+                        (tu/with-err-str
+                          (with-out-str
+                            (run-command #(reset! success? true)
+                                         #(reset! fail? true)
+                                         ["version"]))))))
+          (is (true? @success?))
+          (is (false? @fail?))
+          (is (not-any? (valid-deprecation-pred deprecation-regex) @log))))))
+
+  (testing "deprecation message appears in log and stdout when using JDK 1.6"
+    (let [success? (atom false)
+          fail? (atom false)
+          jdk-version  jdk-1-6-version]
+      (with-redefs [kitchensink/java-version jdk-version]
+        (pllog/with-log-output log
+          (is (re-find deprecation-regex
+                       (tu/with-err-str
+                         (with-out-str
+                           (run-command #(reset! success? true)
+                                        #(reset! fail? true)
+                                        ["version"])))))
+          (is (true? @success?))
+          (is (false? @fail?))
+          (is (some (valid-deprecation-pred deprecation-regex) @log)))))))
 

--- a/test/com/puppetlabs/puppetdb/test/utils.clj
+++ b/test/com/puppetlabs/puppetdb/test/utils.clj
@@ -1,0 +1,64 @@
+(ns com.puppetlabs.puppetdb.test.utils
+  (:require [com.puppetlabs.puppetdb.utils :refer :all]
+            [clojure.test :refer :all]
+            [com.puppetlabs.puppetdb.testutils :as tu]
+            [com.puppetlabs.testutils.logging :as pllog]
+            [puppetlabs.kitchensink.core :as kitchensink]
+            [clojure.string :as str]))
+
+(deftest test-println-err
+  (is (= "foo\n"
+         (tu/with-err-str (println-err "foo"))))
+
+  (is (= "foo bar\n"
+         (tu/with-err-str (println-err "foo" "bar")))))
+
+(def jdk-1-6-version "1.6.0_45")
+
+(def jdk-1-7-version "1.7.0_45")
+
+(def deprecation-regex
+  (re-pattern (format "Warning - Support for JDK 1.6 has been deprecated.*%s" jdk-1-6-version)))
+
+(deftest test-jdk6?
+  (with-redefs [kitchensink/java-version jdk-1-6-version]
+    (is (true? (jdk6?))))
+
+  (with-redefs [kitchensink/java-version jdk-1-7-version]
+    (is (false? (jdk6?)))))
+
+(deftest deprecated-jdk-logging
+  (testing "1.6 jdk version"
+    (with-redefs [kitchensink/java-version jdk-1-6-version]
+      (pllog/with-log-output log
+        (let [result (tu/with-err-str (log-deprecated-jdk))
+              [[category level _ msg]] @log]
+          (is (= "com.puppetlabs.puppetdb.utils" category))
+          (is (= :error level))
+          (is (re-find deprecation-regex msg))
+          (is (str/blank? result))))))
+
+  (testing "1.7 jdk version"
+    (with-redefs [kitchensink/java-version jdk-1-7-version]
+      (pllog/with-log-output log
+        (let [result (tu/with-err-str (log-deprecated-jdk))]
+          (is (empty? @log))
+          (is (str/blank? result)))))))
+
+(deftest deprecated-jdk-alerting
+  (testing "1.6 jdk version"
+    (with-redefs [kitchensink/java-version jdk-1-6-version]
+      (pllog/with-log-output log
+        (let [result (tu/with-err-str (alert-deprecated-jdk))
+              [[category level _ msg]] @log]
+          (is (= "com.puppetlabs.puppetdb.utils" category))
+          (is (= :error level))
+          (is (re-find deprecation-regex msg))
+          (is (re-find deprecation-regex result))))))
+
+  (testing "1.7 jdk version"
+    (with-redefs [kitchensink/java-version jdk-1-7-version]
+      (pllog/with-log-output log
+        (let [result (tu/with-err-str (log-deprecated-jdk))]
+          (is (empty? @log))
+          (is (str/blank? result)))))))

--- a/test/com/puppetlabs/puppetdb/testutils.clj
+++ b/test/com/puppetlabs/puppetdb/testutils.clj
@@ -285,3 +285,12 @@
 
 (def ^{:doc "Creates a temp directory, deletes the directory on JVM shutdown"}
   temp-dir (comp delete-on-exit fs/temp-dir))
+
+(defmacro with-err-str
+  "Similar to with-out-str, but captures standard error rather than standard out"
+  [& body]
+  `(let [sw# (new java.io.StringWriter)]
+     (binding [*err* sw#]
+       ~@body
+       (str sw#))))
+


### PR DESCRIPTION
Adding a warning message to the console and the logs.  The bootstrapped default logger is logged when the user provided log config is not there (such as invoking the version command). It's then logged in services.clj as well (after the logging config would have been applied).

Made some some changes to c.p.p.core.clj to allow testing of the
main launch function (and the deprecation messages). Tried to test commands failing (i.e. running services without a config) but found that cli (in kitchensink) also calls System/exit.  I talked with Chris about this and they have already made changes away from using System/exit over there.  That scenario should hopefully be tested in a newer version of kitchensink.
