### PR TITLE
(#23422) Use JSON in terminus instead of PSON

### DIFF
--- a/contrib/gem/puppetdb-terminus.gemspec
+++ b/contrib/gem/puppetdb-terminus.gemspec
@@ -15,4 +15,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+
+  gem.add_runtime_dependency 'json'
 end

--- a/ext/redhat/puppetdb.spec.erb
+++ b/ext/redhat/puppetdb.spec.erb
@@ -135,6 +135,7 @@ Group: Development/Libraries
 Requires: pe-puppet >= 2.7.12
 <% else -%>
 Requires: puppet >= 2.7.12
+Requires: rubygem-json
 <% end -%>
 
 %description terminus

--- a/ext/templates/deb/control.erb
+++ b/ext/templates/deb/control.erb
@@ -25,6 +25,6 @@ Architecture: all
 <% if @pe -%>
 Depends:  ${misc:Depends}, pe-puppet
 <% else -%>
-Depends:  ${misc:Depends}, puppet-common
+Depends:  ${misc:Depends}, puppet-common, libjson-ruby | ruby-json
 <% end -%>
 Description:Connect Puppet to PuppetDB by setting up a terminus for PuppetDB.

--- a/puppet/lib/puppet/face/node/status.rb
+++ b/puppet/lib/puppet/face/node/status.rb
@@ -12,6 +12,7 @@ Puppet::Face.define(:node, '0.0.1') do
     when_invoked do |*args|
       require 'puppet/network/http_pool'
       require 'puppet/util/puppetdb'
+      require 'json'
 
       opts = args.pop
       raise ArgumentError, "Please provide at least one node" if args.empty?
@@ -25,7 +26,7 @@ Puppet::Face.define(:node, '0.0.1') do
         begin
           response = http.get("/v3/nodes/#{CGI.escape(node)}", headers)
           if response.is_a? Net::HTTPSuccess
-            result = PSON.parse(response.body)
+            result = JSON.parse(response.body)
           elsif response.is_a? Net::HTTPNotFound
             result = {'name' => node}
           else

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -1,6 +1,7 @@
 require 'puppet/node/facts'
 require 'puppet/indirector/rest'
 require 'puppet/util/puppetdb'
+require 'json'
 
 class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
   include Puppet::Util::Puppetdb
@@ -21,7 +22,7 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
       log_x_deprecation_header(response)
 
       if response.is_a? Net::HTTPSuccess
-        result = PSON.parse(response.body)
+        result = JSON.parse(response.body)
         # Note: the Inventory Service API appears to expect us to return nil here
         # if the node isn't found.  However, PuppetDB returns an empty array in
         # this case; for now we will just look for that condition and assume that
@@ -76,14 +77,14 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
     end
 
     query = ["and"] + filters
-    query_param = CGI.escape(query.to_pson)
+    query_param = CGI.escape(query.to_json)
 
     begin
       response = http_get(request, "/v3/nodes?query=#{query_param}", headers)
       log_x_deprecation_header(response)
 
       if response.is_a? Net::HTTPSuccess
-        PSON.parse(response.body).collect {|s| s["name"]}
+        JSON.parse(response.body).collect {|s| s["name"]}
       else
         # Newline characters cause an HTTP error, so strip them
         raise "[#{response.code} #{response.message}] #{response.body.gsub(/[\r\n]/, '')}"

--- a/puppet/lib/puppet/indirector/resource/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/resource/puppetdb.rb
@@ -1,5 +1,6 @@
 require 'puppet/indirector/rest'
 require 'puppet/util/puppetdb'
+require 'json'
 
 class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
   include Puppet::Util::Puppetdb
@@ -20,7 +21,7 @@ class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
     filter_expr = build_expression(filter)
     expr << filter_expr if filter_expr
 
-    query_param = CGI.escape(expr.to_pson)
+    query_param = CGI.escape(expr.to_json)
 
     begin
       response = http_get(request, "/v3/resources?query=#{query_param}", headers)
@@ -34,7 +35,7 @@ class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
       raise Puppet::Error, "Could not retrieve resources from the PuppetDB at #{self.class.server}:#{self.class.port}: #{e}"
     end
 
-    resources = PSON.load(response.body)
+    resources = JSON.load(response.body)
 
     resources.map do |res|
       params = res['parameters'] || {}

--- a/puppet/lib/puppet/util/puppetdb/command.rb
+++ b/puppet/lib/puppet/util/puppetdb/command.rb
@@ -3,6 +3,7 @@ require 'puppet/network/http_pool'
 require 'puppet/util/puppetdb'
 require 'puppet/util/puppetdb/command_names'
 require 'puppet/util/puppetdb/char_encoding'
+require 'json'
 
 class Puppet::Util::Puppetdb::Command
   include Puppet::Util::Puppetdb::CommandNames
@@ -40,7 +41,7 @@ class Puppet::Util::Puppetdb::Command
       Puppet::Util::Puppetdb.log_x_deprecation_header(response)
 
       if response.is_a? Net::HTTPSuccess
-        result = PSON.parse(response.body)
+        result = JSON.parse(response.body)
         Puppet.info "'#{command}' command#{for_whom} submitted to PuppetDB with UUID #{result['uuid']}"
         result
       else

--- a/puppet/spec/unit/face/storeconfigs_spec.rb
+++ b/puppet/spec/unit/face/storeconfigs_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'puppet/face/storeconfigs'
+require 'json'
 
 describe Puppet::Face[:storeconfigs, '0.0.1'], :if => (Puppet.features.sqlite? and Puppet.features.rails?) do
   def setup_scratch_database
@@ -87,12 +88,12 @@ describe Puppet::Face[:storeconfigs, '0.0.1'], :if => (Puppet.features.sqlite? a
 
         results.keys.should =~ ['export-metadata.json', 'catalogs/foo.json']
 
-        metadata = PSON.load(results['export-metadata.json'])
+        metadata = JSON.load(results['export-metadata.json'])
 
         metadata.keys.should =~ ['timestamp', 'command-versions']
         metadata['command-versions'].should == {'replace-catalog' => 2}
 
-        catalog = PSON.load(results['catalogs/foo.json'])
+        catalog = JSON.load(results['catalogs/foo.json'])
 
         catalog.keys.should =~ ['metadata', 'data']
 
@@ -135,7 +136,7 @@ describe Puppet::Face[:storeconfigs, '0.0.1'], :if => (Puppet.features.sqlite? a
 
         results.keys.should =~ ['export-metadata.json', 'catalogs/foo.json']
 
-        catalog = PSON.load(results['catalogs/foo.json'])
+        catalog = JSON.load(results['catalogs/foo.json'])
 
         data = catalog['data']
         data['name'].should == 'foo'

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 require 'puppet/indirector/catalog/puppetdb'
 require 'puppet/util/puppetdb/command_names'
+require 'json'
 
 describe Puppet::Resource::Catalog::Puppetdb do
   before :each do

--- a/puppet/spec/unit/indirector/node/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/node/puppetdb_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 require 'puppet/indirector/node/puppetdb'
 require 'puppet/util/puppetdb/command_names'
+require 'json'
 
 describe Puppet::Node::Puppetdb do
 
@@ -26,14 +27,14 @@ describe Puppet::Node::Puppetdb do
       Puppet::Network::HttpPool.expects(:http_instance).returns http
     end
 
-    it "should POST a '#{CommandDeactivateNode}' command as a URL-encoded PSON string" do
+    it "should POST a '#{CommandDeactivateNode}' command as a URL-encoded JSON string" do
       response.stubs(:body).returns '{"uuid": "a UUID"}'
 
       payload = {
         :command => CommandDeactivateNode,
         :version => 1,
-        :payload => node.to_pson,
-      }.to_pson
+        :payload => node.to_json,
+      }.to_json
 
       http.expects(:post).with do |uri,body,headers|
         body =~ /payload=(.+)/

--- a/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 
 require 'puppet/indirector/resource/puppetdb'
+require 'json'
 
 describe Puppet::Resource::Puppetdb do
   before :each do
@@ -73,14 +74,14 @@ describe Puppet::Resource::Puppetdb do
       end
 
       def stub_response(resource_hashes)
-        body = resource_hashes.to_pson
+        body = resource_hashes.to_json
 
         response = Net::HTTPOK.new('1.1', 200, 'OK')
         response.stubs(:body).returns body
 
         subject.stubs(:http_get).with do |request, uri, headers|
           path, query_string = uri.split('?query=')
-          path == '/v3/resources' and PSON.load(CGI.unescape(query_string)) == query
+          path == '/v3/resources' and JSON.load(CGI.unescape(query_string)) == query
         end.returns response
       end
 

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -6,6 +6,7 @@ require 'net/http'
 require 'puppet/network/http_pool'
 require 'puppet/util/puppetdb/command_names'
 require 'puppet/util/puppetdb/config'
+require 'json'
 
 processor = Puppet::Reports.report(:puppetdb)
 
@@ -29,7 +30,7 @@ describe processor do
     let(:http) { mock "http" }
     let(:httpok) { Net::HTTPOK.new('1.1', 200, '') }
 
-    it "should POST the report command as a URL-encoded PSON string" do
+    it "should POST the report command as a URL-encoded JSON string" do
       httpok.stubs(:body).returns '{"uuid": "a UUID"}'
       subject.stubs(:run_duration).returns(10)
 
@@ -37,7 +38,7 @@ describe processor do
           :command => Puppet::Util::Puppetdb::CommandNames::CommandStoreReport,
           :version => 2,
           :payload => subject.send(:report_to_hash)
-      }.to_pson
+      }.to_json
 
       Puppet::Network::HttpPool.expects(:http_instance).returns(http)
       http.expects(:post).with {|path, body, headers|


### PR DESCRIPTION
The PuppetDB API specifies that it is JSON, so we should parse it as
that and not as PSON.

Some Puppet classes (Puppet::Node and Puppet::Node::Facts) don't support
JSON serialization, so continue to use PSON serialization for them.
In Puppet 3.4.0+ they have methods to do seralization in other formats
than PSON though, so once support for older versions of Puppet is
dropped they can be seralized in JSON as well.
