### PR TITLE
Remove illegal keys from fact payload

### DIFF
--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -10,8 +10,9 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
     facts = request.instance.dup
     facts.values = facts.values.dup
     facts.stringify
+    payload = {"name" => facts.name, "values" => facts.values}.to_pson
 
-    submit_command(request.key, facts.to_pson, CommandReplaceFacts, 1)
+    submit_command(request.key, payload, CommandReplaceFacts, 1)
   end
 
   def find(request)

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -30,10 +30,11 @@ describe Puppet::Node::Facts::Puppetdb do
 
     it "should POST the facts command as a URL-encoded PSON string" do
       facts.stringify
+      f = {"name" => facts.name, "values" => facts.values}
       payload = {
         :command => CommandReplaceFacts,
         :version => 1,
-        :payload => facts.to_pson,
+        :payload => f.to_pson,
       }.to_pson
 
       http.expects(:post).with do |uri, body, headers|


### PR DESCRIPTION
This patch makes us strict about the exact set of keys we want to
include in the payload when we submit facts to puppetdb. The wire format
only allows for "name" and "values" keys, so that's all we should allow.
