### PR TITLE
PDB-106 - report processor handle failed reports / reports with no metrics

### DIFF
--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -84,7 +84,7 @@ Puppet::Reports.register_report(:puppetdb) do
     if metrics["time"] and metrics["time"]["total"]
       metrics["time"]["total"]
     else
-      0
+      raise Puppet::Error, "Report from #{host} contained no metrics - possibly failed run. Not processing. (PDB-106)"
     end
   end
 

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -71,9 +71,9 @@ describe processor do
       subject.add_resource_status(status)
     end
 
-    it "should handle reports with no metrics" do
+    it "should error on reports with no metrics" do
       # at this point subject has no metrics
-      result = subject.send(:report_to_hash)
+      expect { subject.send(:report_to_hash) }.to raise_error(Puppet::Error)
     end
 
     it "should include the transaction uuid or nil" do


### PR DESCRIPTION
When a report comes in from a failed agent run, or an agent terminated mid-run, the report has no metrics (per the report format documentation). Currently, the report processor blindly tries to access metrics["time"]["total"], which isn't present in failed reports, so the report processor dies with:
Report processor failed: undefined method `[]' for nil:NilClass
and the report never makes it into PuppetDB. This is really bad for people who didn't know about the bug, and are checking PuppetDB to alert them of failed runs (which will never be seen).

Further evidence of this can be found in the unit tests for the report processor, which specifically stub :run_duration so this doesn't happen.

I've added a unit test for this condition, and changed run_duration to simply return 0 if the time->total metric is missing, which seems like the most logical thing to do (at least until the puppet agent starts sending metrics for failed runs too).
