### PR TITLE
PDB-273 Fix stubs for HTTP tests to stub a higher level

### DIFF
--- a/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
@@ -78,7 +78,7 @@ describe Puppet::Resource::Puppetdb do
         response = Net::HTTPOK.new('1.1', 200, 'OK')
         response.stubs(:body).returns body
 
-        Net::HTTP.any_instance.stubs(:get).with do |uri, headers|
+        subject.stubs(:http_get).with do |request, uri, headers|
           path, query_string = uri.split('?query=')
           path == '/v3/resources' and PSON.load(CGI.unescape(query_string)) == query
         end.returns response


### PR DESCRIPTION
There was a change to the internals of Puppet in commit 747076f00ce7c6b3b86acf2823be9c6536a821d4
which meant that the way that Net::HTTP was being used changed. In short it was
a change from using Net::HTTP.get to using the full object based methodology
with Net::HTTP::Get.new instead.

Unfortunately we had a stub around Net::HTTP.get which broke when this changed.

This patch corrects our use of that lower level stub, by instead stubbing
the http_get instance method on the subject. This fulfills the spirit of the
stub while also making sure we only rely on the stable and non-internal
http_get API only.

I've also tried to preserve the expectation inside the stub 'when' block to
preserve the spirit of that test as well.

This should also be backwards compatible with the 2.7.x and stable branches.

Signed-off-by: Ken Barber ken@bob.sh
