### PR TITLE
(PDB-107) Support chained CA certificates

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -64,7 +64,7 @@
                  [ring/ring-core "1.1.8"]
                  [ring/ring-jetty-adapter "1.1.8"]
                  [org.apache.commons/commons-compress "1.4.1"]
-                 [puppetlabs/kitchensink "0.1.0"]
+                 [puppetlabs/kitchensink "0.1.1"]
                  [org.bouncycastle/bcpkix-jdk15on "1.49"]
                  [prismatic/schema "0.1.9"]]
 

--- a/src/com/puppetlabs/puppetdb/config.clj
+++ b/src/com/puppetlabs/puppetdb/config.clj
@@ -134,7 +134,7 @@
       (log/warn (format "Found settings for both keystore-based and Puppet PEM-based SSL; using PEM-based settings, ignoring %s"
                   (keys old-ssl-config)))))
   (let [truststore  (-> (ssl/keystore)
-                        (ssl/assoc-cert-file! "PuppetDB CA" ssl-ca-cert))
+                        (ssl/assoc-certs-from-file! "PuppetDB CA" ssl-ca-cert))
         keystore-pw (kitchensink/uuid)
         keystore    (-> (ssl/keystore)
                         (ssl/assoc-private-key-file! "PuppetDB Agent Private Key" ssl-key keystore-pw ssl-cert))]


### PR DESCRIPTION
This patch makes puppetdb load all of the certificates in the CA .pem
file into the in-memory truststore. This allows users to use a
certificate chain (typically represented as a sequence of certs in a
single file) for trust.
