### PR TITLE
(PDB-247) Fixes the namespace override warnings from schema

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -66,7 +66,7 @@
                  [org.apache.commons/commons-compress "1.4.1"]
                  [puppetlabs/kitchensink "0.1.1"]
                  [org.bouncycastle/bcpkix-jdk15on "1.49"]
-                 [prismatic/schema "0.1.9"]]
+                 [puppetlabs/schema "0.2.0-pre-1"]]
 
   ;;The below test-selectors is basically using the PUPPETDB_DBTYPE
   ;;environment variable to be the test selector.  The selector below

--- a/src/com/puppetlabs/puppetdb/schema.clj
+++ b/src/com/puppetlabs/puppetdb/schema.clj
@@ -8,9 +8,11 @@
 
 (defrecord DefaultedMaybe [schema default]
   s/Schema
-  (s/check [this x]
-    (when-not (nil? x)
-      (s/check schema x)))
+  (s/walker [this]
+    (let [sub-walker (s/subschema-walker schema)]
+      (fn [x]
+        (when-not (nil? x)
+          (sub-walker x)))))
   (s/explain [this] (list 'defaulted-maybe (s/explain schema))))
 
 (defn defaulted-maybe
@@ -36,8 +38,8 @@
     construct-fn)
 
   s/Schema
-  (s/check [this x]
-    (s/check predicate-rec x))
+  (s/walker [this]
+    (s/walker predicate-rec))
   (s/explain [this]
     (s/explain predicate-rec)))
 


### PR DESCRIPTION
Schema 0.2.0 has not yet been released, but has the fix for PDB-247. I
made a pre-release (0.2.0-pre-1) of the current state of the branch and
updated PuppetDB to use it.  Some PuppetDB code also needed to change as
one of the protocols is changing in 0.2.0.
