### PR TITLE
PDB-128: Detect make-jpkg packaged JVM's.

### DIFF
--- a/ext/templates/puppetdb_default.erb
+++ b/ext/templates/puppetdb_default.erb
@@ -11,6 +11,11 @@ if [ -f /usr/lib/jvm/java-7-openjdk-amd64/bin/java ]; then
 	JAVA_BIN="/usr/lib/jvm/java-7-openjdk-amd64/bin/java"
 elif [ -f /usr/lib/jvm/java-7-openjdk-i386/bin/java ]; then
 	JAVA_BIN="/usr/lib/jvm/java-7-openjdk-i386/bin/java"
+# Support make-jpkg created debs from Oracle Java distribution
+elif [ -f /usr/lib/jvm/j2re1.7-oracle/bin/java ]; then
+	JAVA_BIN="/usr/lib/jvm/j2re1.7-oracle/bin/java"
+elif [ -f /usr/lib/jvm/j2sdk1.7-oracle/bin/java ]; then
+	JAVA_BIN="/usr/lib/jvm/j2sdk1.7-oracle/bin/java"
 # OpenSUSE
 elif [ -f /usr/lib64/jvm/jre-1.7.0-openjdk/bin/java ]; then
 	JAVA_BIN="/usr/lib64/jvm/jre-1.7.0/bin/java"


### PR DESCRIPTION
On Debian it's possible to create Debian packages from Oracle's Java
releases through the make-jpkg tool: https://wiki.debian.org/JavaPackage

This commit adds detection for make-jpkg packaged versions of the
Java 7 RE or SDK with the RE given priority over the SDK.
