### PR TITLE
PDB-128: Support Oracle Java distribution.

### DIFF
--- a/ext/templates/deb/control.erb
+++ b/ext/templates/deb/control.erb
@@ -15,7 +15,7 @@ Architecture: all
 <% if @pe -%>
 Depends: ${misc:Depends}, pe-java, adduser, pe-puppet
 <% else -%>
-Depends: ${misc:Depends},  java7-runtime-headless | java6-runtime-headless, adduser, puppet (>= 2.7.12)
+Depends: ${misc:Depends},  java7-runtime-headless | j2re1.7 | java6-runtime-headless, adduser, puppet (>= 2.7.12)
 Suggests: postgresql
 <% end -%>
 Description:PuppetDB Centralized Storage.

--- a/ext/templates/puppetdb_default.erb
+++ b/ext/templates/puppetdb_default.erb
@@ -11,6 +11,11 @@ if [ -f /usr/lib/jvm/java-7-openjdk-amd64/bin/java ]; then
 	JAVA_BIN="/usr/lib/jvm/java-7-openjdk-amd64/bin/java"
 elif [ -f /usr/lib/jvm/java-7-openjdk-i386/bin/java ]; then
 	JAVA_BIN="/usr/lib/jvm/java-7-openjdk-i386/bin/java"
+# Support make-jpkg packaged Oracle Java 1.7
+elif [ -f /usr/lib/jvm/j2re1.7-oracle/bin/java ]; then
+	JAVA_BIN="/usr/lib/jvm/j2re1.7-oracle/bin/java"
+elif [ -f /usr/lib/jvm/j2sdk1.7-oracle/bin/java ]; then
+	JAVA_BIN="/usr/lib/jvm/j2sdk1.7-oracle/bin/java"
 # OpenSUSE
 elif [ -f /usr/lib64/jvm/jre-1.7.0-openjdk/bin/java ]; then
 	JAVA_BIN="/usr/lib64/jvm/jre-1.7.0/bin/java"


### PR DESCRIPTION
On Debian it's possible to package releases from Oracle through
make-jpkg, a utility provided by the java-package package:
https://wiki.debian.org/JavaPackage

This commit adds support for:
- Detecting Oracle Java 1.7 packaged RE or SDK
- Satisfy the package requirement of Java by looking for the j2re1.7
  provides that the make-jpkg packages carry, both RE and SDK.

I've left out satisfying the dependency through j2re1.6 as @kenbarber
and I agreed that we shouldn't promote the usage of Java 1.6 any
further.
