### PR TITLE
PDB-303 Utilise final version of prismatic/schema 0.2.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -66,7 +66,7 @@
                  [org.apache.commons/commons-compress "1.4.1"]
                  [puppetlabs/kitchensink "0.1.1"]
                  [org.bouncycastle/bcpkix-jdk15on "1.49"]
-                 [puppetlabs/schema "0.2.0-pre-1"]]
+                 [prismatic/schema "0.2.0"]]
 
   ;;The below test-selectors is basically using the PUPPETDB_DBTYPE
   ;;environment variable to be the test selector.  The selector below


### PR DESCRIPTION
Previously we were using our own published version of a pre 0.2.0 release, this
patch remedies that to now point at the upstream finalized version.

Signed-off-by: Ken Barber ken@bob.sh
