### PR TITLE
PDB-307 Fix ruby-1.8.5 support for using bundler during rspec tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,14 @@ group :test do
 
   gem 'puppet', :require => false
 
-  gem 'beaker', '~> 1.0'
   gem 'mocha', '~> 1.0'
+
+  # Since newer versions of rake are not supported, we pin
+  if RUBY_VERSION == '1.8.5'
+    gem 'rake', '<= 0.8.7'
+  end
+end
+
+group :acceptance do
+  gem 'beaker', '~> 1.0'
 end

--- a/ext/jenkins/terminus-rspec.sh
+++ b/ext/jenkins/terminus-rspec.sh
@@ -10,7 +10,7 @@ then
 fi
 
 # Lets install the gems in bundle
-bundle install --path vendor/bundle
+bundle install --path vendor/bundle --without acceptance
 
 echo "**********************************************"
 echo "RUNNING SPECS; PARAMS FROM UPSTREAM BUILD:"

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -12,7 +12,7 @@ if [ $T_LANG == "ruby" ]; then
   # Using `rvm use` in travis-ci needs a lot more work, so just accepting
   # the default version for now.
   ruby -v
-  bundle install
+  bundle install --without acceptance
   cd puppet
   bundle exec rspec spec/
 else


### PR DESCRIPTION
Ruby 1.8.5 has some limitations in what it supports as far as gems go and
since we have been attempting as part of PDB-307 to use bundler more often
we have hit some problems.
- nokogiri, the version that beaker expects is not supported
- rake > 0.8.7 is also not supported

This patch removes beaker as a dependency while we run the rspec tests. This
will avoid pulling in lots of extra gems and hopefully speed up the whole
thing anyway. I've also applied this to the travis tests to hopefully speed
those up as well.

There is also now a conditional to change the dependencies for `rake` when
applied to a 1.8.5 ruby.

Signed-off-by: Ken Barber ken@bob.sh
