### PR TITLE
(PDB-79) Drop support for Postgres < 8.4

### DIFF
--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -40,7 +40,7 @@ step "Install rubygems and sqlite3 on master" do
   case os
   when :redhat
     if master['platform'].include? 'el-5'
-      on master, "yum install -y rubygems sqlite-devel rubygem-activerecord"
+      on master, "yum install -y rubygems sqlite-devel rubygem-activerecord ruby-devel.x86_64"
       on master, "gem install sqlite3"
     else
       on master, "yum install -y rubygems ruby-sqlite3 rubygem-activerecord"

--- a/acceptance/tests/reports/event_query_with_read_db.rb
+++ b/acceptance/tests/reports/event_query_with_read_db.rb
@@ -7,16 +7,14 @@ test_name "validation of basic PuppetDB resource event queries" do
   skip_test "Skipping read-db test for HyperSQL.  This feature is only available for Postgres" if test_config[:database] == :embedded
 
   step "Create second database as a read-only database" do
-
-    second_db_manifest = <<MANIFEST
+    second_db_manifest = add_el5_postgres(database, "
 include postgresql::server
 postgresql::server::db{ 'puppetdb2':
   user     => 'puppetdb2',
   password => 'puppetdb2',
   grant    => 'all',
   require  => Class['::postgresql::server'],
-}
-MANIFEST
+}")
   
     apply_manifest_on(database, second_db_manifest)
     sleep_until_started(database)

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -283,12 +283,13 @@
     (when (version)
       (log/info (format "PuppetDB version %s" (version))))
 
-    ;; Ensure the database is migrated to the latest version, and warn if it's
-    ;; deprecated. We do this in a single connection because HSQLDB seems to
-    ;; get confused if the database doesn't exist but we open and close a
+    ;; Ensure the database is migrated to the latest version, and warn
+    ;; if it's deprecated, log and exit if it's unsupported. We do
+    ;; this in a single connection because HSQLDB seems to get
+    ;; confused if the database doesn't exist but we open and close a
     ;; connection without creating anything.
     (sql/with-connection write-db
-      (scf-store/warn-on-db-deprecation!)
+      (scf-store/validate-database-version #(System/exit 1))
       (migrate!))
 
     ;; Initialize database-dependent metrics

--- a/src/com/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/com/puppetlabs/puppetdb/scf/migrate.clj
@@ -60,8 +60,7 @@
         [com.puppetlabs.puppetdb.scf.storage-utils :only [sql-array-type-string
                                                           sql-current-connection-database-name
                                                           sql-current-connection-database-version
-                                                          postgres?
-                                                          pg-newer-than-8-1?]]))
+                                                          postgres?]]))
 
 (defn- drop-constraints
   "Drop all constraints of given `constraint-type` on `table`."
@@ -219,10 +218,8 @@
     "CREATE INDEX idx_catalog_resources_type_title ON catalog_resources(type,title)")
 
   (when (postgres?)
-    (if (pg-newer-than-8-1?)
-      (sql/do-commands
-        "CREATE INDEX idx_catalog_resources_tags_gin ON catalog_resources USING gin(tags)")
-      (log/warn (format "Version %s of PostgreSQL is too old to support fast tag searches; skipping GIN index on tags. For reliability and performance reasons, consider upgrading to the latest stable version." (string/join "." (sql-current-connection-database-version)))))))
+    (sql/do-commands
+     "CREATE INDEX idx_catalog_resources_tags_gin ON catalog_resources USING gin(tags)")))
 
 (defn drop-old-tags-index
   "Drops the non-GIN tags index, which is never used (because nobody
@@ -418,8 +415,7 @@
 (defn drop-resource-tags-index
   "Remove the resource tags index, it can get very large and is not used"
   []
-  (when (pg-newer-than-8-1?)
-    (sql/do-commands "DROP INDEX IF EXISTS idx_catalog_resources_tags_gin")))
+  (sql/do-commands "DROP INDEX IF EXISTS idx_catalog_resources_tags_gin"))
 
 (defn use-bigint-instead-of-catalog-hash
   "This migration converts all catalog hash instances to use bigint sequences instead"

--- a/src/com/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -28,11 +28,23 @@
   []
   (= (sql-current-connection-database-name) "PostgreSQL"))
 
-(defn pg-newer-than-8-1?
+(defn pg-older-than-8-4?
   "Returns true if connected to a Postgres instance that is newer than 8.1"
   []
   (and (postgres?)
-       (pos? (compare (sql-current-connection-database-version) [8 1]))))
+       (neg? (compare (sql-current-connection-database-version) [8 4]))))
+
+(defn pg-8-4?
+  "Returns true if connected to a Postgres instance that is newer than 8.1"
+  []
+  (and (postgres?)
+       (= (sql-current-connection-database-version) [8 4])))
+
+(defn pg-newer-than-8-4?
+  "Returns true if connected to a Postgres instance that is newer than 8.1"
+  []
+  (and (postgres?)
+       (pos? (compare (sql-current-connection-database-version) [8 4]))))
 
 (defn sql-current-connection-table-names
   "Return all of the table names that are present in the database based on the
@@ -108,9 +120,7 @@ must be supplied as the value to be matched."
 
 (defmethod sql-array-query-string "PostgreSQL"
   [column]
-  (if (pos? (compare (sql-current-connection-database-version) [8 1]))
-    (format "ARRAY[?::text] <@ %s" column)
-    (format "? = ANY(%s)" column)))
+  (format "ARRAY[?::text] <@ %s" column))
 
 (defmethod sql-array-query-string "HSQL Database Engine"
   [column]


### PR DESCRIPTION
PuppetDB will now log an error and exit if it connects to an instance of Postgres older than 8.4. Users of older versions will need to upgrade (especially EL 5 users as it defaults to 8.1).  The acceptance tests for EL 5 have been updated to be explicit about using Postgres 8.4 packages instead.
