### PR TITLE
Fixes an issue with missing ruby-devel on EL5 (VirtualBox)

### DIFF
--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -40,7 +40,7 @@ step "Install rubygems and sqlite3 on master" do
   case os
   when :redhat
     if master['platform'].include? 'el-5'
-      on master, "yum install -y rubygems sqlite-devel rubygem-activerecord"
+      on master, "yum install -y rubygems sqlite-devel rubygem-activerecord ruby-devel.x86_64"
       on master, "gem install sqlite3"
     else
       on master, "yum install -y rubygems ruby-sqlite3 rubygem-activerecord"


### PR DESCRIPTION
Should already be included on the EC2 EL5 images and just skip over it.
