### PR TITLE
PDB-307 Remove usage of bundler for ruby-1.8.5

### DIFF
--- a/ext/jenkins/terminus-rspec.sh
+++ b/ext/jenkins/terminus-rspec.sh
@@ -11,7 +11,10 @@ fi
 mkdir vendor
 
 # Lets install the gems in bundle
-bundle install --path vendor/bundle --without acceptance
+if [ "$ruby" != "ruby-1.8.5" ];
+then
+  bundle install --path vendor/bundle --without acceptance
+fi
 
 echo "**********************************************"
 echo "RUNNING SPECS; PARAMS FROM UPSTREAM BUILD:"


### PR DESCRIPTION
Bundler times out on ruby-1.8.5. This is probably due to the fact that it is
such an old implementation. We are less concerned with latest gems for 1.8.5
so for now I'm disabling this functionality.

Signed-off-by: Ken Barber ken@bob.sh
