### PR TITLE
PDB-306 Switch to using new el5 imgages to fix DNS resolution hassles

### DIFF
--- a/acceptance/config/vbox-el5-64mda-el5-64a.cfg
+++ b/acceptance/config/vbox-el5-64mda-el5-64a.cfg
@@ -7,15 +7,15 @@ HOSTS:
       - database
     platform: el-5-x86_64
     hypervisor: vagrant
-    box: centos-59-x64-vbox4210-nocm
-    box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-59-x64-vbox4210-nocm.box
+    box: centos-510-x64-virtualbox-nocm
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-510-x64-virtualbox-nocm.box
   el5-64-2.vm:
     roles:
       - agent
     platform: el-5-x86_64
     hypervisor: vagrant
-    box: centos-59-x64-vbox4210-nocm
-    box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-59-x64-vbox4210-nocm.box
+    box: centos-510-x64-virtualbox-nocm
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-510-x64-virtualbox-nocm.box
 
 CONFIG:
   nfs_server: none


### PR DESCRIPTION
This patch switches us to use Ashley Penney's new el5 images.

The problem we were seeing was that dhclient was seeing eth1 up at start up
and trying to use that for its authoritative DHCP interface, thus the box
was not getting correct DNS in /etc/resolv.conf (it was just falling back
to the baked in defaults).

This came down to 'kudzu' trying to add an interface automatically in
/etc/sysconfig/network-scripts/ifcfg-eth1 with dhcp specific details
however, vagrant won't remove this existing configuration when adding a
private network - it will just append.

Removing kudzu from the image did the trick. Now vagrant appending its
configuration will create the desired result.

Signed-off-by: Ken Barber ken@bob.sh
