### PR TITLE
TO REVIEW: (PDB-313) Fix catalog resource metadata not updating with parameters change

### DIFF
--- a/test/com/puppetlabs/puppetdb/examples.clj
+++ b/test/com/puppetlabs/puppetdb/examples.clj
@@ -161,4 +161,51 @@
           :tags       ["node" "default" "class"]
           :type       "Node"}]
         :version          1332533763
+        :transaction-uuid "68b08e2a-eeb1-4322-b241-bfdf151d294b"}}
+      :basic
+      {:metadata      {:api_version 1}
+       :document_type "Catalog"
+       :data
+       {:edges
+        [{:relationship "contains"
+          :target       {:title "Settings" :type "Class"}
+          :source       {:title "main" :type "Stage"}}
+         {:relationship "contains"
+          :target       {:title "main" :type "Class"}
+          :source       {:title "main" :type "Stage"}}
+         {:relationship "contains"
+          :target       {:title "default" :type "Node"}
+          :source       {:title "main" :type "Class"}}]
+        :name        "basic.wire-catalogs.com"
+        :resources
+        [{:exported   false
+          :title      "Settings"
+          :parameters {}
+          :tags       ["class" "settings"]
+          :type       "Class"}
+         {:exported   false
+          :title      "main"
+          :parameters {:name "main"}
+          :tags       ["class"]
+          :type       "Class"}
+         {:exported   false
+          :title      "main"
+          :parameters {:name "main"}
+          :tags       ["stage"]
+          :type       "Stage"}
+         {:exported   false
+          :title      "default"
+          :parameters {}
+          :tags       ["node" "default" "class"]
+          :type       "Node"}
+         {:type       "File"
+          :title      "/etc/foobar"
+          :exported   false
+          :file       "/tmp/foo"
+          :line       10
+          :tags       ["file" "class" "foobar"]
+          :parameters {:ensure "directory"
+                       :group  "root"
+                       :user   "root"}}]
+        :version          1332533763
         :transaction-uuid "68b08e2a-eeb1-4322-b241-bfdf151d294b"}}}})


### PR DESCRIPTION
Catalog resource metadata fields like line number, file and exported were
not being updated properly when only one of those fields changed. Tags have
a similar problem, but the bug is not likely to occur in a real environment
(see PDB-332).

This commit issues an update that includes each updated catalog resource
metadata column when a difference in that column's value is found.
