### PR TITLE
PDB-125 Remove references to reports being 'experimental'

### DIFF
--- a/documentation/api/commands.markdown
+++ b/documentation/api/commands.markdown
@@ -101,8 +101,6 @@ the [fact wire format][facts]
 The payload is expected to be the name of a node, as a JSON string, which will be deactivated
 effective as of the time the command is *processed*.
 
-## Experimental commands
-
 ### "store report", version 1
 
 The payload is expected to be a report, containing events that occurred on Puppet

--- a/documentation/api/index.markdown
+++ b/documentation/api/index.markdown
@@ -96,4 +96,4 @@ All of PuppetDB's "replace" commands contain payload data, which must be in one 
 
 * [Facts wire format](./wire_format/facts_format.html)
 * [Catalog wire format](./wire_format/catalog_format.html)
-* [Report wire format (experimental)](./wire_format/report_format.html)
+* [Report wire format](./wire_format/report_format.html)

--- a/documentation/api/wire_format/report_format.markdown
+++ b/documentation/api/wire_format/report_format.markdown
@@ -1,12 +1,10 @@
 ---
-title: "PuppetDB 1.5 » API » Experimental » Report Wire Format, Version 1"
+title: "PuppetDB 1.5 » API » Report Wire Format, Version 1"
 layout: default
 canonical: "/puppetdb/latest/api/wire_format/report_format.html"
 ---
 
 [api]: ../index.html
-
-> **Note:** This format is **experimental,** and may change at any time without regard for the [normal API versioning rules][api].
 
 ## Report interchange format
 

--- a/documentation/connect_puppet_master.markdown
+++ b/documentation/connect_puppet_master.markdown
@@ -10,8 +10,8 @@ canonical: "/puppetdb/latest/connect_puppet_master.html"
 [exported]: /puppet/2.7/reference/lang_exported.html
 [install_via_module]: ./install_via_module.html
 [report_processors]: http://docs.puppetlabs.com/guides/reporting.html
-[event]: ./api/query/experimental/event.html
-[report]: ./api/query/experimental/report.html
+[event]: ./api/query/v3/event.html
+[report]: ./api/query/v3/report.html
 [store_report]: ./api/commands.html#store-report-version-1
 [report_format]: ./api/wire_format/report_format.html
 
@@ -81,12 +81,12 @@ To enable PuppetDB for the inventory service and saved catalogs/exported resourc
 
 > Note: The `thin_storeconfigs` and `async_storeconfigs` settings should be absent or set to `false`. If you have previously used the puppet queue daemon (puppetqd), you should now disable it. 
 
-#### Enabling experimental report storage
+#### Enabling report storage
 
-Version 1.1 of PuppetDB includes experimental support for storing Puppet
-reports.  This feature can be enabled by simply adding the `puppetdb` report
-processor in your `puppet.conf` file.  If you don't already have a `reports`
-setting in your `puppet.conf` file, you'll probably want to add a line like this:
+PuppetDB includes support for storing Puppet reports.  This feature can be
+enabled by simply adding the `puppetdb` report processor in your `puppet.conf`
+file.  If you don't already have a `reports` setting in your `puppet.conf`
+file, you'll probably want to add a line like this:
 
     reports = store,puppetdb
 
@@ -96,10 +96,10 @@ while also sending the reports to PuppetDB.
 You can configure how long PuppetDB stores these reports, and you can do some
 very basic querying.  For more information, see:
 
-* [The experimental `event` query endpoint][event]
-* [The experimental `report` query endpoint][report]
-* [The experimental `store report` command][store_report]
-* [The experimental report wire format][report_format]
+* [The `event` query endpoint][event]
+* [The `report` query endpoint][report]
+* [The `store report` command][store_report]
+* [The report wire format][report_format]
 
 More information about Puppet report processors in general can be found
 [here][report_processors].

--- a/documentation/maintain_and_tune.markdown
+++ b/documentation/maintain_and_tune.markdown
@@ -8,7 +8,7 @@ canonical: "/puppetdb/latest/maintain_and_tune.html"
 [configure_heap]: ./configure.html#configuring-the-java-heap-size
 [threads]: ./configure.html#command-processing-settings
 [memrec]: ./scaling_recommendations.html#bottleneck-java-heap-size
-[puppetdb_report_processor]: ./connect_puppet_master.html#enabling-experimental-report-storage
+[puppetdb_report_processor]: ./connect_puppet_master.html#enabling-report-storage
 [node_ttl]: ./configure.html#node-ttl
 [report_ttl]: ./configure.html#report-ttl
 [resources_type]: /references/latest/type.html#resources


### PR DESCRIPTION
Reports haven't been really experimental for some time - so this patch removes
any reference to 'experimental' from the formal documentation.

Signed-off-by: Ken Barber ken@bob.sh
