### PR TITLE
(PE-2675) Change the order that filters are applied for events

### DIFF
--- a/src/com/puppetlabs/puppetdb/http/v3/event_counts.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3/event_counts.clj
@@ -7,7 +7,8 @@
             [com.puppetlabs.middleware :only [verify-accepts-json validate-query-params wrap-with-paging-options]]
             [net.cgrand.moustache :only [app]]
             [com.puppetlabs.http :only [parse-boolean-query-param]]
-            [com.puppetlabs.puppetdb.http :only (query-result-response)]))
+            [com.puppetlabs.puppetdb.http :only (query-result-response)]
+            [com.puppetlabs.puppetdb.http.v3.events :only [validate-distinct-options!]]))
 
 (defn produce-body
   "Given a database connection, a query, a value to summarize by, and optionally
@@ -23,12 +24,12 @@
   (try
     (let [query               (json/parse-string query true)
           counts-filter       (if counts-filter (json/parse-string counts-filter true))
-          distinct-resources? (parse-boolean-query-param query-params "distinct-resources")]
+          distinct-options    (validate-distinct-options! query-params)]
       (with-transacted-connection db
         (-> query
             (event-counts/query->sql summarize-by
-              {:counts-filter counts-filter :count-by count-by
-               :distinct-resources? distinct-resources?})
+              (merge {:counts-filter counts-filter :count-by count-by}
+                     distinct-options))
             ((partial event-counts/query-event-counts paging-options summarize-by))
             (query-result-response))))
     (catch com.fasterxml.jackson.core.JsonParseException e
@@ -49,6 +50,8 @@
   (-> routes
       verify-accepts-json
       (validate-query-params {:required ["query" "summarize-by"]
-                              :optional (concat ["counts-filter" "count-by" "distinct-resources"]
+                              :optional (concat ["counts-filter" "count-by"
+                                                 "distinct-resources" "distinct-start-time"
+                                                 "distinct-end-time"]
                                           paging/query-params) })
       wrap-with-paging-options))

--- a/src/com/puppetlabs/puppetdb/query/event_counts.clj
+++ b/src/com/puppetlabs/puppetdb/query/event_counts.clj
@@ -177,7 +177,8 @@
           {counts-filter-where  :where
            counts-filter-params :params}  (get-counts-filter-where-clause counts-filter)
           [event-sql & event-params]      (events/query->sql
-                                            (select-keys query-options [:distinct-resources?])
+                                            (select-keys query-options
+                                              [:distinct-resources? :distinct-start-time :distinct-end-time])
                                             query)
           count-by-sql                    (get-count-by-sql event-sql count-by group-by)
           event-count-sql                 (get-event-count-sql count-by-sql group-by)

--- a/src/com/puppetlabs/puppetdb/query/events.clj
+++ b/src/com/puppetlabs/puppetdb/query/events.clj
@@ -139,53 +139,85 @@
    "containment_path"       ["resource_events"]
    "containing_class"       ["resource_events"]})
 
-;; This is the template for the SELECT statement that we use in the common case.
-(def default-select
-  "SELECT %s
-      FROM resource_events
-      JOIN reports ON resource_events.report = reports.hash
-      WHERE %s")
+(defn default-select
+  "Build the default SELECT statement that we use in the common case.  Returns
+  a two-item vector whose first value is the SQL string and whose second value
+  is a list of parameters for the SQL query."
+  [select-fields where params]
+  {:pre [(string? select-fields)
+         (string? where)
+         ((some-fn nil? sequential?) params)]
+   :post [(vector? %)
+          (= 2 (count %))
+          (string? (first %))
+          ((some-fn nil? sequential?) (second %))]}
+  [(format
+     "SELECT %s
+         FROM resource_events
+         JOIN reports ON resource_events.report = reports.hash
+         WHERE %s"
+     select-fields
+     where)
+   params])
 
-
-;; This is the template for the SELECT statement that we use if we are filtering
-;;  out duplicate events that occurred on the same resource (per node).
-(def distinct-select
-  "SELECT %s
-      FROM resource_events
-      JOIN reports ON resource_events.report = reports.hash
-      JOIN (SELECT reports.certname,
-                   resource_events.resource_type,
-                   resource_events.resource_title,
-                   resource_events.property,
-                   MAX(resource_events.timestamp) AS timestamp
-               FROM resource_events
-               JOIN reports ON resource_events.report = reports.hash
-               WHERE %s
-               GROUP BY certname, resource_type, resource_title, property) latest_events
-           ON reports.certname = latest_events.certname
-            AND resource_events.resource_type = latest_events.resource_type
-            AND resource_events.resource_title = latest_events.resource_title
-            AND ((resource_events.property = latest_events.property) OR
-                 (resource_events.property IS NULL AND latest_events.property IS NULL))
-            AND resource_events.timestamp = latest_events.timestamp")
+(defn distinct-select
+  "Build the SELECT statement that we use in the `distinct-resources` case (where
+  we are filtering out multiple events on the same resource on the same node).
+  Returns a two-item vector whose first value is the SQL string and whose second value
+  is a list of parameters for the SQL query."
+  [select-fields where params distinct-start-time distinct-end-time]
+  {:pre [(string? select-fields)
+         (string? where)
+         ((some-fn nil? sequential?) params)]
+   :post [(vector? %)
+          (= 2 (count %))
+          (string? (first %))
+          ((some-fn nil? sequential?) (second %))]}
+  [(format
+     "SELECT %s
+         FROM resource_events
+         JOIN reports ON resource_events.report = reports.hash
+         JOIN (SELECT reports.certname,
+                      resource_events.resource_type,
+                      resource_events.resource_title,
+                      resource_events.property,
+                      MAX(resource_events.timestamp) AS timestamp
+                  FROM resource_events
+                  JOIN reports ON resource_events.report = reports.hash
+                  WHERE resource_events.timestamp >= ?
+                     AND resource_events.timestamp <= ?
+                  GROUP BY certname, resource_type, resource_title, property) latest_events
+              ON reports.certname = latest_events.certname
+               AND resource_events.resource_type = latest_events.resource_type
+               AND resource_events.resource_title = latest_events.resource_title
+               AND ((resource_events.property = latest_events.property) OR
+                    (resource_events.property IS NULL AND latest_events.property IS NULL))
+               AND resource_events.timestamp = latest_events.timestamp
+         WHERE %s"
+     select-fields
+     where)
+   (concat [distinct-start-time distinct-end-time] params)])
 
 (defn query->sql
   "Compile a resource event `query` into an SQL expression."
   [query-options query]
-  {:pre  [(sequential? query)]
+  {:pre  [(sequential? query)
+          (let [distinct-options [:distinct-resources? :distinct-start-time :distinct-end-time]]
+            (or (not-any? #(contains? query-options %) distinct-options)
+                (every? #(contains? query-options %) distinct-options)))]
    :post [(valid-jdbc-query? %)]}
   (let [{:keys [where params]}  (compile-term resource-event-ops query)
-        select-template         (if (:distinct-resources? query-options)
-                                  distinct-select
-                                  default-select)
-        sql                     (format select-template
-                                  (string/join ", "
-                                    (map
-                                      (fn [[column [table alias]]]
-                                        (str table "." column
-                                          (if alias (format " AS %s" alias) "")))
-                                      event-columns))
-                                  where)]
+        select-fields           (string/join ", "
+                                   (map
+                                     (fn [[column [table alias]]]
+                                       (str table "." column
+                                            (if alias (format " AS %s" alias) "")))
+                                     event-columns))
+        [sql params]            (if (:distinct-resources? query-options)
+                                  (distinct-select select-fields where params
+                                    (:distinct-start-time query-options)
+                                    (:distinct-end-time query-options))
+                                  (default-select select-fields where params))]
     (apply vector sql params)))
 
 (defn limited-query-resource-events

--- a/test/com/puppetlabs/puppetdb/test/http/v3/aggregate_event_counts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v3/aggregate_event_counts.clj
@@ -58,6 +58,8 @@
           response  (get-response "/v3/aggregate-event-counts"
                       ["=" "certname" "foo.local"]
                       "resource"
-                      {"distinct-resources" true})]
+                      {"distinct-resources" true
+                       "distinct-start-time" 0
+                       "distinct-end-time" (now)})]
       (assert-success! response)
       (is (= expected (json/parse-string (:body response) true))))))

--- a/test/com/puppetlabs/puppetdb/test/http/v3/event_counts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v3/event_counts.clj
@@ -100,5 +100,7 @@
           response  (get-response "/v3/event-counts"
                       ["=" "certname" "foo.local"]
                       "resource"
-                      {"distinct-resources" true})]
+                      {"distinct-resources" true
+                       "distinct-start-time" 0
+                       "distinct-end-time" (now)})]
       (response-equal? response expected))))

--- a/test/com/puppetlabs/puppetdb/test/http/v3/events.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v3/events.clj
@@ -10,7 +10,7 @@
         com.puppetlabs.puppetdb.examples.reports
         com.puppetlabs.puppetdb.fixtures
         [clj-time.core :only [ago now secs]]
-        [clj-time.coerce :only [to-string to-long]]
+        [clj-time.coerce :only [to-string to-long to-timestamp]]
         [com.puppetlabs.puppetdb.testutils :only (response-equal? assert-success! get-request paged-results)]
         [com.puppetlabs.puppetdb.testutils.reports :only (store-example-report! get-events-map)]))
 
@@ -164,9 +164,54 @@
         basic3            (store-example-report! (:basic3 reports) (now))
         basic3-events     (get-in reports [:basic3 :resource-events])
         basic3-events-map (get-events-map (:basic3 reports))]
+
+    (testing "should return an error if the caller passes :distinct-resources without timestamps"
+      (let [response  (get-response ["=" "certname" "foo.local"] {:distinct-resources true})
+            body      (get response :body "null")]
+        (is (= (:status response) pl-http/status-bad-request))
+        (is (re-find
+              #"'distinct-resources' query parameter requires accompanying parameters 'distinct-start-time' and 'distinct-end-time'"
+              body)))
+      (let [response  (get-response ["=" "certname" "foo.local"] {:distinct-resources true
+                                                                  :distinct-start-time 0})
+            body      (get response :body "null")]
+        (is (= (:status response) pl-http/status-bad-request))
+        (is (re-find
+              #"'distinct-resources' query parameter requires accompanying parameters 'distinct-start-time' and 'distinct-end-time'"
+              body)))
+      (let [response  (get-response ["=" "certname" "foo.local"] {:distinct-resources true
+                                                                  :distinct-end-time 0})
+            body      (get response :body "null")]
+        (is (= (:status response) pl-http/status-bad-request))
+        (is (re-find
+              #"'distinct-resources' query parameter requires accompanying parameters 'distinct-start-time' and 'distinct-end-time'"
+              body))))
+
     (testing "should return only one event for a given resource"
       (let [expected  (expected-resource-events-response basic3-events basic3)
-            response  (get-response ["=", "certname", "foo.local"] {:distinct-resources true})]
+            response  (get-response ["=", "certname", "foo.local"] {:distinct-resources true
+                                                                    :distinct-start-time 0
+                                                                    :distinct-end-time (now)})]
+        (assert-success! response)
+        (response-equal? response expected munge-event-values)))
+
+    (testing "events should be contained within distinct resource timestamps"
+      (let [expected  (expected-resource-events-response basic-events basic)
+            response  (get-response ["=", "certname", "foo.local"]
+                                    {:distinct-resources true
+                                     :distinct-start-time 0
+                                     :distinct-end-time "2011-01-02T12:00:01-03:00"})]
+        (assert-success! response)
+        (response-equal? response expected munge-event-values)))
+
+    (testing "filters (such as status) should be applied *after* the distinct list of most recent events has been built up"
+      (let [expected  #{}
+            response (get-response ["and" ["=" "certname" "foo.local"]
+                                          ["=" "status" "success"]
+                                          ["=" "resource-title" "notify, yar"]]
+                                   {:distinct-resources true
+                                    :distinct-start-time 0
+                                    :distinct-end-time (now)})]
         (assert-success! response)
         (response-equal? response expected munge-event-values)))))
 


### PR DESCRIPTION
Note: see PE-2675, PE-2704, PE-2705 for more info.

When using the `distinct-resources` flag of an event query, the
previous behavior was that we would do the filtering of the events
_before_ we would eliminate duplicate resources.  This was not
the expected behavior in many cases in the UI; for example,
when filtering events based on event status, the desired behavior
was to find all of the most recent events for each resource _first_,
and then apply the filter to that set of resources.  If we did the
status filtering first, then we might end up in a state where we
found the most recent 'failed' event and showed it in the UI even
if there were 'success' events on that resource afterwards.

This commit changes the order that the filtering happens in.  We
now do the `distinct` portion of the query before we do the filtering.

However, in order to achieve reasonable performance, we need to
at least include timestamp filtering in the `distinct` query; otherwise
that portion of the query has to work against the entire table,
and becomes prohibitively expensive.

Since the existing timestamp filtering can be nested arbitrarily
inside of the query (inside of boolean logic, etc.), it was not
going to be possible to re-use that to handle the timestamp filtering
for the `distinct` part of the query; thus, we had to introduce
two new query parameters to go along with `distinct-resources`:
`distinct-start-time` and `distinct-end-time`.  These are now
required when using `distinct-resources`.

This functionality is fairly specific to PE and should probably
be separated into a PE-specific query endpoint in the future.
