### PR TITLE
DOCS: Document repl 'host' setting

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -495,3 +495,6 @@ The _swank_ type allows emacs' clojure-mode to connect directly to a running Pup
 
 The port to use for the REPL.
 
+### `host`
+
+Specifies the host or IP address for the repl service to listen on. By default this is `127.0.0.1` only, as this is an insecure channel this is the only recommended setting for production environments. Although this is generally not recommended for production, you can listen on all interfaces, you can specify `0.0.0.0` for example.


### PR DESCRIPTION
The [repl] block also supports setting 'host' to change where the repl service
is listening to. This documents this setting, while also warning that changing
it from 127.0.0.1 is not recommended for a production environment.

Signed-off-by: Ken Barber ken@bob.sh
