### PR TITLE
(PDB-377) Disabling JAR repacking when creating RPMS

### DIFF
--- a/ext/redhat/puppetdb.spec.erb
+++ b/ext/redhat/puppetdb.spec.erb
@@ -2,6 +2,8 @@
 %global realversion <%= @version %>
 %global rpmversion <%= @rpmversion %>
 
+%define __jar_repack 0
+
 <% if @pe -%>
 %global open_jdk          pe-java
 <% else -%>


### PR DESCRIPTION
The manipulation of the class files causes issues with AOT compiled Clojure code, specifically around defrecords/deftypes. Disabling repacking prevents the issue.
