### PR TITLE
Invalid namespaces for tests http/nodes|fact_names masking failures

### DIFF
--- a/test/com/puppetlabs/puppetdb/test/http/fact_names.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/fact_names.clj
@@ -1,4 +1,4 @@
-(ns com.puppetlabs.puppetdb.test.http.v3.fact-names
+(ns com.puppetlabs.puppetdb.test.http.fact-names
   (:require [cheshire.core :as json]
             [com.puppetlabs.http :as pl-http]
             [com.puppetlabs.puppetdb.scf.storage :as scf-store])

--- a/test/com/puppetlabs/puppetdb/test/http/nodes.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/nodes.clj
@@ -1,9 +1,9 @@
-(ns com.puppetlabs.puppetdb.test.http.v3.nodes
+(ns com.puppetlabs.puppetdb.test.http.nodes
   (:require [cheshire.core :as json]
             [com.puppetlabs.http :as pl-http])
   (:use clojure.test
         ring.mock.request
-        [com.puppetlabs.utils :only [keyset]]
+        [puppetlabs.kitchensink.core :only [keyset]]
         [com.puppetlabs.puppetdb.fixtures]
         [com.puppetlabs.puppetdb.testutils :only [get-request paged-results]]
         [com.puppetlabs.puppetdb.testutils.nodes :only [store-example-nodes]]))
@@ -48,35 +48,35 @@
                 (is (:facts_timestamp (status-for-node web1))))))
 
           (testing "basic equality is supported for name"
-            (is-query-result ["=" "name" "web1.example.com"] [web1]))
+            (is-query-result endpoint ["=" "name" "web1.example.com"] [web1]))
 
           (testing "regular expressions are supported for name"
-            (is-query-result ["~" "name" "web\\d+.example.com"] [web1 web2])
-            (is-query-result ["~" "name" "\\w+.example.com"] [db puppet web1 web2])
-            (is-query-result ["~" "name" "example.net"] []))
+            (is-query-result endpoint ["~" "name" "web\\d+.example.com"] [web1 web2])
+            (is-query-result endpoint ["~" "name" "\\w+.example.com"] [db puppet web1 web2])
+            (is-query-result endpoint ["~" "name" "example.net"] []))
 
           (testing "basic equality works for facts, and is based on string equality"
-            (is-query-result ["=" ["fact" "operatingsystem"] "Debian"] [db web1 web2])
-            (is-query-result ["=" ["fact" "uptime_seconds"] 10000] [web1])
-            (is-query-result ["=" ["fact" "uptime_seconds"] "10000"] [web1])
-            (is-query-result ["=" ["fact" "uptime_seconds"] 10000.0] [])
-            (is-query-result ["=" ["fact" "uptime_seconds"] true] [])
-            (is-query-result ["=" ["fact" "uptime_seconds"] 0] []))
+            (is-query-result endpoint ["=" ["fact" "operatingsystem"] "Debian"] [db web1 web2])
+            (is-query-result endpoint ["=" ["fact" "uptime_seconds"] 10000] [web1])
+            (is-query-result endpoint ["=" ["fact" "uptime_seconds"] "10000"] [web1])
+            (is-query-result endpoint ["=" ["fact" "uptime_seconds"] 10000.0] [])
+            (is-query-result endpoint ["=" ["fact" "uptime_seconds"] true] [])
+            (is-query-result endpoint ["=" ["fact" "uptime_seconds"] 0] []))
 
           (testing "missing facts are not equal to anything"
-            (is-query-result ["=" ["fact" "fake_fact"] "something"] [])
-            (is-query-result ["not" ["=" ["fact" "fake_fact"] "something"]] [db puppet web1 web2]))
+            (is-query-result endpoint ["=" ["fact" "fake_fact"] "something"] [])
+            (is-query-result endpoint ["not" ["=" ["fact" "fake_fact"] "something"]] [db puppet web1 web2]))
 
           (testing "arithmetic works on facts"
-            (is-query-result ["<" ["fact" "uptime_seconds"] 12000] [web1])
-            (is-query-result ["<" ["fact" "uptime_seconds"] 12000.0] [web1])
-            (is-query-result ["<" ["fact" "uptime_seconds"] "12000"] [web1])
-            (is-query-result ["and" [">" ["fact" "uptime_seconds"] 10000] ["<" ["fact" "uptime_seconds"] 15000]] [web2])
-            (is-query-result ["<=" ["fact" "uptime_seconds"] 15000] [puppet web1 web2]))
+            (is-query-result endpoint ["<" ["fact" "uptime_seconds"] 12000] [web1])
+            (is-query-result endpoint ["<" ["fact" "uptime_seconds"] 12000.0] [web1])
+            (is-query-result endpoint ["<" ["fact" "uptime_seconds"] "12000"] [web1])
+            (is-query-result endpoint ["and" [">" ["fact" "uptime_seconds"] 10000] ["<" ["fact" "uptime_seconds"] 15000]] [web2])
+            (is-query-result endpoint ["<=" ["fact" "uptime_seconds"] 15000] [puppet web1 web2]))
 
           (testing "regular expressions work on facts"
-            (is-query-result ["~" ["fact" "ipaddress"] "192.168.1.11\\d"] [db puppet])
-            (is-query-result ["~" ["fact" "hostname"] "web\\d"] [web1 web2]))))
+            (is-query-result endpoint ["~" ["fact" "ipaddress"] "192.168.1.11\\d"] [db puppet])
+            (is-query-result endpoint ["~" ["fact" "hostname"] "web\\d"] [web1 web2]))))
 
     (deftest node-subqueries
       (testing (str "valid node subqueries for " endpoint ":")
@@ -106,4 +106,4 @@
 
                       [web1]}]
               (testing (str "query: " query " is supported")
-                (is-query-result query expected)))))))))
+                (is-query-result endpoint query expected)))))))))


### PR DESCRIPTION
The test files http/fact_names.clj and nodes.clj had incorrect namespace
declarations that were overridden in other files. This caused these tests
to be skipped and in fact mask a couple of failures.

Luckily these were testing failures only, once fixed this is all passing
again.

Signed-off-by: Ken Barber ken@bob.sh
