### PR TITLE
(packaging) correct path to libexec files for PE

### DIFF
--- a/ext/redhat/puppetdb.spec.erb
+++ b/ext/redhat/puppetdb.spec.erb
@@ -298,11 +298,11 @@ fi
 %{_sbindir}/puppetdb-anonymize
 %{_sbindir}/puppetdb
 %dir %{_libexecdir}/%{name}
-%{_libexecdir}/%{name}/puppetdb-ssl-setup
-%{_libexecdir}/%{name}/puppetdb-foreground
-%{_libexecdir}/%{name}/puppetdb-import
-%{_libexecdir}/%{name}/puppetdb-export
-%{_libexecdir}/%{name}/puppetdb-anonymize
+%{_libexecdir}/%{realname}/puppetdb-ssl-setup
+%{_libexecdir}/%{realname}/puppetdb-foreground
+%{_libexecdir}/%{realname}/puppetdb-import
+%{_libexecdir}/%{realname}/puppetdb-export
+%{_libexecdir}/%{realname}/puppetdb-anonymize
 %{_datadir}/%{realname}
 <% unless @pe -%>
 %{_sharedstatedir}/%{realname}


### PR DESCRIPTION
Prior to this commit, when we installed to the libexec dir when building PE, we
installed to /opt/puppet/libexec/puppetdb. However, the %{name} macro in the
redhat spec will evaluate to pe-puppetdb. This means the %files section looked
for files that don't exist. This commit updates the spec file to use the
  correct %{realname} macro, e.g. 'puppetdb', which is the correct path.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
