### PR TITLE
PDB-177 Replace ssl-host default with 0.0.0.0

### DIFF
--- a/ext/templates/puppetdb-ssl-setup
+++ b/ext/templates/puppetdb-ssl-setup
@@ -237,13 +237,6 @@ fi
 
 set -e
 
-# Variables variables variables
-fqdn=`facter fqdn`
-# use hostname if fqdn is not available
-if [ ! -n "$fqdn" ] ; then
-  fqdn=`facter hostname`
-fi
-
 mycertname=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint  certname`
 
 orig_public_file=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint  hostcert`


### PR DESCRIPTION
By trying to use a hostname, the amount of issues people suffer with during
setup times related to hostname resolution is quite high. This patch
replaces the hostname with 0.0.0.0 which by default listens on all
interfaces.

Signed-off-by: Ken Barber ken@bob.sh
