### PR TITLE
Remove redmine links

### DIFF
--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -16,7 +16,7 @@ canonical: "/puppetdb/latest/index.html"
 [catalog]: /puppet/2.7/reference/lang_summary.html#compilation-and-catalogs
 [releasenotes]: ./release_notes.html
 [github]: https://github.com/puppetlabs/puppetdb
-[redmine]: http://projects.puppetlabs.com/projects/puppetdb/issues
+[tracker]: https://tickets.puppetlabs.com/browse/PDB
 [migrating]: ./migrate.html
 [old_docs]: http://docs.puppetlabs.com/puppetdb/1.1/
 
@@ -107,4 +107,4 @@ For more on fitting PuppetDB to your site, [see "Scaling Recommendations."][scal
 Open Source
 -----
 
-PuppetDB is developed openly, and is released under the [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0.html). You can get the source --- and contribute to it! --- at [the PuppetDB GitHub repo][github]. Bugs and feature requests are welcome at [Puppet Labs's issue tracker][redmine].
+PuppetDB is developed openly, and is released under the [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0.html). You can get the source --- and contribute to it! --- at [the PuppetDB GitHub repo][github]. Bugs and feature requests are welcome at [Puppet Labs's issue tracker][tracker].

--- a/documentation/known_issues.markdown
+++ b/documentation/known_issues.markdown
@@ -8,9 +8,9 @@ canonical: "/puppetdb/latest/known_issues.html"
 Bugs and Feature Requests
 -----
 
-[redmine]: http://projects.puppetlabs.com/projects/puppetdb/issues
+[tracker]: https://tickets.puppetlabs.com/browse/PDB
 
-PuppetDB's bugs and feature requests are managed in [Puppet Labs's issue tracker][redmine]. Search this database if you're having problems and please report any new issues to us!
+PuppetDB's bugs and feature requests are managed in [Puppet Labs's issue tracker][tracker]. Search this database if you're having problems and please report any new issues to us!
 
 Broader Issues
 -----

--- a/documentation/trouble_kahadb_corruption.markdown
+++ b/documentation/trouble_kahadb_corruption.markdown
@@ -5,7 +5,7 @@ canonical: "/puppetdb/latest/trouble_kahadb_corruption.html"
 ---
 
 [configure_vardir]: ./configure.html#vardir
-[redmine]: http://projects.puppetlabs.com/projects/puppetdb
+[tracker]: https://tickets.puppetlabs.com/browse/PDB
 
 What is KahaDB?
 -----
@@ -44,6 +44,6 @@ If these is going to be too destructive, then there is a few things you can do. 
 How do I bring my corruption to the attention of developers?
 -----
 
-In almost all cases though we want to hear about your corruption so we can improve the ways we deal with these problems. We would appreciate if you have these issues to look at our [Bug Tracker][redmine] for the term `kahadb` to see if you're problem is already known, and adding a comment if you see it yourself, including the version of PuppetDB you are using.
+In almost all cases though we want to hear about your corruption so we can improve the ways we deal with these problems. We would appreciate if you have these issues to look at our [Bug Tracker][tracker] for the term `kahadb` to see if you're problem is already known, and adding a comment if you see it yourself, including the version of PuppetDB you are using.
 
 If the problem is unknown or new, make sure you log a new ticket including your `puppetdb.log` file, or at least the pertinent exception including the version of PuppetDB you are using and the potential cause of the corruption if you are aware of it. In all cases, make sure you preserve any backups of the `KahaDB` directory in its original corrupted state, this may be helpful to our Software Engineers to replicate the problem later.

--- a/documentation/upgrade.markdown
+++ b/documentation/upgrade.markdown
@@ -8,7 +8,7 @@ canonical: "/puppetdb/latest/upgrade.html"
 [dashboard]: ./maintain_and_tune.html#monitor-the-performance-dashboard
 [connect_master]: ./connect_puppet_master.html
 [connect_apply]: ./connect_puppet_apply.html
-[redmine]: http://projects.puppetlabs.com/projects/puppetdb/issues
+[tracker]: https://tickets.puppetlabs.com/browse/PDB
 [start_source]: ./install_from_source.html#step-6-start-the-puppetdb-service
 [plugin_source]: ./connect_puppet_master.html#on-platforms-without-packages
 [module]: ./install_via_module.html
@@ -57,7 +57,7 @@ If you upgrade PuppetDB without upgrading the terminus plugins, your Puppet depl
 
 #### On Platforms Without Packages
 
-If you installed PuppetDB by running `rake install`, you should obtain a fresh copy of the source, stop the service, and run `rake install` again. Note that this workflow is not well tested; if you run into problems, please report them on the [PuppetDB issue tracker][redmine].
+If you installed PuppetDB by running `rake install`, you should obtain a fresh copy of the source, stop the service, and run `rake install` again. Note that this workflow is not well tested; if you run into problems, please report them on the [PuppetDB issue tracker][tracker].
 
 If you are running PuppetDB from source, you should stop the service, replace the source, and [start the service as described in the advanced installation guide][start_source].
 


### PR DESCRIPTION
There were still links to the redmine tracker in our documentation. This patch
removes them and replaces them with the Jira URL instead.

Signed-off-by: Ken Barber ken@bob.sh
