### PR TITLE
PDB-308 Drop 2.7.x support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,14 +7,9 @@ group :test do
   gem 'rspec', '2.13.0'
   gem 'puppetlabs_spec_helper', '0.4.1', :require => false
 
-  gem 'puppet', :require => false
+  gem 'puppet', '>= 3.4.2', :require => false
 
   gem 'mocha', '~> 1.0'
-
-  # Since newer versions of rake are not supported, we pin
-  if RUBY_VERSION == '1.8.5'
-    gem 'rake', '<= 0.8.7'
-  end
 end
 
 group :acceptance do

--- a/Rakefile
+++ b/Rakefile
@@ -64,6 +64,10 @@ ENV['PATH'] = "/opt/puppet/bin:" + ENV['PATH'] if @pe
 
 @osfamily = (Facter.value(:osfamily) || "").downcase
 
+# Specific minimum pinning for Puppet & Facter versions
+@puppetminversion = "3.4.2"
+@facterminversion = "1.6.11"
+
 if @pe
     @install_dir = "/opt/puppet/share/puppetdb"
     @etc_dir = "/etc/puppetlabs/puppetdb"

--- a/contrib/gem/puppetdb-terminus.gemspec
+++ b/contrib/gem/puppetdb-terminus.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency 'json'
+  gem.add_runtime_dependency 'puppet', '>= 3.4.2'
 end

--- a/documentation/api/wire_format/catalog_format.markdown
+++ b/documentation/api/wire_format/catalog_format.markdown
@@ -4,19 +4,19 @@ layout: default
 canonical: "/puppetdb/latest/api/wire_format/catalog_format.html"
 ---
 
-[containment]: /puppet/2.7/reference/lang_containment.html
-[relationship]: /puppet/2.7/reference/lang_relationships.html
-[chain]: /puppet/2.7/reference/lang_relationships.html#chaining-arrows
-[metaparameters]: /puppet/2.7/reference/lang_relationships.html#relationship-metaparameters
-[require]: /puppet/2.7/reference/lang_relationships.html#the-require-function
-[resource_ref]: /puppet/2.7/reference/lang_datatypes.html#resource-references
-[numbers]: /puppet/2.7/reference/lang_datatypes.html#numbers
-[undef]: /puppet/2.7/reference/lang_datatypes.html#undef
-[namevar]: /puppet/2.7/reference/lang_resources.html#namenamevar
-[resource]: /puppet/2.7/reference/lang_resources.html
-[title]: /puppet/2.7/reference/lang_resources.html#title
-[type]: /puppet/2.7/reference/lang_resources.html#type
-[attributes]: /puppet/2.7/reference/lang_resources.html#attributes
+[containment]: /puppet/3/reference/lang_containment.html
+[relationship]: /puppet/3/reference/lang_relationships.html
+[chain]: /puppet/3/reference/lang_relationships.html#chaining-arrows
+[metaparameters]: /puppet/3/reference/lang_relationships.html#relationship-metaparameters
+[require]: /puppet/3/reference/lang_relationships.html#the-require-function
+[resource_ref]: /puppet/3/reference/lang_datatypes.html#resource-references
+[numbers]: /puppet/3/reference/lang_datatypes.html#numbers
+[undef]: /puppet/3/reference/lang_datatypes.html#undef
+[namevar]: /puppet/3/reference/lang_resources.html#namenamevar
+[resource]: /puppet/3/reference/lang_resources.html
+[title]: /puppet/3/reference/lang_resources.html#title
+[type]: /puppet/3/reference/lang_resources.html#type
+[attributes]: /puppet/3/reference/lang_resources.html#attributes
 [replace3]: ../commands.html#replace-catalog-version-3
 [replace2]: ../commands.html#replace-catalog-version-2
 [replace1]: ../commands.html#replace-catalog-version-1

--- a/documentation/community_add_ons.markdown
+++ b/documentation/community_add_ons.markdown
@@ -11,7 +11,7 @@ canonical: "/puppetdb/latest/community_add_ons.html"
 [dashboard]: ./maintain_and_tune.html#monitor-the-performance-dashboard
 [query]: https://github.com/dalen/puppet-puppetdbquery
 [exports]: http://forge.puppetlabs.com/zack/exports
-[exported]: /puppet/2.7/reference/lang_exported.html
+[exported]: /puppet/3/reference/lang_exported.html
 
 [Jason Hancock --- nagios-puppetdb][nagios]
 -----

--- a/documentation/connect_puppet_apply.markdown
+++ b/documentation/connect_puppet_apply.markdown
@@ -4,7 +4,7 @@ layout: default
 canonical: "/puppetdb/latest/connect_puppet_apply.html"
 ---
 
-[exported]: /puppet/2.7/reference/lang_exported.html
+[exported]: /puppet/3/reference/lang_exported.html
 [package]: /references/latest/type.html#package
 [file]: /references/latest/type.html#file
 [yumrepo]: /references/latest/type.html#yumrepo
@@ -12,12 +12,12 @@ canonical: "/puppetdb/latest/connect_puppet_apply.html"
 [puppetdb_download]: http://downloads.puppetlabs.com/puppetdb
 [puppetdb_conf]: /guides/configuring.html#puppetdbconf
 [routes_yaml]: /guides/configuring.html#routesyaml
-[exported]: /puppet/2.7/reference/lang_exported.html
+[exported]: /puppet/3/reference/lang_exported.html
 [jetty]: ./configure.html#jetty-http-settings
-[settings_namespace]: /puppet/2.7/reference/lang_variables.html#master-set-variables
+[settings_namespace]: /puppet/3/reference/lang_variables.html#master-set-variables
 [ssl_script]: ./install_from_source.html#step-3-option-a-run-the-ssl-configuration-script
 
-> Note:  To use PuppetDB, the nodes at your site must be running Puppet 2.7.12 or later.
+> Note:  To use PuppetDB, the nodes at your site must be running Puppet 3.4.2 or later.
 
 PuppetDB can also be used with standalone Puppet deployments where each node runs `puppet apply`. Once connected to PuppetDB, `puppet apply` will do the following:
 

--- a/documentation/connect_puppet_master.markdown
+++ b/documentation/connect_puppet_master.markdown
@@ -7,7 +7,7 @@ canonical: "/puppetdb/latest/connect_puppet_master.html"
 [puppetdb_download]: http://downloads.puppetlabs.com/puppetdb
 [puppetdb_conf]: /guides/configuring.html#puppetdbconf
 [routes_yaml]: /guides/configuring.html#routesyaml
-[exported]: /puppet/2.7/reference/lang_exported.html
+[exported]: /puppet/3/reference/lang_exported.html
 [install_via_module]: ./install_via_module.html
 [report_processors]: http://docs.puppetlabs.com/guides/reporting.html
 [event]: ./api/query/v3/event.html
@@ -15,7 +15,7 @@ canonical: "/puppetdb/latest/connect_puppet_master.html"
 [store_report]: ./api/commands.html#store-report-version-1
 [report_format]: ./api/wire_format/report_format.html
 
-> Note: To use PuppetDB, your site's puppet master(s) must be running Puppet 2.7.12 or later .
+> Note: To use PuppetDB, your site's puppet master(s) must be running Puppet 3.4.2 or later .
 
 After PuppetDB is installed and running, you should configure your puppet master(s) to use it. Once connected to PuppetDB, puppet masters will do the following: 
 

--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -4,7 +4,7 @@ layout: default
 canonical: "/puppetdb/latest/index.html"
 ---
 
-[exported]: /puppet/2.7/reference/lang_exported.html
+[exported]: /puppet/3/reference/lang_exported.html
 [inventory]: /guides/inventory_service.html
 [connect]: ./connect_puppet_master.html
 [apply]: ./connect_puppet_apply.html
@@ -12,8 +12,8 @@ canonical: "/puppetdb/latest/index.html"
 [install_from_packages]: ./install_from_packages.html
 [install_advanced]: ./install_from_source.html
 [scaling]: ./scaling_recommendations.html
-[facts]: /puppet/2.7/reference/lang_variables.html#facts
-[catalog]: /puppet/2.7/reference/lang_summary.html#compilation-and-catalogs
+[facts]: /puppet/3/reference/lang_variables.html#facts
+[catalog]: /puppet/3/reference/lang_summary.html#compilation-and-catalogs
 [releasenotes]: ./release_notes.html
 [github]: https://github.com/puppetlabs/puppetdb
 [redmine]: http://projects.puppetlabs.com/projects/puppetdb/issues
@@ -86,9 +86,9 @@ If you're willing to do some manual configuration, PuppetDB can run on any Unix-
 
 [See here for advanced installation instructions.][install_advanced]
 
-### Puppet 2.7.12
+### Puppet 3.4.2
 
-Your site's puppet masters must be running Puppet 2.7.12 or later. [You will need to connect your puppet masters to PuppetDB after installing it][connect]. If you wish to use PuppetDB with [standalone nodes that are running puppet apply][apply], every node must be running 2.7.12 or later.
+Your site's puppet masters must be running Puppet 3.4.2 or later. [You will need to connect your puppet masters to PuppetDB after installing it][connect]. If you wish to use PuppetDB with [standalone nodes that are running puppet apply][apply], every node must be running 3.4.2 or later.
 
 > #### Note about Puppet Enterprise
 >

--- a/documentation/using.markdown
+++ b/documentation/using.markdown
@@ -4,7 +4,7 @@ layout: default
 canonical: "/puppetdb/latest/using.html"
 ---
 
-[exported]: /puppet/2.7/reference/lang_exported.html
+[exported]: /puppet/3/reference/lang_exported.html
 
 
 Currently, the main use for PuppetDB is to enable advanced features in Puppet. We expect additional applications to be built on PuppetDB as it becomes more widespread.

--- a/ext/redhat/puppetdb.spec.erb
+++ b/ext/redhat/puppetdb.spec.erb
@@ -1,6 +1,8 @@
 %global realname puppetdb
 %global realversion <%= Pkg::Config.version %>
 %global rpmversion <%= Pkg::Config.rpmversion %>
+%global puppetminversion <%= @puppetminversion %>
+%global facterminversion <%= @facterminversion %>
 
 %define __jar_repack 0
 
@@ -84,17 +86,17 @@ Group:         System Environment/Daemons
 %endif
 
 <% if @pe -%>
-BuildRequires: pe-facter >= 1.6.2, pe-puppet
+BuildRequires: pe-facter >= %{facterminversion}, pe-puppet
 BuildRequires: pe-rubygem-rake
 BuildRequires: pe-ruby
-Requires:      pe-puppet >= 2.7.12
+Requires:      pe-puppet >= %{puppetminversion}
 <% else -%>
-BuildRequires: facter >= 1.6.8
-BuildRequires: puppet >= 2.7.12
+BuildRequires: facter >= %{facterminversion}
+BuildRequires: puppet >= %{puppetminversion}
 BuildRequires: rubygem-rake
 BuildRequires: ruby
-Requires:      puppet >= 2.7.12
-Requires:      facter >= 1.6.8
+Requires:      puppet >= %{puppetminversion}
+Requires:      facter >= %{facterminversion}
 <% end -%>
 BuildArch:     noarch
 %if 0%{?suse_version}
@@ -134,9 +136,9 @@ Group: System/Libraries
 Group: Development/Libraries
 %endif
 <% if @pe -%>
-Requires: pe-puppet >= 2.7.12
+Requires: pe-puppet >= %{puppetminversion}
 <% else -%>
-Requires: puppet >= 2.7.12
+Requires: puppet >= %{puppetminversion}
 Requires: rubygem-json
 <% end -%>
 

--- a/ext/templates/deb/control.erb
+++ b/ext/templates/deb/control.erb
@@ -3,9 +3,9 @@ Section: utils
 Priority: optional
 Maintainer: Puppet Labs <info@puppetlabs.com>
 <% if @pe -%>
-Build-Depends: debhelper (>= 7.0.0~), cdbs, bc, mawk, lsb-release, pe-rubygem-rake, pe-facter, pe-puppet
+Build-Depends: debhelper (>= 7.0.0~), cdbs, bc, mawk, lsb-release, pe-rubygem-rake, pe-facter (>= <%= @facterminversion %>), pe-puppet (>= <%= @puppetminversion %>)
 <% else -%>
-Build-Depends: debhelper (>= 7.0.0~), cdbs, bc, mawk, lsb-release, rake, facter, puppet
+Build-Depends: debhelper (>= 7.0.0~), cdbs, bc, mawk, lsb-release, rake, facter (>= <%= @facterminversion %>), puppet (>= <%= @puppetminversion %>)
 <% end -%>
 Standards-Version: 3.9.1
 Homepage: http://puppetlabs.com
@@ -13,9 +13,9 @@ Homepage: http://puppetlabs.com
 Package: <%= @name %>
 Architecture: all
 <% if @pe -%>
-Depends: ${misc:Depends}, pe-java, adduser, pe-puppet
+Depends: ${misc:Depends}, pe-java, adduser, pe-puppet (>= <%= @puppetminversion %>)
 <% else -%>
-Depends: ${misc:Depends},  java7-runtime-headless | j2re1.7 | java6-runtime-headless, adduser, puppet (>= 2.7.12)
+Depends: ${misc:Depends},  java7-runtime-headless | j2re1.7 | java6-runtime-headless, adduser, puppet (>= <%= @puppetminversion %>)
 Suggests: postgresql
 <% end -%>
 Description:PuppetDB Centralized Storage.
@@ -23,8 +23,8 @@ Description:PuppetDB Centralized Storage.
 Package: <%= @name %>-terminus
 Architecture: all
 <% if @pe -%>
-Depends:  ${misc:Depends}, pe-puppet
+Depends:  ${misc:Depends}, pe-puppet (>= <%= @puppetminversion %>)
 <% else -%>
-Depends:  ${misc:Depends}, puppet-common, libjson-ruby | ruby-json
+Depends:  ${misc:Depends}, puppet-common (>= <%= @puppetminversion %>), libjson-ruby | ruby-json
 <% end -%>
 Description:Connect Puppet to PuppetDB by setting up a terminus for PuppetDB.

--- a/puppet/lib/puppet/face/node/deactivate.rb
+++ b/puppet/lib/puppet/face/node/deactivate.rb
@@ -16,6 +16,8 @@ Puppet::Face.define(:node, '0.0.1') do
     DESC
 
     when_invoked do |*args|
+      Puppet::Util::Puppetdb::GlobalCheck.run
+
       opts = args.pop
       raise ArgumentError, "Please provide at least one node for deactivation" if args.empty?
 

--- a/puppet/lib/puppet/face/node/status.rb
+++ b/puppet/lib/puppet/face/node/status.rb
@@ -14,6 +14,8 @@ Puppet::Face.define(:node, '0.0.1') do
       require 'puppet/util/puppetdb'
       require 'json'
 
+      Puppet::Util::Puppetdb::GlobalCheck.run
+
       opts = args.pop
       raise ArgumentError, "Please provide at least one node" if args.empty?
 

--- a/puppet/lib/puppet/face/storeconfigs.rb
+++ b/puppet/lib/puppet/face/storeconfigs.rb
@@ -22,6 +22,9 @@ Puppet::Face.define(:storeconfigs, '0.0.1') do
     DESC
 
     when_invoked do |options|
+      require 'puppet/util/puppetdb/global_check'
+      Puppet::Util::Puppetdb::GlobalCheck.run
+
       require 'puppet/rails'
 
       tmpdir = Dir.mktmpdir
@@ -100,15 +103,16 @@ Puppet::Face.define(:storeconfigs, '0.0.1') do
     File.expand_path("storeconfigs-#{timestamp.strftime('%Y%m%d%H%M%S')}.tar")
   end
 
+  # Execute a command using Puppet's execution static method.
+  #
+  # @param command [Array<String>, String] the command to execute. If it is
+  #   an Array the first element should be the executable and the rest of the
+  #   elements should be the individual arguments to that executable.
+  # @return [Puppet::Util::Execution::ProcessOutput] output as specified by options
+  # @raise [Puppet::ExecutionFailure] if the executed chiled process did not exit with status == 0 and `failonfail` is
+  #   `true`.
   def execute(command)
-    # Puppet::Util::Execution is the preferred way to do this in newer Puppets,
-    # but isn't available in older versions. For the sake of not getting
-    # deprecation warnings, we choose intelligently.
-    if Puppet::Util::Execution.respond_to?(:execute)
-      Puppet::Util::Execution.execute(command)
-    else
-      Puppet::Util.execute(command)
-    end
+    Puppet::Util::Execution.execute(command)
   end
 
   def node_to_catalog_hash(node)

--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -6,6 +6,11 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   include Puppet::Util::Puppetdb
   include Puppet::Util::Puppetdb::CommandNames
 
+  # Run initial checks
+  def initialize
+    Puppet::Util::Puppetdb::GlobalCheck.run
+  end
+
   def save(request)
     catalog = munge_catalog(request.instance, extract_extra_request_data(request))
 

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -7,6 +7,11 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
   include Puppet::Util::Puppetdb
   include Puppet::Util::Puppetdb::CommandNames
 
+  # Run initial checks
+  def initialize
+    Puppet::Util::Puppetdb::GlobalCheck.run
+  end
+
   def save(request)
     facts = request.instance.dup
     facts.values = facts.values.dup

--- a/puppet/lib/puppet/indirector/node/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/node/puppetdb.rb
@@ -5,6 +5,11 @@ require 'puppet/util/puppetdb'
 class Puppet::Node::Puppetdb < Puppet::Indirector::REST
   include Puppet::Util::Puppetdb
 
+  # Run initial checks
+  def initialize
+    Puppet::Util::Puppetdb::GlobalCheck.run
+  end
+
   def find(request)
   end
 

--- a/puppet/lib/puppet/indirector/resource/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/resource/puppetdb.rb
@@ -5,6 +5,11 @@ require 'json'
 class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
   include Puppet::Util::Puppetdb
 
+  # Run initial checks
+  def initialize
+    Puppet::Util::Puppetdb::GlobalCheck.run
+  end
+
   def search(request)
     type   = request.key
     host   = request.options[:host]

--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -2,9 +2,10 @@ require 'puppet'
 require 'puppet/util/puppetdb'
 require 'puppet/util/puppetdb/command_names'
 
-
 Puppet::Reports.register_report(:puppetdb) do
   include Puppet::Util::Puppetdb
+
+  Puppet::Util::Puppetdb::GlobalCheck.run
 
   CommandStoreReport = Puppet::Util::Puppetdb::CommandNames::CommandStoreReport
 

--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -1,5 +1,6 @@
 require 'puppet/util'
 require 'puppet/util/logging'
+require 'puppet/util/puppetdb/global_check'
 require 'puppet/util/puppetdb/command_names'
 require 'puppet/util/puppetdb/command'
 require 'puppet/util/puppetdb/config'

--- a/puppet/lib/puppet/util/puppetdb/global_check.rb
+++ b/puppet/lib/puppet/util/puppetdb/global_check.rb
@@ -1,0 +1,31 @@
+require 'semver'
+require 'puppet/version'
+require 'puppet/error'
+
+module Puppet::Util::Puppetdb
+  # Global checks for version support and other validations before the terminus
+  # is used.
+  #
+  class GlobalCheck
+    # Validate that the support for the version of Puppet we are running on is
+    # still maintained.
+    #
+    # @param minimum [String] minimum version for operation
+    # @throws [Puppet::Error] raised if current version is unsupported
+    # @api private
+    def self.puppet_version_check(minimum)
+      minimum_version = ::SemVer.new(minimum)
+      puppet_version = ::SemVer.new(Puppet.version)
+      if (puppet_version <=> minimum_version) == -1 then
+        raise Puppet::Error, "You are attempting to use puppetdb-terminus on an unsupported version of Puppet (#{puppet_version}) the minimum supported version is #{minimum_version}"
+      end
+    end
+
+    # Run all checks
+    #
+    # @throws [Puppet::Error] raised for any validation errors
+    def self.run
+      self.puppet_version_check("3.4.2")
+    end
+  end
+end

--- a/puppet/spec/unit/util/puppetdb/global_check_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/global_check_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'puppet/util/puppetdb'
+
+describe Puppet::Util::Puppetdb::GlobalCheck do
+  describe "#puppet_version_check" do
+    it 'should throw exception if we are running an older version' do
+      expect {
+        Puppet::Util::Puppetdb::GlobalCheck.puppet_version_check("100.0.0")
+      }.to raise_error(Puppet::Error, /You are attempting to use puppetdb-terminus on an unsupported version of Puppet/)
+    end
+
+    it 'should do nothing for newer versions' do
+      Puppet::Util::Puppetdb::GlobalCheck.puppet_version_check("1.0.0")
+    end
+  end
+
+  describe "#run" do
+    it 'should do nothing as tests should only run on valid versions' do
+      Puppet::Util::Puppetdb::GlobalCheck.run
+    end
+  end
+end


### PR DESCRIPTION
This patch removes support for Puppet 2.7.x in several ways:
- New check for every entry point in terminus will return an error if the
  version of Puppet is not supported. This is done in a 'soft' manner to
  avoid Puppet from not working.
- Documentation now only references Puppet 3
- Documentation now states only latest version of Puppet is supported
- Packaging now has hard dependencies on the latest version of Puppet
- Contrib gemspec has been updated
- Gemfile for tests have been updated

Signed-off-by: Ken Barber ken@bob.sh
