### PR TITLE
PDB-463 Fix assertion error in /v1/resources

### DIFF
--- a/src/com/puppetlabs/puppetdb/http/v1/resources.clj
+++ b/src/com/puppetlabs/puppetdb/http/v1/resources.clj
@@ -97,6 +97,7 @@
   (try
     (with-transacted-connection db
       (-> (r/query->sql version (json/parse-string query true))
+          (r/query-resources)
           (:result)
           (munge-result-rows)
           (pl-http/json-response)))


### PR DESCRIPTION
resource-query-limit wasn't removed from this end-point, this removes it
properly.

Signed-off-by: Ken Barber ken@bob.sh
