### PR TITLE
PDB-308 Fix missing files from packaging

### DIFF
--- a/ext/redhat/puppetdb.spec.erb
+++ b/ext/redhat/puppetdb.spec.erb
@@ -347,6 +347,7 @@ fi
 %{puppet_libdir}/puppet/util/puppetdb/command_names.rb
 %{puppet_libdir}/puppet/util/puppetdb/config.rb
 %{puppet_libdir}/puppet/util/puppetdb/blacklist.rb
+%{puppet_libdir}/puppet/util/puppetdb/global_check.rb
 
 %changelog
 <%

--- a/ext/templates/deb/terminus.install.erb
+++ b/ext/templates/deb/terminus.install.erb
@@ -14,3 +14,4 @@
 <%= @plibdir -%>/puppet/util/puppetdb/command_names.rb
 <%= @plibdir -%>/puppet/util/puppetdb/config.rb
 <%= @plibdir -%>/puppet/util/puppetdb/blacklist.rb
+<%= @plibdir -%>/puppet/util/puppetdb/global_check.rb


### PR DESCRIPTION
global_checks.rb was added to the source code, but not the packaging. This
patch fixes that.

Signed-off-by: Ken Barber ken@bob.sh
