### PR TITLE
(pdb-80)(packaging) Fixup logic in defaults file for java on EL

### DIFF
--- a/ext/templates/puppetdb_default.erb
+++ b/ext/templates/puppetdb_default.erb
@@ -20,8 +20,10 @@ elif [ -f /usr/lib/jvm/j2sdk1.7-oracle/bin/java ]; then
 elif [ -f /usr/lib64/jvm/jre-1.7.0-openjdk/bin/java ]; then
 	JAVA_BIN="/usr/lib64/jvm/jre-1.7.0/bin/java"
 # EL/Fedora
-elif [ -f /usr/lib/jvm/jre-1.7.0/bin/java ]; then
-	JAVA_BIN="/usr/lib/jvm/jre-1.7.0/bin/java"
+elif [ -f /usr/lib/jvm/jre-1.7.0-openjdk.x86_64/bin/java ]; then
+    JAVA_BIN="/usr/lib/jvm/jre-1.7.0-openjdk.x86_64/bin/java"
+elif [ -f /usr/lib/jvm/jre-1.7.0-openjdk/bin/java ]; then
+	JAVA_BIN="/usr/lib/jvm/jre-1.7.0-openjdk/bin/java"
 # Fall back to system default Java
 else
 	JAVA_BIN="/usr/bin/java"


### PR DESCRIPTION
On EL {5,6} X86_64 platforms, the direct path to the java-1.7.0-openjdk binaries has
an arch-specific component. This PR adds logic to the /etc/defaults/puppetdb file to
support accessing that path.
