### PR TITLE
Use v3 end-point for import and benchmark tools

### DIFF
--- a/src/com/puppetlabs/puppetdb/command.clj
+++ b/src/com/puppetlabs/puppetdb/command.clj
@@ -225,7 +225,7 @@
            body    (format "checksum=%s&payload=%s"
                            (kitchensink/utf8-string->sha1 message)
                            (url-encode message))
-           url     (format "http://%s:%s/v2/commands" host port)]
+           url     (format "http://%s:%s/v3/commands" host port)]
        (client/post url {:body               body
                          :throw-exceptions   false
                          :content-type       :x-www-form-urlencoded


### PR DESCRIPTION
The function 'submit-command-via-http!' was still posting commands to the
/v2/command end-point which is no longer the latest. This wouldn't have
been a major problem, but it might have messed up some of the metrics based
http stats for users.

The patch switches the function to use the v3 endpoint, in this case an
unversioned end-point would be perfect but we lack that functionality.

Signed-off-by: Ken Barber ken@bob.sh
