### PR TITLE
(pdb-468)(packaging) Fix package build on systemd platforms

### DIFF
--- a/ext/redhat/puppetdb.spec.erb
+++ b/ext/redhat/puppetdb.spec.erb
@@ -298,10 +298,10 @@ fi
 %config(noreplace)%{_sysconfdir}/%{realname}/conf.d/jetty.ini
 %config(noreplace)%{_sysconfdir}/%{realname}/conf.d/repl.ini
 %config(noreplace)%{_realsysconfdir}/logrotate.d/%{name}
+%config(noreplace)%{_realsysconfdir}/sysconfig/%{name}
 %if 0%{?_with_systemd}
 %{_unitdir}/%{name}.service
 %else
-%config(noreplace)%{_realsysconfdir}/sysconfig/%{name}
 %{_initddir}/%{name}
 %endif
 %{_sbindir}/puppetdb-ssl-setup

--- a/tasks/install.rake
+++ b/tasks/install.rake
@@ -68,6 +68,7 @@ task :install => [  JAR_FILE  ] do
     puts "operatingsystemrelease is #{@operatingsystemrelease}"
     if (@operatingsystem == "fedora" && @operatingsystemrelease.to_i >= 17) || (@operatingsystem =~ /redhat|centos/ && @operatingsystemrelease.to_f >= 7 )
       #systemd!
+      mkdir_p "#{DESTDIR}/etc/sysconfig"
       mkdir_p "#{DESTDIR}/usr/lib/systemd/system"
       cp_p "ext/files/puppetdb.default", "#{DESTDIR}/etc/sysconfig/#{@name}"
       cp_p "ext/files/puppetdb.env", "#{DESTDIR}/#{@libexec_dir}/#{@name}.env"


### PR DESCRIPTION
The previous commit for this issue added the defaults file to /etc/sysconfig for
Fedora 19 or Fedora 20, but neglected to create the /etc/sysconfig
directory in the RPM buildroot.

This commit creates the proper directory in the buildroot for builds
on Fedora >= 19 and EL >=7 (systemd platforms)
