### PR TITLE
(PDB-468)(packaging) Fixup systemd service configuration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -116,7 +116,7 @@ case @osfamily
 end
 
 @heap_dump_path = "#{@log_dir}/puppetdb-oom.hprof"
-@default_java_args = "-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=#{@heap_dump_path} "
+@default_java_args = "-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=#{@heap_dump_path}"
 
 # All variables have been set, so we can load the puppetdb tasks
 Dir[ File.join(RAKE_ROOT, 'tasks','*.rake') ].sort.each { |t| load t }

--- a/ext/templates/puppetdb.service.erb
+++ b/ext/templates/puppetdb.service.erb
@@ -5,12 +5,19 @@ After=syslog.target network.target
 [Service]
 Type=simple
 EnvironmentFile=/etc/sysconfig/<%= @name %>
-User=${USER}
-PIDFile=/var/run/${USER}/${USER}.pid
-ExecStart=${JAVA_BIN} \
-          ${JAVA_ARGS} \
+User=<%= @name %>
+PIDFile=/var/run/<%= @name %>/<%= @name %>.pid
+<%- if @pe -%>
+ExecStart=<%= @java_bin %> \
+          $JAVA_ARGS \
           -jar ${INSTALL_DIR}/puppetdb.jar \
-          services -c ${CONFG} $@
+          services -c ${CONFIG} $@
+<%- else -%>
+ExecStart=/usr/lib/jvm/jre-1.7.0-openjdk/bin/java \
+          $JAVA_ARGS \
+          -jar ${INSTALL_DIR}/puppetdb.jar \
+          services -c ${CONFIG} $@
+<%- end -%>
 
 ExecStop=/bin/kill $MAINPID
 

--- a/ext/templates/puppetdb_default_systemd.erb
+++ b/ext/templates/puppetdb_default_systemd.erb
@@ -1,0 +1,17 @@
+###########################################
+# Init settings for <%= @name %>
+###########################################
+
+# Location of your Java binary
+<%- if @pe -%>
+JAVA_BIN="<%= @java_bin %>"
+<%- else -%>
+JAVA_BIN="/usr/lib/jvm/jre-1.7.0-openjdk/bin/java"
+<%- end -%>
+# Modify this if you'd like to change the memory allocation, enable JMX, etc
+JAVA_ARGS="<%= @java_args || @default_java_args -%>"
+
+# These normally shouldn't need to be edited if using OS packages
+USER="<%= @name -%>"
+INSTALL_DIR="<%= @install_dir || "/usr/share/puppetdb" -%>"
+CONFIG="<%= @config_dir -%>"

--- a/tasks/install.rake
+++ b/tasks/install.rake
@@ -70,7 +70,7 @@ task :install => [  JAR_FILE  ] do
       #systemd!
       mkdir_p "#{DESTDIR}/etc/sysconfig"
       mkdir_p "#{DESTDIR}/usr/lib/systemd/system"
-      cp_p "ext/files/puppetdb.default", "#{DESTDIR}/etc/sysconfig/#{@name}"
+      cp_p "ext/files/puppetdb.default.systemd", "#{DESTDIR}/etc/sysconfig/#{@name}"
       cp_p "ext/files/puppetdb.env", "#{DESTDIR}/#{@libexec_dir}/#{@name}.env"
       cp_p "ext/files/systemd/#{@name}.service", "#{DESTDIR}/usr/lib/systemd/system"
       chmod 0644, "#{DESTDIR}/usr/lib/systemd/system/#{@name}.service"

--- a/tasks/template.rake
+++ b/tasks/template.rake
@@ -42,7 +42,8 @@ task :template => [ :clean ] do
     "ext/templates/dev/redhat/redhat_dev_preinst.erb"   => "ext/files/dev/redhat/redhat_dev_preinst",
     "ext/templates/dev/redhat/redhat_dev_postinst.erb"  => "ext/files/dev/redhat/redhat_dev_postinst",
     "ext/templates/init_openbsd.erb"                    => "ext/files/puppetdb.openbsd.init",
-    "ext/templates/puppetdb.service.erb"                => "ext/files/systemd/#{@name}.service"
+    "ext/templates/puppetdb.service.erb"                => "ext/files/systemd/#{@name}.service",
+    "ext/templates/puppetdb_default_systemd.erb"        => "ext/files/puppetdb.default.systemd"
   }
 
   # Set up shared files


### PR DESCRIPTION
Systemd will not allow variable substitution in a number of places in the service definition file. Most importantly, the  first argument to the ExecStart command and the User and PIDFile parameters.

In addition, as the file referenced in EnvironmentFile is not interpreted by a shell, but read in directly by systemd, it can not have logic, but must be composed solely of variable assignments.

This PR updates the service definition file to use a hardcoded reference to the java-1.7.0-openjdk install (checked on F19, F20 and the RHEL 7 beta). Also updates the /etc/sysconfig/puppetdb file on those platforms to conform to the format supported by systemd.
