### PR TITLE
Fix puppetdb-env.erb so we don't get stripped carriage returns

### DIFF
--- a/ext/templates/puppetdb-env.erb
+++ b/ext/templates/puppetdb-env.erb
@@ -3,7 +3,7 @@
 if [ -r "/etc/default/<%= @name -%>" ] ; then
     . /etc/default/<%= @name %>
 elif [ -r  "/etc/sysconfig/<%= @name -%>" ] ; then
-    . /etc/sysconfig/<%= @name -%>
+    . /etc/sysconfig/<%= @name %>
 else
     JAVA_BIN=<%= @java_bin || "/usr/bin/java"  -%>
     INSTALL_DIR="<%= @install_dir || "/usr/share/puppetdb" -%>"


### PR DESCRIPTION
The use of <%= @name -%> here is erroneous and truncates the trailing carriage
return thus returning an error when the script is evaluated.

This patch changes it to use <%= @name %> which does not strip the carriage
return.

Signed-off-by: Ken Barber ken@bob.sh
