### PR TITLE
PDB-354 Deprecate old versions of commands

### DIFF
--- a/documentation/api/commands.markdown
+++ b/documentation/api/commands.markdown
@@ -70,11 +70,15 @@ processed.
 
 ### "replace catalog", version 1
 
+> **Note:** This version is deprecated, use the latest version instead.
+
 The payload is expected to be a Puppet catalog, as a JSON string, including the
 fields of the [catalog wire format][catalog]. Extra fields are
 ignored.
 
 ### "replace catalog", version 2
+
+> **Note:** This version is deprecated, use the latest version instead.
 
 The payload is expected to be a Puppet catalog, as either a JSON string or an
 object, conforming exactly to the [catalog wire
@@ -102,6 +106,8 @@ The payload is expected to be the name of a node, as a JSON string, which will b
 effective as of the time the command is *processed*.
 
 ### "store report", version 1
+
+> **Note:** This version is deprecated, use the latest version instead.
 
 The payload is expected to be a report, containing events that occurred on Puppet
 resources.  It is structured as a JSON object, conforming to the

--- a/src/com/puppetlabs/puppetdb/command.clj
+++ b/src/com/puppetlabs/puppetdb/command.clj
@@ -321,6 +321,7 @@
 (defmethod process-command! [(command-names :replace-catalog) 1]
   [{:keys [version payload] :as command} options]
   {:pre [(= version 1)]}
+  (log/warn "command 'replace catalog' version 1 is deprecated, use the latest version")
   (when-not (string? payload)
     (throw (IllegalArgumentException.
              (format "Payload for a '%s' v1 command must be a JSON string."
@@ -330,6 +331,7 @@
 (defmethod process-command! [(command-names :replace-catalog) 2]
   [{:keys [version] :as  command} options]
   {:pre [(= version 2)]}
+  (log/warn "command 'replace catalog' version 2 is deprecated, use the latest version")
   (replace-catalog* command options))
 
 (defmethod process-command! [(command-names :replace-catalog) 3]
@@ -381,6 +383,7 @@
 (defmethod process-command! [(command-names :store-report) 1]
   [{:keys [version] :as command} {:keys [db]}]
   {:pre [(= version 1)]}
+  (log/warn "command 'store report' version 1 is deprecated, use the latest version")
   (store-report* 1 db command))
 
 (defmethod process-command! [(command-names :store-report) 2]


### PR DESCRIPTION
This patch drops a warning whenever an old version of the commands API is used
and updates the documentation to warn the user these old commands are
deprecated.

Signed-off-by: Ken Barber ken@bob.sh
