### PR TITLE
PDB-113 Remove swank

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -555,13 +555,11 @@ Set to `true` to enable the REPL. Defaults to false.
 
 ### `type`
 
-Either `nrepl` or `swank` or `telnet`.
+Either `nrepl` or `telnet`.
 
 The _telnet_ repl type opens up a socket you can connect to via telnet. The interface is pretty low-level and raw (no completion or command history), but it is nonetheless usable on just about any system without the need of any external tools other than telnet itself.
 
 The _nrepl_ repl type opens up a socket you can connect to via any nrepl-protocol client, such as via [Leiningen](https://github.com/technomancy/leiningen) using `lein repl :connect localhost:8082` or via Emacs (via `M-x nrepl`), Vim, or integration with other editors like Netbeans or Eclipse. This is much more user-friendly than telnet.
-
-The _swank_ type allows emacs' clojure-mode to connect directly to a running PuppetDB instance by using `M-x slime-connect`. This is not recommended, as the upstream Swank project has been deprecated in favor of nrepl.
 
 ### `port`
 

--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,6 @@
                  [org.clojure/tools.logging "0.2.6"]
                  [org.clojure/tools.nrepl "0.2.3"]
                  [puppetlabs/tools.namespace "0.2.4.1"]
-                 [swank-clojure "1.4.3"]
                  [vimclojure/server "2.3.6" :exclusions [org.clojure/clojure]]
                  [clj-stacktrace "0.2.6"]
                  [metrics-clojure "0.7.0" :exclusions [org.clojure/clojure org.slf4j/slf4j-api]]

--- a/src/com/puppetlabs/repl.clj
+++ b/src/com/puppetlabs/repl.clj
@@ -2,8 +2,7 @@
   (:import [vimclojure.nailgun NGServer])
   (:require [clojure.string :as string]
             [clojure.tools.nrepl.server :as nrepl]
-            [clojure.tools.nrepl.transport :as nrepl-transport]
-            [swank.swank :as swank]))
+            [clojure.tools.nrepl.transport :as nrepl-transport]))
 
 (defmulti start-repl
   "Starts and instance of the specified `kind` of REPL, listening on `host` and
@@ -18,10 +17,6 @@
 (defmethod start-repl "nrepl"
   [kind host port]
   (nrepl/start-server :bind host :port port))
-
-(defmethod start-repl "swank"
-  [kind host port]
-  (swank/start-server :host host :port port))
 
 (defmethod start-repl "vimclojure"
   [kind host port]


### PR DESCRIPTION
As swank is now a deprecated project. This patch removes swank support
completely from the code base.

Signed-off-by: Ken Barber ken@bob.sh
