### PR TITLE
PDB-402 Remove ahead-of-time compilation

### DIFF
--- a/acceptance/setup/post_suite/01_validate_database.rb
+++ b/acceptance/setup/post_suite/01_validate_database.rb
@@ -25,7 +25,7 @@ step "Verify we've been talking to the correct database" do
       # in the code, and it's just generally moronic.  We should provide a lein task
       # or some way of interrogating the latest expected schema version from
       # the command line so that we can get rid of this crap.
-      source_migration_version = on(database, "java -jar /usr/share/puppetdb/puppetdb.jar version |grep target_schema_version|cut -f2 -d'='").stdout.strip
+      source_migration_version = on(database, "java -cp /usr/share/puppetdb/puppetdb.jar clojure.main -m com.puppetlabs.puppetdb.core version |grep target_schema_version|cut -f2 -d'='").stdout.strip
 
       assert_equal(db_migration_version, source_migration_version,
                    "Expected migration version from source code '#{source_migration_version}' " +

--- a/ext/templates/init_debian.erb
+++ b/ext/templates/init_debian.erb
@@ -30,7 +30,7 @@ JARFILE="puppetdb.jar"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
-JAVA_ARGS="${JAVA_ARGS} -jar ${INSTALL_DIR}/${JARFILE} services -c ${CONFIG} "
+JAVA_ARGS="${JAVA_ARGS} -cp ${INSTALL_DIR}/${JARFILE} clojure.main -m com.puppetlabs.puppetdb.core services -c ${CONFIG} "
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 
 # Exit if the package is not installed

--- a/ext/templates/init_openbsd.erb
+++ b/ext/templates/init_openbsd.erb
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 daemon=$(/usr/local/bin/javaPathHelper -c <%= @name -%>)
-daemon_flags="-jar /usr/share/puppetdb/puppetdb.jar services -c /etc/puppetdb/conf.d/puppetdb.conf"
+daemon_flags="-cp /usr/share/puppetdb/puppetdb.jar clojure.main -m com.puppetlabs.puppetdb.core services -c /etc/puppetdb/conf.d/puppetdb.conf"
 
 . /etc/rc.d/rc.subr
 

--- a/ext/templates/init_redhat.erb
+++ b/ext/templates/init_redhat.erb
@@ -38,7 +38,7 @@ PATH=/opt/puppet/bin:/opt/puppet/sbin:/sbin:/usr/sbin:/bin:/usr/bin
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 <% end -%>
 JARFILE="puppetdb.jar"
-JAVA_ARGS="${JAVA_ARGS} -jar ${INSTALL_DIR}/${JARFILE} services -c ${CONFIG} "
+JAVA_ARGS="${JAVA_ARGS} -cp ${INSTALL_DIR}/${JARFILE} clojure.main -m com.puppetlabs.puppetdb.core services -c ${CONFIG} "
 EXTRA_ARGS="--chuid $USER --background --make-pidfile"
 lockfile=/var/lock/subsys/$prog
 EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p\" $JAVA_ARGS"

--- a/ext/templates/init_suse.erb
+++ b/ext/templates/init_suse.erb
@@ -33,7 +33,7 @@ JARFILE="puppetdb.jar"
 PIDFILE=/var/run/$NAME/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
-JAVA_ARGS="${JAVA_ARGS} -jar ${INSTALL_DIR}/${JARFILE} services -c ${CONFIG} "
+JAVA_ARGS="${JAVA_ARGS} -cp ${INSTALL_DIR}/${JARFILE} clojure.main -m com.puppetlabs.puppetdb.core services -c ${CONFIG} "
 
 # Exit if the package is not installed
 [ -x "$JAVA_BIN" ] || exit 0

--- a/ext/templates/puppetdb-anonymize.erb
+++ b/ext/templates/puppetdb-anonymize.erb
@@ -2,4 +2,4 @@
 
 . <%= @libexec_dir %>/<%= @name %>.env
 
-${JAVA_BIN} <%= @java_args || @default_java_args -%> -jar ${INSTALL_DIR}/puppetdb.jar anonymize "$@"
+${JAVA_BIN} <%= @java_args || @default_java_args -%> -cp ${INSTALL_DIR}/puppetdb.jar clojure.main -m com.puppetlabs.puppetdb.core anonymize "$@"

--- a/ext/templates/puppetdb-export.erb
+++ b/ext/templates/puppetdb-export.erb
@@ -2,4 +2,4 @@
 
 . <%= @libexec_dir %>/<%= @name %>.env
 
-${JAVA_BIN} <%= @java_args || @default_java_args -%> -jar ${INSTALL_DIR}/puppetdb.jar export "$@"
+${JAVA_BIN} <%= @java_args || @default_java_args -%> -cp ${INSTALL_DIR}/puppetdb.jar clojure.main -m com.puppetlabs.puppetdb.core export "$@"

--- a/ext/templates/puppetdb-foreground.erb
+++ b/ext/templates/puppetdb-foreground.erb
@@ -4,4 +4,4 @@
 
 ARGS="$@"
 
-su ${USER} -s /bin/bash -c "${JAVA_BIN} ${JAVA_ARGS} -jar ${INSTALL_DIR}/puppetdb.jar services -c ${CONFIG} ${@}"
+su ${USER} -s /bin/bash -c "${JAVA_BIN} ${JAVA_ARGS} -cp ${INSTALL_DIR}/puppetdb.jar clojure.main -m com.puppetlabs.puppetdb.core services -c ${CONFIG} ${@}"

--- a/ext/templates/puppetdb-import.erb
+++ b/ext/templates/puppetdb-import.erb
@@ -2,4 +2,4 @@
 
 . <%= @libexec_dir %>/<%= @name %>.env
 
-${JAVA_BIN} <%= @java_args || @default_java_args -%> -jar ${INSTALL_DIR}/puppetdb.jar import "$@"
+${JAVA_BIN} <%= @java_args || @default_java_args -%> -cp ${INSTALL_DIR}/puppetdb.jar clojure.main -m com.puppetlabs.puppetdb.core import "$@"

--- a/ext/templates/puppetdb.service.erb
+++ b/ext/templates/puppetdb.service.erb
@@ -10,12 +10,14 @@ PIDFile=/var/run/<%= @name %>/<%= @name %>.pid
 <%- if @pe -%>
 ExecStart=<%= @java_bin %> \
           $JAVA_ARGS \
-          -jar ${INSTALL_DIR}/puppetdb.jar \
+          -cp ${INSTALL_DIR}/puppetdb.jar \
+          clojure.main -m com.puppetlabs.puppetdb.core \
           services -c ${CONFIG} $@
 <%- else -%>
 ExecStart=/usr/lib/jvm/jre-1.7.0-openjdk/bin/java \
           $JAVA_ARGS \
-          -jar ${INSTALL_DIR}/puppetdb.jar \
+          -cp ${INSTALL_DIR}/puppetdb.jar \
+          clojure.main -m com.puppetlabs.puppetdb.core \
           services -c ${CONFIG} $@
 <%- end -%>
 

--- a/project.clj
+++ b/project.clj
@@ -88,5 +88,4 @@
 
   :jar-exclusions [#"leiningen/"]
 
-  :aot [com.puppetlabs.puppetdb.core clj-time.core]
-  :main com.puppetlabs.puppetdb.core)
+  :main ^:skip-aot com.puppetlabs.puppetdb.core)


### PR DESCRIPTION
This patch removes AOT compilation from our leiningen project and updates
all relevant shell scripts to use the non-AOT methodology for invoking
clojure projects.

Signed-off-by: Ken Barber ken@bob.sh
