### PR TITLE
PDB-476 Decorate the terminus code with Puppet profiling blocks

### DIFF
--- a/documentation/puppetdb-faq.markdown
+++ b/documentation/puppetdb-faq.markdown
@@ -138,3 +138,11 @@ The catalog duplication rate can be found on the
 heavier I/O load on the database. Refer to the [Troubleshooting Low
 Catalog Duplication guide][low_catalog_dupe] for steps to diagnose the
 problem.
+
+## My puppet master is going slow since enabling PuppetDB. How can I profile it?
+
+In Puppet 3.x a new profiling capability was introduced that we have leveraged in the PuppetDB terminus client code. By simply adding `profile=true` to your `puppet.conf` you can enable detailed profiling of all apsects of Puppet including the PuppetDB terminus. For this to work you must enable debugging on your master instance as well.
+
+Of course use your common sense, any profiling mechanism will add more load which can increase your problems when you already have limited capacity. Enabling profiling in production should only be done with care and for a very short amount of time.
+
+All PuppetDB profiling events are prefixed with `PuppetDB:` so can by easily searched for. This information is helpful to our developers to debug performance issues also, so feel free to include these details when raising tickets against PuppetDB.

--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -12,9 +12,11 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   end
 
   def save(request)
-    catalog = munge_catalog(request.instance, extract_extra_request_data(request))
+    profile "catalog#save" do
+      catalog = munge_catalog(request.instance, extract_extra_request_data(request))
 
-    submit_command(request.key, catalog, CommandReplaceCatalog, 3)
+      submit_command(request.key, catalog, CommandReplaceCatalog, 3)
+    end
   end
 
   def find(request)
@@ -29,20 +31,24 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   end
 
   def munge_catalog(catalog, extra_request_data = {})
-    hash = catalog.to_pson_data_hash
+    profile "Munge catalog" do
+      hash = profile "Convert catalog to PSON data hash" do
+        catalog.to_pson_data_hash
+      end
 
-    data = hash['data']
+      data = hash['data']
 
-    add_parameters_if_missing(data)
-    add_namevar_aliases(data, catalog)
-    stringify_titles(data)
-    sort_unordered_metaparams(data)
-    munge_edges(data)
-    synthesize_edges(data, catalog)
-    filter_keys(hash)
-    add_transaction_uuid(data, extra_request_data[:transaction_uuid])
+      add_parameters_if_missing(data)
+      add_namevar_aliases(data, catalog)
+      stringify_titles(data)
+      sort_unordered_metaparams(data)
+      munge_edges(data)
+      synthesize_edges(data, catalog)
+      filter_keys(hash)
+      add_transaction_uuid(data, extra_request_data[:transaction_uuid])
 
-    hash
+      hash
+    end
   end
 
   Relationships = {
@@ -63,214 +69,245 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   end
 
   def stringify_titles(hash)
-    hash['resources'].each do |resource|
-      resource['title'] = resource['title'].to_s
+    resources = hash['resources']
+    profile "Stringify titles (resource count: #{resources.count})" do
+      resources.each do |resource|
+        resource['title'] = resource['title'].to_s
+      end
     end
 
     hash
   end
 
   def add_parameters_if_missing(hash)
-    hash['resources'].each do |resource|
-      resource['parameters'] ||= {}
+    resources = hash['resources']
+    profile "Add parameters if missing (resource count: #{resources.count})" do
+      resources.each do |resource|
+        resource['parameters'] ||= {}
+      end
     end
 
     hash
   end
 
   def add_namevar_aliases(hash, catalog)
-    hash['resources'].each do |resource|
-      real_resource = catalog.resource(resource['type'], resource['title'])
+    resources = hash['resources']
+    profile "Add namevar aliases (resource count: #{resources.count})" do
+      resources.each do |resource|
+        real_resource = catalog.resource(resource['type'], resource['title'])
 
-      # Resources with composite namevars can't be referred to by
-      # anything other than their title when declaring
-      # relationships. Trying to snag the :alias for these resources
-      # will only return _part_ of the name (a problem with Puppet
-      # proper), so skipping the adding of aliases for these resources
-      # is both an optimization and a safeguard.
-      next if real_resource.key_attributes.count > 1
+        # Resources with composite namevars can't be referred to by
+        # anything other than their title when declaring
+        # relationships. Trying to snag the :alias for these resources
+        # will only return _part_ of the name (a problem with Puppet
+        # proper), so skipping the adding of aliases for these resources
+        # is both an optimization and a safeguard.
+        next if real_resource.key_attributes.count > 1
 
-      aliases = [real_resource[:alias]].flatten.compact
+        aliases = [real_resource[:alias]].flatten.compact
 
-      # Non-isomorphic resources aren't unique based on namevar, so we can't
-      # use it as an alias
-      type = real_resource.resource_type
-      if !type.respond_to?(:isomorphic?) or type.isomorphic?
-        # This makes me a little sad.  It turns out that the "to_hash" method
-        #  of Puppet::Resource can have side effects.  In particular, if the
-        #  resource type specifies a title_pattern, calling "to_hash" will trigger
-        #  the title_pattern processing, which can have the side effect of
-        #  populating the namevar (potentially with a munged value).  Thus,
-        #  it is important that we search for namevar aliases in that hash
-        #  rather than in the resource itself.
-        real_resource_hash = real_resource.to_hash
+        # Non-isomorphic resources aren't unique based on namevar, so we can't
+        # use it as an alias
+        type = real_resource.resource_type
+        if !type.respond_to?(:isomorphic?) or type.isomorphic?
+          # This makes me a little sad.  It turns out that the "to_hash" method
+          #  of Puppet::Resource can have side effects.  In particular, if the
+          #  resource type specifies a title_pattern, calling "to_hash" will trigger
+          #  the title_pattern processing, which can have the side effect of
+          #  populating the namevar (potentially with a munged value).  Thus,
+          #  it is important that we search for namevar aliases in that hash
+          #  rather than in the resource itself.
+          real_resource_hash = real_resource.to_hash
 
-        name = real_resource_hash[real_resource.send(:namevar)]
-        unless name.nil? or real_resource.title == name or aliases.include?(name)
-          aliases << name
+          name = real_resource_hash[real_resource.send(:namevar)]
+          unless name.nil? or real_resource.title == name or aliases.include?(name)
+            aliases << name
+          end
         end
-      end
 
-      resource['parameters']['alias'] = aliases unless aliases.empty?
+        resource['parameters']['alias'] = aliases unless aliases.empty?
+      end
     end
 
     hash
   end
 
   def sort_unordered_metaparams(hash)
-    hash['resources'].each do |resource|
-      params = resource['parameters']
-      UnorderedMetaparams.each do |metaparam|
-        if params[metaparam].kind_of? Array then
-          values = params[metaparam].sort
-          params[metaparam] = values unless values.empty?
-        end
-      end
-    end
-    hash
-  end
-
-  def munge_edges(hash)
-    hash['edges'].each do |edge|
-      %w[source target].each do |vertex|
-        edge[vertex] = resource_ref_to_hash(edge[vertex]) if edge[vertex].is_a?(String)
-      end
-      edge['relationship'] ||= 'contains'
-    end
-
-    hash
-  end
-
-  def map_aliases_to_title(hash)
-    aliases = {}
-    hash['resources'].each do |resource|
-      names = resource['parameters']['alias'] || []
-      resource_hash = {'type' => resource['type'], 'title' => resource['title']}
-      names.each do |name|
-        alias_array = [resource['type'], name]
-        aliases[alias_array] = resource_hash
-      end
-    end
-    aliases
-  end
-
-  def synthesize_edges(hash, catalog)
-    aliases = map_aliases_to_title(hash)
-
-    resource_table = {}
-    hash['resources'].each do |resource|
-      resource_table[ [resource['type'], resource['title']] ] = resource
-    end
-
-    hash['resources'].each do |resource|
-      # Standard virtual resources don't appear in the catalog. However,
-      # exported resources which haven't been also collected will appears as
-      # exported and virtual (collected ones will only be exported). They will
-      # eventually be removed from the catalog, so we can't add edges involving
-      # them. Puppet::Resource#to_pson_data_hash omits 'virtual', so we have to
-      # look it up in the catalog to find that information. This isn't done in
-      # a separate step because we don't actually want to send the field (it
-      # will always be false). See ticket #16472.
-      #
-      # The outer conditional is here because Class[main] can't properly be
-      # looked up using catalog.resource and will return nil. See ticket
-      # #16473. Yay.
-      if real_resource = catalog.resource(resource['type'], resource['title'])
-        next if real_resource.virtual?
-      end
-
-      Relationships.each do |param,relation|
-        if value = resource['parameters'][param]
-          [value].flatten.each do |other_ref|
-            edge = {'relationship' => relation[:relationship]}
-
-            resource_hash = {'type' => resource['type'], 'title' => resource['title']}
-            other_hash = resource_ref_to_hash(other_ref)
-
-            # Puppet doesn't always seem to check this correctly. If we don't
-            # users will later get an invalid relationship error instead.
-            #
-            # Primarily we are trying to catch the non-capitalized resourceref
-            # case problem here: http://projects.puppetlabs.com/issues/19474
-            # Once that problem is solved and older versions of Puppet that have
-            # the bug are no longer supported we can probably remove this code.
-            unless other_ref =~ /^[A-Z][a-z0-9_]*(::[A-Z][a-z0-9_]*)*\[.*\]/
-              rel = edge_to_s(resource_hash_to_ref(resource_hash), other_ref, param)
-              raise Puppet::Error, "Invalid relationship: #{rel}, because " +
-                "#{other_ref} doesn't seem to be in the correct format. " +
-                "Resource references should be formatted as: " +
-                "Classname['title'] or Modulename::Classname['title'] (take " +
-                "careful note of the capitalization)."
-            end
-
-            # This is an unfortunate hack.  Puppet does some weird things w/rt
-            # munging off trailing slashes from file resources, and users may
-            # legally specify relationships using a different number of trailing
-            # slashes than the resource was originally declared with.
-            # We do know that for any file resource in the catalog, there should
-            # be a canonical entry for it that contains no trailing slashes.  So,
-            # here, in case someone has specified a relationship to a file resource
-            # and has used one or more trailing slashes when specifying the
-            # relationship, we will munge off the trailing slashes before
-            # we look up the resource in the catalog to create the edge.
-            if other_hash['type'] == 'File' and other_hash['title'] =~ /\/$/
-              other_hash['title'] = other_hash['title'].sub(/\/+$/, '')
-            end
-
-            other_array = [other_hash['type'], other_hash['title']]
-
-            # Try to find the resource by type/title or look it up as an alias
-            # and try that
-            other_resource = resource_table[other_array]
-            if other_resource.nil? and alias_hash = aliases[other_array]
-              other_resource = resource_table[ alias_hash.values_at('type', 'title') ]
-            end
-
-            raise Puppet::Error, "Invalid relationship: #{edge_to_s(resource_hash_to_ref(resource_hash), other_ref, param)}, because #{other_ref} doesn't seem to be in the catalog" unless other_resource
-
-            # As above, virtual exported resources will eventually be removed,
-            # so if a real resource refers to one, it's wrong. Non-virtual
-            # exported resources are exported resources that were also
-            # collected in this catalog, so they're okay. Virtual non-exported
-            # resources can't appear in the catalog in the first place, so it
-            # suffices to check for virtual.
-            if other_real_resource = catalog.resource(other_resource['type'], other_resource['title'])
-              if other_real_resource.virtual?
-                raise Puppet::Error, "Invalid relationship: #{edge_to_s(resource_hash_to_ref(resource_hash), other_ref, param)}, because #{other_ref} is exported but not collected"
-              end
-            end
-
-            # If the ref was an alias, it will have a different title, so use
-            # that
-            other_hash['title'] = other_resource['title']
-
-            if relation[:direction] == :forward
-              edge.merge!('source' => resource_hash, 'target' => other_hash)
-            else
-              edge.merge!('source' => other_hash, 'target' => resource_hash)
-            end
-            hash['edges'] << edge
+    resources = hash['resources']
+    profile "Sort unordered metaparams (resource count: #{resources.count})" do
+      resources.each do |resource|
+        params = resource['parameters']
+        UnorderedMetaparams.each do |metaparam|
+          if params[metaparam].kind_of? Array then
+            values = params[metaparam].sort
+            params[metaparam] = values unless values.empty?
           end
         end
       end
     end
 
-    hash['edges'].uniq!
-
     hash
   end
 
+  def munge_edges(hash)
+    edges = hash['edges']
+    profile "Munge edges (edge count: #{edges.count})" do
+      edges.each do |edge|
+        %w[source target].each do |vertex|
+          edge[vertex] = resource_ref_to_hash(edge[vertex]) if edge[vertex].is_a?(String)
+        end
+        edge['relationship'] ||= 'contains'
+      end
+
+      hash
+    end
+  end
+
+  def map_aliases_to_title(hash)
+    resources = hash['resources']
+    aliases = {}
+
+    profile "Map aliases to title (resource count: #{resources.count})" do
+      resources.each do |resource|
+        names = resource['parameters']['alias'] || []
+        resource_hash = {'type' => resource['type'], 'title' => resource['title']}
+        names.each do |name|
+          alias_array = [resource['type'], name]
+          aliases[alias_array] = resource_hash
+        end
+      end
+    end
+
+    aliases
+  end
+
+  def synthesize_edges(hash, catalog)
+    profile "Synthesize edges" do
+      aliases = map_aliases_to_title(hash)
+
+      resource_table = {}
+      profile "Build up resource_table" do
+        hash['resources'].each do |resource|
+          resource_table[ [resource['type'], resource['title']] ] = resource
+        end
+      end
+
+      profile "Primary synthesis" do
+        hash['resources'].each do |resource|
+          # Standard virtual resources don't appear in the catalog. However,
+          # exported resources which haven't been also collected will appears as
+          # exported and virtual (collected ones will only be exported). They will
+          # eventually be removed from the catalog, so we can't add edges involving
+          # them. Puppet::Resource#to_pson_data_hash omits 'virtual', so we have to
+          # look it up in the catalog to find that information. This isn't done in
+          # a separate step because we don't actually want to send the field (it
+          # will always be false). See ticket #16472.
+          #
+          # The outer conditional is here because Class[main] can't properly be
+          # looked up using catalog.resource and will return nil. See ticket
+          # #16473. Yay.
+          if real_resource = catalog.resource(resource['type'], resource['title'])
+            next if real_resource.virtual?
+          end
+
+          Relationships.each do |param,relation|
+            if value = resource['parameters'][param]
+              [value].flatten.each do |other_ref|
+                edge = {'relationship' => relation[:relationship]}
+
+                resource_hash = {'type' => resource['type'], 'title' => resource['title']}
+                other_hash = resource_ref_to_hash(other_ref)
+
+                # Puppet doesn't always seem to check this correctly. If we don't
+                # users will later get an invalid relationship error instead.
+                #
+                # Primarily we are trying to catch the non-capitalized resourceref
+                # case problem here: http://projects.puppetlabs.com/issues/19474
+                # Once that problem is solved and older versions of Puppet that have
+                # the bug are no longer supported we can probably remove this code.
+                unless other_ref =~ /^[A-Z][a-z0-9_]*(::[A-Z][a-z0-9_]*)*\[.*\]/
+                  rel = edge_to_s(resource_hash_to_ref(resource_hash), other_ref, param)
+                  raise Puppet::Error, "Invalid relationship: #{rel}, because " +
+                    "#{other_ref} doesn't seem to be in the correct format. " +
+                    "Resource references should be formatted as: " +
+                    "Classname['title'] or Modulename::Classname['title'] (take " +
+                    "careful note of the capitalization)."
+                end
+
+                # This is an unfortunate hack.  Puppet does some weird things w/rt
+                # munging off trailing slashes from file resources, and users may
+                # legally specify relationships using a different number of trailing
+                # slashes than the resource was originally declared with.
+                # We do know that for any file resource in the catalog, there should
+                # be a canonical entry for it that contains no trailing slashes.  So,
+                # here, in case someone has specified a relationship to a file resource
+                # and has used one or more trailing slashes when specifying the
+                # relationship, we will munge off the trailing slashes before
+                # we look up the resource in the catalog to create the edge.
+                if other_hash['type'] == 'File' and other_hash['title'] =~ /\/$/
+                  other_hash['title'] = other_hash['title'].sub(/\/+$/, '')
+                end
+
+                other_array = [other_hash['type'], other_hash['title']]
+
+                # Try to find the resource by type/title or look it up as an alias
+                # and try that
+                other_resource = resource_table[other_array]
+                if other_resource.nil? and alias_hash = aliases[other_array]
+                  other_resource = resource_table[ alias_hash.values_at('type', 'title') ]
+                end
+
+                raise Puppet::Error, "Invalid relationship: #{edge_to_s(resource_hash_to_ref(resource_hash), other_ref, param)}, because #{other_ref} doesn't seem to be in the catalog" unless other_resource
+
+                # As above, virtual exported resources will eventually be removed,
+                # so if a real resource refers to one, it's wrong. Non-virtual
+                # exported resources are exported resources that were also
+                # collected in this catalog, so they're okay. Virtual non-exported
+                # resources can't appear in the catalog in the first place, so it
+                # suffices to check for virtual.
+                if other_real_resource = catalog.resource(other_resource['type'], other_resource['title'])
+                  if other_real_resource.virtual?
+                    raise Puppet::Error, "Invalid relationship: #{edge_to_s(resource_hash_to_ref(resource_hash), other_ref, param)}, because #{other_ref} is exported but not collected"
+                  end
+                end
+
+                # If the ref was an alias, it will have a different title, so use
+                # that
+                other_hash['title'] = other_resource['title']
+
+                if relation[:direction] == :forward
+                  edge.merge!('source' => resource_hash, 'target' => other_hash)
+                else
+                  edge.merge!('source' => other_hash, 'target' => resource_hash)
+                end
+                hash['edges'] << edge
+              end
+            end
+          end
+        end
+      end
+
+      profile "Make edges unique" do
+        hash['edges'].uniq!
+      end
+
+      hash
+    end
+  end
+
   def filter_keys(hash)
-    hash['metadata'].delete_if do |k,v|
-      k != 'api_version'
-    end
+    profile "Filter extraneous keys from the catalog" do
+      hash['metadata'].delete_if do |k,v|
+        k != 'api_version'
+      end
 
-    hash['data'].delete_if do |k,v|
-      ! ['name', 'version', 'edges', 'resources'].include?(k)
-    end
+      hash['data'].delete_if do |k,v|
+        ! ['name', 'version', 'edges', 'resources'].include?(k)
+      end
 
-    hash.delete_if do |k,v|
-      ! ['metadata', 'data'].include?(k)
+      hash.delete_if do |k,v|
+        ! ['metadata', 'data'].include?(k)
+      end
     end
   end
 

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -1,3 +1,4 @@
+require 'uri'
 require 'puppet/node/facts'
 require 'puppet/indirector/rest'
 require 'puppet/util/puppetdb'
@@ -13,40 +14,51 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
   end
 
   def save(request)
-    facts = request.instance.dup
-    facts.values = facts.values.dup
-    facts.stringify
-    payload = {"name" => facts.name, "values" => facts.values}.to_pson
+    profile "facts#save" do
+      payload = profile "Encode facts command submission payload" do
+        facts = request.instance.dup
+        facts.values = facts.values.dup
+        facts.stringify
+        {"name" => facts.name, "values" => facts.values}.to_json
+      end
 
-    submit_command(request.key, payload, CommandReplaceFacts, 1)
+      submit_command(request.key, payload, CommandReplaceFacts, 1)
+    end
   end
 
   def find(request)
-    begin
-      response = http_get(request, "/v3/nodes/#{CGI.escape(request.key)}/facts", headers)
-      log_x_deprecation_header(response)
+    profile "facts#find" do
+      begin
+        url = "/v3/nodes/#{CGI.escape(request.key)}/facts"
+        response = profile "Query for nodes facts: #{url}" do
+          http_get(request, url, headers)
+        end
+        log_x_deprecation_header(response)
 
-      if response.is_a? Net::HTTPSuccess
-        result = JSON.parse(response.body)
-        # Note: the Inventory Service API appears to expect us to return nil here
-        # if the node isn't found.  However, PuppetDB returns an empty array in
-        # this case; for now we will just look for that condition and assume that
-        # it means that the node wasn't found, so we will return nil.  In the
-        # future we may want to improve the logic such that we can distinguish
-        # between the "node not found" and the "no facts for this node" cases.
-        if result.empty?
-          return nil
+        if response.is_a? Net::HTTPSuccess
+          profile "Parse fact query response (size: #{response.body.size})" do
+            result = JSON.parse(response.body)
+            # Note: the Inventory Service API appears to expect us to return nil here
+            # if the node isn't found.  However, PuppetDB returns an empty array in
+            # this case; for now we will just look for that condition and assume that
+            # it means that the node wasn't found, so we will return nil.  In the
+            # future we may want to improve the logic such that we can distinguish
+            # between the "node not found" and the "no facts for this node" cases.
+            if result.empty?
+              return nil
+            end
+            facts = result.inject({}) do |a,h|
+              a.merge(h['name'] => h['value'])
+            end
+            Puppet::Node::Facts.new(request.key, facts)
+          end
+        else
+          # Newline characters cause an HTTP error, so strip them
+          raise "[#{response.code} #{response.message}] #{response.body.gsub(/[\r\n]/, '')}"
         end
-        facts = result.inject({}) do |a,h|
-          a.merge(h['name'] => h['value'])
-        end
-        Puppet::Node::Facts.new(request.key, facts)
-      else
-        # Newline characters cause an HTTP error, so strip them
-        raise "[#{response.code} #{response.message}] #{response.body.gsub(/[\r\n]/, '')}"
+      rescue => e
+        raise Puppet::Error, "Failed to find facts from PuppetDB at #{self.class.server}:#{self.class.port}: #{e}"
       end
-    rescue => e
-      raise Puppet::Error, "Failed to find facts from PuppetDB at #{self.class.server}:#{self.class.port}: #{e}"
     end
   end
 
@@ -62,40 +74,47 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
   # `operator` may be one of {eq, ne, lt, gt, le, ge}, and will default to 'eq'
   # if unspecified.
   def search(request)
-    return [] unless request.options
-    operator_map = {
-      'eq' => '=',
-      'gt' => '>',
-      'lt' => '<',
-      'ge' => '>=',
-      'le' => '<=',
-    }
-    filters = request.options.sort.map do |key,value|
-      type, name, operator = key.to_s.split('.')
-      operator ||= 'eq'
-      raise Puppet::Error, "Fact search against keys of type '#{type}' is unsupported" unless type == 'facts'
-      if operator == 'ne'
-        ['not', ['=', ['fact', name], value]]
-      else
-        [operator_map[operator], ['fact', name], value]
+    profile "facts#search" do
+      return [] unless request.options
+      operator_map = {
+        'eq' => '=',
+        'gt' => '>',
+        'lt' => '<',
+        'ge' => '>=',
+        'le' => '<=',
+      }
+      filters = request.options.sort.map do |key,value|
+        type, name, operator = key.to_s.split('.')
+        operator ||= 'eq'
+        raise Puppet::Error, "Fact search against keys of type '#{type}' is unsupported" unless type == 'facts'
+        if operator == 'ne'
+          ['not', ['=', ['fact', name], value]]
+        else
+          [operator_map[operator], ['fact', name], value]
+        end
       end
-    end
 
-    query = ["and"] + filters
-    query_param = CGI.escape(query.to_json)
+      query = ["and"] + filters
+      query_param = CGI.escape(query.to_json)
 
-    begin
-      response = http_get(request, "/v3/nodes?query=#{query_param}", headers)
-      log_x_deprecation_header(response)
+      begin
+        url = "/v3/nodes?query=#{query_param}"
+        response = profile "Fact query request: #{URI.unescape(url)}" do
+          http_get(request, url, headers)
+        end
+        log_x_deprecation_header(response)
 
-      if response.is_a? Net::HTTPSuccess
-        JSON.parse(response.body).collect {|s| s["name"]}
-      else
-        # Newline characters cause an HTTP error, so strip them
-        raise "[#{response.code} #{response.message}] #{response.body.gsub(/[\r\n]/, '')}"
+        if response.is_a? Net::HTTPSuccess
+          profile "Parse fact query response (size: #{response.body.size})" do
+            JSON.parse(response.body).collect {|s| s["name"]}
+          end
+        else
+          # Newline characters cause an HTTP error, so strip them
+          raise "[#{response.code} #{response.message}] #{response.body.gsub(/[\r\n]/, '')}"
+        end
+      rescue => e
+        raise Puppet::Error, "Could not perform inventory search from PuppetDB at #{self.class.server}:#{self.class.port}: #{e}"
       end
-    rescue => e
-      raise Puppet::Error, "Could not perform inventory search from PuppetDB at #{self.class.server}:#{self.class.port}: #{e}"
     end
   end
 


### PR DESCRIPTION
This patch adds some select profiling blocks to the PuppetDB terminus code.

The profiler is provided by puppet core from Puppet::Util::Puppetdb#profile,
which has recently become public for our use. We provide here in our own utils
library our own wrapper implementation that can be mixed in.

Key areas of our terminus functionality have now been profiled with this
patch:
- Entry points are profiled and identified by their entry methods (save, find,
  search etc.)
- Remote calls, HTTP gets/posts
- Code that does any form of encoding/decoding that might be potentially slow
  at capacity.

The style of messages I've used follow along with the existing Puppet profiling
examples already in place so as to be readable together. We have prefixed our
profile message with "PuppetDB" for easy searchability also.

I have provided a small FAQ entry that explains in brief the process of
debugging, although we lack something to link to in Puppet for a more detailed
explanation. This will probably need to be fixed if better documentation comes
available.

Signed-off-by: Ken Barber ken@bob.sh
