### PR TITLE
Unpin beaker now that 1.7.0 is released

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,5 @@ group :test do
 end
 
 group :acceptance do
-#  gem 'beaker', '~> 1.0'
-  # TODO: this needs to be changed back once 1.6.3 of beaker is released
-  gem 'beaker', :git => 'git://github.com/puppetlabs/beaker', :ref => 'c7a388a484e4c53735a5d84bce93f844881290dc'
+  gem 'beaker', '~> 1.7'
 end


### PR DESCRIPTION
We had a pinned version of beaker. This patch unpins it now that the code that
we need has been released.

Signed-off-by: Ken Barber ken@bob.sh
