### PR TITLE
PDB-470 Provide new db setting 'statements-cache-size' with a default of...

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -355,6 +355,12 @@ The maximum time (in minutes) a pooled connection should remain open. Any connec
 
 If not supplied, we won't terminate connections based on their age alone.
 
+###`statements-cache-size`
+
+This setting defines how many prepared statements are cached automatically. For a large amount of dynamic queries this number could be increased to increase performance, at the cost of memory consumption and database resources.
+
+If not supplied, we default to 1000.
+
 `[read-database]` Settings
 -----
 

--- a/src/com/puppetlabs/jdbc.clj
+++ b/src/com/puppetlabs/jdbc.clj
@@ -284,7 +284,7 @@
   "Create a new database connection pool"
   [{:keys [classname subprotocol subname user username password
            partition-conn-min partition-conn-max partition-count
-           stats log-statements log-slow-statements
+           stats log-statements log-slow-statements statements-cache-size
            conn-max-age conn-lifetime conn-keep-alive read-only?]
     :as   db}]
   ;; Load the database driver class
@@ -303,6 +303,7 @@
                           ;; paste the URL back together from parts.
                           (.setJdbcUrl (str "jdbc:" subprotocol ":" subname))
                           (.setConnectionHook (connection-hook log-statements log-slow-statements-duration))
+                          (.setStatementsCacheSize statements-cache-size)
                           (.setDefaultReadOnly read-only?))
         user (or user username)]
     ;; configurable without default

--- a/src/com/puppetlabs/puppetdb/config.clj
+++ b/src/com/puppetlabs/puppetdb/config.clj
@@ -41,7 +41,8 @@
    (s/optional-key :partition-conn-max) (pls/defaulted-maybe s/Int 25)
    (s/optional-key :partition-count) (pls/defaulted-maybe s/Int 1)
    (s/optional-key :stats) (pls/defaulted-maybe String "true")
-   (s/optional-key :log-statements) (pls/defaulted-maybe String "true")})
+   (s/optional-key :log-statements) (pls/defaulted-maybe String "true")
+   (s/optional-key :statements-cache-size) (pls/defaulted-maybe s/Int 1000)})
 
 (def write-database-config-in
   "Includes the common database config params, also the write-db specific ones"
@@ -66,6 +67,7 @@
    :partition-count s/Int
    :stats pls/SchemaBoolean
    :log-statements pls/SchemaBoolean
+   :statements-cache-size s/Int
    (s/optional-key :conn-lifetime) (s/maybe pls/Minutes)
    (s/optional-key :username) String
    (s/optional-key :password) String


### PR DESCRIPTION
... 1000

This setting adjusts how many SQL prepared statements get cached via BoneCP.

By using this setting we've seen an almost 40% decrease in wall clock time it
takes to insert into resource_params_cache for a new catalog (as an example).

This patch adds the new configuration item as a user configurable one, with a
default set to 1000 for now. Documentation has also been added for this
setting.

Signed-off-by: Ken Barber ken@bob.sh
