### PR TITLE
Aded Archlinux build/install support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -117,6 +117,8 @@ case @osfamily
     @plibdir = @pe ? PE_SITELIBDIR : (%x(ruby -rrbconfig -e "puts RbConfig::CONFIG['sitelibdir']").chomp)
   when /openbsd/
     @plibdir = @pe ? PE_SITELIBDIR : '/usr/local/lib/ruby/site_ruby/1.9.1'
+  when /Archlinux/
+    @plibdir = @pe ? PE_SITELIBDIR : '/usr/lib/ruby/gems/2.1.0'
 end
 
 @heap_dump_path = "#{@log_dir}/puppetdb-oom.hprof"

--- a/tasks/install.rake
+++ b/tasks/install.rake
@@ -100,6 +100,14 @@ task :install => [  JAR_FILE  ] do
     cp_p "ext/files/puppetdb.openbsd.init", "#{DESTDIR}/etc/rc.d/#{@name}.rc"
     cp_p "ext/files/puppetdb.env", "#{DESTDIR}/#{@libexec_dir}/#{@name}.env"
     chmod 0755, "#{DESTDIR}/etc/rc.d/#{@name}.rc"
+  elsif @osfamily == "archlinux"
+    #systemd!
+    mkdir_p "#{DESTDIR}/etc/sysconfig"
+    mkdir_p "#{DESTDIR}/usr/lib/systemd/system"
+    cp_p "ext/files/puppetdb.default.systemd", "#{DESTDIR}/etc/sysconfig/#{@name}"
+    cp_p "ext/files/puppetdb.env", "#{DESTDIR}/#{@libexec_dir}/#{@name}.env"
+    cp_p "ext/files/systemd/#{@name}.service", "#{DESTDIR}/usr/lib/systemd/system"
+    chmod 0644, "#{DESTDIR}/usr/lib/systemd/system/#{@name}.service"
   else
     raise "Unknown or unsupported osfamily: #{@osfamily}"
   end


### PR DESCRIPTION
Added Archlinux support,

Only issue is at the moment that it is hardcoded to '/usr/lib/ruby/gems/2.1.0/
need a way to make this autodetect where ruby gem dir is.

Puppetdb redhat initscript already work on archlinux
