### PR TITLE
(maint) Add RHEL7 to list of mocks to build against

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -9,7 +9,7 @@ gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-fedora-19-i386 pl-fedora-20-i386'
+final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-i386 pl-fedora-19-i386 pl-fedora-20-i386'
 yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE


### PR DESCRIPTION
As per Ken, this has been retargeted at 1.5.x, with an eye on rolling it up into 1.6.x. We're only adding a mock listing for RHEL7 x86_64, since there is currently no 32-bit RHEL7 platform.
