### PR TITLE
(maint) Replace shell logic for OS release with Facter

### DIFF
--- a/ext/redhat/puppetdb.spec.erb
+++ b/ext/redhat/puppetdb.spec.erb
@@ -84,12 +84,12 @@ Group:         System Environment/Daemons
 %endif
 
 <% if @pe -%>
-BuildRequires: pe-facter >= 1.6.2, pe-puppet
+BuildRequires: pe-facter >= 1.7.0, pe-puppet
 BuildRequires: pe-rubygem-rake
 BuildRequires: pe-ruby
 Requires:      pe-puppet >= 2.7.12
 <% else -%>
-BuildRequires: facter >= 1.6.8
+BuildRequires: facter >= 1.7.0
 BuildRequires: puppet >= 2.7.12
 BuildRequires: rubygem-rake
 BuildRequires: ruby

--- a/tasks/install.rake
+++ b/tasks/install.rake
@@ -63,7 +63,7 @@ task :install => [  JAR_FILE  ] do
   # figure out which init script to install based on facter
   if @osfamily == "redhat"
     @operatingsystem = Facter.value(:operatingsystem).downcase
-    @operatingsystemrelease = `cat /etc/redhat-release | awk '{print $3}'`.chomp
+    @operatingsystemrelease = Facter.value(:operatingsystemmajrelease)
     puts "operatingsystem is #{@operatingsystem}"
     puts "operatingsystemrelease is #{@operatingsystemrelease}"
     if (@operatingsystem == "fedora" && @operatingsystemrelease.to_i >= 17) || (@operatingsystem =~ /redhat|centos/ && @operatingsystemrelease.to_f >= 7 )


### PR DESCRIPTION
To generate the correct init script components, install.rake
was shelling out to get a static field from /etc/redhat-release.
This is a fragile technique and Facter uses a much more robust
technique to derive the correct value across numerous RPM-based
platforms. This technique was part of the 1.7.x Facter branch,
so a build-time dependency has been added on Facter 1.7.0 or greater.
