### PR TITLE
PDB-453 Add environments to all termini

### DIFF
--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -19,10 +19,14 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
         facts = request.instance.dup
         facts.values = facts.values.dup
         facts.stringify
-        {"name" => facts.name, "values" => facts.values}.to_json
+        {
+          "name" => facts.name,
+          "values" => facts.values,
+          "environment" => request.environment,
+        }.to_json
       end
 
-      submit_command(request.key, payload, CommandReplaceFacts, 1)
+      submit_command(request.key, payload, CommandReplaceFacts, 2)
     end
   end
 

--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -18,7 +18,7 @@ Puppet::Reports.register_report(:puppetdb) do
 
   def process
     profile "report#process" do
-      submit_command(self.host, report_to_hash, CommandStoreReport, 2)
+      submit_command(self.host, report_to_hash, CommandStoreReport, 3)
     end
   end
 
@@ -55,7 +55,8 @@ Puppet::Reports.register_report(:puppetdb) do
           "configuration-version"   => configuration_version.to_s,
           "start-time"              => Puppet::Util::Puppetdb.to_wire_time(time),
           "end-time"                => Puppet::Util::Puppetdb.to_wire_time(time + run_duration),
-          "resource-events"         => build_events_list
+          "resource-events"         => build_events_list,
+          "environment"             => environment,
         })
     end
   end

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -19,6 +19,7 @@ describe Puppet::Node::Facts::Puppetdb do
     let(:response) { Net::HTTPOK.new('1.1', 200, 'OK') }
     let(:facts)    { Puppet::Node::Facts.new('foo') }
     let(:http)     { mock 'http' }
+    let(:env)      { "my_environment" }
 
     before :each do
       Puppet::Network::HttpPool.expects(:http_instance).returns http
@@ -26,15 +27,20 @@ describe Puppet::Node::Facts::Puppetdb do
     end
 
     def save
-      subject.save(Puppet::Node::Facts.indirection.request(:save, facts.name, facts))
+      subject.save(Puppet::Node::Facts.indirection.request(:save, facts.name, facts, :environment => env))
     end
 
     it "should POST the facts as a JSON string" do
       facts.stringify
-      f = {"name" => facts.name, "values" => facts.values}
+      f = {
+        "name" => facts.name,
+        "values" => facts.values,
+        "environment" => env,
+      }
+
       payload = {
         :command => CommandReplaceFacts,
-        :version => 1,
+        :version => 2,
         :payload => f.to_pson,
       }.to_json
 

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -36,7 +36,7 @@ describe processor do
 
       payload = {
         :command => Puppet::Util::Puppetdb::CommandNames::CommandStoreReport,
-        :version => 2,
+        :version => 3,
         :payload => subject.send(:report_to_hash),
       }.to_json
 


### PR DESCRIPTION
This patch ensures that the request environment is sent to PuppetDB inside
the payloads for the object types: facts, catalogs & reports. To support this
we bump the command version as per PDB-452.

The new version of catalog requires a flattening, which this patch provides.

Signed-off-by: Ken Barber ken@bob.sh
