### PR TITLE
NEEDS TESTS: fix storeconfig export for array values (PDB-518)

### DIFF
--- a/puppet/lib/puppet/face/storeconfigs.rb
+++ b/puppet/lib/puppet/face/storeconfigs.rb
@@ -134,7 +134,12 @@ Puppet::Face.define(:storeconfigs, '0.0.1') do
 
   def resource_to_hash(resource)
     parameters = resource.param_values.inject({}) do |params,param_value|
-      params.merge(param_value.param_name.name => param_value.value)
+      if params.has_key?(param_value.param_name.name)
+        value = [params[param_value.param_name.name],param_value.value].flatten
+      else
+        value = param_value.value
+      end
+      params.merge(param_value.param_name.name => value)
     end
 
     tags = resource.puppet_tags.map(&:name).uniq.sort


### PR DESCRIPTION
For exported Resources with parameters which value is a Array the storeconfig export fails to collect them. Instead of collecting all the parameter values into a array it simply override the value with each value in turn.
