### PR TITLE
Use the puppet agent configprint to get local certificate informations

### DIFF
--- a/ext/templates/puppetdb-ssl-setup
+++ b/ext/templates/puppetdb-ssl-setup
@@ -237,11 +237,11 @@ fi
 
 set -e
 
-mycertname=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint  certname`
+mycertname=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint  certname`
 
-orig_public_file=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint  hostcert`
-orig_private_file=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint hostprivkey`
-orig_ca_file=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint localcacert`
+orig_public_file=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint  hostcert`
+orig_private_file=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint hostprivkey`
+orig_ca_file=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint localcacert`
 
 ssl_dir=${puppetdb_confdir}/ssl
 


### PR DESCRIPTION
As described in PDB-143 it should be better to ask for the agent version
of certificate related informations. This will also work on nodes where
no puppet master is configured.
