### PR TITLE
PDB-453 Normalize request.environment with to_s to avoid 'stack level to...

### DIFF
--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -22,7 +22,10 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
         {
           "name" => facts.name,
           "values" => facts.values,
-          "environment" => request.environment,
+          # PDB-453: we call to_s to avoid a 'stack level too deep' error
+          # when we attempt to use ActiveSupport 2.3.16 on RHEL 5 with
+          # legacy storeconfigs.
+          "environment" => request.environment.to_s,
         }.to_json
       end
 


### PR DESCRIPTION
...o deep'

Without calling to_s we get:

```
Info: Connecting to sqlite3 database: /tmp/storeconfigs.sqlite3.x30558
Error: stack level too deep
... snip ...
/usr/lib/ruby/gems/1.8/gems/activesupport-2.3.16/lib/active_support/json/encoders/hash.rb:37:in `each'
/usr/lib/ruby/gems/1.8/gems/activesupport-2.3.16/lib/active_support/json/encoders/hash.rb:37:in `map'
/usr/lib/ruby/gems/1.8/gems/activesupport-2.3.16/lib/active_support/json/encoders/hash.rb:37:in `to_json'
/usr/lib/ruby/site_ruby/1.8/puppet/indirector/facts/puppetdb.rb:26:in `save'
/usr/lib/ruby/site_ruby/1.8/puppet/util/profiler/none.rb:6:in `profile'
/usr/lib/ruby/site_ruby/1.8/puppet/util/profiler.rb:31:in `profile'
/usr/lib/ruby/site_ruby/1.8/puppet/util/puppetdb.rb:90:in `profile'
/usr/lib/ruby/site_ruby/1.8/puppet/indirector/facts/puppetdb.rb:18:in `save'
... snip ...
/usr/bin/puppet:4
```

When running on RHEL 5 with ActiveSupport 2.3.16 when attempting to use the
legacy storeconfigs_backend=activerecord. This is important to us, because
we want people to use our tooling to migrate.

Signed-off-by: Ken Barber ken@bob.sh
