### PR TITLE
Removed unused command attribute "puppetdb-version"

### DIFF
--- a/src/com/puppetlabs/puppetdb/catalog/utils.clj
+++ b/src/com/puppetlabs/puppetdb/catalog/utils.clj
@@ -18,7 +18,7 @@
       (update-in [:resources] vals)
       (update-in [:edges] (fn [edges]
                             (map #(update-in % [:relationship] name) edges)))
-      (dissoc :puppetdb-version :api-version)
+      (dissoc :api-version)
       (set/rename-keys {:certname :name})
       walk/stringify-keys))
 

--- a/src/com/puppetlabs/puppetdb/catalogs.clj
+++ b/src/com/puppetlabs/puppetdb/catalogs.clj
@@ -97,15 +97,15 @@
   (:use [clojure.core.match :only [match]]))
 
 (def ^:const catalog-version
-  ^{:doc "Constant representing the version number of the PuppetDB
-  catalog format"}
-  (Integer. 3))
+  "Constant representing the version number of the PuppetDB
+  catalog format"
+  3)
 
 (def ^:const valid-relationships
   #{:contains :required-by :notifies :before :subscription-of})
 
 (def ^:const catalog-attributes
-  #{:certname :puppetdb-version :api-version :transaction-uuid :version :edges :resources :environment})
+  #{:certname :api-version :transaction-uuid :version :edges :resources :environment})
 
 (def v4-catalog-attributes
   (disj catalog-attributes :api-version))
@@ -250,14 +250,12 @@
 (defn transform-metadata
   "Standardizes the metadata in the given `catalog`. In particular:
     * Stringifies the `version`
-    * Adds a `puppetdb-version` with the current catalog format version
     * Renames `api_version` to `api-version`
     * Renames `name` to `certname`
     * If we don't have  a `transaction-uuid` key, adds one with a value of `nil`."
   [catalog]
   {:pre [(map? catalog)]
    :post [(string? (:version %))
-          (= (:puppetdb-version %) catalog-version)
           (:certname %)
           (= (:certname %) (:name catalog))
           (= (:api-version %) (:api_version catalog))
@@ -267,7 +265,6 @@
           (contains? % :transaction-uuid)]}
   (-> catalog
       (update-in [:version] str)
-      (assoc :puppetdb-version catalog-version)
       (set/rename-keys {:name :certname :api_version :api-version})))
 
 (def transform

--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -76,7 +76,6 @@
   {(s/optional-key :api-version) s/Int
    :version String
    :certname String
-   :puppetdb-version s/Int
    :resources resource-ref->resource-schema
    :edges #{edge-schema}
    (s/optional-key :transaction-uuid) (s/maybe s/Str)

--- a/test/com/puppetlabs/puppetdb/examples.clj
+++ b/test/com/puppetlabs/puppetdb/examples.clj
@@ -1,10 +1,8 @@
-(ns com.puppetlabs.puppetdb.examples
-  (:use [com.puppetlabs.puppetdb.catalogs :only [catalog-version]]))
+(ns com.puppetlabs.puppetdb.examples)
 
 (def catalogs
   {:empty
    {:certname         "empty.catalogs.com"
-    :puppetdb-version catalog-version
     :api-version      1
     :version          "1330463884"
     :edges            #{{:source       {:type "Stage" :title "main"}
@@ -31,7 +29,6 @@
 
    :basic
    {:certname         "basic.catalogs.com"
-    :puppetdb-version catalog-version
     :api-version      1
     :transaction-uuid "68b08e2a-eeb1-4322-b241-bfdf151d294b"
     :environment      "DEV"
@@ -68,7 +65,6 @@
 
    :invalid
    {:certname         "invalid.catalogs.com"
-    :puppetdb-version catalog-version
     :api-version      1
     :transaction-uuid "68b08e2a-eeb1-4322-b241-bfdf151d294b"
     :version          123456789

--- a/test/com/puppetlabs/puppetdb/test/catalogs.clj
+++ b/test/com/puppetlabs/puppetdb/test/catalogs.clj
@@ -43,7 +43,7 @@
         (let [catalog  {:data {:name "myhost" :version "12345" :foo "bar" :transaction-uuid "HIYA"}
                         :metadata {:api_version 1}}]
           (is (= (transform-fn (assoc-in catalog [:data :transaction-uuid] "HIYA"))
-                {:certname "myhost" :version "12345" :api-version 1 :foo "bar" :puppetdb-version catalog-version :transaction-uuid "HIYA"}))))
+                {:certname "myhost" :version "12345" :api-version 1 :foo "bar" :transaction-uuid "HIYA"}))))
 
       (testing "should error on malformed input"
         (is (thrown? AssertionError (transform-fn {})))
@@ -250,7 +250,6 @@
 
     {:certname "nick-lewis.puppetlabs.lan",
      :api-version 1,
-     :puppetdb-version catalog-version,
      :edges #{{:source {:title "/tmp/baz", :type "File"},
                :target {:title "/tmp/bar", :type "File"},
                :relationship :required-by}
@@ -424,7 +423,6 @@
 
     {:certname "nick-lewis.puppetlabs.lan",
      :api-version 1,
-     :puppetdb-version catalog-version,
      :edges #{{:source {:title "/tmp/baz", :type "File"},
                :target {:title "/tmp/bar", :type "File"},
                :relationship :required-by}
@@ -600,7 +598,6 @@
 
     {:certname "nick-lewis.puppetlabs.lan",
      :api-version 1,
-     :puppetdb-version catalog-version,
      :edges #{{:source {:title "/tmp/baz", :type "File"},
                :target {:title "/tmp/bar", :type "File"},
                :relationship :required-by}

--- a/test/com/puppetlabs/puppetdb/test/scf/hash.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/hash.clj
@@ -188,9 +188,8 @@
           ;; Functions that tweak various attributes of a catalog
           tweak-api-version  #(assoc % :api-version (inc (:api-version %)))
           tweak-version      #(assoc % :version (str (:version %) "?"))
-          tweak-puppetdb-version #(assoc % :puppetdb-version (inc (:puppetdb-version %)))
           ;; List of all the tweaking functions
-          chaos-monkeys      [tweak-api-version tweak-version tweak-puppetdb-version]
+          chaos-monkeys      [tweak-api-version tweak-version]
           ;; Function that will apply a random tweak function
           apply-monkey       #((rand-nth chaos-monkeys) %)]
 


### PR DESCRIPTION
Best I can tell it's not really being used anywhere and it's not being stored. Currently it's always being populated with 3.
