### PR TITLE
WIP Fixed 'same file' error when running rake install

### DIFF
--- a/tasks/install.rake
+++ b/tasks/install.rake
@@ -39,7 +39,7 @@ task :install => [  JAR_FILE  ] do
     mkdir_p "#{DESTDIR}/etc/puppetlabs/puppetdb"
   end
 
-  cp_p JAR_FILE, "#{DESTDIR}/#{@install_dir}"
+  cp_p JAR_FILE, "#{DESTDIR}/#{@install_dir}" unless File.exist?(JAR_FILE)
   cp_pr "ext/files/config.ini", "#{DESTDIR}/#{@config_dir}"
   cp_pr "ext/files/database.ini", "#{DESTDIR}/#{@config_dir}"
   cp_pr "ext/files/jetty.ini", "#{DESTDIR}/#{@config_dir}"


### PR DESCRIPTION
Setup:

CentOS 6.5 x86_64
RVM Ruby - 1.9.3
Puppet Gem - 3.4.3
Facter Gem - 1.7.5
Java (openjdk) - 1.7.0_51

When trying to install PuppetDB from source, I noticed that I was getting this error when I ran `rake install`:

```
# rake install
mkdir -p //usr/share/puppetdb
mkdir -p //etc/puppetdb/conf.d
mkdir -p //etc/puppetdb/conf.d/..
mkdir -p //var/log/puppetdb
mkdir -p /etc/init.d/
mkdir -p //var/lib/puppetdb
mkdir -p //usr/libexec/puppetdb
mkdir -p //usr/sbin
mkdir -p /etc/logrotate.d/
ln -sf /etc/puppetdb/conf.d //var/lib/puppetdb/config
ln -sf /var/log/puppetdb //usr/share/puppetdb/log
mkdir -p /var/lib/puppetdb/state
mkdir -p /var/lib/puppetdb/db
mkdir -p /var/lib/puppetdb/mq
ln -sf /var/lib/puppetdb/state /usr/share/puppetdb/state
ln -sf /var/lib/puppetdb/db /usr/share/puppetdb/db
ln -sf /var/lib/puppetdb/mq /usr/share/puppetdb/mq
mkdir -p /etc/puppetdb
cp -p puppetdb.jar //usr/share/puppetdb
rake aborted!
same file: puppetdb.jar and //usr/share/puppetdb/puppetdb.jar
```

I tried setting :force, but it didn't recognize the option so I went with using unless File.exists? to fix it.

I'll bring up how I got to this point as well, because I had to deviate from the documentation even just to get to this point.
1. git clone and cd into /usr/share/puppetdb (I cloned branch 1.6.x)
2. "echo `git describe --always --dirty` > version" so that I don't end up with puppetdb-0.0-dev-build.jar & puppetdb-0.0-dev-build-standalone.jar files in puppetdb/target.  If I don't `rake install` fails like so:

```
# rake install
lein uberjar
Compiling com.puppetlabs.puppetdb.core
Compiling clj-time.core
Compiling com.puppetlabs.puppetdb.core
Created /usr/share/puppetdb/target/puppetdb-0.0-dev-build.jar
Created /usr/share/puppetdb/target/puppetdb-0.0-dev-build-standalone.jar
mv target/puppetdb-1.6.3-standalone.jar puppetdb.jar
rake aborted!
No such file or directory - target/puppetdb-1.6.3-standalone.jar
```
1. run `rake package:bootstrap` so that the [puppetlabs/packaging](https://github.com/puppetlabs/packaging) repo gets put in puppetdb/ext/. Otherwise I get this error (this is also if I manually resolve the first error by creating puppetdb/puppetdb.jar):

```
# rake install
rm -rf ext/files pkg
mkdir -p ext/files/debian
rake aborted!
uninitialized constant Pkg
```
1. Once all those 3 steps have been done, I can then run `rake install` with some success until it tries to cp puppetdb.jar in the same directory (unnecessary?) 

```
# rake install
lein uberjar
Compiling com.puppetlabs.puppetdb.core
Compiling clj-time.core
Compiling com.puppetlabs.puppetdb.core
Created /usr/share/puppetdb/target/puppetdb-1.6.3.jar
Created /usr/share/puppetdb/target/puppetdb-1.6.3-standalone.jar
mv target/puppetdb-1.6.3-standalone.jar puppetdb.jar
rm -rf ext/files pkg
mkdir -p ext/files/debian
Generated: ext/files/log4j.properties
Generated: ext/files/config.ini
Generated: ext/files/jetty.ini
Generated: ext/files/repl.ini
Generated: ext/files/database.ini
Generated: ext/files/puppetdb-foreground
Generated: ext/files/puppetdb-import
Generated: ext/files/puppetdb-export
Generated: ext/files/puppetdb-anonymize
Generated: ext/files/puppetdb
Generated: ext/files/puppetdb-legacy
Generated: ext/files/puppetdb.debian.init
Generated: ext/files/puppetdb.env
chmod 700 ext/files/puppetdb-foreground
chmod 700 ext/files/puppetdb-import
chmod 700 ext/files/puppetdb-export
chmod 700 ext/files/puppetdb-anonymize
cp -p ext/templates/puppetdb-ssl-setup ext/files
chmod 700 ext/files/puppetdb-ssl-setup
chmod 700 ext/files/puppetdb
chmod 700 ext/files/puppetdb-legacy
Generated: ext/files/debian/puppetdb.init
Generated: ext/files/debian/puppetdb.default
Generated: ext/files/debian/control
Generated: ext/files/debian/puppetdb.prerm
Generated: ext/files/debian/puppetdb.postrm
Generated: ext/files/debian/puppetdb.install
Generated: ext/files/debian/puppetdb-terminus.install
Generated: ext/files/debian/rules
Generated: ext/files/debian/changelog
Generated: ext/files/debian/puppetdb.preinst
Generated: ext/files/debian/puppetdb.postinst
Generated: ext/files/debian/puppetdb.logrotate
chmod 755 ext/files/debian/rules
cp -rp ext/templates/deb/copyright ext/templates/deb/source ext/templates/deb/gbp.conf ext/templates/deb/compat ext/templates/deb/lintian-overrides ext/files/debian
mkdir -p ext/files/dev/redhat
mkdir -p ext/files/systemd
Generated: ext/files/puppetdb.spec
Generated: ext/files/puppetdb.logrotate
Generated: ext/files/puppetdb.redhat.init
Generated: ext/files/puppetdb.suse.init
Generated: ext/files/puppetdb.default
Generated: ext/files/dev/redhat/redhat_dev_preinst
Generated: ext/files/dev/redhat/redhat_dev_postinst
Generated: ext/files/puppetdb.openbsd.init
Generated: ext/files/systemd/puppetdb.service
Generated: ext/files/puppetdb.default.systemd
chmod 644 ext/files/systemd/puppetdb.service
mkdir -p //usr/share/puppetdb
mkdir -p //etc/puppetdb/conf.d
mkdir -p //etc/puppetdb/conf.d/..
mkdir -p //var/log/puppetdb
mkdir -p /etc/init.d/
mkdir -p //var/lib/puppetdb
mkdir -p //usr/libexec/puppetdb
mkdir -p //usr/sbin
mkdir -p /etc/logrotate.d/
ln -sf /etc/puppetdb/conf.d //var/lib/puppetdb/config
ln -sf /var/log/puppetdb //usr/share/puppetdb/log
mkdir -p /var/lib/puppetdb/state
mkdir -p /var/lib/puppetdb/db
mkdir -p /var/lib/puppetdb/mq
ln -sf /var/lib/puppetdb/state /usr/share/puppetdb/state
ln -sf /var/lib/puppetdb/db /usr/share/puppetdb/db
ln -sf /var/lib/puppetdb/mq /usr/share/puppetdb/mq
mkdir -p /etc/puppetdb
cp -p puppetdb.jar //usr/share/puppetdb
rake aborted!
same file: puppetdb.jar and //usr/share/puppetdb/puppetdb.jar
```

If my workaround is acceptable great! If not, maybe I'm going about this all wrong? Should the documentation be updated to say that you may need to `rake package:bootstrap` beforehand? If you'd like me test anything, or would like anymore information, please let me know.
