### PR TITLE
WIP (maint) have beaker tests use the host.hostname instead of host.name

### DIFF
--- a/acceptance/tests/soft_fail/soft_write_fail.rb
+++ b/acceptance/tests/soft_fail/soft_write_fail.rb
@@ -17,7 +17,7 @@ test_name "soft write failure" do
     start_puppetdb(database)
   end
 
-  names = hosts.map(&:name)
+  names = hosts.map(&:hostname)
   tmpdir = master.tmpdir('storeconfigs')
 
   manifest_file_export = manifest_file_collect = nil

--- a/acceptance/tests/storeconfigs/basic_collection.rb
+++ b/acceptance/tests/storeconfigs/basic_collection.rb
@@ -3,7 +3,7 @@ test_name "general collection should get all exported resources except the host'
     clear_and_restart_puppetdb(database)
   end
 
-  names = hosts.map(&:name)
+  names = hosts.map(&:hostname)
 
   manifest = names.map do |name|
     <<-PIECE


### PR DESCRIPTION
- when you want the current hostname use host.hostname, for some
  provisioners host.name is the name provided by the user but the
  current hostname is generated on the fly and thus different.

This will depend on https://github.com/puppetlabs/beaker/pull/205 landing and being rolled into a gem - we may want to pin to a beaker version to ensure that this works once the update rolls out.
