### PR TITLE
(PDB-454) - Added environment support for querying reports, events, event-counts and aggregate-event-counts

### DIFF
--- a/documentation/api/query/v4/aggregate-event-counts.markdown
+++ b/documentation/api/query/v4/aggregate-event-counts.markdown
@@ -5,6 +5,7 @@ canonical: "/puppetdb/latest/api/query/v4/aggregate-event-counts.html"
 ---
 
 [event-counts]: ./event-counts.html
+[events]: ./events.html
 [curl]: ../curl.html
 
 > **Note:** The v4 API is experimental and may change without notice. For stability, it is recommended that you use the v3 API instead.
@@ -23,7 +24,7 @@ This endpoint builds on top of the [`event-counts`][event-counts] endpoint and w
 parameters. Supported parameters are listed below for reference.
 
 * `query`: Required. A JSON array of query predicates in prefix form (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`).
-This query is forwarded to the [`event-counts`][event-counts] endpoint - see there for additional documentation.
+This query is forwarded to the [`events`][events] endpoint - see there for additional documentation.
 
 * `summarize-by`: Required. A string specifying which type of object you'd like count. Supported values are
 `resource`, `containing-class`, and `certname`.

--- a/documentation/api/query/v4/events.markdown
+++ b/documentation/api/query/v4/events.markdown
@@ -158,6 +158,9 @@ operators.
 value of this field is always boolean (`true` or `false` without quotes), and it
 is not supported by the regex match operator.
 
+`environment`
+: the environment associated with the reporting node
+
 ##### Notes on fields that allow `NULL` values
 
 In the case of a `skipped` resource event, some of the fields of an event may

--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -42,6 +42,9 @@ The only available [OPERATOR][] is `=`.
 : the id of the report; these ids can be acquired
   via event queries (see the [`/events`][event] query endpoint).
 
+`environment`
+: the environment associated to report's node
+
 #### Response format
 
 The response is a JSON array of report summaries for all reports

--- a/src/com/puppetlabs/puppetdb/http.clj
+++ b/src/com/puppetlabs/puppetdb/http.clj
@@ -48,3 +48,8 @@
   "Removes environment from a seq of results"
   [version rows]
   (map #(remove-environment % version) rows))
+
+(defn v4?
+  "Returns a function that always returns true if `version` is :v4"
+  [version]
+  (constantly (= :v4 version)))

--- a/src/com/puppetlabs/puppetdb/http/events.clj
+++ b/src/com/puppetlabs/puppetdb/http/events.clj
@@ -62,7 +62,7 @@
       (-> query
           (json/parse-string true)
           ((partial query/query->sql version query-options))
-          ((partial query/limited-query-resource-events limit paging-options))
+          ((partial query/limited-query-resource-events version limit paging-options))
           (query-result-response)))
     (catch com.fasterxml.jackson.core.JsonParseException e
       (pl-http/error-response e))

--- a/src/com/puppetlabs/puppetdb/http/v3.clj
+++ b/src/com/puppetlabs/puppetdb/http/v3.clj
@@ -63,7 +63,7 @@
    {:any (aec/aggregate-event-counts-app version)}
 
    ["reports" &]
-   {:any reports/reports-app}
+   {:any (reports/reports-app version)}
 
    ["server-time" &]
    {:any st/server-time-app}))

--- a/src/com/puppetlabs/puppetdb/http/v4.clj
+++ b/src/com/puppetlabs/puppetdb/http/v4.clj
@@ -63,7 +63,7 @@
    {:any (aec/aggregate-event-counts-app version)}
 
    ["reports" &]
-   {:any reports/reports-app}
+   {:any (reports/reports-app version)}
 
    ["server-time" &]
    {:any st/server-time-app}))

--- a/src/com/puppetlabs/puppetdb/query.clj
+++ b/src/com/puppetlabs/puppetdb/query.clj
@@ -62,7 +62,8 @@
 ;;
 (ns com.puppetlabs.puppetdb.query
   (:require [clojure.string :as string]
-            [clojure.set :as set])
+            [clojure.set :as set]
+            [com.puppetlabs.puppetdb.http :refer [v4?]])
   (:use [puppetlabs.kitchensink.core :only [parse-number keyset valset order-by-expr?]]
         [com.puppetlabs.puppetdb.scf.storage-utils :only [db-serialize sql-as-numeric sql-array-query-string sql-regexp-match sql-regexp-array-match]]
         [com.puppetlabs.jdbc :only [valid-jdbc-query? limited-query-to-vec query-to-vec paged-sql count-sql get-result-count]]
@@ -323,12 +324,6 @@
   (let [{:keys [where params]} (compile-term ops query)
         sql (format "SELECT %s FROM certnames WHERE %s" (column-map->sql node-columns) where)]
     (apply vector sql params)))
-
-(defn v4?
-  "When `version` is :v4, returns a function that will always
-   return true, otherwise will always return false"
-  [version]
-  (constantly (= version :v4)))
 
 (defn compile-resource-equality
   "Compile an = operator for a resource query. `path` represents the field

--- a/test/com/puppetlabs/puppetdb/examples/reports.clj
+++ b/test/com/puppetlabs/puppetdb/examples/reports.clj
@@ -243,15 +243,3 @@
   "Removes the environment key (keyword or string) from a catalog"
   [catalog]
   (dissoc catalog :environment "environment"))
-
-(defn report=
-  "Checks to see that reports are equal. Can also compare lists of catalogs.
-   Ignores environment so results queried from the web api cand be compared with
-   the command values. This function is not needed once the query API supports
-   returning environments"
-  [& args]
-  (apply = (map #(if (seq? %)
-                   (map dissoc-env %)
-                   (dissoc-env %))
-                args)))
-

--- a/test/com/puppetlabs/puppetdb/test/cli/export.clj
+++ b/test/com/puppetlabs/puppetdb/test/cli/export.clj
@@ -5,7 +5,6 @@
             [com.puppetlabs.cheshire :as json]
             [com.puppetlabs.puppetdb.testutils.catalogs :as testcat]
             [com.puppetlabs.puppetdb.testutils.reports :as testrep]
-            [com.puppetlabs.puppetdb.examples.reports :refer [report=]]
             [com.puppetlabs.puppetdb.cli.export :as export]
             [com.puppetlabs.puppetdb.command :as command]
             [com.puppetlabs.puppetdb.command.constants :refer [command-names]]
@@ -35,10 +34,9 @@
             original-report      (clojure.walk/keywordize-keys (json/parse-string original-report-str))]
         (testrep/store-example-report! original-report "2012-10-09T22:15:17-07:00")
 
-        ;; This is explicitly set to v3, as per the current CLI tooling
-        (let [exported-report (first (r/reports-for-node :v3 "myhost.localdomain"))]
-          (is (report= (testrep/munge-report-for-comparison original-report)
-                       (testrep/munge-report-for-comparison exported-report)))))))
+        (let [exported-report (first (r/reports-for-node :v4 "myhost.localdomain"))]
+          (is (= (testrep/munge-report-for-comparison original-report)
+                 (testrep/munge-report-for-comparison exported-report)))))))
 
   (testing "Export metadata"
     (let [{:keys [msg file-suffix contents]} (export/export-metadata)

--- a/test/com/puppetlabs/puppetdb/test/http/paging.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/paging.clj
@@ -22,7 +22,6 @@
                     "/v4/nodes"
                     "/v4/reports"
                     "/v4/resources"]]
-
     (testing (str endpoint " 'order-by' should properly handle malformed JSON input")
       (let [malformed-JSON  "[{\"field\":\"status\" \"order\":\"DESC\"}]"
             response        (*app* (get-request endpoint

--- a/test/com/puppetlabs/puppetdb/test/http/v4/event_counts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v4/event_counts.clj
@@ -106,3 +106,116 @@
                        "distinct-start-time" 0
                        "distinct-end-time" (now)})]
       (response-equal? response expected))))
+
+(deftest query-with-environment
+  (store-example-report! (:basic reports) (now))
+  (store-example-report! (assoc (:basic2 reports)
+                           :certname "bar.local"
+                           :environment "PROD") (now))
+  (are [result query] (response-equal? (get-response endpoint
+                                                     query
+                                                     "resource"
+                                                     {"distinct-resources" false
+                                                      "distinct-start-time" 0
+                                                      "distinct-end-time" (now)})
+                                       result)
+       #{{:subject-type "resource"
+          :subject {:type "Notify" :title "notify, yo"}
+          :failures 0
+          :successes 1
+          :noops 0
+          :skips 0}
+         {:subject-type "resource"
+          :subject {:type "Notify" :title "notify, yar"}
+          :failures 0
+          :successes 1
+          :noops 0
+          :skips 0}
+         {:subject-type "resource"
+          :subject {:type "Notify" :title "hi"}
+          :failures 0
+          :successes 0
+          :noops 0
+          :skips 1}}
+       ["=" "environment" "DEV"]
+
+       #{{:subject-type "resource"
+          :subject {:type "Notify" :title "notify, yo"}
+          :failures 0
+          :successes 1
+          :noops 0
+          :skips 0}
+         {:subject-type "resource"
+          :subject {:type "Notify" :title "notify, yar"}
+          :failures 0
+          :successes 1
+          :noops 0
+          :skips 0}
+         {:subject-type "resource"
+          :subject {:type "Notify" :title "hi"}
+          :failures 0
+          :successes 0
+          :noops 0
+          :skips 1}}
+       ["~" "environment" "DE.*"]
+
+       #{{:subject-type "resource"
+          :subject {:type "Notify" :title "notify, yo"}
+          :failures 0
+          :successes 1
+          :noops 0
+          :skips 0}
+         {:subject-type "resource"
+          :subject {:type "Notify" :title "notify, yar"}
+          :failures 0
+          :successes 1
+          :noops 0
+          :skips 0}
+         {:subject-type "resource"
+          :subject {:type "Notify" :title "hi"}
+          :failures 0
+          :successes 0
+          :noops 0
+          :skips 1}}
+       ["not" ["=" "environment" "PROD"]]
+
+       #{{:subject-type "resource"
+          :subject {:type "Notify" :title "notify, yo"}
+          :failures 0
+          :successes 1
+          :noops 0
+          :skips 0}
+         {:subject-type "resource"
+          :subject {:type "Notify" :title "notify, yar"}
+          :failures 0
+          :successes 1
+          :noops 0
+          :skips 0}
+         {:subject-type "resource"
+          :subject {:type "Notify" :title "hi"}
+          :failures 0
+          :successes 0
+          :noops 0
+          :skips 1}
+         {:subject-type "resource",
+          :noops 0,
+          :skips 0,
+          :successes 1,
+          :failures 0,
+          :subject {:type "File", :title "tmp-directory"}}
+         {:subject-type "resource",
+          :noops 0,
+          :skips 0,
+          :successes 1,
+          :failures 0,
+          :subject {:type "File", :title "puppet-managed-file"}}
+         {:subject-type "resource",
+          :noops 0,
+          :skips 0,
+          :successes 1,
+          :failures 0,
+          :subject
+          {:type "Notify", :title "Creating tmp directory at /Users/foo/tmp"}}}
+       ["OR"
+        ["=" "environment" "PROD"]
+        ["=" "environment" "DEV"]]))

--- a/test/com/puppetlabs/puppetdb/test/http/v4/events.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v4/events.clj
@@ -3,7 +3,8 @@
             [puppetlabs.kitchensink.core :as kitchensink]
             [com.puppetlabs.http :as pl-http]
             [com.puppetlabs.puppetdb.scf.storage :as scf-store]
-            [cheshire.core :as json])
+            [cheshire.core :as json]
+            [com.puppetlabs.puppetdb.testutils.events :refer [http-expected-resource-events]])
   (:use clojure.test
         [clojure.walk :only [stringify-keys]]
         ring.mock.request
@@ -39,26 +40,6 @@
   ;; tests.
   (map #(kitchensink/maptrans {[:old-value :new-value] stringify-keys} %) events))
 
-(defn expected-resource-event-response
-  [resource-event report]
-  (-> resource-event
-    ;; the examples don't include the report hash or config version,
-    ;; so we munge them into place
-    (assoc-in [:report] (:hash report))
-    (assoc-in [:configuration-version] (:configuration-version report))
-    (assoc-in [:run-start-time] (to-string (:start-time report)))
-    (assoc-in [:run-end-time] (to-string (:end-time report)))
-    (assoc-in [:report-receive-time] (to-string (:receive-time report)))
-    ;; the timestamps are already strings, but calling to-string on them forces
-    ;; them to be coerced to dates and then back to strings, which normalizes
-    ;; the timezone so that it will match the value returned form the db.
-    (update-in [:timestamp] to-string)
-    (dissoc :test-id)))
-
-(defn expected-resource-events-response
-  [resource-events report]
-  (set (map #(expected-resource-event-response % report) resource-events)))
-
 (deftest query-by-report
   (let [basic             (store-example-report! (:basic reports) (now))
         basic-events      (get-in reports [:basic :resource-events])
@@ -69,7 +50,7 @@
 
     (testing "should return the list of resource events for a given report hash"
       (let [response (get-response ["=" "report" report-hash])
-            expected (expected-resource-events-response basic-events basic)]
+            expected (http-expected-resource-events :v4 basic-events basic)]
         (response-equal? response expected munge-event-values)))
 
     (testing "query exceeding event-query-limit"
@@ -88,43 +69,46 @@
 
         (testing "should support single term timestamp queries"
           (let [response (get-response ["<" "timestamp" end-time])
-                expected (expected-resource-events-response
-                            (kitchensink/select-values basic-events-map [1 3])
-                            basic)]
+                expected (http-expected-resource-events
+                          :v4
+                          (kitchensink/select-values basic-events-map [1 3])
+                          basic)]
             (response-equal? response expected munge-event-values)))
 
         (testing "should support compound timestamp queries"
           (let [response (get-response ["and" [">" "timestamp" start-time]
-                                              ["<" "timestamp" end-time]])
-                expected (expected-resource-events-response
-                            (kitchensink/select-values basic-events-map [3])
-                            basic)]
+                                        ["<" "timestamp" end-time]])
+                expected (http-expected-resource-events
+                          :v4
+                          (kitchensink/select-values basic-events-map [3])
+                          basic)]
             (response-equal? response expected munge-event-values)))))
 
     (testing "compound queries"
       (doseq [[query matches]
               [[["and"
-                  ["or"
-                    ["=" "resource-title" "hi"]
-                    ["=" "resource-title" "notify, yo"]]
-                  ["=" "status" "success"]]                       [1]]
+                 ["or"
+                  ["=" "resource-title" "hi"]
+                  ["=" "resource-title" "notify, yo"]]
+                 ["=" "status" "success"]]                       [1]]
                [["or"
-                  ["and"
-                    ["=" "resource-title" "hi"]
-                    ["=" "status" "success"]]
-                  ["and"
-                    ["=" "resource-type" "Notify"]
-                    ["=" "property" "message"]]]                  [1 2]]
+                 ["and"
+                  ["=" "resource-title" "hi"]
+                  ["=" "status" "success"]]
+                 ["and"
+                  ["=" "resource-type" "Notify"]
+                  ["=" "property" "message"]]]                  [1 2]]
                [["and"
-                  ["=" "status" "success"]
-                  ["<" "timestamp" "2011-01-01T12:00:02-03:00"]]  [1]]
+                 ["=" "status" "success"]
+                 ["<" "timestamp" "2011-01-01T12:00:02-03:00"]]  [1]]
                [["or"
-                  ["=" "status" "skipped"]
-                  ["<" "timestamp" "2011-01-01T12:00:02-03:00"]]  [1 3]]]]
+                 ["=" "status" "skipped"]
+                 ["<" "timestamp" "2011-01-01T12:00:02-03:00"]]  [1 3]]]]
         (let [response  (get-response query)
-              expected  (expected-resource-events-response
-                          (kitchensink/select-values basic-events-map matches)
-                          basic)]
+              expected  (http-expected-resource-events
+                         :v4
+                         (kitchensink/select-values basic-events-map matches)
+                         basic)]
           (response-equal? response expected munge-event-values))))
 
 
@@ -132,22 +116,23 @@
                             ["with" true]]]
       (testing (str "should support paging through events " label " counts")
         (let [results (paged-results
-                        {:app-fn  *app*
-                         :path    endpoint
-                         :query   ["=" "report" report-hash]
-                         :limit   1
-                         :total   (count basic-events)
-                         :include-total  count?
-                         :params  {:order-by (json/generate-string [{"field" "status"}])}})]
+                       {:app-fn  *app*
+                        :path    endpoint
+                        :query   ["=" "report" report-hash]
+                        :limit   1
+                        :total   (count basic-events)
+                        :include-total  count?
+                        :params  {:order-by (json/generate-string [{"field" "status"}])}})]
           (is (= (count basic-events) (count results)))
-          (is (= (expected-resource-events-response
-                   basic-events
-                   basic)
-                (set (munge-event-values results)))))))
+          (is (= (http-expected-resource-events
+                  :v4
+                  basic-events
+                  basic)
+                 (set (munge-event-values results)))))))
 
     (testing "order-by field names"
       (testing "should accept dashes"
-        (let [expected  (expected-resource-events-response basic-events basic)
+        (let [expected  (http-expected-resource-events :v4 basic-events basic)
               response  (get-response [">", "timestamp", 0] {:order-by (json/generate-string [{:field "resource-title"}])})]
           (is (= (:status response) pl-http/status-ok))
           (response-equal? response expected munge-event-values)))
@@ -190,7 +175,7 @@
               body))))
 
     (testing "should return only one event for a given resource"
-      (let [expected  (expected-resource-events-response basic3-events basic3)
+      (let [expected  (http-expected-resource-events :v4 basic3-events basic3)
             response  (get-response ["=", "certname", "foo.local"] {:distinct-resources true
                                                                     :distinct-start-time 0
                                                                     :distinct-end-time (now)})]
@@ -198,7 +183,7 @@
         (response-equal? response expected munge-event-values)))
 
     (testing "events should be contained within distinct resource timestamps"
-      (let [expected  (expected-resource-events-response basic-events basic)
+      (let [expected  (http-expected-resource-events :v4 basic-events basic)
             response  (get-response ["=", "certname", "foo.local"]
                                     {:distinct-resources true
                                      :distinct-start-time 0
@@ -225,13 +210,13 @@
         basic3-events (get-in reports [:basic3 :resource-events])]
 
     (testing "query by report start time"
-      (let [expected  (expected-resource-events-response basic-events basic)
+      (let [expected  (http-expected-resource-events :v4 basic-events basic)
             response  (get-response ["<", "run-start-time" "2011-01-02T00:00:00-03:00"])]
         (assert-success! response)
         (response-equal? response expected munge-event-values)))
 
     (testing "query by report end time"
-      (let [expected  (expected-resource-events-response basic3-events basic3)
+      (let [expected  (http-expected-resource-events :v4 basic3-events basic3)
             response  (get-response [">", "run-end-time" "2011-01-02T00:00:00-03:00"])]
         (assert-success! response)
         (response-equal? response expected munge-event-values)))
@@ -248,7 +233,7 @@
         basic           (store-example-report! (:basic reports) (now))
         basic-events    (get-in reports [:basic :resource-events])]
     (testing "query by report receive time"
-      (let [expected  (expected-resource-events-response basic-events basic)
+      (let [expected  (http-expected-resource-events :v4 basic-events basic)
             response  (get-response [">", "report-receive-time" (to-string test-start-time)])]
         (assert-success! response)
         (response-equal? response expected munge-event-values)))

--- a/test/com/puppetlabs/puppetdb/test/scf/migrate.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/migrate.clj
@@ -73,49 +73,7 @@
       (migrate!)
       (sql/insert-record :schema_migrations
                          {:version (inc migrate/desired-schema-version) :time (to-timestamp (now))})
-      (is (thrown? IllegalStateException (migrate!)))))
-
-  (testing "burgundy migration should populate the new `latest_reports` table correctly"
-    (sql/with-connection db
-      (clear-db-for-testing!)
-      (let [latest-report-migration   13
-            applied                   (range 1 latest-report-migration)
-            basic                     (:basic reports)
-            old-timestamp             (ago (days 1))
-            older-timestamp           (ago (days 2))
-            new-timestamp             (now)
-            node1                     "foocertname"
-            node2                     "barcertname"
-            store-report-fn           (fn [certname end-time received-time]
-                                        (store-v2-example-report!
-                                          (-> basic
-                                            (assoc :certname certname
-                                                   :end-time end-time)
-                                            dissoc-env)
-                                          received-time
-                                          false))]
-        ;; first we run all of the schema migrations *prior* to the
-        ;; introduction of the `latest_reports` table
-        (doseq [i applied]
-          (apply-migration-for-testing i))
-        ;; now we create a few reports for a few nodes.
-        ;; we'll make the `received-time` older for the newest report,
-        ;; to make sure that `latest_reports` table is being populated
-        ;; by `end-time` and not by `received-time`
-        (store-report-fn node1 new-timestamp (ago (secs 20)))
-        (store-report-fn node1 old-timestamp (now))
-        (store-report-fn node1 older-timestamp (now))
-        (store-report-fn node2 new-timestamp (ago (secs 30)))
-        (store-report-fn node2 old-timestamp (now))
-        (store-report-fn node2 older-timestamp (now))
-        ;; now we finish the migration (which should introduce the `latest_reports`
-        ;; table and populate it.
-        (migrate!)
-        ;; now we can validate the data from the migration.
-        (let [latest_reports (query-to-vec "SELECT latest_reports.*, reports.end_time from latest_reports INNER JOIN reports ON latest_reports.report = reports.hash")]
-          (is (= 2 (count latest_reports)))
-          (doseq [report latest_reports]
-            (is (= (:end_time report) (to-timestamp new-timestamp)))))))))
+      (is (thrown? IllegalStateException (migrate!))))))
 
 (deftest migration-14
   (testing "building parameter cache"

--- a/test/com/puppetlabs/puppetdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/storage.clj
@@ -16,7 +16,7 @@
             [puppetlabs.trapperkeeper.testutils.logging :as pllog]
             [clojure.string :as str])
   (:use [com.puppetlabs.puppetdb.examples :only [catalogs]]
-        [com.puppetlabs.puppetdb.examples.reports :only [reports report=]]
+        [com.puppetlabs.puppetdb.examples.reports :only [reports]]
         [com.puppetlabs.puppetdb.testutils.reports]
         [com.puppetlabs.puppetdb.testutils.events]
         [com.puppetlabs.puppetdb.query.reports :only [is-latest-report?]]
@@ -989,8 +989,8 @@
             certname      (:certname report1)
             _             (delete-reports-older-than! (ago (days 3)))
             expected      (expected-reports [(assoc report2 :hash report2-hash)])
-            actual        (reports-query-result ["=" "certname" certname])]
-        (is (report= expected actual)))))
+            actual        (reports-query-result :v4 ["=" "certname" certname])]
+        (is (= expected actual)))))
 
   (deftest resource-events-cleanup
     (testing "should delete all events for reports older than the specified age"

--- a/test/com/puppetlabs/puppetdb/testutils/reports.clj
+++ b/test/com/puppetlabs/puppetdb/testutils/reports.clj
@@ -75,7 +75,7 @@
     (validate-fn)
     (scf-store/maybe-activate-node! (:certname example-report) timestamp)
     (scf-store/add-report!* example-report timestamp update-latest-report?)
-    (query/report-for-hash report-hash)))
+    (query/report-for-hash :v4 report-hash)))
 
 (defn store-example-report!
   "See store-example-reports*! calls that, passing in a version 3 validation function"
@@ -106,23 +106,24 @@
   (map expected-report example-reports))
 
 (defn raw-reports-query-result
-  [query paging-options]
+  [version query paging-options]
   (letfn [(munge-fn
             [reports]
             (map #(dissoc % :receive-time) reports))]
     ;; the example reports don't have a receive time (because this is
     ;; calculated by the server), so we remove this field from the response
     ;; for test comparison
-    (update-in (->> (query/report-query->sql query)
-                    (query/query-reports paging-options))
+    (update-in (->> query
+                    (query/report-query->sql version)
+                    (query/query-reports :v4 paging-options))
                [:result]
                munge-fn)))
 
 (defn reports-query-result
-  ([query]
-   (reports-query-result query nil))
-  ([query paging-options]
-   (:result (raw-reports-query-result query paging-options))))
+  ([version query]
+   (reports-query-result version query nil))
+  ([version query paging-options]
+   (:result (raw-reports-query-result version query paging-options))))
 
 (defn get-events-map
   [example-report]


### PR DESCRIPTION
This commit has the last set of environment query API changes. Reports and events
both allowing environment in the query criteria and return environments in the result.
Event counts and aggregate event counts allow events in the query criteria.
