### PR TITLE
(PDB-457) - Update import/export/anonymization for v4 API

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -374,7 +374,7 @@ module PuppetDBExtensions
 
 
     ############################################################################
-    # NOTE: A lot of the differences between the PE and FOSS manifests here is 
+    # NOTE: A lot of the differences between the PE and FOSS manifests here is
     #   only necessary because the puppetdb::database::postgresql module
     #   doesn't parameterize things like the service name. It would be nice
     #   to simplify this once we've added more paramters to the module.
@@ -726,9 +726,9 @@ EOS
 
   def munge_catalog_for_comparison(cat_path)
     meta = JSON.parse(File.read(cat_path))
-    munged_resources = meta["data"]["resources"].map { |resource| munge_resource_for_comparison(resource) }
-    meta["data"]["resources"] = Set.new(munged_resources)
-    meta["data"]["edges"] = Set.new(meta["data"]["edges"])
+    munged_resources = meta["resources"].map { |resource| munge_resource_for_comparison(resource) }
+    meta["resources"] = Set.new(munged_resources)
+    meta["edges"] = Set.new(meta["edges"])
     meta
   end
 

--- a/project.clj
+++ b/project.clj
@@ -85,6 +85,7 @@
   :profiles {:dev {:resource-paths ["test-resources"],
                    :dependencies [[ring-mock "0.1.5"]
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
+                                  [puppetlabs/kitchensink ~ks-version :classifier "test"]
                                   [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version :classifier "test"]
                                   [org.flatland/ordered "1.5.2"]]}}
 

--- a/src/com/puppetlabs/puppetdb/anonymizer.clj
+++ b/src/com/puppetlabs/puppetdb/anonymizer.clj
@@ -57,8 +57,8 @@
   ;; that the master gives us.
   (and
     (map? catalog)
-    (contains? catalog "data")
-    (contains? catalog "metadata")))
+    (contains? catalog "name")
+    (contains? catalog "version")))
 
 ;; Rules engine functions
 
@@ -154,7 +154,8 @@
         :line (rand-int 300)
         :transaction-uuid (uuid)
         :fact-name (random-string 15)
-        :fact-value (random-string 30)))))
+        :fact-value (random-string 30)
+        :environment (random-string 15)))))
 
 (defn anonymize-leaf
   "Anonymize leaf data, if the context matches a rule"
@@ -370,12 +371,13 @@
   [config catalog]
   {:pre  [(catalog? catalog)]
    :post [(catalog? %)]}
-  (let [context {"node" (get catalog ["data" "name"])}]
+  (let [context {"node" (get catalog ["name"])}]
     (-> catalog
-      (update-in ["data" "resources"]        anonymize-resources context config)
-      (update-in ["data" "edges"]            anonymize-edges context config)
-      (update-in ["data" "name"]             anonymize-leaf :node context config)
-      (update-in ["data" "transaction-uuid"] anonymize-leaf :transaction-uuid context config))))
+      (update-in ["resources"]        anonymize-resources context config)
+      (update-in ["edges"]            anonymize-edges context config)
+      (update-in ["name"]             anonymize-leaf :node context config)
+      (update-in ["transaction-uuid"] anonymize-leaf :transaction-uuid context config)
+      (update-in ["environment"] anonymize-leaf :environment context config))))
 
 (defn anonymize-report
   "Anonymize a report"
@@ -386,7 +388,8 @@
     (-> report
       (update-in ["certname"]         anonymize-leaf :node context config)
       (update-in ["resource-events"]  anonymize-resource-events context config)
-      (update-in ["transaction-uuid"] anonymize-leaf :transaction-uuid context config))))
+      (update-in ["transaction-uuid"] anonymize-leaf :transaction-uuid context config)
+      (update-in ["environment"] anonymize-leaf :environment context config))))
 
 (defn anonymize-fact-values
   "Anonymizes fact names and values"
@@ -405,4 +408,5 @@
   (let [context {"node" (get wire-facts "name")}]
     (-> wire-facts
         (update-in ["name"] anonymize-leaf :node context config)
-        (update-in ["values"] anonymize-fact-values context config))))
+        (update-in ["values"] anonymize-fact-values context config)
+        (update-in ["environment"] anonymize-leaf :environment context config))))

--- a/src/com/puppetlabs/puppetdb/cli/anonymize.clj
+++ b/src/com/puppetlabs/puppetdb/cli/anonymize.clj
@@ -99,7 +99,10 @@
                                   "productname" "ps" "puppetversion" "rubysitedir" "rubyversion" "/^selinux.*/"
                                   "swapencrypted" "/^swapfree.*/" "/^swapsize.*/" "timezone" "/^uptime.*/" "virtual"]}
           "anonymize" false}
-         {"context" {} "anonymize" true}]}
+         {"context" {} "anonymize" true}]
+
+        "environment"
+        [{"context" {} "anonymize" true}]}
     }
     "low" {
       "rules" {
@@ -147,6 +150,8 @@
          {"context" {"fact-name" ["/password/" "/pwd/" "/secret/" "/key/" "/private/"]}
           "anonymize" true}
          {"context" {} "anonymize" false}]
+
+        "environment" [{"context" {} "anonymize" false}]
       }
     }
     "none" {
@@ -162,6 +167,7 @@
         "transaction-uuid" [ {"context" {} "anonymize" false} ]
         "fact-name" [{"context" {} "anonymize" false}]
         "fact-value" [{"context" {} "anonymize" false}]
+        "environment" [{"context" {} "anonymize" false}]
       }
     }
   })

--- a/src/com/puppetlabs/puppetdb/cli/import.clj
+++ b/src/com/puppetlabs/puppetdb/cli/import.clj
@@ -74,7 +74,7 @@
 (defn submit-facts
   "Send the given wire-format `facts` (associated with `host`) to a
   command-processing endpoint located at `puppetdb-host`:`puppetdb-port`."
-  [puppetdb-host puppetdb-port fact-payload]
+  [puppetdb-host puppetdb-port facts-version fact-payload]
   {:pre  [(string?  puppetdb-host)
           (integer? puppetdb-port)
           (string?  fact-payload)]}
@@ -83,7 +83,7 @@
         result  (command/submit-command-via-http!
                  puppetdb-host puppetdb-port
                  (command-names :replace-facts)
-                 1
+                 facts-version
                  fact-payload)]
     (when-not (= pl-http/status-ok (:status result))
       (log/error result))))
@@ -118,7 +118,7 @@
         (archive/read-entry-content tar-reader)))
     (when (re-find (re-pattern facts-pattern) path)
       (println (format "Importing facts from archive entry '%s'" path))
-      (submit-facts host port
+      (submit-facts host port (get-in metadata [:command-versions :replace-facts])
         (archive/read-entry-content tar-reader)))))
 
 (defn- validate-cli!

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -212,10 +212,19 @@
           (log/warnf "%s rejected by certificate whitelist %s" ssl-client-cn whitelist)
           false)))))
 
+(defn shutdown-mq-broker
+  "Explicitly shut down the queue `broker`"
+  [{:keys [broker]}]
+  (when broker
+    (log/info "Shutting down message broker.")
+    ;; Stop the mq the old-fashioned way
+    (mq/stop-broker! broker)))
+
 (defn stop-puppetdb
   "Callback to execute any necessary cleanup during a normal shutdown."
   [context]
   (log/info "Shutdown request received; puppetdb exiting.")
+  (shutdown-mq-broker context)
   context)
 
 (defn error-shutdown!
@@ -231,10 +240,7 @@
     (log/info "Shutting down updater thread.")
     (future-cancel updater))
 
-  (when-let [broker (context :broker)]
-    (log/info "Shutting down message broker.")
-    ;; Stop the mq the old-fashioned way
-    (mq/stop-broker! broker)))
+  (shutdown-mq-broker context))
 
 
 (defn start-puppetdb

--- a/src/com/puppetlabs/puppetdb/command.clj
+++ b/src/com/puppetlabs/puppetdb/command.clj
@@ -222,7 +222,7 @@
             (map? command-map)]}
      (let [message (json/generate-string command-map)
            checksum (kitchensink/utf8-string->sha1 message)
-           url     (format "http://%s:%s/v3/commands?checksum=%s" host port checksum)]
+           url     (format "http://%s:%s/v4/commands?checksum=%s" host port checksum)]
        (client/post url {:body               message
                          :throw-exceptions   false
                          :content-type       :json
@@ -350,7 +350,7 @@
                                    payload)
         id                       (:id annotations)
         timestamp                (:received annotations)]
-    
+
     (jdbc/with-transacted-connection' db :repeatable-read
       (scf-storage/maybe-activate-node! name timestamp)
       (scf-storage/replace-facts! facts timestamp))
@@ -374,7 +374,7 @@
   [version db {:keys [payload annotations]}]
   (let [id          (:id annotations)
         report      (upon-error-throw-fatality
-                      (report/validate! version payload))
+                     (report/validate! version payload))
         certname    (:certname report)
         timestamp   (:received annotations)]
     (jdbc/with-transacted-connection db

--- a/test/com/puppetlabs/puppetdb/examples.clj
+++ b/test/com/puppetlabs/puppetdb/examples.clj
@@ -143,7 +143,7 @@
   "Converts a v3 wire catalog to v4"
   [catalog]
   (-> catalog
-      v1->v2-catalog
+      v2->v3-catalog
       :data
       (assoc :environment "DEV")))
 
@@ -168,4 +168,4 @@
                                               :parameters {:ensure "directory"
                                                            :group  "root"
                                                            :user   "root"}}))}
-   4 {:empty (v3->v4-catalog (:data v1-empty-wire-catalog))}})
+   4 {:empty (v3->v4-catalog v1-empty-wire-catalog)}})

--- a/test/com/puppetlabs/puppetdb/examples/reports.clj
+++ b/test/com/puppetlabs/puppetdb/examples/reports.clj
@@ -24,6 +24,7 @@
           :timestamp        "2011-01-01T12:00:01-03:00"
           :resource-type    "Notify"
           :resource-title   "notify, yo"
+          :environment      "DEV"
           :property         "message"
           :new-value        "notify, yo"
           :old-value        ["what" "the" "woah"]
@@ -37,6 +38,7 @@
           :status           "success"
           :timestamp        "2011-01-01T12:00:03-03:00"
           :resource-type    "Notify"
+          :environment      "DEV"
           :resource-title   "notify, yar"
           :property         "message"
           :new-value        {"absent" 5}
@@ -50,6 +52,7 @@
           :certname         "foo.local"
           :status           "skipped"
           :timestamp        "2011-01-01T12:00:02-03:00"
+          :environment      "DEV"
           :resource-type    "Notify"
           :resource-title   "hi"
           :property         nil

--- a/test/com/puppetlabs/puppetdb/test/cli/export.clj
+++ b/test/com/puppetlabs/puppetdb/test/cli/export.clj
@@ -1,14 +1,10 @@
 (ns com.puppetlabs.puppetdb.test.cli.export
   (:require [com.puppetlabs.puppetdb.query.catalogs :as c]
             [com.puppetlabs.puppetdb.query.reports :as r]
-            [com.puppetlabs.puppetdb.query.events :as e]
             [com.puppetlabs.cheshire :as json]
             [com.puppetlabs.puppetdb.testutils.catalogs :as testcat]
             [com.puppetlabs.puppetdb.testutils.reports :as testrep]
-            [com.puppetlabs.puppetdb.cli.export :as export]
-            [com.puppetlabs.puppetdb.command :as command]
-            [com.puppetlabs.puppetdb.command.constants :refer [command-names]]
-            [com.puppetlabs.puppetdb.testutils.repl :as turepl])
+            [com.puppetlabs.puppetdb.cli.export :as export])
   (:use  [clojure.java.io :only [resource]]
          clojure.test
          [com.puppetlabs.puppetdb.fixtures]))
@@ -41,10 +37,9 @@
   (testing "Export metadata"
     (let [{:keys [msg file-suffix contents]} (export/export-metadata)
           metadata (json/parse-string contents true)]
-      (is (= {:replace-catalog 3
-              :store-report 2
-              :replace-facts 1}
+      (is (= {:replace-catalog 4
+              :store-report 3
+              :replace-facts 2}
              (:command-versions metadata)))
       (is (= ["export-metadata.json"] file-suffix))
       (is (= "Exporting PuppetDB metadata" msg)))))
-

--- a/test/com/puppetlabs/puppetdb/test/cli/import_export_roundtrip.clj
+++ b/test/com/puppetlabs/puppetdb/test/cli/import_export_roundtrip.clj
@@ -1,0 +1,234 @@
+(ns com.puppetlabs.puppetdb.test.cli.import-export-roundtrip
+  (:require [com.puppetlabs.puppetdb.cli.export :as export]
+            [com.puppetlabs.puppetdb.cli.import :as import]
+            [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
+            [com.puppetlabs.puppetdb.cli.services :refer [puppetdb-service]]
+            [puppetlabs.trapperkeeper.core :as tk]
+            [clojure.test :refer :all]
+            [com.puppetlabs.puppetdb.testutils :as testutils]
+            [fs.core :as fs]
+            [puppetlabs.kitchensink.core :as kitchensink]
+            [com.puppetlabs.puppetdb.fixtures :as fixt]
+            [puppetlabs.trapperkeeper.app :as tka]
+            [clj-http.client :as client]
+            [com.puppetlabs.cheshire :as json]
+            [com.puppetlabs.puppetdb.command.constants :refer [command-names]]
+            [com.puppetlabs.puppetdb.examples :refer [wire-catalogs]]
+            [puppetlabs.trapperkeeper.testutils.bootstrap :as tkbs]
+            [com.puppetlabs.puppetdb.testutils.catalogs :as tuc]
+            [com.puppetlabs.puppetdb.command :as command]
+            [com.puppetlabs.puppetdb.examples.reports :refer [reports]]
+            [com.puppetlabs.puppetdb.testutils.reports :as tur]
+            [clojure.walk :as walk]
+            [clj-time.core :refer [now]]
+            [com.puppetlabs.archive :as archive]
+            [com.puppetlabs.puppetdb.utils :as utils]
+            [slingshot.slingshot :refer [throw+]]))
+
+(def ^:dynamic *port* nil)
+
+(defn current-port
+  "Given a trapperkeeper server, return the port of the running jetty instance.
+   Note there can be more than one port (i.e. SSL + non-SSL connector). This only
+   returns the first one."
+  [server]
+  (-> @(tka/app-context server)
+      (get-in [:WebserverService :jetty9-server :server])
+      .getConnectors
+      first
+      .getLocalPort))
+
+(defn create-config
+  "Creates a default config, populated with a temporary vardir and
+   a fresh hypersql instance"
+  []
+  {:repl {},
+   :global {:vardir (testutils/temp-dir)},
+   :jetty {:port 0},
+   :database (fixt/create-db-map) ,
+   :command-processing {}})
+
+(defn current-url
+  "Uses the dynamically bound port to create a v4 URL to the
+   currently running PuppetDB instance"
+  []
+  (format "http://localhost:%s/v4/" *port*))
+
+(defn puppetdb-instance
+  "Stands up a puppetdb instance with `config`, tears down once `f` returns.
+   If the port is assigned by Jetty, use *port* to get the currently running port."
+  ([f] (puppetdb-instance (create-config) f))
+  ([config f]
+     (tkbs/with-app-with-config server
+       [jetty9-service puppetdb-service]
+       config
+       (binding [*port* (current-port server)]
+         (f)))))
+
+(defn current-queue-depth
+  "Return the queue depth currently running PuppetDB instance (see `puppetdb-instance` for launching PuppetDB)"
+  []
+  (-> (format "%smetrics/mbean/org.apache.activemq:BrokerName=localhost,Type=Queue,Destination=com.puppetlabs.puppetdb.commands" (current-url))
+      (client/get {:as :json})
+      (get-in [:body :QueueSize])))
+
+(defn block-until-queue-empty
+  "Blocks the current thread until all messages from the queue have been processed."
+  []
+  (loop [depth (current-queue-depth)]
+    (when (< 0 depth)
+      (Thread/sleep 10)
+      (recur (current-queue-depth)))))
+
+(defn submit-command
+  "Submits a command to the running PuppetDB, launched by `puppetdb-instance`."
+  [cmd-kwd version payload]
+  (command/submit-command-via-http! "localhost" *port* (command-names cmd-kwd) version payload))
+
+(defn block-until-results-fn
+  "Executes `f`, if results are found, return them, otherwise
+   wait and try again. Will throw an exception if results aren't found
+   after 100 tries"
+  [f]
+  (loop [count 0
+         results (f)]
+    (cond
+     (seq results)
+     results
+
+     (< 100 count)
+     (throw+ "Results not found after 100 iterations, giving up")
+
+     :else
+     (do
+       (Thread/sleep 100)
+       (recur (inc count) (f))))))
+
+(defmacro block-until-results
+  "Body is some expression that will be executed in a future. All
+   errors from the body of the macro are ignored. Will block until
+   results are returned from the body of the macro"
+  [& body]
+  `(future
+     (block-until-results-fn
+      (fn []
+        (try
+          (do ~@body)
+          (catch Exception e#
+            ;; Ignore
+            ))))))
+
+(defn block-on-node
+  "Waits for the queue to be empty, then blocks until the catalog, facts and reports are all
+   found for `node-name`. Ensures that the commands have been stored before proceeding in a test."
+  [node-name]
+  (block-until-queue-empty)
+  (let [catalog-fut (block-until-results (json/parse-string (export/catalog-for-node "localhost" *port* node-name)))
+        report-fut (block-until-results (export/reports-for-node "localhost" *port* node-name))
+        facts-fut (block-until-results (export/facts-for-node "localhost" *port* node-name))]
+    @catalog-fut
+    @report-fut
+    @facts-fut))
+
+(deftest test-basic-roundtrip
+  (let [facts {:name "foo.local"
+               :environment "DEV"
+               :values {:foo "the foo"
+                        :bar "the bar"
+                        :baz "the baz"}}
+        export-out-file (testutils/temp-file "export-test" ".tar.gz")
+        catalog (-> (get-in wire-catalogs [4 :empty])
+                    (assoc :name "foo.local"))
+        report (:basic reports)]
+
+    (puppetdb-instance
+     (fn []
+
+       (is (empty? (export/get-nodes "localhost" *port*)))
+       (submit-command :replace-catalog 4 catalog)
+       (submit-command :store-report 3 (tur/munge-example-report-for-storage report))
+       (submit-command :replace-facts 2 (json/generate-string facts))
+
+       (block-on-node (:name facts))
+
+       (is (= (tuc/munge-catalog-for-comparison :v4 catalog)
+              (tuc/munge-catalog-for-comparison :v4 (json/parse-string (export/catalog-for-node "localhost" *port* (:name catalog))))))
+
+       (is (= (tur/munge-report-for-comparison (tur/munge-example-report-for-storage report))
+              (tur/munge-report-for-comparison (-> (export/reports-for-node "localhost" *port* (:certname report))
+                                                   first
+                                                   tur/munge-example-report-for-storage))))
+       (is (= facts (export/facts-for-node "localhost" *port* "foo.local")))
+
+       (export/-main "--outfile" export-out-file "--host" "localhost" "--port" *port*)))
+
+    (puppetdb-instance
+     (fn []
+
+       (is (empty? (export/get-nodes "localhost" *port*)))
+       (import/-main "--infile" export-out-file "--host" "localhost" "--port" *port*)
+
+       (block-on-node  (:name facts))
+
+       (is (= (tuc/munge-catalog-for-comparison :v4 catalog)
+              (tuc/munge-catalog-for-comparison :v4 (json/parse-string (export/catalog-for-node "localhost" *port* (:name catalog))))))
+       (is (= (tur/munge-report-for-comparison (tur/munge-example-report-for-storage report))
+              (tur/munge-report-for-comparison (-> (export/reports-for-node "localhost" *port* (:certname report))
+                                                   first
+                                                   tur/munge-example-report-for-storage))))
+       (is (= facts (export/facts-for-node "localhost" *port* "foo.local")))))))
+
+(defn spit-v3-export-tar
+  "Takes mtadata, catalog, facts, report for a node and spits a tarball (with v3 metadata)
+   to `tar-path`."
+  [tar-path metadata node-catalog node-facts node-report]
+  (with-open [tar-writer (archive/tarball-writer tar-path)]
+    (utils/add-tar-entry tar-writer {:msg (str "Exporting PuppetDB metadata")
+                                     :file-suffix [export/export-metadata-file-name]
+                                     :contents (json/generate-pretty-string metadata)})
+
+    (utils/add-tar-entry tar-writer (export/facts->tar (:name node-facts) node-facts))
+    (utils/add-tar-entry tar-writer (export/catalog->tar (get-in node-catalog [:data :name])
+                                                         (json/generate-string node-catalog)))
+    (utils/add-tar-entry tar-writer (first (export/report->tar (:certname node-report)
+                                                               [(tur/munge-example-report-for-storage (dissoc node-report :environment))])))))
+
+(deftest test-v3->v4-migration
+  (let [facts {:name "foo.local"
+               :values {:foo "the foo"
+                        :bar "the bar"
+                        :baz "the baz"}}
+        export-out-file (testutils/temp-file "export-test" ".tar.gz")
+        catalog (assoc-in (get-in wire-catalogs [2 :empty])
+                          [:data :name] "foo.local")
+        report (:basic reports)]
+
+    (spit-v3-export-tar export-out-file
+                        {:timestamp (now)
+                         :command-versions
+                         {:replace-catalog 3
+                          :store-report 2
+                          :replace-facts 1}}
+                        catalog
+                        facts
+                        report)
+
+    (puppetdb-instance
+     (fn []
+
+       (import/-main "--infile" export-out-file "--host" "localhost" "--port" *port*)
+
+       (block-on-node (:name facts))
+       (Thread/sleep 5000)
+
+       (is (= (tuc/munge-catalog-for-comparison :v3 catalog)
+              (tuc/munge-catalog-for-comparison :v3 (->> (get-in catalog [:data :name])
+                                                         (export/catalog-for-node "localhost" *port* :v3)
+                                                         json/parse-string))))
+       (is (= (tur/munge-report-for-comparison (-> report
+                                                   (dissoc :environment)
+                                                   tur/munge-example-report-for-storage))
+              (tur/munge-report-for-comparison (-> (first (export/reports-for-node "localhost" *port* :v3 (:certname report)))
+                                                   (update-in [:resource-events] vec)))))
+
+       (is (= facts (export/facts-for-node "localhost" *port* :v3 "foo.local")))))))

--- a/test/com/puppetlabs/puppetdb/test/query/events.clj
+++ b/test/com/puppetlabs/puppetdb/test/query/events.clj
@@ -338,7 +338,7 @@
                 actual    (resource-events-query-result version ["and" ["=" "resource-type" "File"] ["=" "latest-report?" true]])]
             (is (= actual expected)))))
 
-      (testing "retrieval of events prior to latest report"
+      (testing (str "retrieval of events prior to latest report " version)
         (testing "applied to entire query"
           (let [expected  (expected-resource-events version events1 basic1)
                 actual    (resource-events-query-result version ["=" "latest-report?" false])]

--- a/test/com/puppetlabs/puppetdb/testutils/facts.clj
+++ b/test/com/puppetlabs/puppetdb/testutils/facts.clj
@@ -18,10 +18,10 @@
   {"facts"
    {node
     {"name" node
+     "environment" "DEV"
      "values" (merge base-facts additional-facts)}}})
 
 (defn spit-facts-tarball
   "Merges fact-maps, then spits the file to disk at `f`"
   [f & fact-maps]
   (tar/spit-tar f (apply merge-with merge fact-maps)))
-


### PR DESCRIPTION
This involves adding supporting the new wire formats (with environments) and adding anonymization for environments. This commit also adds full stack testing of PuppetDB from within Clojure.

We'll probably want to eventually move and possibly abstract out some of the full stack testing stuff for use in other areas of the code. I have left that for when we need it to test other things.
