### PR TITLE
(PDB-574) 404 should be returned when querying for a missing catalog

### DIFF
--- a/src/com/puppetlabs/puppetdb/query/catalogs.clj
+++ b/src/com/puppetlabs/puppetdb/query/catalogs.clj
@@ -86,8 +86,8 @@
        :relationship relationship})))
 
 (defn get-full-catalog [catalog-version node]
-  (let [{:keys [version transaction-uuid environment api_version]} (get-catalog-info node)]
-    (when catalog-version
+  (let [{:keys [version transaction-uuid environment api_version] :as catalog} (get-catalog-info node)]
+    (when (and catalog-version catalog)
       {:name             node
        :edges            (get-edges node)
        :resources        (get-resources version node)

--- a/test/com/puppetlabs/puppetdb/test/http/v4/catalogs.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/v4/catalogs.clj
@@ -27,9 +27,17 @@
       (let [{:keys [status body] :as response} (get-response certname)
             result (json/parse-string body)]
         (is (= status 200))
-        
+
         (is (string? (get result "environment")))
         (is (= (get original-catalog "environment")
                (get result "environment")))
         (is (= (testcat/munge-catalog-for-comparison :v4 original-catalog)
                (testcat/munge-catalog-for-comparison :v4 result)))))))
+
+(deftest catalog-not-found
+  (testing
+      (let [result (get-response "something-random.com")]
+        (is (= 404 (:status result)))
+        (is (re-find #"Could not find catalog" (-> (:body result)
+                                                   (json/parse-string true)
+                                                   :error))))))


### PR DESCRIPTION
Previously a schema validation error was being thrown (returning a 500).
Now 404 is returned with an error message indicating it could not find
the catalog.
