### PR TITLE
(PDB-567) Use hash not config_version for report export files

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -63,7 +63,7 @@
                  [net.cgrand/moustache "1.1.0" :exclusions [ring/ring-core org.clojure/clojure]]
                  [clj-http "0.5.3"]
                  [ring/ring-core "1.2.1" :exclusions [javax.servlet/servlet-api]]
-                 [org.apache.commons/commons-compress "1.4.1"]
+                 [org.apache.commons/commons-compress "1.8"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]


### PR DESCRIPTION
Some users have complained of the inability for the compression library to
translate the configuration version when it contains a forward slash.

It comes down to the configuration version proving not to be a great
token for uniqueness as the format can be very variable and possibly
not link safe.

This patch changes the configuration version to instead use the hash, and
for good measure ensures the hash can be randomized using the hard-core
anonymization modes for the paranoid.

The ticket PDB-567 also suggested an alternative was to upgrade the
compression library to achieve the ability to parse / safely. Since this
is a good idea anyway, I've also upgrade that.

Signed-off-by: Ken Barber ken@bob.sh
