### PR TITLE
(PDB-552) Pin support for Puppet to 3.5.1 and above

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,7 @@ ENV['PATH'] = "/opt/puppet/bin:" + ENV['PATH'] if @pe
 @osfamily = (Facter.value(:osfamily) || "").downcase
 
 # Specific minimum pinning for Puppet & Facter versions
-@puppetminversion = "3.4.2"
+@puppetminversion = "3.5.1"
 @facterminversion = "1.6.11"
 
 if @pe

--- a/puppet/lib/puppet/util/puppetdb/global_check.rb
+++ b/puppet/lib/puppet/util/puppetdb/global_check.rb
@@ -25,7 +25,7 @@ module Puppet::Util::Puppetdb
     #
     # @throws [Puppet::Error] raised for any validation errors
     def self.run
-      self.puppet_version_check("3.4.2")
+      self.puppet_version_check("3.5.1")
     end
   end
 end


### PR DESCRIPTION
A bug with environments was solved in Puppet 3.5.1, so for the best results we
are pinning against that release version now.

Signed-off-by: Ken Barber ken@bob.sh
