### PR TITLE
(PDB-457) Storconfigs acceptance tests broken on Fedora

### DIFF
--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -53,13 +53,16 @@ step "Install rubygems and sqlite3 on master" do
   os = test_config[:os_families][master.name]
 
   case os
-  when :redhat, :fedora
+  when :redhat
     if master['platform'].include? 'el-5'
       on master, "yum install -y rubygems sqlite-devel rubygem-activerecord ruby-devel.x86_64"
       on master, "gem install sqlite3"
     else
       on master, "yum install -y rubygems ruby-sqlite3 rubygem-activerecord"
     end
+  when :fedora
+    on master, "yum install -y rubygems ruby-sqlite3"
+    on master, "gem install activerecord -v 2.3.17 --no-ri --no-rdoc -V --backtrace"
   when :debian
     on master, "apt-get install -y rubygems libsqlite3-ruby"
     # this is to work around the absense of a decent package in lucid


### PR DESCRIPTION
Fedora 20 ships with a newer version of activerecord that removes the
verify_active_connections! method and breaks testing. This commit uses
gems (rather than the Fedora RPM) to get a supported version of activerecord
