### PR TITLE
Allow gem source to come from env vars

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gem 'facter'
 


### PR DESCRIPTION
This will allow CI (among other things) to use a different mirror should
they so choose.
