### PR TITLE
(PDB-557) Add support for standard query operators and subqueries

### DIFF
--- a/documentation/api/query/v4/environments.markdown
+++ b/documentation/api/query/v4/environments.markdown
@@ -18,6 +18,19 @@ endpoint.
 
 This will return all environments known to PuppetDB
 
+#### URL Parameters
+
+* `query`: Optional. A JSON array containing the query in prefix notation. If
+  not provided, all results will be returned.
+
+#### Available Fields
+
+* `"name"`: matches environments of the given name
+
+#### Operators
+
+See [the Operators page](./operators.html)
+
 #### Response format
 
 The response is a JSON array of hashes of the form:
@@ -34,7 +47,7 @@ The array is unsorted.
 
 ### `GET /v4/environments/<ENVIRONMENT>`
 
-This will return the name of the environment if it currently exists in PuppetDB.
+This will return the name of the environment if it currently exists in PuppetDB. This route also supports the same URL parameters and operators as the '/v4/environments' route above.
 
 #### Response format
 

--- a/src/com/puppetlabs/puppetdb/http/query.clj
+++ b/src/com/puppetlabs/puppetdb/http/query.clj
@@ -48,11 +48,11 @@
 (defn restrict-query-to-environment
   "Restrict the query parameter of the supplied request so that it
    only returns results for the supplied environment"
-  [node req]
-  {:pre  [(string? node)]
+  [environment req]
+  {:pre  [(string? environment)]
    :post [(are-queries-different? req %)]}
   (restrict-query ["and"
-                   ["=" "environment" node]]
+                   ["=" "environment" environment]]
                   req))
 
 (defn restrict-fact-query-to-name

--- a/src/com/puppetlabs/puppetdb/query/environments.clj
+++ b/src/com/puppetlabs/puppetdb/query/environments.clj
@@ -1,10 +1,29 @@
 (ns com.puppetlabs.puppetdb.query.environments
   (:require [com.puppetlabs.jdbc :as jdbc]
-            [com.puppetlabs.puppetdb.query :as query]))
+            [com.puppetlabs.puppetdb.query :as query]
+            [com.puppetlabs.jdbc :refer [valid-jdbc-query?]]
+            [com.puppetlabs.puppetdb.query.paging :refer [validate-order-by!]]
+            [puppetlabs.kitchensink.core :as ks]))
 
-(defn all-environments []
-  (query/execute-query* 0 ["select name from environments"]))
+(def environments-columns
+  [:name])
 
-(defn query-environment [environment]
-  (-> (query/execute-query* 0 ["select name from environments where name=?" environment])
-      (update-in [:result] first)))
+(defn query->sql
+  "Converts a vector-structured `query` to a corresponding SQL query which will
+   return nodes matching the `query`."
+  [version query]
+  {:pre  [((some-fn nil? sequential?) query)]
+   :post [(valid-jdbc-query? %)]}
+  (let [operators (query/environments-operators version)]
+    (query/environments-query->sql operators query)))
+
+(defn query-environments
+  "Search for environments satisfying the given SQL filter."
+  ([version filter-expr] (query-environments version filter-expr nil))
+  ([version filter-expr paging-options]
+     {:pre  [((some-fn nil? sequential?) filter-expr)]
+      :post [(map? %)
+             (vector? (:result %))
+             (every? #(= (set environments-columns) (ks/keyset %)) (:result %))]}
+     (validate-order-by! environments-columns paging-options)
+     (query/execute-query (query->sql version filter-expr) paging-options)))

--- a/test/com/puppetlabs/puppetdb/test/query/environments.clj
+++ b/test/com/puppetlabs/puppetdb/test/query/environments.clj
@@ -2,13 +2,14 @@
   (:require [com.puppetlabs.puppetdb.query.environments :refer :all]
             [clojure.test :refer :all]
             [com.puppetlabs.puppetdb.scf.storage :as storage]
-            [com.puppetlabs.puppetdb.fixtures :as fixt]))
+            [com.puppetlabs.puppetdb.fixtures :as fixt]
+            [com.puppetlabs.cheshire :as json]))
 
 (fixt/defixture super-fixture :each fixt/with-test-db)
 
 (deftest test-all-environments
   (testing "without environments"
-    (is (empty? (:result (all-environments)))))
+    (is (empty? (:result (query-environments :v4 nil {})))))
 
   (testing "with environments"
     (doseq [env ["foo" "bar" "baz"]]
@@ -17,13 +18,55 @@
     (is (= #{{:name "foo"}
              {:name "bar"}
              {:name "baz"}}
-           (set (:result (all-environments)))))))
+           (set (:result (query-environments :v4 nil {})))))))
 
-(deftest test-query-environment
-  (testing "environment not present"
-    (is (empty? (:result (query-environment "foo")))))
-  (testing "environment present"
+(def jsonify (comp json/parse-string json/generate-string))
+
+(deftest test-environment-queries
+  (testing "without environments"
+    (is (empty? (:result (query-environments :v4 nil)))))
+
+  (testing "with environments"
     (doseq [env ["foo" "bar" "baz"]]
       (storage/ensure-environment env))
-    (is (= {:name "foo"}
-           (:result (query-environment "foo"))))))
+
+    (are [query result] (= result (set (:result (query-environments :v4 (jsonify query) {}))))
+
+         '[= name foo]
+         #{{:name "foo"}}
+
+         '["~" name f.*]
+         #{{:name "foo"}}
+
+         '[not [= name foo]]
+         #{{:name "bar"}
+           {:name "baz"}}
+
+         '[not ["~" name f.*]]
+         #{{:name "bar"}
+           {:name "baz"}}
+
+         '[or
+           [= name foo]
+           [= name bar]]
+         #{{:name "foo"}
+           {:name "bar"}}
+
+         '[and
+           ["~" name f.*]
+           ["~" name .*o]]
+         #{{:name "foo"}}
+
+         '[and
+           ["~" name f.*]
+           ["~" name .*o]]
+         #{{:name "foo"}})))
+
+(deftest test-failed-comparison
+  (are [query] (thrown-with-msg? IllegalArgumentException
+                                 #"Value foo must be a number"
+                                 (query-environments :v4 (jsonify query) {}))
+       '[<= name foo]
+       '[>= name foo]
+       '[< name foo]
+       '[> name foo]))


### PR DESCRIPTION
Now environments can be queried via URI or query parameter with the normal operations (i.e. =, ~, not, and, or etc). Subqueries for resources and facts are also supported.
