### PR TITLE
(PDB-605) Pin facter requirement to 1.7.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -66,7 +66,7 @@ ENV['PATH'] = "/opt/puppet/bin:" + ENV['PATH'] if @pe
 
 # Specific minimum pinning for Puppet & Facter versions
 @puppetminversion = "3.5.1"
-@facterminversion = "1.6.11"
+@facterminversion = "1.7.0"
 
 if @pe
     @install_dir = "/opt/puppet/share/puppetdb"


### PR DESCRIPTION
Puppet 3.5.1 pins to Facter 1.7.0, and whats more 1.6.x is no longer
maintained so this patch just corrects that.

Signed-off-by: Ken Barber ken@bob.sh
