### PR TITLE
(PDB-309) Update config conversion code for Schema 0.2.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -67,7 +67,7 @@
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]
-                 [prismatic/schema "0.2.0"]
+                 [prismatic/schema "0.2.1"]
                  [org.clojure/tools.macro "0.1.5"]
                  [com.novemberain/pantomime "2.1.0"]]
 

--- a/src/com/puppetlabs/puppetdb/config.clj
+++ b/src/com/puppetlabs/puppetdb/config.clj
@@ -4,7 +4,8 @@
 
    The schemas in this file define what is expected to be present in the INI file
    and the format expected by the rest of the application."
-  (:import [java.security KeyStore])
+  (:import [java.security KeyStore]
+           [org.joda.time Minutes Days Period])
   (:require [clojure.tools.logging :as log]
             [puppetlabs.kitchensink.ssl :as ssl]
             [puppetlabs.kitchensink.core :as kitchensink]
@@ -35,6 +36,7 @@
    (s/optional-key :subprotocol) (s/maybe String)
    (s/optional-key :subname) (s/maybe String)
    (s/optional-key :username) String
+   (s/optional-key :user) String
    (s/optional-key :password) String
    (s/optional-key :syntax_pgs) String
    (s/optional-key :read-only?) (pls/defaulted-maybe String "false")
@@ -51,7 +53,7 @@
          {(s/optional-key :gc-interval) (pls/defaulted-maybe s/Int 60)
           (s/optional-key :report-ttl) (pls/defaulted-maybe String "14d")
           (s/optional-key :node-purge-ttl) (pls/defaulted-maybe String "0s")
-          (s/optional-key :node-ttl) (s/maybe String)
+          (s/optional-key :node-ttl) String
           (s/optional-key :node-ttl-days) (s/maybe s/Int)}))
 
 (def database-config-out
@@ -59,28 +61,29 @@
   {:classname String
    :subprotocol String
    :subname String
-   :log-slow-statements pls/Days
-   :conn-max-age pls/Minutes
-   :conn-keep-alive pls/Minutes
-   :read-only? pls/SchemaBoolean
+   :log-slow-statements Days
+   :conn-max-age Minutes
+   :conn-keep-alive Minutes
+   :read-only? Boolean
    :partition-conn-min s/Int
    :partition-conn-max s/Int
    :partition-count s/Int
-   :stats pls/SchemaBoolean
-   :log-statements pls/SchemaBoolean
+   :stats Boolean
+   :log-statements Boolean
    :statements-cache-size s/Int
-   (s/optional-key :conn-lifetime) (s/maybe pls/Minutes)
+   (s/optional-key :conn-lifetime) (s/maybe Minutes)
    (s/optional-key :username) String
+   (s/optional-key :user) String
    (s/optional-key :password) String
    (s/optional-key :syntax_pgs) String})
 
 (def write-database-config-out
   "Schema for parsed/processed database config that includes write database params"
   (merge database-config-out
-         {:gc-interval pls/Minutes
-          :report-ttl pls/Period
-          :node-purge-ttl pls/Period
-          :node-ttl (s/either pls/Period pls/Days)}))
+         {:gc-interval Minutes
+          :report-ttl Period
+          :node-purge-ttl Period
+          (s/optional-key :node-ttl) (s/either Period Days)}))
 
 (defn half-the-cores*
   "Function for computing half the cores of the system, useful
@@ -105,13 +108,13 @@
 
 (def command-processing-out
   "Schema for parsed/processed command processing config - currently incomplete"
-  {:dlo-compression-threshold pls/Period
+  {:dlo-compression-threshold Period
    :threads s/Int
    (s/optional-key :store-usage) s/Int
    (s/optional-key :temp-usage) s/Int})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Database config 
+;;; Database config
 
 (defn maybe-days
   "Convert the non-nil integer to days"
@@ -159,17 +162,19 @@
   "Assoc into `db-config` a :node-ttl when not already present. Default to node-ttl-days, if that's not there,
    use 0 seconds"
   [db-config]
-  (if (:node-ttl db-config)
-    db-config
-    (assoc db-config :node-ttl (or (maybe-days (:node-ttl-days db-config))
-                                   (pl-time/parse-period "0s")))))
+  (dissoc (if (:node-ttl db-config)
+            db-config
+            (-> db-config
+                (assoc :node-ttl (or (maybe-days (:node-ttl-days db-config))
+                                     (pl-time/parse-period "0s")))  ))
+          :node-ttl-days))
 
 (defn convert-write-db-config
   "Converts the `database` config using the write database config schema. Also defaults
    the node-ttl parameter."
   [global database]
-  (->> (convert-db-config write-database-config-in write-database-config-out global database)
-       default-node-ttl
+  (->> (default-node-ttl database)
+       (convert-db-config write-database-config-in write-database-config-out global)
        (pls/strip-unknown-keys write-database-config-out)))
 
 (defn configure-write-db

--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -51,11 +51,11 @@
   {:type String
    :title String})
 
-(def json-primitive-schema (s/either String Number pls/SchemaBoolean))
+(def json-primitive-schema (s/either String Number Boolean))
 
 (def resource-schema
   (merge resource-ref-schema
-         {(s/optional-key :exported) pls/SchemaBoolean
+         {(s/optional-key :exported) Boolean
           (s/optional-key :file) String
           (s/optional-key :line) s/Int
           (s/optional-key :tags) #{String}

--- a/test/com/puppetlabs/puppetdb/test/schema.clj
+++ b/test/com/puppetlabs/puppetdb/test/schema.clj
@@ -4,7 +4,9 @@
             [schema.core :as s]
             [clj-time.core :as time]
             [clj-time.coerce :as tc]
-            [com.puppetlabs.time :as pl-time]))
+            [com.puppetlabs.time :as pl-time]
+            [schema.coerce :as sc])
+  (:import [org.joda.time Minutes Days Seconds Period]))
 
 (deftest defaulted-maybe-test
   (let [defaulted-schema {:foo (defaulted-maybe Number 10)}]
@@ -134,7 +136,7 @@
 
 (deftest schema-type-construction
   (are [expected target-schema source-schema value]
-    (= expected ((get-construct-fn target-schema) source-schema value))
+    (= expected ((sc/coercer target-schema conversion-fns) value))
 
     (time/minutes 10) Minutes String "10"
     (time/minutes 10) Minutes Number 10
@@ -150,13 +152,13 @@
     :foo s/Keyword s/Keyword :foo
     10 s/Int s/Int 10
 
-    true SchemaBoolean String "true"
-    false SchemaBoolean String "false"
-    true SchemaBoolean String "TRUE"
-    false SchemaBoolean String "FALSE"
-    true SchemaBoolean String "True"
-    false SchemaBoolean String "False"
-    false SchemaBoolean String "really false"))
+    true Boolean String "true"
+    false Boolean String "false"
+    true Boolean String "TRUE"
+    false Boolean String "FALSE"
+    true Boolean String "True"
+    false Boolean String "False"
+    false Boolean String "really false"))
 
 (deftest schema-conversion
   (testing "conversion of days/minutes/seconds"

--- a/test/com/puppetlabs/test/jdbc.clj
+++ b/test/com/puppetlabs/test/jdbc.clj
@@ -13,9 +13,9 @@
 
   (testing "can construct pool with numeric usernames and passwords"
     (let [pool (-> (test-db)
-                   (assoc :username 1234 :password 1234)
+                   (assoc :username "1234" :password "1234")
                    fixt/defaulted-write-db-config
-                   (subject/pooled-datasource))]
+                   subject/pooled-datasource)]
       (.close (:datasource pool))))
 
   (testing "writes not allowed on read-only pools"
@@ -29,7 +29,7 @@
       (subject/with-transacted-connection read-pool
         (is (thrown-with-msg? java.sql.SQLException #"read-only.*transaction"
                               (insert-map {"bar" 1}))))
-      
+
       (.close (:datasource write-pool))
       (.close (:datasource read-pool)))))
 


### PR DESCRIPTION
Much of the code for converting user provided config to the internal types (i.e. "10" to Joda time 10 Seconds etc) is no longer necessary with the new coerce features of Schema. This commit switches to the new version and makes the necessary changes to use the coerce feature.
