### PR TITLE
Unpin the version of beaker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,5 @@ group :test do
 end
 
 group :acceptance do
-#  gem 'beaker', '~> 1.7'
-  # Temp branch with new ec2 backend
-  gem 'beaker', :git => 'git://github.com/kbarber/beaker.git', :branch => 'ticket/master/pdb-554'
+  gem 'beaker', '~> 1.11'
 end


### PR DESCRIPTION
We had pinned beaker previously because we were waiting for some of our new EC2
customisations to be merged in and released. This has been done now.

Signed-off-by: Ken Barber ken@bob.sh
