### PR TITLE
Fix comparison in dup resources acceptance test

### DIFF
--- a/acceptance/tests/storeconfigs/dup_collected_resources.rb
+++ b/acceptance/tests/storeconfigs/dup_collected_resources.rb
@@ -46,7 +46,7 @@ MANIFEST
       collectors.each do |collector|
         result = on collector, "puppet agent --test --server #{master}",
                     :acceptable_exit_codes => [1]
-        assert_match("Another local or imported resource exists with the type and title Notify[DUPE NOTIFY]",
+        assert_match("A duplicate resource was found while collecting exported resources, with the type and title Notify[DUPE NOTIFY]",
                      result.output,
                      "#{collector.node_name} collected duplicate resources without failing!")
       end


### PR DESCRIPTION
Due to changes in Puppet 3.6.0, the comparison done in our resource duplication
tests no longer matches the actual output. This patch ammends the comparison to
match Puppet 3.6.0 output now.

Signed-off-by: Ken Barber ken@bob.sh
