### PR TITLE
Added case logic for sbin_dir

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -98,7 +98,12 @@ else
       end
     @link = "/usr/share/puppetdb"
     @name = "puppetdb"
-    @sbin_dir = "/usr/sbin"
+    @sbin_dir = case @osfamily
+      when /archlinux/
+        "/usr/bin"
+      else
+        "/usr/sbin"
+      end
 end
 
 @initscriptname = "/etc/init.d/#{@name}"


### PR DESCRIPTION
Archlinux only has /usr/bin and this symlinks to /usr/sbin
