### PR TITLE
(PDB 686) Add warning about PDB-686 to release notes

### DIFF
--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -15,13 +15,6 @@ breaking changes" section below for more information.
 
 Things to take note of before upgrading:
 
-* There is a known issue in Puppet 3.4.0, 3.4.1 and 3.4.2 with
-duplicate failed events being tracked here:
-https://tickets.puppetlabs.com/browse/PUP-1524. This is being fixed in
-an upcoming release of Puppet. Since 1.6.0 this error will become more
-obvious as we are now raising full stack traces, so you may notice it
-more readily after the upgrade.
-
 * If you receive the error “Could not open
 /etc/puppet/log4j.properties” or "Problem parsing XML document",
 this is because we have changed the packaged config.ini to point at a new logging configuration file:
@@ -29,8 +22,14 @@ logback.xml. However during package installation some package managers
 will cowardly refuse to just update config.ini, this in particular
 affects RPM. After upgrading you should ensure any .rpmnew files are
 reviewed and that changes to our vendored version are now merged with
-your version of config.ini on disk. See this ticket for more
-information: https://tickets.puppetlabs.com/browse/PDB-656
+your version of config.ini on disk. See
+[PDB-656](https://tickets.puppetlabs.com/browse/PDB-656) for more details.
+
+* If you are running Ubuntu 12.04 and Ruby 1.9.3-p0 then you may find
+that you will sometimes receive the error "idle timeout expired" in your
+Puppet agent/master logs, and your PuppetDB logs. This is due to a bug
+in that version of Ruby in particular. See
+[PDB-686](https://tickets.puppetlabs.com/browse/PDB-686) for more details.
 
 * Make sure all your PuppetDB instances are shut down and only upgrade
 one at a time.


### PR DESCRIPTION
This adds a warning about PDB-686 to the release notes so users know how to work-around it.

This also cleans up the linking in our current release notes, and removes the warning about Puppet 3.4.x, because we pin against 3.5.1 and greater anyway.
