### PR TITLE
Typo in v4/reports.markdown

### DIFF
--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -8,7 +8,7 @@ canonical: "/puppetdb/latest/api/query/v4/reports.html"
 [operator]: ../v4/operators.html
 [event]: ./events.html
 [paging]: ./paging.html
-[statues]: ./puppet/3/reference/format_report.html#puppettransactionreport
+[statuses]: ./puppet/3/reference/format_report.html#puppettransactionreport
 
 Querying reports is accomplished by making an HTTP request to the `/reports` REST
 endpoint.


### PR DESCRIPTION
The alias for the link to the statuses page was incorrect. Fixed.

Signed-off-by: Ken Barber ken@bob.sh
