### PR TITLE
(PDB-657) Query logic refactor

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
   :pedantic? :abort
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [cheshire "5.2.0"]
+                 [cheshire "5.3.1"]
                  [org.clojure/core.match "0.2.0-rc5"]
                  [org.clojure/math.combinatorics "0.0.4"]
                  [org.clojure/tools.logging "0.2.6"]
@@ -69,7 +69,10 @@
                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]
                  [prismatic/schema "0.2.1"]
                  [org.clojure/tools.macro "0.1.5"]
-                 [com.novemberain/pantomime "2.1.0"]]
+                 [com.novemberain/pantomime "2.1.0"]
+                 [fast-zip-visit "1.0.2"]]
+
+  :jvm-opts ["-XX:MaxPermSize=128M"]
 
   ;;The below test-selectors is basically using the PUPPETDB_DBTYPE
   ;;environment variable to be the test selector.  The selector below
@@ -87,7 +90,8 @@
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
                                   [puppetlabs/kitchensink ~ks-version :classifier "test"]
                                   [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version :classifier "test"]
-                                  [org.flatland/ordered "1.5.2"]]}}
+                                  [org.flatland/ordered "1.5.2"]
+                                  [org.clojure/test.check "0.5.8"]]}}
 
   :jar-exclusions [#"leiningen/"]
 

--- a/src/com/puppetlabs/cheshire.clj
+++ b/src/com/puppetlabs/cheshire.clj
@@ -63,6 +63,8 @@
 
 (def parse-string core/parse-string)
 
+(def parse-strict-string core/parse-string-strict)
+
 (def parse-stream core/parse-stream)
 
 (defn spit-json

--- a/src/com/puppetlabs/puppetdb/query.clj
+++ b/src/com/puppetlabs/puppetdb/query.clj
@@ -492,7 +492,7 @@
           (compile-resource-regexp :v3 (get v3-renamed-resource-columns path path) value))
     (match [path]
            ["tag"]
-           {:where (sql-regexp-array-match "catalog_resources" "tags")
+           {:where (sql-regexp-array-match "catalog_resources" "catalog_resources" "tags")
             :params [value]}
 
            ;; node join.

--- a/src/com/puppetlabs/puppetdb/query_eng.clj
+++ b/src/com/puppetlabs/puppetdb/query_eng.clj
@@ -1,0 +1,388 @@
+(ns com.puppetlabs.puppetdb.query-eng
+  (:require [clojure.string :as str]
+            [com.puppetlabs.puppetdb.zip :as zip]
+            [com.puppetlabs.puppetdb.scf.storage-utils :as su]
+            [clojure.string :as str]
+            [com.puppetlabs.puppetdb.scf.storage-utils :refer [db-serialize]]
+            [clojure.core.match :as cm]
+            [fast-zip.visit :as zv]
+            [com.puppetlabs.puppetdb.schema :as pls]
+            [schema.core :as s]
+            [com.puppetlabs.jdbc :as jdbc]
+            [com.puppetlabs.cheshire :as json]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Plan - functions/transformations of the internal query plan
+
+(defrecord Query [source source-table alias project where subquery? queryable-fields])
+(defrecord EqualsExpression [column value])
+(defrecord RegexExpression [column value])
+(defrecord ArrayRegexExpression [table alias column value])
+(defrecord NullExpression [column null?])
+(defrecord ArrayEqualsExpression [column value])
+(defrecord InExpression [column subquery])
+(defrecord AndExpression [clauses])
+(defrecord OrExpression [clauses])
+(defrecord NotExpression [clause])
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Queryable Entities
+
+(def nodes-query
+  "Query for nodes entities, mostly used currently for subqueries"
+  (map->Query {:project {"certname" :string
+                         "deactivated" :string}
+               :queryable-fields ["certname" "deactivated"]
+               :source-table "certnames"
+               :alias "nodes"
+               :subquery? false
+               :source "SELECT name as certname, deactivated FROM certnames"}))
+
+(def resource-params-query
+  "Query for the resource-params query, mostly used as a subquery"
+  (map->Query {:project {"res_param_resource" :string
+                         "res_param_name" :string
+                         "res_param_value" :string}
+               :queryable-fields ["res_param_resource" "res_param_name" "res_param_value"]
+               :source-table "resource_params"
+               :alias "resource_params"
+               :subquery? false
+               :source "select resource as res_param_resource, name as res_param_name, value as res_param_value from resource_params"}))
+
+(def facts-query
+  "Query for the top level facts query"
+  (map->Query {:project {"name" :string
+                         "value" :string
+                         "certname" :string}
+               :alias "facts"
+               :queryable-fields ["name" "value" "certname"]
+               :source-table "certname_facts"
+               :subquery? false
+               :source "select cf.certname, cf.name, cf.value, env.name as environment
+                        FROM certname_facts cf
+                             INNER JOIN certname_facts_metadata cfm on cf.certname = cfm.certname
+                             LEFT OUTER JOIN environments as env on cfm.environment_id = env.id"}))
+
+(def resources-query
+  "Query for the top level resource entity"
+  (map->Query {:project {"certname" :string
+                         "environment" :string
+                         "resource" :string
+                         "type" :string
+                         "title" :string
+                         "tags" :array
+                         "exported" :string
+                         "file" :string
+                         "line" :string
+                         "parameters" :string}
+               :queryable-fields ["certname" "environment" "resource" "type" "title" "tag" "exported" "file" "line" "parameters"]
+               :alias "resources"
+               :subquery? false
+               :source-table "catalog_resources"
+               :source (str  "SELECT c.certname, c.hash as catalog, e.name as environment, cr.resource,
+                                       type, title, tags, exported, file, line, rpc.parameters
+                                FROM catalog_resources cr
+                                     INNER JOIN catalogs c on cr.catalog_id = c.id
+                                     LEFT OUTER JOIN environments e on c.environment_id = e.id
+                                     LEFT OUTER JOIN resource_params_cache rpc on rpc.resource = cr.resource")}))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Conversion from plan to SQL
+
+(defprotocol SQLGen
+  (-plan->sql [query] "Given the `query` plan node, convert it to a SQL string"))
+
+(defn parenthize
+  "Wrap `s` in parens if `wrap-in-parens?`"
+  [wrap-in-parens? s]
+  (if wrap-in-parens?
+    (str " ( " s " ) ")
+    s))
+
+(extend-protocol SQLGen
+  Query
+  (-plan->sql [query]
+    (let [alias (:alias query)]
+      (parenthize
+       (:subquery? query)
+       (format "SELECT %s FROM ( %s ) AS %s WHERE %s"
+               (str/join ", " (map #(format "%s.%s" alias %) (keys (:project query))))
+               (:source query)
+               (:alias query)
+               (-plan->sql (:where query))))))
+
+  InExpression
+  (-plan->sql [expr]
+    (format "%s in %s"
+            (:column expr)
+            (-plan->sql (:subquery expr))))
+
+  EqualsExpression
+  (-plan->sql [expr]
+    (format "%s = %s"
+            (-plan->sql (:column expr))
+            (-plan->sql (:value expr))))
+
+  ArrayEqualsExpression
+  (-plan->sql [expr]
+    (su/sql-array-query-string (:column expr)))
+
+  RegexExpression
+  (-plan->sql [expr]
+    (su/sql-regexp-match (:column expr)))
+
+  ArrayRegexExpression
+  (-plan->sql [expr]
+    (su/sql-regexp-array-match (:table expr) (:alias expr) (:column expr)))
+
+  NullExpression
+  (-plan->sql [expr]
+    (format "%s IS %s"
+            (-plan->sql (:column expr))
+            (if (:null? expr)
+              "NULL"
+              "NOT NULL")))
+
+  AndExpression
+  (-plan->sql [expr]
+    (str/join " AND " (map -plan->sql (:clauses expr))))
+
+  OrExpression
+  (-plan->sql [expr]
+    (str/join " OR " (map -plan->sql (:clauses expr))))
+
+  NotExpression
+  (-plan->sql [expr]
+    (format "NOT ( %s )" (-plan->sql (:clause expr))))
+
+  Object
+  (-plan->sql [obj]
+    (str obj)))
+
+(defn plan->sql
+  "Convert `query` to a SQL string"
+  [query]
+  (-plan->sql query))
+
+(defn binary-expression?
+  "True if the plan node is a binary expression"
+  [node]
+  (or (instance? EqualsExpression node)
+      (instance? RegexExpression node)
+      (instance? ArrayEqualsExpression node)
+      (instance? ArrayRegexExpression node)))
+
+(defn extract-params
+  "Extracts the node's expression value, puts it in state
+   replacing it with `?`, used in a prepared statement"
+  [node state]
+  (when (binary-expression? node)
+    {:node (assoc node :value "?")
+     :state (conj state (:value node))}))
+
+(defn extract-all-params
+  "Zip through the query plan, replacing each user provided query paramter with '?'
+   and return the parameters as a vector"
+  [plan]
+  (let [{:keys [node state]} (zip/post-order-visit (zip/tree-zipper plan)
+                                                   []
+                                                   [extract-params])]
+    {:plan node
+     :params state}))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; User Query - functions/transformations of the user defined query
+;;;              language
+
+(def user-query->logical-obj
+  "Keypairs of the stringified subquery keyword (found in user defined queries) to the
+   appropriate plan node"
+  {"select-nodes" (assoc nodes-query :subquery? true)
+   "select-resources" (assoc resources-query :subquery? true)
+   "select-params" (assoc resource-params-query :subquery? true)
+   "select-facts" (assoc facts-query :subquery? true)})
+
+(defn expand-query-node
+  "Expands/normalizes the user provided query to a minimal subset of the
+   query language"
+  [node]
+  (cm/match [node]
+
+            [["=" ["node" "active"] value]]
+            ["in" "certname"
+             ["extract" "certname"
+              ["select-nodes"
+               ["nil?" "deactivated" (not value)]]]]
+
+            [["=" ["parameter" param-name] param-value]]
+            ["in" "resource"
+             ["extract" "res_param_resource"
+              ["select-params"
+               ["and"
+                ["=" "res_param_name" param-name]
+                ["=" "res_param_value" (db-serialize param-value)]]]]]
+
+            [[op "tag" array-value]]
+            [op "tags" array-value]
+
+            :else nil))
+
+(def binary-operators
+  #{"=" ">" "<" ">=" "<=" "~"})
+
+(def binary-operator-checker
+  "A function that will return nil if the query snippet successfully validates, otherwise
+   will return a data structure with error information"
+  (s/checker [(s/one
+               (apply s/either (map s/eq binary-operators))
+               :operator)
+              (s/one s/Str :field)
+              (s/one (s/either s/Str s/Bool s/Int) :value)]))
+
+(defn validate-binary-operators
+  "Validation of the user provided query"
+  [node]
+  (cm/match [node]
+
+            [[op & _]]
+            (when (and (contains? binary-operators op)
+                       (binary-operator-checker node))
+              (throw (IllegalArgumentException. (format "%s requires exactly two arguments" op))))
+
+            :else nil))
+
+(defn expand-user-query
+  "Expands/translates the query from a user provided one to a
+   normalized query that only contains our lower-level operators.
+   Things like [node active] will be expanded into a full
+   subquery (via the `in` and `extract` operators)"
+  [user-query]
+  (:node (zip/post-order-transform (zip/tree-zipper user-query)
+                                   [expand-query-node validate-binary-operators])))
+
+(defn user-node->plan-node
+  "Create a query plan for `node` in the context of the given query (as `query-rec`)"
+  [query-rec node]
+  (cm/match [node]
+            [["=" column value]]
+            (let [col-type (get-in query-rec [:project column])]
+              (if (= col-type :string)
+                (map->EqualsExpression {:column column
+                                        :value value})
+                (map->ArrayEqualsExpression {:column column
+                                             :value value})))
+
+            [["nil?" column value]]
+            (map->NullExpression {:column column
+                                  :null? (not value)})
+
+            [["~" column value]]
+            (let [col-type (get-in query-rec [:project column])]
+              (if (= :string col-type)
+                (map->RegexExpression {:column column
+                                       :value value})
+                (map->ArrayRegexExpression {:table (:source-table query-rec)
+                                            :alias (:alias query-rec)
+                                            :column column
+                                            :value value})))
+
+            [["and" & expressions]]
+            (map->AndExpression {:clauses (map #(user-node->plan-node query-rec %) expressions)})
+
+            [["or" & expressions]]
+            (map->OrExpression {:clauses (map #(user-node->plan-node query-rec %) expressions)})
+
+            [["in" column subquery-expression]]
+            (map->InExpression {:column column
+                                :subquery (user-node->plan-node query-rec subquery-expression)})
+
+            [["not" expression]] (map->NotExpression {:clause (user-node->plan-node query-rec expression)})
+
+            [["extract" column
+              [subquery-name subquery-expression]]]
+            (assoc (user-query->logical-obj subquery-name)
+              :project {column nil}
+              :where (user-node->plan-node (user-query->logical-obj subquery-name) subquery-expression))
+            :else nil))
+
+(defn convert-to-plan
+  "Converts the given `user-query` to a query plan that can later be converted into
+   a SQL statement"
+  [query-rec user-query]
+  (assoc query-rec :where (user-node->plan-node query-rec user-query)))
+
+(declare push-down-context)
+
+(defn vec?
+  "Same as set?/list?/map? but for vectors"
+  [x]
+  (instance? clojure.lang.IPersistentVector x))
+
+(defn annotate-with-context
+  "Add `context` as meta on each `node` that is a vector. This associates the
+   the query context assocated to each query clause with it's associated context"
+  [context]
+  (fn [node state]
+    (when (vec? node)
+      (cm/match [node]
+             [["extract" column
+               [subquery-name subquery-expression]]]
+             {:node (:node (push-down-context (user-query->logical-obj subquery-name) subquery-expression))
+              :cut true
+              :state state}
+
+             :else
+             {:node (vary-meta node assoc :query-context context)
+              :state state}))))
+
+(defn validate-query-fields
+  "Add an error message to `state` if the field is not available for querying
+   by the associated query-context"
+  [node state]
+  (cm/match [node]
+            [[(:or "=" "~") field _]]
+            (let [query-context (:query-context (meta node))
+                  queryable-fields (:queryable-fields query-context)]
+              (when (and (not (vec? field))
+                         (not (contains? (set queryable-fields) field)))
+                {:node node
+                 :state (conj state (format "'%s' is not a queryable object for %s, known queryable objects are %s"
+                                            field
+                                            (:alias query-context)
+                                            (json/generate-string queryable-fields)))}))
+            :else nil))
+
+(defn push-down-context
+  "Pushes the top level query context down to each query node, throws IllegalArgumentException
+   if any unrecognized fields appear in the query"
+  [context user-query]
+  (let [{annotated-query :node
+         errors :state} (zip/pre-order-visit (zip/tree-zipper user-query)
+                                             []
+                                             [(annotate-with-context context) validate-query-fields])]
+    (when (seq errors)
+      (throw (IllegalArgumentException. (str/join \newline errors))))
+
+    annotated-query))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Public
+
+(defn compile-user-query->sql
+  "Given a user provided query and a Query instance, convert the
+   user provided query to SQL and extract the parameters, to be used
+   in a prepared statement"
+  [query-rec user-query & [{:keys [count?] :as paging-options}]]
+  (let [{:keys [plan params]} (->> user-query
+                                   (push-down-context query-rec)
+                                   expand-user-query
+                                   (convert-to-plan query-rec)
+                                   extract-all-params)
+        sql (plan->sql plan)
+        paged-sql (if paging-options
+                    (jdbc/paged-sql (plan->sql plan) paging-options)
+                    sql)
+        result-query {:results-query (apply vector paged-sql params)}]
+    (if count?
+      (assoc result-query :count-query (apply vector (jdbc/count-sql sql) params))
+      result-query)))

--- a/src/com/puppetlabs/puppetdb/zip.clj
+++ b/src/com/puppetlabs/puppetdb/zip.clj
@@ -1,0 +1,109 @@
+(ns com.puppetlabs.puppetdb.zip
+  (:require [fast-zip.visit :as zv]
+            [fast-zip.core :as z]))
+
+(defprotocol NodeTraversal
+  (-branch? [x] "Returns true if it's possible for this type to have children")
+  (-children [x] "Returns the children (if any) of this node")
+  (-make-node [orig-node children] "Creates a new node from the existing `orig-node` and (potentially new) children"))
+
+(defn transfer-meta [old-node new-node]
+  (with-meta new-node (meta old-node)))
+
+(extend-protocol NodeTraversal
+
+  clojure.lang.IPersistentMap
+  (-branch? [_] true)
+  (-children [x] (seq x))
+  (-make-node [orig-map new-map-seq]
+    (let [new-map (if (instance? clojure.lang.IRecord orig-map)
+                    orig-map
+                    (empty orig-map))]
+      (transfer-meta orig-map (into new-map (seq new-map-seq)))))
+
+  clojure.lang.IPersistentVector
+  (-branch? [_] true)
+  (-children [x] (when (seq x) x))
+  (-make-node [orig-vec new-children]
+    (transfer-meta orig-vec (when (seq new-children)
+                              (if (vector? new-children)
+                                new-children
+                                (vec new-children)))))
+
+  clojure.lang.IPersistentSet
+  (-branch? [_] true)
+  (-children [x] (when (seq x) x))
+  (-make-node [orig-set new-children]
+    (transfer-meta orig-set (when (seq new-children)
+                              (into (empty orig-set) new-children))))
+
+  clojure.lang.IPersistentList
+  (-branch? [_] true)
+  (-children [x] x)
+  (-make-node [orig-list new-children]
+    (transfer-meta orig-list
+                   (apply list new-children)))
+
+  clojure.lang.ISeq
+  (-branch? [_] true)
+  (-children [x] x)
+  (-make-node [node new-children]
+    (transfer-meta node
+                   (when (seq new-children)
+                     (into (empty node) (reverse new-children)))))
+
+  Object
+  (-branch? [_] false)
+  (-children [_] nil)
+  (-make-node [_ child]
+    child)
+
+  nil
+  (-branch? [_] false)
+  (-children [_] nil)
+  (-make-node [_ _]
+    nil))
+
+(defn tree-zipper
+  "Zipper that knows how to walk clojure data structures.
+  Modifications while zipping are replaced with structures of the same
+  time"
+  [node]
+  (z/zipper -branch? -children -make-node node))
+
+(defn post-order-visit
+  "Does a post-order travsersal of `zipper`. `visitors` is a seq of
+  functions that take two args, node and state"
+  [zipper initial-state
+   visitors]
+  (zv/visit zipper
+            initial-state
+            (map (fn [f]
+                   (fn [dir node state]
+                     (when (= :post dir)
+                       (f node state)))) visitors)))
+
+(defn post-order-transform
+  "Zips through `zipper` applying each visitor function in `visitors`.
+  `visitors` is a seq of functions that accepts one argument (the node
+  to transform)"
+  [zipper visitors]
+  (post-order-visit zipper
+                    nil
+                    (map (fn [f]
+                           (fn [node state]
+                             (when-let [new-node (f node)]
+                               {:node new-node})))
+                         visitors)))
+
+(defn pre-order-visit
+  "Does a pre-order travsersal of `zipper`. `visitors` is a seq of
+  functions that take two args, node and state"
+  [zipper initial-state
+   visitors]
+  (zv/visit zipper
+            initial-state
+            (map (fn [f]
+                   (fn [dir node state]
+                     (when (= :pre dir)
+                       (f node state)))) visitors)))

--- a/test/com/puppetlabs/puppetdb/test/query_eng.clj
+++ b/test/com/puppetlabs/puppetdb/test/query_eng.clj
@@ -1,0 +1,91 @@
+(ns com.puppetlabs.puppetdb.test.query-eng
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
+            [com.puppetlabs.puppetdb.query-eng :refer :all]
+            [com.puppetlabs.puppetdb.fixtures :as fixt]
+            [com.puppetlabs.puppetdb.scf.storage-utils :as su]))
+
+(use-fixtures :each fixt/with-test-db)
+
+(deftest test-parenthize
+  (is (= " ( foo ) " (parenthize true "foo")))
+  (is (= "foo" (parenthize false "foo"))))
+
+(deftest test-plan-sql
+  (are [sql plan] (= sql (plan->sql plan))
+
+       "foo = ?"
+       (->EqualsExpression "foo" "?")
+
+       (su/sql-regexp-match "foo")
+       (->RegexExpression "foo" "?")
+
+       (su/sql-array-query-string "foo")
+       (->ArrayEqualsExpression "foo" "?")
+
+       "foo = ? AND bar = ?"
+       (->AndExpression [(->EqualsExpression "foo" "?")
+                         (->EqualsExpression "bar" "?")])
+
+       "foo = ? OR bar = ?"
+       (->OrExpression [(->EqualsExpression "foo" "?")
+                        (->EqualsExpression "bar" "?")])
+
+       "NOT ( foo = ? )"
+       (->NotExpression (->EqualsExpression "foo" "?"))
+
+       "foo IS NULL"
+       (->NullExpression "foo" true)
+
+       "foo IS NOT NULL"
+       (->NullExpression "foo" false)
+
+       "SELECT thefoo.foo FROM ( select foo from table ) AS thefoo WHERE 1 = 1"
+       (map->Query {:project {"foo" :string}
+                    :alias "thefoo"
+                    :subquery? false
+                    :where (->EqualsExpression 1 1)
+                    :source "select foo from table"})))
+
+(deftest test-extract-params
+
+  (are [expected plan] (= expected (extract-all-params plan))
+
+       {:plan (->AndExpression [(->EqualsExpression "foo" "?")
+                                (->RegexExpression "bar" "?")
+                                (->NotExpression (->EqualsExpression "baz" "?"))])
+        :params ["1" "2" "3"]}
+       (->AndExpression [(->EqualsExpression "foo" "1")
+                         (->RegexExpression "bar" "2")
+                         (->NotExpression (->EqualsExpression "baz" "3"))])
+
+       {:plan (map->Query {:where (->EqualsExpression "foo" "?")})
+        :params ["1"]}
+       (map->Query {:where (->EqualsExpression "foo" "1")})))
+
+(deftest test-expand-user-query
+  (is (= [["=" "prop" "foo"]]
+         (expand-user-query [["=" "prop" "foo"]])))
+
+  (is (= [["=" "prop" "foo"]
+          ["in" "certname"
+           ["extract" "certname"
+            ["select-nodes"
+             ["nil?" "deactivated" false]]]]]
+         (expand-user-query [["=" "prop" "foo"]
+                             ["=" ["node" "active"] true]])))
+  (is (= [["=" "prop" "foo"]
+          ["in" "resource"
+           ["extract" "res_param_resource"
+            ["select-params"
+             ["and"
+              ["=" "res_param_name" "bar"]
+              ["=" "res_param_value" "\"baz\""]]]]]]
+         (expand-user-query [["=" "prop" "foo"]
+                             ["=" ["parameter" "bar"] "baz"]]))))
+
+
+(deftest test-valid-query-fields
+  (is (thrown-with-msg? IllegalArgumentException
+                        #"'foo' is not a queryable object for resources, known queryable objects are.*"
+       (compile-user-query->sql resources-query ["=" "foo" "bar"]))))

--- a/test/com/puppetlabs/puppetdb/test/zip.clj
+++ b/test/com/puppetlabs/puppetdb/test/zip.clj
@@ -1,0 +1,129 @@
+(ns com.puppetlabs.puppetdb.test.zip
+  (:require [com.puppetlabs.puppetdb.zip :refer :all]
+            [clojure.test :refer :all]
+            [clojure.test.check.clojure-test :as cct]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]))
+
+(defn tree-generator
+  "Returns a generator that creates trees using collections generated
+  from `coll-generators`. `coll-generators` is a list of functions
+  that accepts `leaf-values` (such as gen/vector, gen/list etc). The
+  test-check size feature ensures the trees aren't too large."
+  [coll-generators leaf-values]
+  (fn [size]
+    (if (= size 0)
+      leaf-values
+      (let [new-size (quot size 2)
+            smaller-tree (gen/resize new-size (gen/sized (tree-generator coll-generators leaf-values)))]
+        (gen/frequency
+         (conj (mapv (fn [coll-generator]
+                       [3 (coll-generator smaller-tree)]) coll-generators)
+               [5 leaf-values]))))))
+
+(def misc-leaves
+  "Used for emulating typical tree contents with strings numbers and keywords"
+  (gen/one-of [gen/int
+               gen/string-alpha-numeric
+               gen/keyword]))
+
+(defrecord Foo [a b c d])
+
+(defn foo-gen
+  "Generator for the defrecord Foo. Requires a leaves generator for
+  the values of the defrecord (i.e. gen/int)"
+  [leaves]
+   (gen/fmap (partial apply ->Foo)
+             (apply gen/tuple (repeat 4 leaves))))
+
+(defn seq-gen
+  "Generator for seqs of `leaves`"
+  [leaves]
+  (gen/fmap seq (gen/list leaves)))
+
+(def sequential-gen
+  "Generates sequential? things"
+  [gen/vector
+   gen/list
+   seq-gen])
+
+(def with-maps
+  "Generates sequential? values, along with hash-maps and
+   defrecords (instances of Foo)"
+  (-> sequential-gen
+      (conj #(gen/map (gen/one-of [gen/keyword gen/string]) %))
+      (conj foo-gen)))
+
+(cct/defspec no-op-zipper
+  50
+  (prop/for-all [v (gen/sized (tree-generator with-maps gen/any))]
+                (= v
+                   (:node (post-order-transform (tree-zipper v) [identity])))))
+
+(defn flip-sign
+  "Zipper function to make positive numbers negative and negative numbers positive"
+  [x]
+  (when (number? x)
+    (- x)))
+
+(cct/defspec flip-sign-zipper
+  50
+  (prop/for-all [tree (gen/sized (tree-generator with-maps gen/int))]
+                (let [flipped (:node (post-order-transform (tree-zipper tree)
+                                                           [flip-sign]))]
+                  (not= tree flipped)
+                  (= tree
+                     (:node (post-order-transform (tree-zipper flipped)
+                                                  [flip-sign]))))))
+
+(defn extract-item
+  "Zipper function for putting items matching `pred` into the state of
+  the zipper"
+  [pred]
+  (fn [node state]
+    (when (pred node)
+      {:state (conj state node)})))
+
+(cct/defspec post-order-collect
+  50
+  (prop/for-all [w (gen/such-that coll? (gen/sized (tree-generator sequential-gen misc-leaves)))]
+                (= (:state (post-order-visit (tree-zipper w) [] [(extract-item number?)]))
+                   (filter number? (flatten (seq w))))))
+
+(deftest test-metadata-copying
+  (let [tree {:a
+              (with-meta
+                {:b (with-meta
+                      {:c
+                       (with-meta
+                         [1 2 3 (with-meta
+                                  (list 4 5 6)
+                                  {:tag "the end"})]
+                         {:tag "baz"})}
+                      {:tag "bar"})}
+                {:tag "foo"})}
+        result (:node (post-order-transform (tree-zipper tree) [flip-sign]))
+        result2 (:node (post-order-transform (tree-zipper result) [flip-sign]))]
+
+    (is (not= tree result))
+    (is (= tree result2))
+
+    (are [expected get-in-args] (= expected
+                                   (meta (get-in result get-in-args))
+                                   (meta (get-in result2 get-in-args)))
+
+         {:tag "foo"} [:a]
+         {:tag "bar"} [:a :b]
+         {:tag "baz"} [:a :b :c]
+         {:tag "the end"} [:a :b :c 3])))
+
+(deftest test-pre-order-traversal
+  (let [tree [1 [2 3 [4 5]] [6 7 8]]
+        {:keys [node state]} (pre-order-visit (tree-zipper tree) [] [(extract-item coll?)])]
+
+    (is (= [tree
+            [2 3 [4 5]]
+            [4 5]
+            [6 7 8]]
+           state))
+    (is (= node tree))))


### PR DESCRIPTION
First cut at creating an intermediate query language for PuppetDB. The initial user query is expanded from the more sugared syntax to a smaller set of basic operators and subqueries. The query then goes from the
"expanded form" to a query plan and then ultimately down to sql. The user query is manipulated in the context of a "source query", specific to each endpoint. This commit supports resources, but will next expand to the other endpoints.
