### PR TITLE
(PDB-658) Move reports endpoint over to the new query engine

### DIFF
--- a/src/com/puppetlabs/puppetdb/http/reports.clj
+++ b/src/com/puppetlabs/puppetdb/http/reports.clj
@@ -17,8 +17,7 @@
   [version query paging-options db]
   (try
     (with-transacted-connection db
-      (->> (json/parse-string query true)
-           (query/report-query->sql version)
+      (->> (json/parse-strict-string query true)
            (query/query-reports version paging-options)
            (query-result-response)))
     (catch com.fasterxml.jackson.core.JsonParseException e

--- a/test/com/puppetlabs/puppetdb/testutils/reports.clj
+++ b/test/com/puppetlabs/puppetdb/testutils/reports.clj
@@ -113,9 +113,7 @@
     ;; the example reports don't have a receive time (because this is
     ;; calculated by the server), so we remove this field from the response
     ;; for test comparison
-    (update-in (->> query
-                    (query/report-query->sql version)
-                    (query/query-reports :v4 paging-options))
+    (update-in (query/query-reports :v4 paging-options query)
                [:result]
                munge-fn)))
 


### PR DESCRIPTION
All existing reports functionality works with the new query engine. In addition to what was previously supported, the following new features were added once it was moved over:

Allows querying on the following new fields:

puppet_version
report_format
configuration_version
start_time
end_time
receive_time (though not really useful without >, <, <=, >= which has not been done yet)
transaction_uuid

Reports also now supports more of the "standard" query operators such as:

or
~ (regex)
in
not
