### PR TITLE
(PDB-651) Fix spec failure on ruby 1.8.7

### DIFF
--- a/puppet/spec/unit/util/puppetdb/command_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/command_spec.rb
@@ -64,7 +64,7 @@ describe Puppet::Util::Puppetdb::Command do
         Puppet::Util::Puppetdb.expects(:config).at_least_once.returns(config)
 
         httpok.stubs(:body).returns '{"uuid": "a UUID"}'
-        http.expects(:post).with { |path|
+        http.expects(:post).with { |path, payload, headers|
           path.start_with?("/puppetdb" + Puppet::Util::Puppetdb::Command::CommandsUrl)
         }.returns httpok
 


### PR DESCRIPTION
One of the new spec tests contained an expectation that used
a block argument destructuring syntax which has changed
between ruby 1.8.7 and ruby 1.9.3.  This commit fixes
the test to use a syntax that is compatible with both
ruby versions.
