### PR TITLE
(PDB-658) Move environments endpoint to the query engine

### DIFF
--- a/src/com/puppetlabs/puppetdb/http/environments.clj
+++ b/src/com/puppetlabs/puppetdb/http/environments.clj
@@ -14,6 +14,7 @@
             [com.puppetlabs.jdbc :refer [with-transacted-connection get-result-count]]
             [com.puppetlabs.cheshire :as json]))
 
+
 (defn produce-body
   "Given a query, and database connection, return a Ring response with the query
   results.
@@ -22,7 +23,7 @@
   [version query paging-options db]
   (try
     (with-transacted-connection db
-      (let [parsed-query (json/parse-string query true)
+      (let [parsed-query (json/parse-strict-string query true)
             {[sql & params] :results-query
              count-query    :count-query} (e/query->sql version parsed-query paging-options)
             resp (pl-http/stream-json-response

--- a/test/com/puppetlabs/puppetdb/test/query/environments.clj
+++ b/test/com/puppetlabs/puppetdb/test/query/environments.clj
@@ -20,7 +20,7 @@
              {:name "baz"}}
            (set (:result (query-environments :v4 (query->sql :v4 nil))))))))
 
-(def jsonify (comp json/parse-string json/generate-string))
+(def jsonify (comp json/parse-strict-string json/generate-string))
 
 (deftest test-environment-queries
   (testing "without environments"
@@ -64,8 +64,9 @@
 
 (deftest test-failed-comparison
   (are [query] (thrown-with-msg? IllegalArgumentException
-                                 #"Value foo must be a number"
+                                 #"Query operators >,>=,<,<= are not allowed on field name"
                                  (query-environments :v4 (query->sql :v4 (jsonify query))))
+
        '[<= name foo]
        '[>= name foo]
        '[< name foo]


### PR DESCRIPTION
Needed to add support for an empty query to the engine. This was needed to query for ALL environments. Will need to rebase after https://github.com/puppetlabs/puppetdb/pull/982 is merged.
