### PR TITLE
(PDB-697) Test and document new reports features

### DIFF
--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -30,7 +30,7 @@ JSON query structure would be:
 
 ##### Operators
 
-The only available [OPERATOR][] is `=`.
+See [the Operators page](./operators.html)
 
 ##### Fields
 
@@ -48,6 +48,27 @@ The only available [OPERATOR][] is `=`.
 
 `status`
 : the status associated to report's node, possible values for this field come from Puppet's report status which can be found [here][statuses]
+
+`puppet-version`
+: the version of puppet that generated the report
+
+`report-format`
+: the version number of the report format that puppet used to generate the original report data
+
+`configuration-version`
+: an identifier string that puppet uses to match a specific catalog for a node to a specific puppet run
+
+`start-time`
+: is the time at which the puppet run began
+
+`end-time`
+: is the time at which the puppet run ended
+
+`receive-time`
+: is the time at which puppetdb recieved the report
+
+`transaction-uuid`
+: string used to identify a puppet run
 
 #### Response format
 


### PR DESCRIPTION
Moving reports to the new query engine enabled querying on many new
fields and all of the "standard" operators. This commit adds tests for
each of those fields and add docs around them.

This commit also fixes and issue with testing resources. The previous
code was not running some of the query tests on the new query engine.
The tests at the http layer were going through to the query engine
correctly, but the ones below that layer were not.
