### PR TITLE
(PDB-697) Added docs/tests for new queryable nodes fields and operators

### DIFF
--- a/documentation/api/query/v4/nodes.markdown
+++ b/documentation/api/query/v4/nodes.markdown
@@ -22,24 +22,48 @@ aren't included in the response.
 
 #### Parameters
 
-* `query`: Optional. A JSON array of query predicates, in prefix form,
-  conforming to the format described below.
+* `query`: Required. A JSON array of query predicates, in prefix form. (The standard `["<OPERATOR>", "<FIELD>", "<VALUE>"]` format.)
 
-The `query` parameter is a similar format to [resource queries][resource].
+To query for the latest fact/catalog/report timestamp submitted by 'example.local', the JSON query structure would be:
 
-Only queries against `"name"`, `"catalog-environment"`, `"facts-environment"`, `"report-environment"` and facts are currently supported.
+    ["=", "certname", "example.local"]
 
-Fact terms must be of the form `["fact", <fact name>]`.
+##### Operators
 
-Node query supports [all available operators](./operators.html). Inequality
-operators are only supported for fact queries, but regular expressions are
-supported for all valid query parameters.
+See [the Operators page](./operators.html)
 
-Inequality operators are strictly arithmetic, and will ignore any fact values
-which are not numeric.
+##### Fields
+
+The below fields are allowed as filter criteria and are returned in all responses.
+
+`certname`
+: the name of the node that the report was received from.
+
+`catalog-environment`
+: the environment for the last received catalog
+
+`facts-environment`
+: the environment for the last received fact set
+
+`report-environment`
+: the environment for the last received report
+
+`catalog-timestamp`
+: last time a catalog was received
+
+`facts-timestamp`
+: last time a fact set was received
+
+`report-timestamp`
+: last time a report run was complete
+
+`["fact", <fact name>]`
+: queries for <fact name> associated to a node, inequality operators are allowed, non-numeric values will be skipped
 
 Note that nodes which are missing a fact referenced by a `not` query will match
 the query.
+
+##### Query Example
 
 This query will return nodes whose kernel is Linux and whose uptime is less
 than 30 days:
@@ -64,31 +88,6 @@ The response is a JSON array of hashes of the form:
      "report-environment": <string}
 
 The array is unsorted.
-
-##### Fields
-
-Valid fields returned by the query are as follows.
-
-`name`
-: the name of the node
-
-`catalog-timestamp`
-: last time a catalog was received
-
-`facts-timestamp`
-: last time a fact set was received
-
-`report-timestamp`
-: last time a report run was complete
-
-`catalog-environment`
-: the environment for the last received catalog
-
-`facts-environment`
-: the environment for the last received fact set
-
-`report-environment`
-: the environment for the last received report
 
 #### Example
 
@@ -210,4 +209,3 @@ for this route.
 This query endpoint supports paged results via the common PuppetDB paging
 query parameters.  For more information, please see the documentation
 on [paging][paging].
-

--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -23,31 +23,27 @@ The available fields for each endpoint are listed in that endpoint's documentati
 
 ### `=` (equality)
 
-**Matches if:** the field's actual value is exactly the same as the provided value. Note that this **does not** coerce values --- the provided value must be the same data type as the field. In particular, be aware that:
+**Matches if:** the field's actual value is exactly the same as the provided value. Note that this **will** coerce values if the provided value is numeric and the target field is coercible (i.e. fact values), but will not coerce if the provided value is a string
 
 * Most fields are strings.
 * Some fields are booleans.
-* Numbers in resource parameters from Puppet are usually stored as strings, and equivalent numbers will **not** match --- if the value of `someparam` were "0", then `["=", "someparam", "0.0"]` wouldn't match.
+* Numbers in resource parameters from Puppet are usually stored as strings, if the value of `someparam` were "0", then `["=", "someparam", "0.0"]` wouldn't match, use `["=", "someparam", 0.0]`.
 
 ### `>` (greater than)
 
-**Matches if:** the field is greater than the provided value. Coerces both the field and value to floats or integers; if
-they can't be coerced, the operator will not match.
+**Matches if:** the field is greater than the provided value. If the column is coercible (such as fact values), it will coerce both the field and value to floats or integers. This operator can be used on timestamps but is not supported on strings.
 
 ### `<` (less than)
 
-**Matches if:** the field is less than the provided value. Coerces both the field and value to floats or integers; if
-they can't be coerced, the operator will not match.
+**Matches if:** the field is greater than the provided value. If the column is coercible (such as fact values), it will coerce both the field and value to floats or integers. This operator can be used on timestamps but is not supported on strings.
 
 ### `>=` (less than or equal to)
 
-**Matches if:** the field is greater than or equal to the provided value. Coerces both the field and value to floats or integers; if
-they can't be coerced, the operator will not match.
+**Matches if:** the field is greater than the provided value. If the column is coercible (such as fact values), it will coerce both the field and value to floats or integers. This operator can be used on timestamps but is not supported on strings.
 
 ### `<=` (greater than or equal to)
 
-**Matches if:** the field is less than or equal to the provided value. Coerces both the field and value to floats or integers; if
-they can't be coerced, the operator will not match.
+**Matches if:** the field is greater than the provided value. If the column is coercible (such as fact values), it will coerce both the field and value to floats or integers. This operator can be used on timestamps but is not supported on strings.
 
 ### `~` (regexp match)
 

--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -34,7 +34,7 @@ See [the Operators page](./operators.html)
 
 ##### Fields
 
-`FIELD` may be any of the following.  All fields support only the equality operator.
+`FIELD` may be any of the following:
 
 `certname`
 : the name of the node that the report was received from.

--- a/test/com/puppetlabs/puppetdb/test/http/resources.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/resources.clj
@@ -10,7 +10,9 @@
             [ring.mock.request :refer :all]
             [com.puppetlabs.puppetdb.testutils :refer [get-request paged-results
                                                        deftestseq]]
-            [com.puppetlabs.puppetdb.testutils.resources :refer [store-example-resources]]))
+            [com.puppetlabs.puppetdb.testutils.resources :refer [store-example-resources]]
+            [clojure.java.jdbc :as sql]
+            [com.puppetlabs.puppetdb.scf.storage-utils :refer [db-serialize]]))
 
 (def v2-endpoint "/v2/resources")
 (def v3-endpoint "/v3/resources")

--- a/test/com/puppetlabs/puppetdb/testutils.clj
+++ b/test/com/puppetlabs/puppetdb/testutils.clj
@@ -13,7 +13,9 @@
             [com.puppetlabs.puppetdb.scf.storage-utils :refer [sql-current-connection-table-names]]
             [puppetlabs.kitchensink.core :refer [parse-int excludes? keyset]]
             [clojure.test :refer :all]
-            [clojure.set :refer [difference]]))
+            [clojure.set :refer [difference]]
+            [clj-time.format :as tfmt]
+            [clj-time.coerce :as tcoerce]))
 
 (def c-t "application/json")
 


### PR DESCRIPTION
New fields are now available as part of the nodes endpoint that resulted
from moving the endpoint into the query engine. This commit tests and
documents those new fields
