### PR TITLE
(PDB-577) Lower KahaDB MessageDatabase logging threshold.

### DIFF
--- a/ext/templates/logback.xml.erb
+++ b/ext/templates/logback.xml.erb
@@ -19,6 +19,10 @@
     <!-- Supress internal Spring Framework logging -->
     <logger name="org.springframework.jms.connection" level="warn"/>
 
+    <!-- Lower the log level for ActiveMQ KahaDB MessageDatabase -->
+    <logger name="org.apache.activemq.store.kahadb.MessageDatabase"
+        level="info"/>
+
     <!-- turn on to see verbose storage activity -->
     <!--
     <logger name="com.puppetlabs.puppetdb.scf.storage" level="debug"/>

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -8,6 +8,8 @@
     <!-- Silence particularly noisy packages -->
     <logger name="org.apache.activemq" level="warn"/>
     <logger name="org.springframework.jms.connection" level="warn"/>
+    <logger name="org.apache.activemq.store.kahadb.MessageDatabase"
+        level="info"/>
 
     <!-- turn on to see verbose storage activity -->
     <!--


### PR DESCRIPTION
- Previously, premature termination of PuppetDB import under specific ownership
  conditions led to a residual KahaDB lock file that could prevent subsequent imports
  from running for no obvious reason.  This patch lowers the log threshold
  for KahaDB MessageDataBase so affected users are informed of the cause (permissions conflict.)
