### PR TITLE
(PDB-697) Document and test new events and resources features

### DIFF
--- a/documentation/api/query/v4/events.markdown
+++ b/documentation/api/query/v4/events.markdown
@@ -49,9 +49,9 @@ type 'Service':
     ["and", ["=", "status", "failure"],
             ["~", "certname", "^foo\\."],
             ["=", "resource-type", "Service"]]
-            
-To retrieve latest events that are tied to the class found in your update.pp file    
-    
+
+To retrieve latest events that are tied to the class found in your update.pp file
+
     ["and", ["=", "latest-report?", true],
             ["~", "file", "update.pp"]]
 
@@ -161,13 +161,18 @@ is not supported by the regex match operator.
 `environment`
 : the environment associated with the reporting node
 
+`configuration-version`
+: an identifier string that puppet uses to match a specific catalog for a node to a specific puppet run
+
+`containment-path`
+: checks for the supplied string in the collection of containment path strings associated to the event
+
 ##### Notes on fields that allow `NULL` values
 
 In the case of a `skipped` resource event, some of the fields of an event may
-not have values.  We handle this case in a slightly special way when these
-fields are used in equality (`=`) or inequality (`!=`) queries; specifically,
-an equality query will always return `false` for an event with no value for
-the field, and an inequality query will always return `true`.
+not have values. Queries using equality (`=`) and inequality (`!=`) will not return
+null values. See the `null?` operator, if you want to query for nodes that do not
+have a value.
 
 #### Response format
 

--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -61,6 +61,17 @@ The following example would match if the `certname` field's actual value resembl
 > * [PostgreSQL regexp features](http://www.postgresql.org/docs/9.1/static/functions-matching.html#POSIX-SYNTAX-DETAILS)
 > * [HSQLDB (embedded database) regexp features](http://docs.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html)
 
+### `null?` (is null)
+
+**Matches if:** the field's value is null, or if there is a value specified for the field, depending on the second argument to the operator
+
+The following example would return events that do not have an associated line number:
+
+    ["null?" "line" true]
+
+Similarly, the below query would return events that have a specified line number:
+
+    ["null?" "line" false]
 
 
 ## Boolean Operators

--- a/documentation/api/query/v4/resources.markdown
+++ b/documentation/api/query/v4/resources.markdown
@@ -71,8 +71,8 @@ for "example.local" the JSON query structure would be:
             ["=", ["parameter", "ensure"], "enabled"]
 
 See [the Operators page](./operators.html) for the full list of available operators. Note that
-resource queries *do not support* inequality, and regexp matching *is not
-supported* against node status or parameter values.
+resource queries only support inequality on line, regexp matching *is not supported* against node
+status or parameter values.
 
 ### `GET /v4/resources/<TYPE>`
 

--- a/src/com/puppetlabs/puppetdb/query_eng.clj
+++ b/src/com/puppetlabs/puppetdb/query_eng.clj
@@ -96,7 +96,7 @@
                          "tags" :array
                          "exported" :string
                          "file" :string
-                         "line" :string
+                         "line" :number
                          "parameters" :string}
                :queryable-fields ["certname" "environment" "resource" "type" "title" "tag" "exported" "file" "line" "parameters"]
                :alias "resources"
@@ -151,7 +151,7 @@
                          "old_value" :string
                          "message" :string
                          "file" :string
-                         "line" :string
+                         "line" :number
                          "containment_path" :array
                          "containing_class" :string
                          "environment" :string}
@@ -327,7 +327,7 @@
             ["in" "certname"
              ["extract" "certname"
               ["select-nodes"
-               ["nil?" "deactivated" value]]]]
+               ["null?" "deactivated" value]]]]
 
             [["=" ["parameter" param-name] param-value]]
             ["in" "resource"
@@ -357,7 +357,7 @@
             [op field (db-serialize value)]
 
             [["=" field nil]]
-            ["nil?" (jdbc/dashes->underscores field) true]
+            ["null?" (jdbc/dashes->underscores field) true]
 
             [[op "tag" array-value]]
             [op "tags" (str/lower-case array-value)]
@@ -475,7 +475,7 @@
                         (format "Value %s must be a number for %s comparison." value op)))))
 
 
-            [["nil?" column value]]
+            [["null?" column value]]
             (map->NullExpression {:column column
                                   :null? value})
 

--- a/test/com/puppetlabs/puppetdb/test/http/resources.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/resources.clj
@@ -265,6 +265,17 @@ to the result of the form supplied to this method."
           (is-response-equal (get-response endpoint query) result))
         (let [query ["=" "line" 22]
               result #{bar2}]
+          (is-response-equal (get-response endpoint query) result))
+
+        (let [query ["and"
+                     [">" "line" 21]
+                     ["<" "line" 23]]
+              result #{bar2}]
+          (is-response-equal (get-response endpoint query) result))
+        (let [query ["and"
+                     [">" "line" "21"]
+                     ["<" "line" "23"]]
+              result #{bar2}]
           (is-response-equal (get-response endpoint query) result))))))
 
 (deftestseq resource-query-paging

--- a/test/com/puppetlabs/puppetdb/test/query_eng.clj
+++ b/test/com/puppetlabs/puppetdb/test/query_eng.clj
@@ -71,7 +71,7 @@
           ["in" "certname"
            ["extract" "certname"
             ["select-nodes"
-             ["nil?" "deactivated" true]]]]]
+             ["null?" "deactivated" true]]]]]
          (expand-user-query [["=" "prop" "foo"]
                              ["=" ["node" "active"] true]])))
   (is (= [["=" "prop" "foo"]


### PR DESCRIPTION
This change adds tests and docs for events/resources features inherited
by the switch over to the query engine.

This change also documents and tests an explicit "null?" operator. Some
endpoints for v2/v3, when using not, such as ["not" ["=" "line" 10]]
would return line values that were NULL in addition to other line
numbers. In v4, this is no longer the behavior. Users wanting null
values in addition to lines != 10, can use "null?" with an "or"
statement.
