### PR TITLE
(PDB-337) Remove extraneous _timestamp fact

### DIFF
--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -17,7 +17,7 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
     profile "facts#save" do
       payload = profile "Encode facts command submission payload" do
         facts = request.instance.dup
-        facts.values = facts.values.dup
+        facts.values = facts.strip_internal
         facts.stringify
         {
           "name" => facts.name,

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -34,7 +34,7 @@ describe Puppet::Node::Facts::Puppetdb do
       facts.stringify
       f = {
         "name" => facts.name,
-        "values" => facts.values,
+        "values" => facts.strip_internal,
         "environment" => env,
       }
 


### PR DESCRIPTION
Previously a _timestamp fact was submitted to puppetDB even though _timestamp
was originally intended for internal use.  This commit strips internal data
(all preceded by "_") from the factset before submission to PuppetDB.
