### PR TITLE
(PDB-240) Replace anonymize.clj read-string with clojure.edn/read-string

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/anonymize.clj
+++ b/src/com/puppetlabs/puppetdb/cli/anonymize.clj
@@ -255,7 +255,7 @@
 (defn -main
   [& args]
   (let [[{:keys [outfile infile profile config]} _] (validate-cli! args)
-        extra-config                                (if (empty? config) {} (read-string (slurp config)))
+        extra-config                                (if (empty? config) {} (clojure.edn/read-string (slurp config)))
         profile-config                              (get (merge anon-profiles extra-config) profile)
         metadata                                    (parse-metadata infile)]
 


### PR DESCRIPTION
This patch replaces a call to read-string in anonymize.clj with a call to
clojure.edn/read-string. Unlike clojure.core/read-string,
clojure.edn/read-string is safe to use with untrusted data and guaranteed to
be free of side-effects.
