### PR TITLE
(PDB-601) Do not require query operator on reports endpoint

### DIFF
--- a/src/com/puppetlabs/puppetdb/http/reports.clj
+++ b/src/com/puppetlabs/puppetdb/http/reports.clj
@@ -48,6 +48,6 @@
   [version]
   (-> (routes version)
     verify-accepts-json
-    (validate-query-params {:required ["query"]
-                            :optional paging/query-params})
+    (validate-query-params 
+      {:optional (cons "query" paging/query-params)})
     wrap-with-paging-options))


### PR DESCRIPTION
With this pull request, hitting the reports endpoint without a query argument
will return the full reports collection.  This behavior is consistent with
that of the nodes, facts, and resources endpoints.
