### PR TITLE
(PDB-162) Add regexp support to resource parameter queries

### DIFF
--- a/src/com/puppetlabs/puppetdb/query_eng.clj
+++ b/src/com/puppetlabs/puppetdb/query_eng.clj
@@ -329,13 +329,13 @@
               ["select-nodes"
                ["null?" "deactivated" value]]]]
 
-            [["=" ["parameter" param-name] param-value]]
+            [[(op :guard #{"=" "~"}) ["parameter" param-name] param-value]]
             ["in" "resource"
              ["extract" "res_param_resource"
               ["select-params"
                ["and"
-                ["=" "res_param_name" param-name]
-                ["=" "res_param_value" (db-serialize param-value)]]]]]
+                [op "res_param_name" param-name]
+                [op "res_param_value" (db-serialize param-value)]]]]]
 
             [[(op :guard #{"=" "~" ">" "<" "<=" ">="}) ["fact" fact-name] fact-value]]
             ["in" "certname"
@@ -370,7 +370,10 @@
   (s/checker [(s/one
                (apply s/either (map s/eq binary-operators))
                :operator)
-              (s/one s/Str :field)
+              (s/one (s/either s/Str
+                               [(s/one s/Str :nested-field)
+                                (s/one s/Str :nested-value)])
+                     :field)
               (s/one (s/either s/Str s/Bool s/Int pls/Timestamp) :value)]))
 
 (defn vec?

--- a/test/com/puppetlabs/puppetdb/test/http/resources.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/resources.clj
@@ -93,6 +93,12 @@ to the result of the form supplied to this method."
                               [["=" ["parameter" "acl"] ["john:rwx" "fred:rwx"]] #{foo1 bar1}]]]
         (is-response-equal (get-response endpoint query) result)))
 
+    (testing "only v4 or after queries"
+      (when-not (contains? #{:v2 :v3} version)
+        (doseq [[query result] [[["~" ["parameter" "owner"] "ro.t"] #{foo1 bar1}]
+                                [["not" ["~" ["parameter" "owner"] "ro.t"]] #{foo2 bar2}]]]
+          (is-response-equal (get-response endpoint query) result))))
+
     (testing "fact subqueries are supported"
       (let [{:keys [body status]} (get-response endpoint
                                                 ["and"


### PR DESCRIPTION
The query engine supported this, but the existing "rewrite" rule, to go
from the shorthand parameter syntax to the nested resource query didn't
recognize ~. That is fixed with this commit, so regexps will now work on parameters.
