### PR TITLE
(PDB-675) Stop pdb process even if pidfile missing

### DIFF
--- a/ext/templates/init_debian.erb
+++ b/ext/templates/init_debian.erb
@@ -83,6 +83,7 @@ do_stop()
     if [ -e $PIDFILE ] ; then
       start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --user $NAME --pidfile $PIDFILE --exec $JAVA_BIN
     else
+      log_warning_msg "PIDfile $PIDFILE for $NAME is missing. Stopping process started by $NAME that is an instance of $JAVA_BIN" "$NAME"
       start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --user $NAME --exec $JAVA_BIN
     fi
     RETVAL="$?"


### PR DESCRIPTION
Prior to this commit, there were issues about the init.d script failling
silently if the PIDfile was missing. Although the fact that the PIDfile
was missing is a greater issue, this at least provides a workaround for
that. When trying to stop the puppetdb service with a missing PIDfile,
the stop would fail silently, assuming the process had already been
stopped because of the missing PIDfile. However, running `ps auwx | grep
puppetdb` would show that the process has in fact, not been stopped.
This change updated the init.d script to check if the PIDfile is
present before atttempting a stop. If it is, it uses that information to
stop the process as it always has. If it isn't, then it uses the
puppetdb user to stop the process. It is likely that this is too heavy a
hammer to user for this particular problem, but I think it should do
just what we need it do. We still specify --exec when searching for the
process that needs to be stopped, which should limit the possibility of
stopping a process we actually don't want to stop.
