### PR TITLE
(PDB-47) Enable structured facts from facts terminus

### DIFF
--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -18,7 +18,6 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
       payload = profile "Encode facts command submission payload" do
         facts = request.instance.dup
         facts.values = facts.strip_internal
-        facts.stringify
         {
           "name" => facts.name,
           "values" => facts.values,
@@ -29,7 +28,7 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
         }
       end
 
-      submit_command(request.key, payload, CommandReplaceFacts, 2)
+      submit_command(request.key, payload, CommandReplaceFacts, 3)
     end
   end
 

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -31,7 +31,6 @@ describe Puppet::Node::Facts::Puppetdb do
     end
 
     it "should POST the facts as a JSON string" do
-      facts.stringify
       f = {
         "name" => facts.name,
         "values" => facts.strip_internal,
@@ -40,7 +39,7 @@ describe Puppet::Node::Facts::Puppetdb do
 
       payload = {
         :command => CommandReplaceFacts,
-        :version => 2,
+        :version => 3,
         :payload => f,
       }.to_json
 
@@ -51,7 +50,7 @@ describe Puppet::Node::Facts::Puppetdb do
       save
     end
 
-    it "should stringify fact values before submitting" do
+    it "should preserve integer type when submitting" do
       facts.values['something'] = 100
 
       sent_payload = nil
@@ -66,7 +65,7 @@ describe Puppet::Node::Facts::Puppetdb do
 
       # We shouldn't modify the original instance
       facts.values['something'].should == 100
-      sent_facts['values']['something'].should == '100'
+      sent_facts['values']['something'].should == 100
     end
   end
 

--- a/src/com/puppetlabs/puppetdb/facts.clj
+++ b/src/com/puppetlabs/puppetdb/facts.clj
@@ -1,0 +1,24 @@
+(ns com.puppetlabs.puppetdb.facts
+  (:require [puppetlabs.kitchensink.core :as kitchensink]
+            [com.puppetlabs.cheshire :as json]))
+
+(defn flatten-fact-value
+  "Flatten a fact value to a string either using JSON or coercement depending on
+  the type."
+  [value]
+  {:post [(string? %)]}
+  (cond
+   (string? value) value
+   (kitchensink/boolean? value) (str value)
+   (integer? value) (str value)
+   (float? value) (str value)
+   (map? value) (json/generate-string value)
+   (coll? value) (json/generate-string value)
+   :else (throw (IllegalArgumentException. (str "Value " value " is not valid for flattening")))))
+
+(defn flatten-fact-value-map
+  "Flatten a map of facts depending on the type of the value."
+  [factmap]
+  (reduce-kv (fn [acc k v]
+               (assoc acc k (flatten-fact-value v)))
+             {} factmap))

--- a/test/com/puppetlabs/puppetdb/test/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/facts.clj
@@ -1,0 +1,18 @@
+(ns com.puppetlabs.puppetdb.test.facts
+  (:require [com.puppetlabs.puppetdb.facts :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest flatten-fact-value-test
+  (testing "check basic types work"
+    (is (= (flatten-fact-value "foo") "foo"))
+    (is (= (flatten-fact-value 3) "3"))
+    (is (= (flatten-fact-value true) "true"))
+    (is (= (flatten-fact-value {:a :b}) "{\"a\":\"b\"}"))
+    (is (= (flatten-fact-value [:a :b]) "[\"a\",\"b\"]"))))
+
+(deftest flatten-fact-value-map-test
+  (testing "ensure we get back a flattened set of values"
+    (is (= (flatten-fact-value-map {"networking"
+                                    {"eth0"
+                                     {"ipaddresses" ["192.168.1.1"]}}})
+           {"networking" "{\"eth0\":{\"ipaddresses\":[\"192.168.1.1\"]}}"}))))


### PR DESCRIPTION
This patch disables the stringify that we perform on outbound facts before
they are sent to the PuppetDB service.

To keep backwards compatibility, for now we are flattening these facts out
to strings before they are stored.

Signed-off-by: Ken Barber ken@bob.sh
