### PR TITLE
(docs) Port recent docs revisions to 1.6.x branch

### DIFF
--- a/documentation/api/query/v1/resources.markdown
+++ b/documentation/api/query/v1/resources.markdown
@@ -28,32 +28,23 @@ The `query` parameter adheres to the following grammar:
 
 `field` strings may be any of the following:
 
-`tag`
-: a case-insensitive tag on the resource
+* `tag`: a case-insensitive tag on the resource
 
-`["node", "name"]`
-: the name of the node associated with the resource
+* `["node", "name"]`: the name of the node associated with the resource
 
-`["node", "active"]`
-: `true` if the node has not been deactivated, `false` if it has
+* `["node", "active"]`: `true` if the node has not been deactivated, `false` if it has
 
-`["parameter", "<parameter name>"]`
-: a parameter of the resource
+*`["parameter", "<parameter name>"]`: a parameter of the resource
 
-`type`
-: the resource type
+* `type`: the resource type
 
-`title`
-: the resource title
+* `title`: the resource title
 
-`exported`
-: whether or not the resource is exported
+* `exported`: whether or not the resource is exported
 
-`sourcefile`
-: the manifest file where the resource was declared
+* `sourcefile`: the manifest file where the resource was declared
 
-`sourceline`
-: the line of the manifest in which the resource was declared
+* `sourceline`: the line of the manifest in which the resource was declared
 
 For example, the JSON query structure for file resources, tagged "magical", and present on any active host except
 for "example.local" would be:
@@ -66,19 +57,15 @@ for "example.local" would be:
 
 The following conditionals for type behaviors are defined:
 
-`or`
-: If *any* condition is true, the result is true.
+* `or`: If *any* condition is true, the result is true.
 
-`and`
-: If *all* conditions are true, the result is true.
+* `and`: If *all* conditions are true, the result is true.
 
-`not`
-: If *none* of the conditions are true, the result is true.
+* `not`: If *none* of the conditions are true, the result is true.
 
 The following match operator behaviors are defined:
 
-`=`
-: Exact string equality of the field and the value.
+* `=`: Exact string equality of the field and the value.
 
 ## Response format
 

--- a/documentation/api/query/v2/fact-names.markdown
+++ b/documentation/api/query/v2/fact-names.markdown
@@ -8,6 +8,7 @@ canonical: "/puppetdb/latest/api/query/v2/fact-names.html"
 
 The `/fact-names` endpoint can be used to retrieve all known fact names.
 
+> **Note:** The v2 API is deprecated. We recommend that you use the v3 API instead.
 
 ## Routes
 

--- a/documentation/api/query/v2/facts.markdown
+++ b/documentation/api/query/v2/facts.markdown
@@ -9,6 +9,7 @@ canonical: "/puppetdb/latest/api/query/v2/facts.html"
 Querying facts occurs via an HTTP request to the
 `/facts` REST endpoint.
 
+> **Note:** The v2 API is deprecated. We recommend that you use the v3 API instead.
 
 ## Routes
 
@@ -108,4 +109,4 @@ The result will be a JSON array, with one entry per fact. Each entry is of the f
       "value": <fact value>
     }
 
-If no facts are known for the supplied node, an HTTP 404 is returned.
+If no facts match the query, an empty JSON array will be returned.

--- a/documentation/api/query/v2/metrics.markdown
+++ b/documentation/api/query/v2/metrics.markdown
@@ -11,6 +11,8 @@ canonical: "/puppetdb/latest/api/query/v2/metrics.html"
 Querying PuppetDB metrics is accomplished by making an HTTP request
 to paths under the `/v2/metrics` REST endpoint.
 
+> **Note:** The v2 API is deprecated. We recommend that you use the v3 API instead.
+
 ## Listing available metrics
 
 ### Request format

--- a/documentation/api/query/v2/nodes.markdown
+++ b/documentation/api/query/v2/nodes.markdown
@@ -10,6 +10,7 @@ canonical: "/puppetdb/latest/api/query/v2/nodes.html"
 Nodes can be queried by making an HTTP request to the `/nodes` REST
 endpoint with a JSON-formatted parameter called `query`.
 
+> **Note:** The v2 API is deprecated. We recommend that you use the v3 API instead.
 
 ## Routes
 
@@ -74,8 +75,17 @@ not.
 
 #### Response format
 
-The response is the same format as for the [/v1/status](../v1/status.html)
-endpoint.
+The response is a single hash, of the same form used for the plain `nodes` endpoint:
+
+    {"name": <string>,
+     "deactivated": <timestamp>,
+     "catalog_timestamp": <timestamp>,
+     "facts_timestamp": <timestamp>,
+     "report_timestamp": <timestamp>}
+
+If a node of that certname doesn't exist, the response will instead be a hash of the form:
+
+    {"error": "No information is known about <NODE>"}
 
 ### `GET /v2/nodes/<NODE>/facts`
 

--- a/documentation/api/query/v2/operators.markdown
+++ b/documentation/api/query/v2/operators.markdown
@@ -10,8 +10,7 @@ canonical: "/puppetdb/latest/api/query/v2/operators.html"
 
 PuppetDB's [query strings][query] can use several common operators.
 
-> **Note:** The operators below apply to **version 2** of the query API. Not all of them are available to version 1 queries. 
-
+> **Note:** The v2 API is deprecated. We recommend that you use the v3 API instead.
 
 ## Binary Operators
 
@@ -20,7 +19,7 @@ Each of these operators accepts two arguments: a **field,** and a
 
     ["<OPERATOR>", "<FIELD>", "<VALUE>"]
 
-The available fields for each endpoint are listed in that endpoint's documentation. 
+The available fields for each endpoint are listed in that endpoint's documentation.
 
 ### `=` (equality)
 
@@ -52,17 +51,17 @@ they can't be coerced, the operator will not match.
 
 ### `~` (regexp match)
 
-**Matches if:** the field's actual value matches the provided regular expression. The provided value must be a regular expression represented as a JSON string: 
+**Matches if:** the field's actual value matches the provided regular expression. The provided value must be a regular expression represented as a JSON string:
 
 * The regexp **must not** be surrounded by the slash characters (`/rexegp/`) that delimit regexps in many languages.
-* Every backslash character **must** be escaped with an additional backslash. Thus, a sequence like `\d` would be represented as `\\d`, and a literal backslash (represented in a regexp as a double-backslash `\\`) would be represented as a quadruple-backslash (`\\\\`). 
+* Every backslash character **must** be escaped with an additional backslash. Thus, a sequence like `\d` would be represented as `\\d`, and a literal backslash (represented in a regexp as a double-backslash `\\`) would be represented as a quadruple-backslash (`\\\\`).
 
 The following example would match if the `certname` field's actual value resembled something like `www03.example.com`:
 
     ["~", "certname", "www\\d+\\.example\\.com"]
 
 > **Note:** Regular expression matching is performed by the database backend, and the available regexp features are backend-dependent. For best results, use the simplest and most common features that can accomplish your task. See the links below for details:
-> 
+>
 > * [PostgreSQL regexp features](http://www.postgresql.org/docs/9.1/static/functions-matching.html#POSIX-SYNTAX-DETAILS)
 > * [HSQLDB (embedded database) regexp features](http://docs.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html)
 
@@ -100,19 +99,19 @@ Subqueries are unlike the other operators listed above:
 These statements work together as follows (working "outward" and starting with the subquery):
 
 * The subquery collects a group of PuppetDB objects (specifically, a group of [resources][] or a group of [facts][]). Each of these objects has many **fields.**
-* The `extract` statement collects the value of a **single field** across every object returned by the subquery. 
-* The `in` statement **matches** if the value of its field is present in the list returned by the `extract` statement. 
+* The `extract` statement collects the value of a **single field** across every object returned by the subquery.
+* The `in` statement **matches** if the value of its field is present in the list returned by the `extract` statement.
 
 Subquery | Extract | In
 ---------|---------|---
 Every resource whose type is "Class" and title is "Apache." (Note that all resource objects have a `certname` field, among other fields.) | Every `certname` field from the results of the subquery. | Match if the `certname` field is present in the list from the `extract` statement.
 
-The complete `in` statement described in the table above would match any object that shares a `certname` with a node that has `Class[Apache]`. This could be combined with a boolean operator to get a specific fact from every node that matches the `in` statement. 
+The complete `in` statement described in the table above would match any object that shares a `certname` with a node that has `Class[Apache]`. This could be combined with a boolean operator to get a specific fact from every node that matches the `in` statement.
 
 
 ### `in`
 
-An `in` statement constitutes a full query string, which can be used alone or as an argument for a [boolean operator](#boolean-operators). 
+An `in` statement constitutes a full query string, which can be used alone or as an argument for a [boolean operator](#boolean-operators).
 
 "In" statements are **non-transitive** and take two arguments:
 
@@ -127,14 +126,14 @@ An `extract` statement **does not** constitute a full query string. It may only 
 
 "Extract" statements are **non-transitive** and take two arguments:
 
-* The first argument **must** be a valid **field** for the endpoint **being subqueried** (see second argument). 
+* The first argument **must** be a valid **field** for the endpoint **being subqueried** (see second argument).
 * The second argument **must** be a **subquery.**
 
-As the second argument of an `in` statement, an `extract` statement acts as a list of possible values. This list is compiled by extracting the value of the requested field from every result of the subquery. 
+As the second argument of an `in` statement, an `extract` statement acts as a list of possible values. This list is compiled by extracting the value of the requested field from every result of the subquery.
 
 ### Available Subqueries
 
-A subquery may only be used as the second argument of an `extract` statement, where it acts as a collection of PuppetDB objects. Each of the objects returned by the subquery has many fields; the `extract` statement takes the value of one field from each of those objects, and passes that list of values to the `in` statement that contains it. 
+A subquery may only be used as the second argument of an `extract` statement, where it acts as a collection of PuppetDB objects. Each of the objects returned by the subquery has many fields; the `extract` statement takes the value of one field from each of those objects, and passes that list of values to the `in` statement that contains it.
 
 In version 2 of the query API, the available subqueries are:
 
@@ -143,15 +142,15 @@ In version 2 of the query API, the available subqueries are:
 
 #### `select-resources`
 
-A `select-resources` subquery may **only** be used as the second argument of an `extract` statement. 
+A `select-resources` subquery may **only** be used as the second argument of an `extract` statement.
 
-It takes a single argument, which must be a **complete query string** which would be valid for [the `/v2/resources` endpoint][resources]. (Note that `/v2/resources/<TYPE>` and `/v2/resources/<TYPE>/<TITLE>` cannot be directly subqueried.) Since the argument is a normal query string, it can itself include any number of `in` statements and subqueries. 
+It takes a single argument, which must be a **complete query string** which would be valid for [the `/v2/resources` endpoint][resources]. (Note that `/v2/resources/<TYPE>` and `/v2/resources/<TYPE>/<TITLE>` cannot be directly subqueried.) Since the argument is a normal query string, it can itself include any number of `in` statements and subqueries.
 
 #### `select-facts`
 
-A `select-facts` subquery may **only** be used as the second argument of an `extract` statement. 
+A `select-facts` subquery may **only** be used as the second argument of an `extract` statement.
 
-It takes a single argument, which must be a **complete query string** which would be valid for [the `/v2/facts` endpoint][facts]. (Note that `/v2/facts/<NAME>` and `/v2/facts/<NAME>/<VALUE>` cannot be directly subqueried.) Since the argument is a normal query string, it can itself include any number of `in` statements and subqueries. 
+It takes a single argument, which must be a **complete query string** which would be valid for [the `/v2/facts` endpoint][facts]. (Note that `/v2/facts/<NAME>` and `/v2/facts/<NAME>/<VALUE>` cannot be directly subqueried.) Since the argument is a normal query string, it can itself include any number of `in` statements and subqueries.
 
 ### Subquery Examples
 

--- a/documentation/api/query/v2/query.markdown
+++ b/documentation/api/query/v2/query.markdown
@@ -14,19 +14,21 @@ canonical: "/puppetdb/latest/api/query/v2/query.html"
 
 ## Summary
 
-PuppetDB's query API can retrieve data objects from PuppetDB for use in other applications. For example, the terminus plugins for puppet masters use this API to collect exported resources, and to translate node facts into the inventory service. 
+PuppetDB's query API can retrieve data objects from PuppetDB for use in other applications. For example, the terminus plugins for puppet masters use this API to collect exported resources, and to translate node facts into the inventory service.
 
-The query API is implemented as HTTP URLs on the PuppetDB server. By default, it can only be accessed over the network via host-verified HTTPS; [see the jetty settings][jetty] if you need to access the API over unencrypted HTTP. 
+The query API is implemented as HTTP URLs on the PuppetDB server. By default, it can only be accessed over the network via host-verified HTTPS; [see the jetty settings][jetty] if you need to access the API over unencrypted HTTP.
+
+> **Note:** The v2 API is deprecated. We recommend that you use the v3 API instead.
 
 ## API URLs
 
-The first component of an API URL is the API version, written as `v1`, `v2`, etc. This page describes version 2 of the API, so every URL will begin with `/v2`. After the version, URLs are organized into a number of **endpoints.** 
+The first component of an API URL is the API version, written as `v1`, `v2`, etc. This page describes version 2 of the API, so every URL will begin with `/v2`. After the version, URLs are organized into a number of **endpoints.**
 
 ### Endpoints
 
 Conceptually, an endpoint represents a reservoir of some type of PuppetDB object. Each version of the PuppetDB API defines a set number of endpoints.
 
-See the [API index][index] for a list of the available endpoints. Each endpoint may have additional sub-endpoints under it; these are generally just shortcuts for the most common types of query, so that you can write terser and simpler query strings. 
+See the [API index][index] for a list of the available endpoints. Each endpoint may have additional sub-endpoints under it; these are generally just shortcuts for the most common types of query, so that you can write terser and simpler query strings.
 
 ## Query Structure
 
@@ -54,13 +56,13 @@ JSON arrays are delimited by square brackets (`[` and `]`), and items in the arr
 
 "Prefix notation" means every array in a query string must begin with an [operator][operators], and the remaining elements in the array will be interpreted as that operator's arguments, in order. (The similarity to Lisp is intentional.)
 
-A complete query string describes a comparison operation. When submitting a query, PuppetDB will check every _possible_ result from the endpoint to see if it matches the comparison from the query string, and will only return those objects that match. 
+A complete query string describes a comparison operation. When submitting a query, PuppetDB will check every _possible_ result from the endpoint to see if it matches the comparison from the query string, and will only return those objects that match.
 
-For a more complete description of how to construct query strings, see [the Operators page][operators]. 
+For a more complete description of how to construct query strings, see [the Operators page][operators].
 
 ## Query Responses
 
-All queries return data with a content type of `application/json`. 
+All queries return data with a content type of `application/json`.
 
 ## Tutorial and Tips
 

--- a/documentation/api/query/v2/resources.markdown
+++ b/documentation/api/query/v2/resources.markdown
@@ -9,6 +9,7 @@ canonical: "/puppetdb/latest/api/query/v2/resources.html"
 Resources are queried via an HTTP request to the
 `/resources` REST endpoint.
 
+> **Note:** The v2 API is deprecated. We recommend that you use the v3 API instead.
 
 ## Routes
 
@@ -33,29 +34,21 @@ The `query` parameter is described by the following grammar:
 
 `field` may be any of:
 
-`tag`
-: a case-insensitive tag on the resource
+* `tag`: a case-insensitive tag on the resource
 
-`certname`
-: the name of the node associated with the resource
+* `certname`: the name of the node associated with the resource
 
-`[parameter <resource_param>]`
-: a parameter of the resource
+* `[parameter <resource_param>]`: a parameter of the resource
 
-`type`
-: the resource type
+* `type`: the resource type
 
-`title`
-: the resource title
+* `title`: the resource title
 
-`exported`
-: whether or not the resource is exported
+* `exported`: whether or not the resource is exported
 
-`sourcefile`
-: the manifest file the resource was declared in
+* `sourcefile`: the manifest file the resource was declared in
 
-`sourceline`
-: the line of the manifest on which the resource was declared
+* `sourceline`: the line of the manifest on which the resource was declared
 
 For example, for file resources, tagged "magical", on any host except
 for "example.local" the JSON query structure would be:

--- a/documentation/api/query/v3/aggregate-event-counts.markdown
+++ b/documentation/api/query/v3/aggregate-event-counts.markdown
@@ -5,23 +5,34 @@ canonical: "/puppetdb/latest/api/query/v3/aggregate-event-counts.html"
 ---
 
 [event-counts]: ./event-counts.html
+[events]: ./events.html
 [curl]: ../curl.html
+[query]: ./query.html
 
-## Routes
+Puppet agent nodes submit reports after their runs, and the puppet master forwards these to PuppetDB. Each report includes:
 
-### `GET /v3/aggregate-event-counts`
+* Some data about the entire run
+* Some metadata about the report
+* Many _events,_ describing what happened during the run
+
+Once this information is stored in PuppetDB, it can be queried in various ways.
+
+* You can query **data about the run** and **report metadata** by making an HTTP request to the [`/reports`](./reports.html) endpoint.
+* You can query **data about individual events** by making an HTTP request to the [`/events`][events] endpoint.
+* You can query **summaries of event data** by making an HTTP request to the [`/event-counts`][event-counts] or `aggregate-event-counts` endpoints.
+
+## `GET /v3/aggregate-event-counts`
 
 This will return aggregated count information about all of the resource events matching the given query.
 This endpoint is built entirely on the [`event-counts`][event-counts] endpoint and will aggregate those
 results into a single map.
 
-#### Parameters
+### URL Parameters
 
-This endpoint builds on top of the [`event-counts`][event-counts] endpoint and will forward to it all
-parameters. Supported parameters are listed below for reference.
+This endpoint builds on top of the [`event-counts`][event-counts] endpoint, and it uses all of the same URL parameters. The supported parameters are re-listed below for reference.
 
 * `query`: Required. A JSON array of query predicates in prefix form (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`).
-This query is forwarded to the [`event-counts`][event-counts] endpoint - see there for additional documentation.
+This query is forwarded to the [`events`][events] endpoint - see there for additional documentation. For general info about queries, see [the page on query structure.][query]
 
 * `summarize-by`: Required. A string specifying which type of object you'd like count. Supported values are
 `resource`, `containing-class`, and `certname`.
@@ -37,15 +48,15 @@ the final event-counts output, but before the results are aggregated. Supported 
 of this parameter may change in future releases.)  This parameter is passed along
 to the [`event`][events] query - see there for additional documentation.
 
-##### Operators
+### Query Operators
 
-This endpoint builds on top of the [`event-counts`][event-counts] and therefore supports all of the same operators.
+This endpoint builds on top of the [`event-counts`][event-counts] and [`events`][events] endpoints, and supports all of the [same operators.](./events.html#query-operators)
 
-##### Fields
+### Query Fields
 
-This endpoint builds on top of the [`event-counts`][event-counts] and therefore supports all of the same fields.
+This endpoint builds on top of the [`event-counts`][event-counts] and [`events`][events] endpoints, and supports all of the [same fields.](./events.html#query-fields)
 
-#### Response Format
+### Response Format
 
 The response is a single JSON map containing aggregated event-count information and a `total` for how many
 event-count results were aggregated.
@@ -58,14 +69,15 @@ event-count results were aggregated.
       "total": 3
     }
 
-#### Paging
-
-This endpoint always returns a single result so paging is not necessary.
-
-#### Example
+### Examples
 
 You can use [`curl`][curl] to query information about aggregated resource event counts like so:
 
     curl -G 'http://localhost:8080/v3/aggregate-event-counts'
             --data-urlencode 'query=["=", "certname", "foo.local"]' \
             --data-urlencode 'summarize-by=containing-class'
+
+## No Paging
+
+This endpoint always returns a single result, so paging is not necessary.
+

--- a/documentation/api/query/v3/catalogs.markdown
+++ b/documentation/api/query/v3/catalogs.markdown
@@ -5,18 +5,29 @@ canonical: "/puppetdb/latest/api/query/v3/catalogs.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
-[catalog]: ../../wire_format/catalog_format.html
+[catalog]: ../../wire_format/catalog_format_v1.html
+[query]: ./query.html
 
-Querying catalogs occurs via an HTTP request to the
-`/catalogs` REST endpoint.
+You can query catalogs by making an HTTP request to the
+`/catalogs` endpoint.
 
-## Routes
-
-### `GET /v3/catalogs/<NODE>`
+## `GET /v3/catalogs/<NODE>`
 
 This will return the most recent catalog for the given node.
 
-#### Examples
+This endpoint does not use any URL parameters or query strings.
+
+### Response Format
+
+Successful responses will be in `application/json`. Errors will be returned as
+non-JSON strings.
+
+The result will be a JSON map, with a `metadata` key and a `data` key.  The value
+of the `data` key is another map, containing the keys `name`, `version`,
+`transaction-uuid`, `edges`, and `resources`.  For more details on any of this
+data, please refer to the [catalog wire format][catalog].
+
+### Examples
 
     curl -X GET http://puppetdb:8080/v3/catalogs/foo.localdomain
 
@@ -36,12 +47,6 @@ This will return the most recent catalog for the given node.
 **Note:** the `edges` and `resources` fields above will be populated with data
 conforming to the [catalog wire format][catalog].
 
-## Response Format
+## No Paging
 
-Successful responses will be in `application/json`. Errors will be returned as
-non-JSON strings.
-
-The result will be a JSON map, with a `metadata` key and a `data` key.  The value
-of the `data` key is another map, containing the keys `name`, `version`,
-`transaction-uuid`, `edges`, and `resources`.  For more details on any of this
-data, please refer to the [catalog wire format][catalog].
+This endpoint always returns a single result, so paging is not necessary.

--- a/documentation/api/query/v3/event-counts.markdown
+++ b/documentation/api/query/v3/event-counts.markdown
@@ -7,10 +7,21 @@ canonical: "/puppetdb/latest/api/query/v3/event-counts.html"
 [events]: ./events.html
 [paging]: ./paging.html
 [curl]: ../curl.html
+[query]: ./query.html
 
-## Routes
+Puppet agent nodes submit reports after their runs, and the puppet master forwards these to PuppetDB. Each report includes:
 
-### `GET /v3/event-counts`
+* Some data about the entire run
+* Some metadata about the report
+* Many _events,_ describing what happened during the run
+
+Once this information is stored in PuppetDB, it can be queried in various ways.
+
+* You can query **data about the run** and **report metadata** by making an HTTP request to the [`/reports`](./reports.html) endpoint.
+* You can query **data about individual events** by making an HTTP request to the [`/events`][events] endpoint.
+* You can query **summaries of event data** by making an HTTP request to the `/event-counts` or [`aggregate-event-counts`](./aggregate-event-counts.html) endpoints.
+
+## `GET /v3/event-counts`
 
 This will return count information about all of the resource events matching the given query.
 For a given object type (resource, containing-class, or node), you can retrieve counts of the
@@ -19,10 +30,10 @@ or `skip`.
 
 See the [`events`][events] endpoint for additional documentation as this endpoint builds heavily on it.
 
-#### Parameters
+### URL Parameters
 
 * `query`: Required. A JSON array of query predicates in prefix form (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`).
-This query is forwarded to the [`events`][events] endpoint - see there for additional documentation.
+This query is forwarded to the [`events`][events] endpoint - see there for additional documentation. For general info about queries, see [the page on query structure.][query]
 
 * `summarize-by`: Required. A string specifying which type of object you'd like to see counts for.
 Supported values are `resource`, `containing-class`, and `certname`.
@@ -39,15 +50,15 @@ Supported fields are `failures`, `successes`, `noops`, and `skips`.
 of this parameter may change in future releases.)  This parameter is passed along
 to the [`event`][events] query - see there for additional documentation.
 
-##### Operators
+### Query Operators
 
-This endpoint builds on top of the [`events`][events] endpoint and therefore supports all of the same operators.
+This endpoint builds on top of the [`events`][events] endpoint, and supports all of the [same operators.](./events.html#query-operators)
 
-##### Fields
+### Query Fields
 
-This endpoint builds on top of the [`events`][events] endpoint and therefore supports all of the same fields.
+This endpoint builds on top of the [`events`][events] endpoint, and supports all of the [same fields.](./events.html#query-fields)
 
-#### Response Format
+### Response Format
 
 The response is a JSON array of maps. Each map contains the counts of events that matched the input
 parameters. The events are counted based on their statuses: `failures`, `successes`, `noops`, `skips`.
@@ -120,12 +131,7 @@ When summarizing by `containing-class`, the `subject` will contain a `title` key
       }
     ]
 
-#### Paging
-
-This endpoint supports paged results via the common PuppetDB paging query parameters.
-For more information, please see the documentation on [paging][paging].
-
-#### Example
+### Examples
 
 You can use [`curl`][curl] to query information about resource event counts like so:
 
@@ -134,3 +140,9 @@ You can use [`curl`][curl] to query information about resource event counts like
             --data-urlencode 'summarize-by=resource' \
             --data-urlencode 'count-by=certname' \
             --data-urlencode 'counts-filter=[">", "failures", 0]'
+
+## Paging
+
+This endpoint supports paged results via the common PuppetDB paging query parameters.
+For more information, please see the documentation on [paging][paging].
+

--- a/documentation/api/query/v3/events.markdown
+++ b/documentation/api/query/v3/events.markdown
@@ -8,167 +8,126 @@ canonical: "/puppetdb/latest/api/query/v3/events.html"
 [report]: ./reports.html
 [operators]: ./operators.html
 [paging]: ./paging.html
+[query]: ./query.html
+[8601]: http://en.wikipedia.org/wiki/ISO_8601
+[event]: ./events.html
 
+Puppet agent nodes submit reports after their runs, and the puppet master forwards these to PuppetDB. Each report includes:
 
-## Routes
+* Some data about the entire run
+* Some metadata about the report
+* Many _events,_ describing what happened during the run
 
-### `GET /v3/events`
+Once this information is stored in PuppetDB, it can be queried in various ways.
+
+* You can query **data about the run** and **report metadata** by making an HTTP request to the [`/reports`][report] endpoint.
+* You can query **data about individual events** by making an HTTP request to the `/events` endpoint.
+* You can query **summaries of event data** by making an HTTP request to the [`/event-counts`](./event-counts.html) or [`aggregate-event-counts`](./aggregate-event-counts.html) endpoints.
+
+## `GET /v3/events`
 
 This will return all resource events matching the given query.  (Resource events
 are generated from Puppet reports.)
 
-#### Parameters
+### URL Parameters
 
-* `query`: Required. A JSON array of query predicates, in prefix form (the standard
- `["<OPERATOR>", "<FIELD>", "<VALUE>"]` format), conforming to the format described
- below.
+* `query`: Required. A JSON array of query predicates, in prefix form (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`). See the sections below for the supported operators and fields. For general info about queries, see [the page on query structure.][query]
 
-The `query` parameter is described by the following grammar:
+* `distinct-resources`: Optional. Boolean. (I.e. `distinct-resources=true`.) (EXPERIMENTAL: it is possible that the behavior
+of this parameter may change in future releases.) If specified, the result set will only return the most recent event for a given resource on a given node.
 
-    query: [ {bool} {query}+ ] | [ "not" {query} ] | [ {match} {field} {value} ] | [ {inequality} {field} {value} ]
-    field:          FIELD (conforming to [Fields](#fields) specification below)
-    value:          string
-    bool:           "or" | "and"
-    match:          "=" | "~"
-    inequality:     ">" | ">=" | "<" | "<="
+    For example: if the resource `File[/tmp/foo]` was failing on some node
+    but has since been fixed and is now succeeding, then a "normal" event query might
+    return both the success and failure events.  A query with `distinct-resources=true`
+    would only return the success event, since it's the most recent event for that resource.
 
-For example, for all events in the report with hash
-'38ff2aef3ffb7800fe85b322280ade2b867c8d27', the JSON query structure would be:
+    Since a `distinct-resources` query can be expensive, it requires a limited
+    window of time to examine. Use the `distinct-start-time` and
+    `distinct-end-time` parameters to define this interval.
+    Issuing a `distinct-resources` query without specifying both of these parameters will cause an error.
 
-    ["=", "report", "38ff2aef3ffb7800fe85b322280ade2b867c8d27"]
+* `distinct-start-time`: Used with `distinct-resources`. The start of the window of time to examine, as an [ISO-8601][8601] compatible date/time string.
+* `distinct-end-time`: Used with `distinct-resources`. The end of the window of time to examine, as an [ISO-8601][8601] compatible date/time string.
 
-To retrieve all of the events within a given time period:
-
-    ["and", ["<", "timestamp", "2011-01-01T12:01:00-03:00"],
-            [">", "timestamp", "2011-01-01T12:00:00-03:00"]]
-
-To retrieve all of the 'failure' events for nodes named 'foo.*' and resources of
-type 'Service':
-
-    ["and", ["=", "status", "failure"],
-            ["~", "certname", "^foo\\."],
-            ["=", "resource-type", "Service"]]
-            
-To retrieve latest events that are tied to the class found in your update.pp file    
-    
-    ["and", ["=", "latest-report?", true],
-            ["~", "file", "update.pp"]]
-
-For more information on the available values for `FIELD`, see the [fields](#fields) section below.
-
-* `distinct-resources`: Optional.  (EXPERIMENTAL: it is possible that the behavior
-of this parameter may change in future releases.) If specified, then in addition
-to the normal event query filtering, the result set will be limited to only
-returning the most recent event for a given resource on a given node.
-
-So, for example, if the resource `File[/tmp/foo]` was failing on a certain node,
-but has since been fixed and is now succeeding, then a "normal" event query might
-return both the success and failure events.  Using the `distinct-resources` flag
-ensures that your query only returns the most recent event for a given resource,
-so you would only get the success event in your result set.
-
-The `distinct-resources` query can be expensive; therefore, it requires two
-additional query parameters to go along with it:  `distinct-start-time` and
-`distinct-end-time`.  (Issuing a `distinct-resources` query without
-specifying both of these parameters will cause an error.)  The values of these
-parameters should be timestamp strings in the same format as used with the normal
-"timestamp" field, and will define a window of time in which to find the most
-recent event for each resource.
-
-##### Operators
+### Query Operators
 
 See [the Operators page][operators] for the full list of available operators.
 Note that inequality operators (`<`, `>`, `<=`, `>=`) are only supported against
-the `timestamp` FIELD.
+the `timestamp` field.
 
-##### Fields
+### Query Fields
 
-`FIELD` may be any of the following.  Unless otherwise noted, all fields support
+Unless otherwise noted, all fields support
 both equality and regular expression match operators, but do not support inequality
 operators.
 
-`certname`
-: the name of the node that the event occurred on.
+> **Note on fields without values**
+>
+> In the case of a `skipped` resource event, some of the fields of an event may
+> not have values.  We handle this case in a slightly special way when these
+> fields are used in equality (`=`) or inequality (`!=`) queries; specifically,
+> an equality query will always return `false` for an event with no value for
+> the field, and an inequality query will always return `true`.
 
-`report`
-: the id of the report that the event occurred in; these ids can be acquired
+* `certname`: the name of the node that the event occurred on.
+
+* `report`: the id of the report that the event occurred in; these ids can be acquired
   via event queries or via the [`/reports`][report] query endpoint.
 
-`status`
-: the status of the event; legal values are `success`, `failure`, `noop`, and `skipped`.
+* `status`: the status of the event; legal values are `success`, `failure`, `noop`, and `skipped`.
 
-`timestamp`
-: the timestamp (from the puppet agent) at which the event occurred.  This field
+* `timestamp`: the timestamp (from the puppet agent) at which the event occurred.  This field
+  supports the inequality operators.  All values should be specified as [ISO-8601][8601]
+  compatible date/time strings.
+
+* `run-start-time`: the timestamp (from the puppet agent) at which the puppet run began.  This field
   supports the inequality operators.  All values should be specified as ISO-8601
   compatible date/time strings.
 
-`run-start-time`
-: the timestamp (from the puppet agent) at which the puppet run began.  This field
+* `run-end-time`: the timestamp (from the puppet agent) at which the puppet run finished.  This field
   supports the inequality operators.  All values should be specified as ISO-8601
   compatible date/time strings.
 
-`run-end-time`
-: the timestamp (from the puppet agent) at which the puppet run finished.  This field
-  supports the inequality operators.  All values should be specified as ISO-8601
-  compatible date/time strings.
-
-`report-receive-time`
-: the timestamp (from the PuppetDB server) at which the puppet report was
+* `report-receive-time`: the timestamp (from the PuppetDB server) at which the puppet report was
   received.  This field supports the inequality operators.  All values should be
   specified as ISO-8601 compatible date/time strings.
 
-`resource-type`
-: the type of resource that the event occurred on; e.g., `File`, `Package`, etc.
+* `resource-type`: the type of resource that the event occurred on; e.g., `File`, `Package`, etc.
 
-`resource-title`
-: the title of the resource that the event occurred on
+* `resource-title`: the title of the resource that the event occurred on.
 
-`property`:
-: the property/parameter of the resource that the event occurred on; e.g., for a
+* `property`: the property/parameter of the resource that the event occurred on; e.g., for a
   `Package` resource, this field might have a value of `ensure`.  NOTE: this field
   may contain `NULL` values; see notes below.
 
-`new-value`
-: the new value that Puppet was attempting to set for the specified resource
+* `new-value`: the new value that Puppet was attempting to set for the specified resource
   property.  NOTE: this field may contain `NULL` values; see notes below.
 
-`old-value`
-: the previous value of the resource property, which Puppet was attempting to
+* `old-value`: the previous value of the resource property, which Puppet was attempting to
   change.  NOTE: this field may contain `NULL` values; see notes below.
 
-`message`
-: a description (supplied by the resource provider) of what happened during the
+* `message`: a description (supplied by the resource provider) of what happened during the
   event.  NOTE: this field may contain `NULL` values; see notes below.
 
-`file`
-: the manifest file in which the resource definition is located.
+* `file`: the manifest file in which the resource definition is located.
   NOTE: this field may contain `NULL` values; see notes below.
 
-`line`
-: the line (of the containing manifest file) at which the resource definition
+* `line`: the line (of the containing manifest file) at which the resource definition
   can be found.  NOTE: this field may contain `NULL` values; see notes below.
 
-`containing-class`
-: the Puppet class where this resource is declared.  NOTE: this field may
+* `containing-class`: the Puppet class where this resource is declared.  NOTE: this field may
   contain `NULL` values; see notes below.
 
-`latest-report?`
-: whether the event occurred in the most recent Puppet run (per-node).  NOTE: the
+* `latest-report?`: whether the event occurred in the most recent Puppet run (per-node).  NOTE: the
 value of this field is always boolean (`true` or `false` without quotes), and it
 is not supported by the regex match operator.
 
-##### Notes on fields that allow `NULL` values
+* `environment`: the environment associated with the reporting node.
 
-In the case of a `skipped` resource event, some of the fields of an event may
-not have values.  We handle this case in a slightly special way when these
-fields are used in equality (`=`) or inequality (`!=`) queries; specifically,
-an equality query will always return `false` for an event with no value for
-the field, and an inequality query will always return `true`.
+### Response Format
 
-#### Response format
-
- The response is a JSON array of events that matched the input parameters.
- The events are sorted by their timestamps, in descending order:
+The response is a JSON array of events that matched the input parameters.
+The events are sorted by their timestamps, from newest to oldest:
 
     [
       {
@@ -212,14 +171,37 @@ the field, and an inequality query will always return `true`.
     ]
 
 
-#### Paging
+### Example
+
+[You can use `curl`][curl] to query information about events like so:
+
+    curl -G 'http://localhost:8080/v3/events' --data-urlencode 'query=["=", "report", "38ff2aef3ffb7800fe85b322280ade2b867c8d27"]' --data-urlencode 'limit=1000'
+
+For all events in the report with hash
+'38ff2aef3ffb7800fe85b322280ade2b867c8d27', the JSON query structure would be:
+
+    ["=", "report", "38ff2aef3ffb7800fe85b322280ade2b867c8d27"]
+
+To retrieve all of the events within a given time period:
+
+    ["and", ["<", "timestamp", "2011-01-01T12:01:00-03:00"],
+            [">", "timestamp", "2011-01-01T12:00:00-03:00"]]
+
+To retrieve all of the 'failure' events for nodes named 'foo.*' and resources of
+type 'Service':
+
+    ["and", ["=", "status", "failure"],
+            ["~", "certname", "^foo\\."],
+            ["=", "resource-type", "Service"]]
+
+To retrieve latest events that are tied to the class found in your update.pp file:
+
+    ["and", ["=", "latest-report?", true],
+            ["~", "file", "update.pp"]]
+
+## Paging
 
 This query endpoint supports paged results via the common PuppetDB paging
 query parameters.  For more information, please see the documentation
 on [paging][paging].
 
-#### Example
-
-[You can use `curl`][curl] to query information about events like so:
-
-    curl -G 'http://localhost:8080/v3/events' --data-urlencode 'query=["=", "report", "38ff2aef3ffb7800fe85b322280ade2b867c8d27"]' --data-urlencode 'limit=1000'

--- a/documentation/api/query/v3/fact-names.markdown
+++ b/documentation/api/query/v3/fact-names.markdown
@@ -6,18 +6,28 @@ canonical: "/puppetdb/latest/api/query/v3/fact-names.html"
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
 [paging]: ./paging.html
+[query]: ./query.html
 
 The `/fact-names` endpoint can be used to retrieve all known fact names.
 
 
-## Routes
 
-### `GET /fact-names`
+## `GET /fact-names`
 
 This will return an alphabetical list of all known fact names, *including* those which are
 known only for deactivated nodes.
 
-#### Examples
+This endpoint does not use any URL parameters or query strings.
+
+### Response Format
+
+The response will be in `application/json`, and will contain an alphabetical
+JSON array containing fact names. Each fact name will appear only once,
+regardless of how many nodes have that fact.
+
+    [<fact>, <fact>, ..., <fact>, <fact>]
+
+### Examples
 
 [Using `curl` from localhost][curl]:
 
@@ -28,13 +38,6 @@ known only for deactivated nodes.
 ## Paging
 
 This query endpoint supports paged results via the common PuppetDB paging
-query parameters.  For more information, please see the documentation
+URL parameters.  For more information, please see the documentation
 on [paging][paging].
 
-## Response Format
-
-The response will be in `application/json`, and will contain an alphabetical
-JSON array containing fact names. Each fact name will appear only once,
-regardless of how many nodes have that fact.
-
-    [<fact>, <fact>, ..., <fact>, <fact>]

--- a/documentation/api/query/v3/facts.markdown
+++ b/documentation/api/query/v3/facts.markdown
@@ -7,33 +7,47 @@ canonical: "/puppetdb/latest/api/query/v3/facts.html"
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
 [paging]: ./paging.html
 
-Querying facts occurs via an HTTP request to the
-`/facts` REST endpoint.
+You can query facts by making an HTTP request to the `/facts` endpoint.
 
 
-## Routes
 
-### `GET /v3/facts`
+## `GET /v3/facts`
 
 This will return all facts matching the given query. Facts for
 deactivated nodes are not included in the response.
 
-#### URL Parameters
+### URL Parameters
 
-* `query`: Optional. A JSON array containing the query in prefix notation. If
-  not provided, all results will be returned.
+* `query`: Optional. A JSON array containing the query in prefix notation (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`). See the sections below for the supported operators and fields. For general info about queries, see [the page on query structure.][query]
 
-#### Available Fields
+    If a query parameter is not provided, all results will be returned.
+
+### Query Operators
+
+See [the Operators page.](./operators.html)
+
+### Query Fields
 
 * `"name"`: matches facts of the given name
 * `"value"`: matches facts with the given value
 * `"certname"`: matches facts for the given node
 
-#### Operators
+### Response Format
 
-See [the Operators page](./operators.html)
+Successful responses will be in `application/json`. Errors will be returned as
+non-JSON strings.
 
-#### Examples
+The result will be a JSON array, with one entry per fact. Each entry is of the form:
+
+    {
+      "certname": <node name>,
+      "name": <fact name>,
+      "value": <fact value>
+    }
+
+If no facts match the query, an empty JSON array will be returned.
+
+### Examples
 
 [Using `curl` from localhost][curl]:
 
@@ -53,21 +67,19 @@ Get all facts for a single node:
      {"certname": "a.example.com", "name": "ipaddress", "value": "192.168.1.105"},
      {"certname": "a.example.com", "name": "uptime_days", "value": "26 days"}]
 
-### `GET /v3/facts/<NAME>`
+## `GET /v3/facts/<FACT NAME>`
 
-This will return all facts for all nodes with the indicated
-name.
+This will return all facts with the given fact name, for all nodes. It behaves exactly like a call to `/v3/facts` with a query string of `["=", "name", "<FACT NAME>"]`.
 
-#### URL Parameters
+### URL Parameters / Query Operators / Query Fields / Response Format
 
-* `query`: Optional. A JSON array containing the query in prefix
-  notation. The syntax and semantics are identical to the `query`
-  parameter for the `/facts` route, mentioned above. When supplied,
-  the query is assumed to supply _additional_ criteria that can be
-  used to return a _subset_ of the information normally returned by
-  this route.
+This route is an extension of the plain `facts` endpoint. It uses the exact same parameters, operators, fields, and response format.
 
-#### Examples
+If you provide a `query` parameter, it will specify additional criteria, which will be
+used to return a subset of the information normally returned by
+this route.
+
+### Examples
 
     curl -X GET http://puppetdb:8080/v3/facts/operatingsystem
 
@@ -75,21 +87,24 @@ name.
      {"certname": "b.example.com", "name": "operatingsystem", "value": "Redhat"},
      {"certname": "c.example.com", "name": "operatingsystem", "value": "Ubuntu"}]
 
-### `GET /v3/facts/<NAME>/<VALUE>`
+## `GET /v3/facts/<FACT NAME>/<VALUE>`
 
-This will return all facts for all nodes with the indicated name and
-value.
+This will return all facts with the given fact name and
+value, for all nodes. (That is, only the `certname` field will differ in each result.) It behaves exactly like a call to `/v3/facts` with a query string of:
 
-#### URL Parameters
+    ["and",
+        ["=", "name", "<FACT NAME>"],
+        ["=", "value", "<VALUE>"]]
 
-* `query`: Optional. A JSON array containing the query in prefix
-  notation. The syntax and semantics are identical to the `query`
-  parameter for the `/facts` route, mentioned above. When supplied,
-  the query is assumed to supply _additional_ criteria that can be
-  used to return a _subset_ of the information normally returned by
-  this route.
+### URL Parameters / Query Operators / Query Fields / Response Format
 
-#### Examples
+This route is an extension of the plain `facts` endpoint. It uses the exact same parameters, operators, fields, and response format.
+
+If you provide a `query` parameter, it will specify additional criteria, which will be
+used to return a subset of the information normally returned by
+this route.
+
+### Examples
 
     curl -X GET http://puppetdb:8080/v3/facts/operatingsystem/Debian
 
@@ -99,20 +114,6 @@ value.
 ## Paging
 
 This query endpoint supports paged results via the common PuppetDB paging
-query parameters.  For more information, please see the documentation
+URL parameters.  For more information, please see the documentation
 on [paging][paging].
 
-## Response Format
-
-Successful responses will be in `application/json`. Errors will be returned as
-non-JSON strings.
-
-The result will be a JSON array, with one entry per fact. Each entry is of the form:
-
-    {
-      "certname": <node name>,
-      "name": <fact name>,
-      "value": <fact value>
-    }
-
-If no facts are known for the supplied node, an HTTP 404 is returned.

--- a/documentation/api/query/v3/metrics.markdown
+++ b/documentation/api/query/v3/metrics.markdown
@@ -102,6 +102,8 @@ available via the `/v3/metrics/mbeans` endpoint.
 
 Additionally, we also support the following explicit names:
 
+**Note:** The use of these explicit names is deprecated; please use, e.g., `/v3/commands` instead.
+
 * `commands`: Stats relating to the command processing REST
   endpoint. The PuppetDB terminus in Puppet talks to this endpoint to
   submit new catalogs, facts, etc.

--- a/documentation/api/query/v3/nodes.markdown
+++ b/documentation/api/query/v3/nodes.markdown
@@ -7,28 +7,26 @@ canonical: "/puppetdb/latest/api/query/v3/nodes.html"
 [resource]: ./resources.html
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
 [paging]: ./paging.html
+[query]: ./query.html
 
-Nodes can be queried by making an HTTP request to the `/nodes` REST
-endpoint with a JSON-formatted parameter called `query`.
+Nodes can be queried by making an HTTP request to the `/nodes` endpoint.
 
 
-## Routes
 
-### `GET /v3/nodes`
+## `GET /v3/nodes`
 
 This will return all nodes matching the given query. Deactivated nodes
 aren't included in the response.
 
-#### Parameters
+### URL Parameters
 
-* `query`: Optional. A JSON array of query predicates, in prefix form,
-  conforming to the format described below.
+* `query`: Optional. A JSON array of query predicates, in prefix notation (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`). See the sections below for the supported operators and fields. For general info about queries, see [the page on query structure.][query]
 
-The `query` parameter is a similar format to [resource queries][resource].
+    The `query` parameter is a similar format to [resource queries][resource].
 
-Only queries against `"name"` and facts are currently supported.
+    If no `query` parameter is supplied, all nodes will be returned.
 
-Fact terms must be of the form `["fact", <fact name>]`.
+### Query Querators
 
 Node query supports [all available operators](./operators.html). Inequality
 operators are only supported for fact queries, but regular expressions are
@@ -40,16 +38,13 @@ which are not numeric.
 Note that nodes which are missing a fact referenced by a `not` query will match
 the query.
 
-This query will return nodes whose kernel is Linux and whose uptime is less
-than 30 days:
+### Query Fields
 
-    ["and",
-      ["=", ["fact", "kernel"], "Linux"],
-      [">", ["fact", "uptime_days"], 30]]
+Only queries against `"name"` and facts are currently supported.
 
-If no `query` parameter is supplied, all nodes will be returned.
+Fact terms must be of the form `["fact", <fact name>]`.
 
-#### Response format
+### Response format
 
 The response is a JSON array of hashes of the form:
 
@@ -61,122 +56,167 @@ The response is a JSON array of hashes of the form:
 
 The array is sorted alphabetically by `name`.
 
-#### Example
+### Examples
 
 [You can use `curl`][curl] to query information about nodes like so:
 
     curl 'http://localhost:8080/v3/nodes'
     curl -G 'http://localhost:8080/v3/nodes' --data-urlencode 'query=["=", ["fact", "kernel"], "Linux"]'
 
-### `GET /v3/nodes/<NODE>`
+This query will return nodes whose kernel is Linux and whose uptime is less
+than 30 days:
+
+    ["and",
+      ["=", ["fact", "kernel"], "Linux"],
+      [">", ["fact", "uptime_days"], 30]]
+
+## `GET /v3/nodes/<NODE>`
 
 This will return status information for the given node, active or
-not.
+not. It behaves exactly like a call to `/v3/nodes` with a query string of `["=", "name", "<NODE>"]`.
 
-#### Response format
+### URL Parameters / Query Operators / Query Fields
 
-The response is the same format as for the [/v1/status](../v1/status.html)
-endpoint.
+This route is an extension of the plain `nodes` endpoint. It uses the exact same parameters, operators, and fields.
 
-### `GET /v3/nodes/<NODE>/facts`
+If you provide a `query` parameter, it will specify additional criteria, which will be
+used to return a subset of the information normally returned by
+this route.
+
+### Response Format
+
+The response is a single hash, of the same form used for the plain `nodes` endpoint:
+
+    {"name": <string>,
+     "deactivated": <timestamp>,
+     "catalog_timestamp": <timestamp>,
+     "facts_timestamp": <timestamp>,
+     "report_timestamp": <timestamp>}
+
+If a node of that name doesn't exist, the response will instead be a hash of the form:
+
+    {"error": "No information is known about <NODE>"}
+
+## `GET /v3/nodes/<NODE>/facts`
+
+[facts]: ./facts.html
 
 This will return the facts for the given node. Facts from deactivated
 nodes aren't included in the response.
 
-#### Parameters
+This is a shortcut to the [`/v3/facts`][facts] endpoint. It behaves the same as a call to [`/v3/facts`][facts] with a query string of `["=", "certname", "<NODE>"]`.
 
-* `query`: Optional. A JSON array containing the query in prefix
-  notation. The syntax and semantics are identical to the `query`
-  parameter for the `/v3/facts` route. When supplied, the query is
-  assumed to supply _additional_ criteria that can be used to return a
-  _subset_ of the information normally returned by this route.
+### URL Parameters / Query Operators / Query Fields / Response Format
 
-#### Response format
+This route is an extension of the `facts` endpoint. It uses the exact same parameters, operators, fields, and response format.
 
-The response is the same format as for the [/v3/facts](./facts.html)
-endpoint.
+If you provide a `query` parameter, it will specify additional criteria, which will be
+used to return a subset of the information normally returned by
+this route.
 
-### `GET /v3/nodes/<NODE>/facts/<NAME>`
+
+## `GET /v3/nodes/<NODE>/facts/<NAME>`
 
 This will return facts with the given name for the given node. Facts
 from deactivated nodes aren't included in the response.
 
-#### Parameters
+This is a shortcut to the [`/v3/facts`][facts] endpoint. It behaves the same as a call to [`/v3/facts`][facts] with a query string of:
 
-* `query`: Optional. A JSON array containing the query in prefix
-  notation. The syntax and semantics are identical to the `query`
-  parameter for the `/v3/facts` route. When supplied, the query is
-  assumed to supply _additional_ criteria that can be used to return a
-  _subset_ of the information normally returned by this route.
+    ["and",
+        ["=", "certname", "<NODE>"],
+        ["=", "name", "<NAME>"]]
 
-#### Response format
+### URL Parameters / Query Operators / Query Fields / Response Format
 
-The response is the same format as for the [/v3/facts](./facts.html)
-endpoint.
+This route is an extension of the [`facts`][facts] endpoint. It uses the exact same parameters, operators, fields, and response format.
 
+If you provide a `query` parameter, it will specify additional criteria, which will be
+used to return a subset of the information normally returned by
+this route.
 
-### `GET /v3/nodes/<NODE>/facts/<NAME>/<VALUE>`
+## `GET /v3/nodes/<NODE>/facts/<NAME>/<VALUE>`
 
 This will return facts with the given name and value for the given
 node. Facts from deactivated nodes aren't included in the
 response.
 
-#### Parameters
+This is a shortcut to the [`/v3/facts`][facts] endpoint. It behaves the same as a call to [`/v3/facts`][facts] with a query string of:
 
-* `query`: Optional. A JSON array containing the query in prefix
-  notation. The syntax and semantics are identical to the `query`
-  parameter for the `/v3/facts` route. When supplied, the query is
-  assumed to supply _additional_ criteria that can be used to return a
-  _subset_ of the information normally returned by this route.
+    ["and",
+        ["=", "certname", "<NODE>"],
+        ["=", "name", "<NAME>"],
+        ["=", "value", "<VALUE>"]]
 
-#### Response format
+### URL Parameters / Query Operators / Query Fields / Response Format
 
-The response is the same format as for the [/v3/facts](./facts.html)
-endpoint.
+This route is an extension of the [`facts`][facts] endpoint. It uses the exact same parameters, operators, fields, and response format.
 
-### `GET /v3/nodes/<NODE>/resources`
+If you provide a `query` parameter, it will specify additional criteria, which will be
+used to return a subset of the information normally returned by
+this route.
+
+(However, for this particular route, there aren't any practical criteria left.)
+
+
+## `GET /v3/nodes/<NODE>/resources`
 
 This will return the resources for the given node. Resources from
 deactivated nodes aren't included in the response.
 
-#### Parameters
+This is a shortcut to the [`/v3/resources`][resource] route. It behaves the same as a call to [`/v3/resources`][resource] with a query string of `["=", "certname", "<NODE>"]`.
 
-* `query`: Optional. A JSON array containing the query in prefix
-  notation. The syntax and semantics are identical to the `query`
-  parameter for the `/v3/resources` route. When supplied, the query is
-  assumed to supply _additional_ criteria that can be used to return a
-  _subset_ of the information normally returned by this route.
+### URL Parameters / Query Operators / Query Fields / Response Format
 
-#### Response format
+This route is an extension of the [`resources`][resource] endpoint. It uses the exact same parameters, operators, fields, and response format.
 
-The response is the same format as for the [/v3/resources][resource]
-endpoint.
+If you provide a `query` parameter, it will specify additional criteria, which will be
+used to return a subset of the information normally returned by
+this route.
 
-### `GET /v3/nodes/<NODE>/resources/<TYPE>`
+## `GET /v3/nodes/<NODE>/resources/<TYPE>`
 
 This will return the resources of the indicated type for the given
 node. Resources from deactivated nodes aren't included in the
 response.
 
-This endpoint behaves identically to the
-[`/v3/resources/<TYPE>`][resource] endpoint, except the resources
-returned include _only_ those belonging to the node given in the URL
-for this route.
+This is a shortcut to the [`/v3/resources/<TYPE>`][resource] route. It behaves the same as a call to [`/v3/resources`][resource] with a query string of:
 
-### `GET /v3/nodes/<NODE>/resources/<TYPE>/<TITLE>`
+    ["and",
+        ["=", "certname", "<NODE>"],
+        ["=", "type", "<TYPE>"]]
+
+### URL Parameters / Query Operators / Query Fields / Response Format
+
+This route is an extension of the [`resources`][resource] endpoint. It uses the exact same parameters, operators, fields, and response format.
+
+If you provide a `query` parameter, it will specify additional criteria, which will be
+used to return a subset of the information normally returned by
+this route.
+
+## `GET /v3/nodes/<NODE>/resources/<TYPE>/<TITLE>`
 
 This will return the resource of the indicated type and title for the
 given node. Resources from deactivated nodes aren't included in the
 response.
 
-This endpoint behaves identically to the
-[`/v3/resources/<TYPE>`][resource] endpoint, except the resources
-returned include _only_ those belonging to the node given in the URL
-for this route.
+This is a shortcut to the [`/v3/resources/<TYPE>/<TITLE>`][resource] route. It behaves the same as a call to [`/v3/resources`][resource] with a query string of:
+
+    ["and",
+        ["=", "certname", "<NODE>"],
+        ["=", "type", "<TYPE>"],
+        ["=", "title", "<TITLE>"]]
+
+### URL Parameters / Query Operators / Query Fields / Response Format
+
+This route is an extension of the [`resources`][resource] endpoint. It uses the exact same parameters, operators, fields, and response format.
+
+If you provide a `query` parameter, it will specify additional criteria, which will be
+used to return a subset of the information normally returned by
+this route.
+
 
 ## Paging
 
 This query endpoint supports paged results via the common PuppetDB paging
-query parameters.  For more information, please see the documentation
+URL parameters.  For more information, please see the documentation
 on [paging][paging].
-

--- a/documentation/api/query/v3/operators.markdown
+++ b/documentation/api/query/v3/operators.markdown
@@ -6,11 +6,12 @@ canonical: "/puppetdb/latest/api/query/v3/operators.html"
 
 [resources]: ./resources.html
 [facts]: ./facts.html
+[nodes]: ./nodes.html
 [query]: ./query.html
 
 PuppetDB's [query strings][query] can use several common operators.
 
-> **Note:** The operators below apply to **version 2** of the query API. Not all of them are available to version 1 queries. 
+> **Note:** The operators below apply to **version 3** of the query API. Not all of them are available to version 1 or 2 queries.
 
 
 ## Binary Operators
@@ -20,7 +21,7 @@ Each of these operators accepts two arguments: a **field,** and a
 
     ["<OPERATOR>", "<FIELD>", "<VALUE>"]
 
-The available fields for each endpoint are listed in that endpoint's documentation. 
+The available fields for each endpoint are listed in that endpoint's documentation.
 
 ### `=` (equality)
 
@@ -52,17 +53,17 @@ they can't be coerced, the operator will not match.
 
 ### `~` (regexp match)
 
-**Matches if:** the field's actual value matches the provided regular expression. The provided value must be a regular expression represented as a JSON string: 
+**Matches if:** the field's actual value matches the provided regular expression. The provided value must be a regular expression represented as a JSON string:
 
 * The regexp **must not** be surrounded by the slash characters (`/rexegp/`) that delimit regexps in many languages.
-* Every backslash character **must** be escaped with an additional backslash. Thus, a sequence like `\d` would be represented as `\\d`, and a literal backslash (represented in a regexp as a double-backslash `\\`) would be represented as a quadruple-backslash (`\\\\`). 
+* Every backslash character **must** be escaped with an additional backslash. Thus, a sequence like `\d` would be represented as `\\d`, and a literal backslash (represented in a regexp as a double-backslash `\\`) would be represented as a quadruple-backslash (`\\\\`).
 
 The following example would match if the `certname` field's actual value resembled something like `www03.example.com`:
 
     ["~", "certname", "www\\d+\\.example\\.com"]
 
 > **Note:** Regular expression matching is performed by the database backend, and the available regexp features are backend-dependent. For best results, use the simplest and most common features that can accomplish your task. See the links below for details:
-> 
+>
 > * [PostgreSQL regexp features](http://www.postgresql.org/docs/9.1/static/functions-matching.html#POSIX-SYNTAX-DETAILS)
 > * [HSQLDB (embedded database) regexp features](http://docs.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html)
 
@@ -91,28 +92,32 @@ Subqueries allow you to correlate data from multiple sources or multiple
 rows. (For instance, a query such as "fetch the IP addresses of all nodes with
 `Class[Apache]`" would have to use both facts and resources to return a list of facts.)
 
-Subqueries are unlike the other operators listed above:
+Subqueries are unlike the other operators listed above. They always appear together in the following form:
+
+    ["in", "<FIELD>", ["extract", "<FIELD>", <SUBQUERY STATEMENT>] ]
+
+That is:
 
 * The `in` operator results in a complete query string. The `extract` operator and the subqueries do not.
 * An `in` statement **must** contain a field and an `extract` statement.
-* An `extract` statement **must** contain a field and a subquery.
+* An `extract` statement **must** contain a field and a subquery statement.
 
 These statements work together as follows (working "outward" and starting with the subquery):
 
 * The subquery collects a group of PuppetDB objects (specifically, a group of [resources][] or a group of [facts][]). Each of these objects has many **fields.**
-* The `extract` statement collects the value of a **single field** across every object returned by the subquery. 
-* The `in` statement **matches** if the value of its field is present in the list returned by the `extract` statement. 
+* The `extract` statement collects the value of a **single field** across every object returned by the subquery.
+* The `in` statement **matches** if the value of its field is present in the list returned by the `extract` statement.
 
 Subquery | Extract | In
 ---------|---------|---
 Every resource whose type is "Class" and title is "Apache." (Note that all resource objects have a `certname` field, among other fields.) | Every `certname` field from the results of the subquery. | Match if the `certname` field is present in the list from the `extract` statement.
 
-The complete `in` statement described in the table above would match any object that shares a `certname` with a node that has `Class[Apache]`. This could be combined with a boolean operator to get a specific fact from every node that matches the `in` statement. 
+The complete `in` statement described in the table above would match any object that shares a `certname` with a node that has `Class[Apache]`. This could be combined with a boolean operator to get a specific fact from every node that matches the `in` statement.
 
 
 ### `in`
 
-An `in` statement constitutes a full query string, which can be used alone or as an argument for a [boolean operator](#boolean-operators). 
+An `in` statement constitutes a full query string, which can be used alone or as an argument for a [boolean operator](#boolean-operators).
 
 "In" statements are **non-transitive** and take two arguments:
 
@@ -127,29 +132,40 @@ An `extract` statement **does not** constitute a full query string. It may only 
 
 "Extract" statements are **non-transitive** and take two arguments:
 
-* The first argument **must** be a valid **field** for the endpoint **being subqueried** (see second argument). 
-* The second argument **must** be a **subquery.**
+* The first argument **must** be a valid **field** for the endpoint **being subqueried** (see second argument).
+* The second argument **must** be a **subquery statement.**
 
-As the second argument of an `in` statement, an `extract` statement acts as a list of possible values. This list is compiled by extracting the value of the requested field from every result of the subquery. 
+As the second argument of an `in` statement, an `extract` statement acts as a list of possible values. This list is compiled by extracting the value of the requested field from every result of the subquery.
+
+### Subquery Statements
+
+A subquery statement **does not** constitute a full query string. It may only be used as the second argument of an `extract` statement.
+
+Subquery statements are **non-transitive** and take two arguments:
+
+* The first argument **must** be the **name** of one of the available subqueries (listed below).
+* The second argument **must** be a **full query string** that makes sense for the endpoint being subqueried.
+
+As the second argument of an `extract` statement, a subquery statement acts as a collection of PuppetDB objects. Each of the objects returned by the subquery has many fields; the `extract` statement takes the value of one field from each of those objects, and passes that list of values to the `in` statement that contains it.
 
 ### Available Subqueries
 
-A subquery may only be used as the second argument of an `extract` statement, where it acts as a collection of PuppetDB objects. Each of the objects returned by the subquery has many fields; the `extract` statement takes the value of one field from each of those objects, and passes that list of values to the `in` statement that contains it. 
+Each subquery acts as a normal query to one of the PuppetDB endpoints. For info on constructing useful queries, see the docs page for that endpoint.
 
-In version 2 of the query API, the available subqueries are:
+The available subqueries are:
 
 * [`select-resources`](#select-resources)
 * [`select-facts`](#select-facts)
 
 #### `select-resources`
 
-A `select-resources` subquery may **only** be used as the second argument of an `extract` statement. 
+A `select-resources` subquery may **only** be used as the second argument of an `extract` statement.
 
 It takes a single argument, which must be a **complete query string** which would be valid for [the `/v3/resources` endpoint][resources]. (Note that `/v3/resources/<TYPE>` and `/v3/resources/<TYPE>/<TITLE>` cannot be directly subqueried.) Since the argument is a normal query string, it can itself include any number of `in` statements and subqueries.
 
 #### `select-facts`
 
-A `select-facts` subquery may **only** be used as the second argument of an `extract` statement. 
+A `select-facts` subquery may **only** be used as the second argument of an `extract` statement.
 
 It takes a single argument, which must be a **complete query string** which would be valid for [the `/v3/facts` endpoint][facts]. (Note that `/v3/facts/<NAME>` and `/v3/facts/<NAME>/<VALUE>` cannot be directly subqueried.) Since the argument is a normal query string, it can itself include any number of `in` statements and subqueries.
 

--- a/documentation/api/query/v3/paging.markdown
+++ b/documentation/api/query/v3/paging.markdown
@@ -6,18 +6,19 @@ canonical: "/puppetdb/latest/api/query/v3/paging.html"
 
 [api]: ../../index.html
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
+[query]: ./query.html
 
-Most of PuppetDB's [query endpoints][api] support a general set of HTTP query parameters that
+Most of PuppetDB's [query endpoints][api] support a general set of HTTP URL parameters that
 can be used for paging results.
 
 > **Note:** The operators below apply to **version 3** of the query API.  They are not available in v1 or v2 queries.
 
-## Query Parameters
+## URL Parameters for Paging Results
 
 ### `order-by`
 
 This parameter can be used to ask PuppetDB to return results sorted by one or more fields, in
-ascending or descending order.  The value must be an array of maps.  Each map represents a field
+ascending or descending order.  The value must be a JSON array of maps.  Each map represents a field
 to sort by, and the order that they are specified in the array determines the precedence for the
 sorting.
 
@@ -39,14 +40,14 @@ lists of legal fields, please refer to the documentation for the specific query 
 
 ### `limit`
 
-This query parameter can be used to restrict the result set to a maximum number of results.
+This parameter can be used to restrict the result set to a maximum number of results.
 The value should be an integer.
 
 ### `include-total`
 
-This query parameter is used to indicate whether or not you wish to receive a count of how many total records would have been returned, had the query not been limited using the `limit` parameter.  The value should be a boolean, and defaults to `false`.
+This parameter lets you request a count of how many total records would have been returned, had the query not been limited using the `limit` parameter. This is useful if you want your application to show how far the user has navigated (e.g. "page 3 of 15").
 
-If `true`, the HTTP response will contain a header `X-Records`, whose value is an integer indicating the total number of results available.
+The value should be a boolean, and defaults to `false`. If `true`, the HTTP response will contain a header `X-Records`, whose value is an integer indicating the total number of results available.
 
 NOTE: setting this flag to `true` will introduce a minor performance hit on the query.
 
@@ -72,4 +73,3 @@ should generally be used in conjunction with `order-by`.
 [Using `curl` from localhost][curl]:
 
     curl -X GET http://localhost:8080/v3/facts --data-urlencode 'order-by=[{"field": "value"}]' --data-urlencode 'limit=5' --data-urlencode 'offset=5'
-

--- a/documentation/api/query/v3/query.markdown
+++ b/documentation/api/query/v3/query.markdown
@@ -15,61 +15,107 @@ canonical: "/puppetdb/latest/api/query/v3/query.html"
 
 ## Summary
 
-PuppetDB's query API can retrieve data objects from PuppetDB for use in other applications. For example, the terminus plugins for puppet masters use this API to collect exported resources, and to translate node facts into the inventory service. 
+PuppetDB's query API can retrieve data objects from PuppetDB for use in other applications. For example, the terminus plugins for puppet masters use this API to collect exported resources, and to translate node facts into the inventory service.
 
-The query API is implemented as HTTP URLs on the PuppetDB server. By default, it can only be accessed over the network via host-verified HTTPS; [see the jetty settings][jetty] if you need to access the API over unencrypted HTTP. 
-
-## API URLs
-
-The first component of an API URL is the API version, written as `v1`, `v3`, etc. This page describes version 2 of the API, so every URL will begin with `/v3`. After the version, URLs are organized into a number of **endpoints.**
-
-### Endpoints
-
-Conceptually, an endpoint represents a reservoir of some type of PuppetDB object. Each version of the PuppetDB API defines a set number of endpoints.
-
-See the [API index][index] for a list of the available endpoints. Each endpoint may have additional sub-endpoints under it; these are generally just shortcuts for the most common types of query, so that you can write terser and simpler query strings. 
-
-## Paging
-
-Most PuppetDB query endpoints support paged results via the common PuppetDB paging
-query parameters.  For more information, please see the documentation
-on [paging][paging].
+The query API is implemented as HTTP URLs on the PuppetDB server. By default, it can only be accessed over the network via host-verified HTTPS; [see the jetty settings][jetty] if you need to access the API over unencrypted HTTP.
 
 ## Query Structure
 
 A query consists of:
 
 * An HTTP GET request to an endpoint URL...
-* ...which may or may not contain a **query string** as a `query` URL parameter.
+* ...which may or may not contain a `query` URL parameter, whose value is a **query string...**
+* ...and which may or may not contain other URL parameters, to configure [paging][] or other behavior.
 
-That is, nearly every query will look like a GET request to a URL that resembles the following:
+That is, most queries will look like a GET request to a URL that resembles the following:
 
     https://puppetdb:8081/v3/<ENDPOINT>?query=<QUERY STRING>
 
-Query strings are optional for some endpoints, required for others, and prohibited for others; see each endpoint's documentation.
+### API URLs
 
-### Query Strings
+API URLs generally look like this:
 
-A query string must be:
+    https://<SERVER>:<PORT>/<API VERSION>/<ENDPOINT>?<PARAMETER>=<VALUE>&<PARAMETER>=<VALUE>
+
+For example: `https://puppetdb:8081/v3/resources?limit=50&offset=50`.
+
+### API Version
+
+After the server and port, the first part of an API URL is the **API version,** written as `v2`, `v3`, etc. This section describes version 3 of the API, so every URL will begin with `/v3`.
+
+### Endpoints
+
+After the version, URLs are organized into a number of **endpoints.**
+
+Conceptually, an endpoint represents a reservoir of some type of PuppetDB object. Each version of the PuppetDB API defines a set number of endpoints.
+
+See the [API index][index] for a list of the available endpoints. Each endpoint may have additional sub-endpoints under it; these are generally just shortcuts for the most common types of query, so that you can write terser and simpler query strings.
+
+### URL Parameters
+
+Finally, the URL may include some **URL parameters.** Some endpoints require certain parameters; for others they're optional or disallowed. Each endpoint's page lists the parameters it accepts, and most endpoints also support the [paging][] parameters.
+
+A group of parameters begins with a question mark (`?`). Each parameter is formatted as `<PARAMETER>=<VALUE>`, and additional parameters are separated by ampersands (`&`). All parameter values must be [URL-encoded.][urlencode]
+
+#### `query`
+
+The most common URL parameter is `query`, which lets you define the set of results returned by most endpoints. The value of `query` must be a **query string.** Query strings are described in more detail [below](#query-strings).
+
+#### Paging
+
+The next most common URL parameters are the **paging** parameters.
+
+Most PuppetDB query endpoints support paged results via a set of shared URL parameters.  For more information, please see the documentation on [paging][paging].
+
+## Query Strings
+
+A query string passed to the `query` URL parameter must be:
 
 * A [URL-encoded][urlencode]...
-* ...JSON array, which may contain scalar data types (usually strings) and additional arrays...
+* ...JSON array...
+    * ...which may contain scalar data types (usually strings) and additional arrays...
 * ...which describes a complex _comparison operation..._
-* ...in [_prefix notation._][prefix]
+* ...in [_prefix notation_][prefix], with an **operator** first and its **arguments** following.
 
-JSON arrays are delimited by square brackets (`[` and `]`), and items in the array are separated by commas. JSON strings are delimited by straight double-quotes (`"`) and must be UTF-8 text; literal double quotes and literal backslashes in the string must be escaped with a backslash (`"` is `\"` and `\` is `\\`).
+That is, before being URL-encoded, all query strings follow the form:
 
-"Prefix notation" means every array in a query string must begin with an [operator][operators], and the remaining elements in the array will be interpreted as that operator's arguments, in order. (The similarity to Lisp is intentional.)
+    [ "<OPERATOR>", "<ARGUMENT>", (..."<ARGUMENT>"...) ]
 
-A complete query string describes a comparison operation. When submitting a query, PuppetDB will check every _possible_ result from the endpoint to see if it matches the comparison from the query string, and will only return those objects that match. 
+A complete query string describes a comparison operation. When submitting a query, PuppetDB will check every _possible_ result from the endpoint to see if it matches the comparison from the query string, and will only return those objects that match.
 
-For a more complete description of how to construct query strings, see [the Operators page][operators]. 
+Different operators may take different numbers (and types) of arguments. Each endpoint may have a slightly different set of operators available.
+
+> ### Explicit Grammar for Query Strings
+>
+> More explicitly, the following grammar describes a query string (before it is URL-encoded):
+>
+>     query: [ {bool}, {query}+ ] | [ "not", {query} ] | [ {binary_op}, {field}, {value} ] |
+>                 [ "in", {field}, [ "extract", {field}, [ {subquery_name}, {query} ] ] ]
+>     field:          string, which is the name of a valid FIELD listed in the endpoint's doc page
+>     value:          string
+>     bool:           "or" | "and"
+>     binary_op:      "=" | "~" | ">" | ">=" | "<" | "<="
+>     subquery_name:  "select-resources" | "select-facts" | "select-nodes"
+
+> ### Note on JSON Formatting
+>
+> JSON arrays are delimited by square brackets (`[` and `]`), and items in the array are separated by commas. JSON strings are delimited by straight double-quotes (`"`) and must be UTF-8 text; literal double quotes and literal backslashes in the string must be escaped with a backslash (`"` is `\"` and `\` is `\\`).
+
+### Operators
+
+[The Operators page][operators] describes all of the available operators and their behavior. Also, each endpoint's page will list which operators are useful with that endpoint.
+
+PuppetDB uses three main kinds of operators:
+
+* **Binary comparison operators** like `=` or `<`, which take exactly one **field** and exactly one **value** as arguments. (`["=", "certname", "magpie.example.com"]`)
+* **Boolean operators** like `not` or `and`, which take complete query strings as arguments. `["and", ["<", "timestamp", "2011-01-01T12:01:00-03:00"], [">", "timestamp", "2011-01-01T12:00:00-03:00"]]`
+* **Subquery operators,** which always occur in the form `["in", "<FIELD>", ["extract", "<FIELD>", <SUBQUERY STATEMENT>] ]`.
+
 
 ## Query Responses
 
-All queries return data with a content type of `application/json`. 
+All queries return data with a content type of `application/json`. Each endpoint's page describes the format of its return data.
 
 ## Tutorial and Tips
 
 For a walkthrough on constructing queries, see [the Query Tutorial page][tutorial]. For quick tips on using curl to make ad-hoc queries, see [the Curl Tips page][curl].
-

--- a/documentation/api/query/v3/reports.markdown
+++ b/documentation/api/query/v3/reports.markdown
@@ -5,42 +5,45 @@ canonical: "/puppetdb/latest/api/query/v3/reports.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
-[operator]: ../v3/operators.html
+[operator]: ./operators.html
 [event]: ./events.html
 [paging]: ./paging.html
+[statuses]: /puppet/latest/reference/format_report.html#puppettransactionreport
+[query]: ./query.html
 
-Querying reports is accomplished by making an HTTP request to the `/reports` REST
-endpoint.
+Puppet agent nodes submit reports after their runs, and the puppet master forwards these to PuppetDB. Each report includes:
 
-## Routes
+* Some data about the entire run
+* Some metadata about the report
+* Many _events,_ describing what happened during the run
 
-### `GET /v3/reports`
+Once this information is stored in PuppetDB, it can be queried in various ways.
 
-#### Parameters
+* You can query **data about the run** and **report metadata** by making an HTTP request to the `/reports` endpoint.
+* You can query **data about individual events** by making an HTTP request to the [`/events`][event] endpoint.
+* You can query **summaries of event data** by making an HTTP request to the [`/event-counts`](./event-counts.html) or [`aggregate-event-counts`](./aggregate-event-counts.html) endpoints.
 
-* `query`: Required. A JSON array of query predicates, in prefix form. (The standard `["<OPERATOR>", "<FIELD>", "<VALUE>"]` format.)
+## `GET /v3/reports`
 
-For example, for all reports run on the node with certname 'example.local', the
-JSON query structure would be:
+### URL Parameters
 
-    ["=", "certname", "example.local"]
+* `query`: Optional. A JSON array of query predicates, in prefix notation (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`). See the sections below for the supported operators and fields. For general info about queries, see [the page on query structure.][query]
 
-##### Operators
+    If the `query` parameter is absent, PuppetDB will return all reports.
 
-The only available [OPERATOR][] is `=`.
+### Query Operators
 
-##### Fields
+See [the Operators page](./operators.html)
 
-`FIELD` may be any of the following.  All fields support only the equality operator.
+### Query Fields
 
-`certname`
-: the name of the node that the report was received from.
+The below fields are allowed as filter criteria and are returned in all responses.
 
-`hash`
-: the id of the report; these ids can be acquired
-  via event queries (see the [`/events`][event] query endpoint).
+* `certname`: the name of the node that the report was received from.
 
-#### Response format
+* `hash`: the id of the report; these ids can be acquired via event queries (see the [`/events`][event] endpoint).
+
+### Response format
 
 The response is a JSON array of report summaries for all reports
 that matched the input parameters.  The summaries are sorted by
@@ -71,15 +74,15 @@ the completion time of the report, in descending order:
         }
     ]
 
+### Example
 
-#### Paging
+[You can use `curl`][curl] to query information about reports like so:
+
+    curl -G 'http://localhost:8080/v3/reports' --data-urlencode 'query=["=", "certname", "example.local"]'
+
+## Paging
 
 This query endpoint supports paged results via the common PuppetDB paging
 query parameters.  For more information, please see the documentation
 on [paging][paging].
 
-#### Example
-
-[You can use `curl`][curl] to query information about reports like so:
-
-    curl -G 'http://localhost:8080/v3/reports' --data-urlencode 'query=["=", "certname", "example.local"]'

--- a/documentation/api/query/v3/resources.markdown
+++ b/documentation/api/query/v3/resources.markdown
@@ -6,86 +6,95 @@ canonical: "/puppetdb/latest/api/query/v3/resources.html"
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
 [paging]: ./paging.html
+[query]: ./query.html
 
-Resources are queried via an HTTP request to the
-`/resources` REST endpoint.
+You can query resources by making an HTTP request to the
+`/resources` endpoint.
 
 
-## Routes
 
-### `GET /v3/resources`
+## `GET /v3/resources`
 
 This will return all resources matching the given query. Resources for
 deactivated nodes are not included in the response.
 
-#### Parameters
+### URL Parameters
 
-* `query`: Optional. A JSON array of query predicates, in prefix form,
-  conforming to the format described below. If not provided, all results will
-  be returned.
+* `query`: Optional. A JSON array of query predicates, in prefix notation (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`). See the sections below for the supported operators and fields. For general info about queries, see [the page on query structure.][query]
 
-The `query` parameter is described by the following grammar:
+    If no query is provided, all resources will be returned.
 
-    query: [ {bool} {query}+ ] | [ "not" {query} ] | [ {match} {field} {value} ]
-    field:  string | [ string+ ]
-    value:  string
-    bool:   "or" | "and"
-    match:  "=" | "~"
+### Query Operators
 
-`field` may be any of:
+See [the Operators page](./operators.html) for the full list of available operators. Note that:
 
-`tag`
-: a case-insensitive tag on the resource
+* The inequality operators are only supported for the `line` field.
+* Regexp matching is **not** supported against parameter values.
 
-`certname`
-: the name of the node associated with the resource
+### Query Fields
 
-`[parameter <resource_param>]`
-: a parameter of the resource
+* `tag`: a case-insensitive tag on the resource.
 
-`type`
-: the resource type
+* `certname`: the name of the node associated with the resource.
 
-`title`
-: the resource title
+* `[parameter <PARAMETER NAME>]`: the value of the `<PARAMETER NAME>` parameter of the resource.
 
-`exported`
-: whether or not the resource is exported
+* `type`: the resource type.
 
-`file`
-: the manifest file the resource was declared in
+* `title`: the resource title.
 
-`line`
-: the line of the manifest on which the resource was declared
+* `exported`: whether or not the resource is exported.
 
-For example, for file resources, tagged "magical", on any host except
-for "example.local" the JSON query structure would be:
+* `file`: the manifest file the resource was declared in.
+
+* `line`: the line of the manifest on which the resource was declared.
+
+
+### Response format
+
+An array of zero or more resource objects, with each object having the
+following form:
+
+    {"certname":   "the certname of the associated host",
+     "resource":   "the resource's unique hash",
+     "type":       "File",
+     "title":      "/etc/hosts",
+     "exported":   "true",
+     "tags":       ["foo", "bar"],
+     "file": "/etc/puppet/manifests/site.pp",
+     "line": "1",
+     "parameters": {<parameter>: <value>,
+                   <parameter>: <value>,
+                   ...}}
+
+### Examples
+
+For file resources tagged "magical", on any host except
+for "example.local," the JSON query structure would be:
 
     ["and", ["not", ["=", "certname", "example.local"]],
             ["=", "type", "File"],
             ["=", "tag", "magical"],
             ["=", ["parameter", "ensure"], "enabled"]
 
-See [the Operators page](./operators.html) for the full list of available operators. Note that
-resource queries *do not support* inequality, and regexp matching *is not
-supported* against node status or parameter values.
 
-### `GET /v3/resources/<TYPE>`
+## `GET /v3/resources/<TYPE>`
 
 This will return all resources for all nodes with the given
 type. Resources from deactivated nodes aren't included in the
 response.
 
-#### Parameters
+This behaves exactly like a call to `/v3/resources` with a query string of `["=", "type", "<TYPE>"]`.
 
-* `query`: Optional. A JSON array containing the query in prefix
-  notation. The syntax and semantics are identical to the `query`
-  parameter for the `/resources` route, mentioned above. When
-  supplied, the query is assumed to supply _additional_ criteria that
-  can be used to return a _subset_ of the information normally
-  returned by this route.
+### URL Parameters / Query Operators / Query Fields / Response Format
 
-#### Examples
+This route is an extension of the plain `resources` endpoint. It uses the exact same parameters, operators, fields, and response format.
+
+If you provide a `query` parameter, it will specify additional criteria, which will be
+used to return a subset of the information normally returned by
+this route.
+
+### Examples
 
 [Using `curl` from localhost][curl]:
 
@@ -124,22 +133,27 @@ response.
       "type" : "User",
       "certname" : "host2.mydomain.com"}]
 
-### `GET /v3/resources/<TYPE>/<TITLE>`
+## `GET /v3/resources/<TYPE>/<TITLE>`
 
 This will return all resources for all nodes with the given type and
 title. Resources from deactivated nodes aren't included in the
 response.
 
-#### Parameters
+This behaves exactly like a call to `/v3/resources` with a query string of:
 
-* `query`: Optional. A JSON array containing the query in prefix
-  notation. The syntax and semantics are identical to the `query`
-  parameter for the `/resources` route, mentioned above. When
-  supplied, the query is assumed to supply _additional_ criteria that
-  can be used to return a _subset_ of the information normally
-  returned by this route.
+    ["and",
+        ["=", "type", "<TYPE>"],
+        ["=", "title", "<TITLE>"]]
 
-#### Examples
+### URL Parameters / Query Operators / Query Fields / Response Format
+
+This route is an extension of the plain `resources` endpoint. It uses the exact same parameters, operators, fields, and response format.
+
+If you provide a `query` parameter, it will specify additional criteria, which will be
+used to return a subset of the information normally returned by
+this route.
+
+### Examples
 
 [Using `curl` from localhost][curl]:
 
@@ -166,22 +180,6 @@ response.
 ## Paging
 
 This query endpoint supports paged results via the common PuppetDB paging
-query parameters.  For more information, please see the documentation
+URL parameters.  For more information, please see the documentation
 on [paging][paging].
 
-## Response format
-
-An array of zero or more resource objects, with each object having the
-following form:
-
-    {"certname":   "the certname of the associated host",
-     "resource":   "the resource's unique hash",
-     "type":       "File",
-     "title":      "/etc/hosts",
-     "exported":   "true",
-     "tags":       ["foo", "bar"],
-     "file": "/etc/puppet/manifests/site.pp",
-     "line": "1",
-     "parameters": {<parameter>: <value>,
-                   <parameter>: <value>,
-                   ...}}

--- a/documentation/api/query/v3/server-time.markdown
+++ b/documentation/api/query/v3/server-time.markdown
@@ -8,27 +8,28 @@ canonical: "/puppetdb/latest/api/query/v3/server-time.html"
 
 The `/server-time` endpoint can be used to retrieve the server time from the PuppetDB server.
 
-## Routes
 
-### `GET /v3/server-time`
+## `GET /v3/server-time`
 
 This query endpoint will return the current time of the clock on the PuppetDB
 server.  This can be useful as input to other time-based queries against PuppetDB,
 to eliminate the possibility of time differences between the clocks on client
 machines.
 
-#### Examples
+This endpoint does not use any URL parameters or query strings.
 
-[Using `curl` from localhost][curl]:
-
-    curl -X GET http://localhost:8080/v3/server-time
-
-    {"server-time": "2013-09-20T20:54:27.472Z"}
-
-## Response Format
+### Response Format
 
 The response will be in `application/json`, and will return a JSON map with a
 single key: `server-time`, whose value is an ISO-8601 representation of the
 current time on the PuppetDB server.
+
+    {"server-time": "2013-09-20T20:54:27.472Z"}
+
+### Examples
+
+[Using `curl` from localhost][curl]:
+
+    curl -X GET http://localhost:8080/v3/server-time
 
     {"server-time": "2013-09-20T20:54:27.472Z"}

--- a/documentation/api/query/v3/version.markdown
+++ b/documentation/api/query/v3/version.markdown
@@ -8,14 +8,23 @@ canonical: "/puppetdb/latest/api/query/v3/version.html"
 
 The `/version` endpoint can be used to retrieve version information from the PuppetDB server.
 
-## Routes
 
-### `GET /v3/version`
+## `GET /v3/version`
 
 This query endpoint will return version information about the running PuppetDB
 server.
 
-#### Examples
+This endpoint does not use any URL parameters or query strings.
+
+### Response Format
+
+The response will be in `application/json`, and will return a JSON map with a
+single key: `version`, whose value is a string representation of the version
+of the running PuppetDB server.
+
+    {"version": "X.Y.Z"}
+
+### Examples
 
 [Using `curl` from localhost][curl]:
 
@@ -23,10 +32,3 @@ server.
 
     {"version": "X.Y.Z"}
 
-## Response Format
-
-The response will be in `application/json`, and will return a JSON map with a
-single key: `version`, whose value is a string representation of the version
-of the running PuppetDB server.
-
-    {"version": "X.Y.Z"}

--- a/documentation/api/wire_format/catalog_format.markdown
+++ b/documentation/api/wire_format/catalog_format.markdown
@@ -1,22 +1,22 @@
 ---
 title: "PuppetDB 1.6 » API » Catalog Wire Format, Version 1"
 layout: default
-canonical: "/puppetdb/latest/api/wire_format/catalog_format.html"
+canonical: "/puppetdb/latest/api/wire_format/catalog_format_v1.html"
 ---
 
-[containment]: /puppet/2.7/reference/lang_containment.html
-[relationship]: /puppet/2.7/reference/lang_relationships.html
-[chain]: /puppet/2.7/reference/lang_relationships.html#chaining-arrows
-[metaparameters]: /puppet/2.7/reference/lang_relationships.html#relationship-metaparameters
-[require]: /puppet/2.7/reference/lang_relationships.html#the-require-function
-[resource_ref]: /puppet/2.7/reference/lang_datatypes.html#resource-references
-[numbers]: /puppet/2.7/reference/lang_datatypes.html#numbers
-[undef]: /puppet/2.7/reference/lang_datatypes.html#undef
-[namevar]: /puppet/2.7/reference/lang_resources.html#namenamevar
-[resource]: /puppet/2.7/reference/lang_resources.html
-[title]: /puppet/2.7/reference/lang_resources.html#title
-[type]: /puppet/2.7/reference/lang_resources.html#type
-[attributes]: /puppet/2.7/reference/lang_resources.html#attributes
+[containment]: /puppet/latest/reference/lang_containment.html
+[relationship]: /puppet/latest/reference/lang_relationships.html
+[chain]: /puppet/latest/reference/lang_relationships.html#chaining-arrows
+[metaparameters]: /puppet/latest/reference/lang_relationships.html#relationship-metaparameters
+[require]: /puppet/latest/reference/lang_relationships.html#the-require-function
+[resource_ref]: /puppet/latest/reference/lang_datatypes.html#resource-references
+[numbers]: /puppet/latest/reference/lang_datatypes.html#numbers
+[undef]: /puppet/latest/reference/lang_datatypes.html#undef
+[namevar]: /puppet/latest/reference/lang_resources.html#namenamevar
+[resource]: /puppet/latest/reference/lang_resources.html
+[title]: /puppet/latest/reference/lang_resources.html#title
+[type]: /puppet/latest/reference/lang_resources.html#type
+[attributes]: /puppet/latest/reference/lang_resources.html#attributes
 [replace3]: ../commands.html#replace-catalog-version-3
 [replace2]: ../commands.html#replace-catalog-version-2
 [replace1]: ../commands.html#replace-catalog-version-1
@@ -28,7 +28,7 @@ Catalog Interchange Format
 
 ### Version
 
-This is **version 1** of the catalog interchange format, which is used by PuppetDB 1 (and all pre-1.0 releases).
+This is **version 1** of the catalog interchange format, which is used by PuppetDB 1.x (and all pre-1.0 releases).
 
 
 ### Encoding
@@ -60,25 +60,30 @@ Each of the keys is mandatory unless otherwise noted, although values that are l
 
 The value of each key in the data object is as follows:
 
-`"name"`
-: String. The name of the node for which the catalog was compiled.
+#### `name`
 
-`"version"`
-: String. An arbitrary string that uniquely identifies this specific catalog across time for a single node. This is controlled by Puppet's [`config_version` setting](/references/latest/configuration.html#configversion) and is usually the seconds elapsed since the epoch.
+String. The name of the node for which the catalog was compiled.
 
-`"edges"`
-: List of [`<edge>` objects](#data-type-edge). **Every** [relationship][] between any two resources in the catalog, which may have been made with [chaining arrows][chain], [metaparameters][], or [the `require` function][require].
+#### `version`
 
-  > **Notes:**
-  >
-  > * "Autorequire" relationships are not currently encoded in the catalog.
-  > * This key is significantly different from its equivalent in Puppet's internal catalog format, which only encodes containment edges.
+String. An arbitrary string that uniquely identifies this specific catalog across time for a single node. This is controlled by Puppet's [`config_version` setting](/references/latest/configuration.html#configversion) and is usually the seconds elapsed since the epoch.
 
-`"resources"`
-: List of [`<resource>` objects](#data-type-resource). Contains **every** resource in the catalog.
+#### `edges`
 
-`"transaction-uuid"`
-: String. A string used to match the catalog with the corresponding report that was issued during the same puppet run.
+List of [`<edge>` objects](#data-type-edge). **Every** [relationship][] between any two resources in the catalog, which may have been made with [chaining arrows][chain], [metaparameters][], or [the `require` function][require].
+
+> **Notes:**
+>
+> * "Autorequire" relationships are not currently encoded in the catalog.
+> * This key is significantly different from its equivalent in Puppet's internal catalog format, which only encodes containment edges.
+
+#### `resources`
+
+List of [`<resource>` objects](#data-type-resource). Contains **every** resource in the catalog.
+
+#### `transaction-uuid`
+
+String. A string used to match the catalog with the corresponding report that was issued during the same puppet run.
 This field may be `null`.  (Note: support for this field was introduced in
 [Version 3 of the "replace catalog" command][replace3].  Versions prior to version 3 will populate this field with
 a `null` value.
@@ -107,17 +112,17 @@ All edges are normalized so that the "source" resource is managed **before** the
 
 The keys of an edge are `source`, `target`, and `relationship`, all of which are required.
 
-`source`
+#### `source`
 
-: A [`<resource-spec>`](#data-type-resource-spec). The resource which should be managed **first.**
+A [`<resource-spec>`](#data-type-resource-spec). The resource which should be managed **first.**
 
-`target`
+#### `target`
 
-: A [`<resource-spec>`](#data-type-resource-spec). The resource which should be managed **second.**
+A [`<resource-spec>`](#data-type-resource-spec). The resource which should be managed **second.**
 
-`relationship`
+#### `relationship`
 
-: A [`<relationship>`](#data-type-relationship). The way the two resources are related.
+A [`<relationship>`](#data-type-relationship). The way the two resources are related.
 
 ### Data Type: `<resource-spec>`
 
@@ -170,37 +175,37 @@ A JSON object of the following form, which represents a [Puppet resource][resour
 
 The eight keys in a resource object are `type`, `title`, `aliases`, `exported`, `file`, `line`, `tags` and `parameters`. All of them are **required.**
 
-`type`
+#### `type`
 
-: String. The [type][] of the resource, **capitalized.** (E.g. `File`, `Service`, `Class`, `Apache::Vhost`.) Note that every segment must be capitalized if the type includes a namespace separator (`::`).
+String. The [type][] of the resource, **capitalized.** (E.g. `File`, `Service`, `Class`, `Apache::Vhost`.) Note that every segment must be capitalized if the type includes a namespace separator (`::`).
 
-`title`
+#### `title`
 
-: String. The [title][] of the resource.
+String. The [title][] of the resource.
 
-`aliases`
+#### `aliases`
 
-: List of strings. Includes **every** alias for the resource, including the value of its [name/namevar][namevar] and any extra names added with the `"alias"` metaparameter.
+List of strings. Includes **every** alias for the resource, including the value of its [name/namevar][namevar] and any extra names added with the `"alias"` metaparameter.
 
-`exported`
+#### `exported`
 
-: Boolean. Whether or not this is an exported resource.
+Boolean. Whether or not this is an exported resource.
 
-`file`
+#### `file`
 
-: String. The manifest file in which the resource definition is located.
+String. The manifest file in which the resource definition is located.
 
-`line`
+#### `line`
 
-: Positive integer. The line (of the containing manifest file) at which the resource definition can be found.
+Positive integer. The line (of the containing manifest file) at which the resource definition can be found.
 
-`tags`
+#### `tags`
 
-: List of strings. Includes every tag the resource has. This is a normalized superset of the value of the resource's `tag` attribute.
+List of strings. Includes every tag the resource has. This is a normalized superset of the value of the resource's `tag` attribute.
 
-`parameters`
+#### `parameters`
 
-: JSON object. Includes all of the resource's [attributes][] and their associated values. The value of an attribute may be any JSON data type, but Puppet will only provide booleans, strings, arrays, and hashes --- [resource references][resource_ref] and [numbers][] in attributes are converted to strings before being inserted into the catalog. Attributes with [undef][] values are not added to the catalog.
+JSON object. Includes all of the resource's [attributes][] and their associated values. The value of an attribute may be any JSON data type, but Puppet will only provide booleans, strings, arrays, and hashes --- [resource references][resource_ref] and [numbers][] in attributes are converted to strings before being inserted into the catalog. Attributes with [undef][] values are not added to the catalog.
 
 
 

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -36,25 +36,11 @@ Debian/Ubuntu (PE)          | `/etc/default/pe-puppetdb`
 
  In this file, you can change the following settings:
 
-`JAVA_BIN`
-
-: The location of the Java binary.
-
-`JAVA_ARGS`
-
-: Command line options for the Java binary, most notably the `-Xmx` (max heap size) flag.
-
-`USER`
-
-: The user PuppetDB should be running as.
-
-`INSTALL_DIR`
-
-: The directory into which PuppetDB is installed.
-
-`CONFIG`
-
-: The location of the PuppetDB config file, which may be a single file or a directory of .ini files.
+- **`JAVA_BIN`** --- The location of the Java binary.
+- **`JAVA_ARGS`** --- Command line options for the Java binary, most notably the `-Xmx` (max heap size) flag.
+- **`USER`** --- The user PuppetDB should be running as.
+- **`INSTALL_DIR`** --- The directory into which PuppetDB is installed.
+- **`CONFIG`** --- The location of the PuppetDB config file, which may be a single file or a directory of .ini files.
 
 ### Configuring the Java Heap Size
 

--- a/documentation/load_testing_tool.markdown
+++ b/documentation/load_testing_tool.markdown
@@ -57,20 +57,9 @@ are below.
 
 ##### Arguments
 
-`--config/-c`
-: Path to the INI file that has the host/port configuration for the PuppetDB instance to be tested
-
-`--catalogs/-C`
-: Directory containing catalogs to use for testing (probably from a previous PuppetDB export)
-
-`--reports/-R`
-: Directory containing reports to use for testing (probably from a previous PuppetDB export)
-
-`--runinterval/-i`
-: Integer indicating the amount of time in minutes between puppet runs for each simulated node, 30 or 60 would be a typical value for this
-
-`--numhosts/-n`
-: Number of separate hosts that the tool should simulate
-
-`--rand-perc/-rp`
-: What percentage of catalogs submissions should be changed (i.e. simulating normal/typical catalog changes, as in adding a resource, edge or something similar). More changes to catalogs will cause a higher load on PuppetDB, 10 is a pretty typical change percentage.
+- **`--config / -c`** --- Path to the INI file that has the host/port configuration for the PuppetDB instance to be tested
+- **`--catalogs / -C`** --- Directory containing catalogs to use for testing (probably from a previous PuppetDB export)
+- **`--reports / -R`** --- Directory containing reports to use for testing (probably from a previous PuppetDB export)
+- **`--runinterval / -i`** --- Integer indicating the amount of time in minutes between puppet runs for each simulated node, 30 or 60 would be a typical value for this
+- **`--numhosts / -n`** --- Number of separate hosts that the tool should simulate
+- **`--rand-perc / -rp`** --- What percentage of catalogs submissions should be changed (i.e. simulating normal/typical catalog changes, as in adding a resource, edge or something similar). More changes to catalogs will cause a higher load on PuppetDB, 10 is a pretty typical change percentage.

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -13,19 +13,19 @@ Notable improvements and fixes:
 
 * (PDB-510) Add migration to fix sequence for catalog.id
 
-  The sequence for catalog.id had not been incremented during insert for migration
-  20 'differential-catalog-resources'.
+    The sequence for catalog.id had not been incremented during insert for migration
+    20 'differential-catalog-resources'.
 
-  This meant that the catalog.id column would throw a constraint exception during
-  insertion until the sequence had increased enough to be greater then the max id
-  already used in the column.
+    This meant that the catalog.id column would throw a constraint exception during
+    insertion until the sequence had increased enough to be greater then the max id
+    already used in the column.
 
-  While this was only a temporary error, it does cause puppetdb to start to throw
-  errors and potentially dropping some catalog updates until a certain number of
-  catalogs had been attempted. In some cases catalogs had been queued up and
-  retried successfully, other cases meant they were simply dropped into the DLQ.
+    While this was only a temporary error, it does cause puppetdb to start to throw
+    errors and potentially dropping some catalog updates until a certain number of
+    catalogs had been attempted. In some cases catalogs had been queued up and
+    retried successfully, other cases meant they were simply dropped into the DLQ.
 
-  The fix is to reset the sequence to match the max id on the catalogs.id column.
+    The fix is to reset the sequence to match the max id on the catalogs.id column.
 
 * RHEL 7 beta packages are now included
 
@@ -33,18 +33,18 @@ Notable improvements and fixes:
 
 * (PDB-468) Update CLI tools to use correct JAVA_BIN and JAVA_ARGS
 
-  Some tools such as `puppetdb import|export` and `puppetdb foreground` where not
-  honouring the JAVA_BIN defined in /etc/default|sysconfig/puppetdb.
+    Some tools such as `puppetdb import|export` and `puppetdb foreground` where not
+    honouring the JAVA_BIN defined in /etc/default|sysconfig/puppetdb.
 
 * (PDB-437) Reduce API source code and version inconsistencies
 
-  The API code when split between different versions created an opportunity for
-  inconsistencies to grow. For example, some versioning inside the code supported
-  this file based way of abstracting versions, but other functions required
-  version specific handling.
+    The API code when split between different versions created an opportunity for
+    inconsistencies to grow. For example, some versioning inside the code supported
+    this file based way of abstracting versions, but other functions required
+    version specific handling.
 
-  This patch solidifies the version handling to ensure we reduce in regressions
-  relating to different versions of the query API and different operator handling.
+    This patch solidifies the version handling to ensure we reduce in regressions
+    relating to different versions of the query API and different operator handling.
 
 * Use v3 end-point for import and benchmark tools
 
@@ -75,64 +75,64 @@ Notable improvements and fixes:
 * Provided an early release RPM SPEC for RHEL 7, no automated builds yet.
 
 * (PDB-377) - Fixed a Fedora RPM packaging issue preventing PuppetDB
-  from starting by disabling JAR repacking
+    from starting by disabling JAR repacking
 
 * (PDB-341) - Fixed a naming issue when using subqueries for resource
-  metadata like file and line with v3 of the API
+    metadata like file and line with v3 of the API
 
 * (PDB-128) - Oracle Java 7 package support
 
-  Add support for Oracle Java 7 packages on Debian. This
-  means that users who have older Debian based distros but do not have
-  native JDK 7 packages can build their own Oracle Java 7 package (see
-  https://wiki.debian.org/JavaPackage) and we will pull it in as a
-  dependency.
- 
+    Add support for Oracle Java 7 packages on Debian. This
+    means that users who have older Debian based distros but do not have
+    native JDK 7 packages can build their own Oracle Java 7 package (see
+    https://wiki.debian.org/JavaPackage) and we will pull it in as a
+    dependency.
+
 * (PDB-106) - Added an explicit log message upon a failed agent run
-  (previously would fail with “undefined method `[]' for nil:NilClass”)
+    (previously would fail with “undefined method `[]' for nil:NilClass”)
 
 * Change the order that filters are applied for events
 
-  When using the `distinct-resources` flag of an event query, the
-  previous behavior was that we would do the filtering of the events
-  *before* we would eliminate duplicate resources. This was not the
-  expected behavior in many cases in the UI; for example, when filtering
-  events based on event status, the desired behavior was to find all of
-  the most recent events for each resource *first*, and then apply the
-  filter to that set of resources. If we did the status filtering first,
-  then we might end up in a state where we found the most recent
-  'failed' event and showed it in the UI even if there were 'success'
-  events on that resource afterwards.
+    When using the `distinct-resources` flag of an event query, the
+    previous behavior was that we would do the filtering of the events
+    *before* we would eliminate duplicate resources. This was not the
+    expected behavior in many cases in the UI; for example, when filtering
+    events based on event status, the desired behavior was to find all of
+    the most recent events for each resource *first*, and then apply the
+    filter to that set of resources. If we did the status filtering first,
+    then we might end up in a state where we found the most recent
+    'failed' event and showed it in the UI even if there were 'success'
+    events on that resource afterwards.
 
-  This commit changes the order that the filtering happens in.  We
-  now do the `distinct` portion of the query before we do the filtering.
+    This commit changes the order that the filtering happens in.    We
+    now do the `distinct` portion of the query before we do the filtering.
 
-  However, in order to achieve reasonable performance, we need to
-  at least include timestamp filtering in the `distinct` query; otherwise
-  that portion of the query has to work against the entire table,
-  and becomes prohibitively expensive.
+    However, in order to achieve reasonable performance, we need to
+    at least include timestamp filtering in the `distinct` query; otherwise
+    that portion of the query has to work against the entire table,
+    and becomes prohibitively expensive.
 
-  Since the existing timestamp filtering can be nested arbitrarily
-  inside of the query (inside of boolean logic, etc.), it was not
-  going to be possible to re-use that to handle the timestamp filtering
-  for the `distinct` part of the query; thus, we had to introduce
-  two new query parameters to go along with `distinct-resources`:
-  `distinct-start-time` and `distinct-end-time`.  These are now
-  required when using `distinct-resources`.
+    Since the existing timestamp filtering can be nested arbitrarily
+    inside of the query (inside of boolean logic, etc.), it was not
+    going to be possible to re-use that to handle the timestamp filtering
+    for the `distinct` part of the query; thus, we had to introduce
+    two new query parameters to go along with `distinct-resources`:
+    `distinct-start-time` and `distinct-end-time`.  These are now
+    required when using `distinct-resources`.
 
 * (PDB-407) - Add Fedora 20 acceptance tests
 
 * (PDB-425) - System V to SystemD upgrade
 
-  Fixed issues upgrading from 1.5.2 to 1.6.2 on Fedora.
-  1.5.2 used System V scripts while 1.6.x used SystemD which caused
-  failures.
+    Fixed issues upgrading from 1.5.2 to 1.6.2 on Fedora.
+    1.5.2 used System V scripts while 1.6.x used SystemD which caused
+    failures.
 
 1.6.1
 -----
 
 Not released due to SystemD-related packaging issues on Fedora
-  
+
 
 1.6.0
 -----
@@ -145,154 +145,154 @@ Notable improvements and fixes:
 
 * (#21083) Differential fact storage
 
-  Previously when facts for a node were replaced, all previous facts
-  for that node were deleted and all new facts were inserted. Now
-  existing facts are updated, old facts (no longer present) are
-  deleted and new facts are inserted. This results in much less I/O,
-  both because we have to write much less data and also because we
-  reduce churn in the database tables, allowing them to stay compact
-  and fast.
+    Previously when facts for a node were replaced, all previous facts
+    for that node were deleted and all new facts were inserted. Now
+    existing facts are updated, old facts (no longer present) are
+    deleted and new facts are inserted. This results in much less I/O,
+    both because we have to write much less data and also because we
+    reduce churn in the database tables, allowing them to stay compact
+    and fast.
 
 * (PDB-68) Differential edge storage
 
-  Previously when a catalog wasn't detected as a duplicate, we'd have
-  to reinsert all edges into the database using the new catalog's
-  hash. This meant that even if 99% of the edges were the same, we'd
-  still insert 100% of them anew and wait for our periodic GC to clean
-  up the old rows. We now only modify the edges that have actually
-  changed, and leave unchanged edges alone. This results in much less
-  I/O as we touch substantially fewer rows.
+    Previously when a catalog wasn't detected as a duplicate, we'd have
+    to reinsert all edges into the database using the new catalog's
+    hash. This meant that even if 99% of the edges were the same, we'd
+    still insert 100% of them anew and wait for our periodic GC to clean
+    up the old rows. We now only modify the edges that have actually
+    changed, and leave unchanged edges alone. This results in much less
+    I/O as we touch substantially fewer rows.
 
 * (PDB-69) Differential resource storage
 
-  Previously when a catalog wasn't detected as a duplicate, we'd have
-  to reinsert all resource metadata into the catalog_resources table
-  using the catalog's new hash. Even if only 1 resource changed out of
-  a possible 1000, we'd still insert 1000 new rows. We now only modify
-  resources that have actually changed. This results in much less I/O
-  in the common case.
+    Previously when a catalog wasn't detected as a duplicate, we'd have
+    to reinsert all resource metadata into the catalog_resources table
+    using the catalog's new hash. Even if only 1 resource changed out of
+    a possible 1000, we'd still insert 1000 new rows. We now only modify
+    resources that have actually changed. This results in much less I/O
+    in the common case.
 
 * Streaming resource and fact queries. Previously, we'd load all rows
-  from a resource or fact query into RAM, then do a bunch of sorting
-  and aggregation to transform them into a format that clients
-  expect. That has obvious problems involving RAM usage for large
-  result sets. Furthermore, this does all the work for querying
-  up-front...if a client disconnects, the query continues to tax the
-  database until it completes. And lastly, we'd have to wait until all
-  the query results have been paged into RAM before we could send
-  anything to the client. New streaming support massively reduces RAM
-  usage and time-to-first-result. Note that currently only resource
-  and fact queries employ streaming, as they're the most
-  frequently-used endpoints.
+    from a resource or fact query into RAM, then do a bunch of sorting
+    and aggregation to transform them into a format that clients
+    expect. That has obvious problems involving RAM usage for large
+    result sets. Furthermore, this does all the work for querying
+    up-front...if a client disconnects, the query continues to tax the
+    database until it completes. And lastly, we'd have to wait until all
+    the query results have been paged into RAM before we could send
+    anything to the client. New streaming support massively reduces RAM
+    usage and time-to-first-result. Note that currently only resource
+    and fact queries employ streaming, as they're the most
+    frequently-used endpoints.
 
 * Improvements to our deduplication algorithm. We've improved our
-  deduplication algorithms to better detect when we've already stored
-  the necessary data. Early reports from the field has show users who
-  previously had deduplication rates in the 0-10% range jumping up to
-  the 60-70% range. This has a massive impact on performance, as the
-  fastest way to persist data is to already have it persisted!
+    deduplication algorithms to better detect when we've already stored
+    the necessary data. Early reports from the field has show users who
+    previously had deduplication rates in the 0-10% range jumping up to
+    the 60-70% range. This has a massive impact on performance, as the
+    fastest way to persist data is to already have it persisted!
 
 * Eliminate joins for parameter retrieval. Much of the slowness of
-  resource queries comes from the format of the resultset. We get back
-  one row per parameter, and we need to collapse multiple rows into
-  single resource objects that we can emit to the client. It's much
-  faster and tidier to just have a separate table that contains a
-  json-ified version of all a resource's parameters. That way, there's
-  no need to collapse multiple rows at all, or do any kind of ORDER BY
-  to ensure that the rows are properly sequenced.  In testing, this
-  appears to speed up queries between 2x-3x...the improvement is much
-  better the larger the resultset.
+    resource queries comes from the format of the resultset. We get back
+    one row per parameter, and we need to collapse multiple rows into
+    single resource objects that we can emit to the client. It's much
+    faster and tidier to just have a separate table that contains a
+    json-ified version of all a resource's parameters. That way, there's
+    no need to collapse multiple rows at all, or do any kind of ORDER BY
+    to ensure that the rows are properly sequenced.  In testing, this
+    appears to speed up queries between 2x-3x...the improvement is much
+    better the larger the resultset.
 
 * (#22350) Support for dedicated, read-only databases. Postgres
-  supports Hot Standby (http://wiki.postgresql.org/wiki/Hot_Standby)
-  which uses one database for writes and another database for
-  reads. PuppetDB can now point read-only queries at the hot standby,
-  resulting in improved IO throughput for writes.
+    supports Hot Standby (http://wiki.postgresql.org/wiki/Hot_Standby)
+    which uses one database for writes and another database for
+    reads. PuppetDB can now point read-only queries at the hot standby,
+    resulting in improved IO throughput for writes.
 
 * (#22960) Don't automatically sort fact query results
 
-  Previously, we'd sort fact query results by default, regardless of
-  whether or not the user has requested sorting. That incurs a
-  performance penalty, as the DB has to now to a costly sort
-  operation. This patch removes the sort, and if users want sorted
-  results they can use the new sorting parameters to ask for that
-  explicitly.
+    Previously, we'd sort fact query results by default, regardless of
+    whether or not the user has requested sorting. That incurs a
+    performance penalty, as the DB has to now to a costly sort
+    operation. This patch removes the sort, and if users want sorted
+    results they can use the new sorting parameters to ask for that
+    explicitly.
 
 * (#22947) Remove resource tags GIN index on Postgres. These indexes
-  can get large and they aren't used. This should free up some
-  precious disk space.
+    can get large and they aren't used. This should free up some
+    precious disk space.
 
 * (22977) Add a debugging option to help diagnose catalogs for a host
-  that hash to different values
+    that hash to different values
 
-  Added a new global config parameter to allow debugging of catalogs
-  that hash to a different value. This makes it easier for users to
-  determine why their catalog duplication rates are low. More details
-  are in the included "Troubleshooting Low Catalog Duplication" guide.
+    Added a new global config parameter to allow debugging of catalogs
+    that hash to a different value. This makes it easier for users to
+    determine why their catalog duplication rates are low. More details
+    are in the included "Troubleshooting Low Catalog Duplication" guide.
 
 * (PDB-56) Gzip HTTP responses
 
-  This patchset enables Jetty's gzip filter, which will automatically
-  compress output with compressible mime-types (text, JSON, etc). This
-  should reduce bandwidth requirements for clients who can handle
-  compressed responses.
+    This patchset enables Jetty's gzip filter, which will automatically
+    compress output with compressible mime-types (text, JSON, etc). This
+    should reduce bandwidth requirements for clients who can handle
+    compressed responses.
 
 * (PDB-70) Add index on catalog_resources.exported
 
-  This increases performance for exported resource collection
-  queries. For postgresql the index is only a partial on exported =
-  true, since indexing on the very common 'false' case is not that
-  effective. This gives us a big perf boost with minimal disk usage.
+    This increases performance for exported resource collection
+    queries. For postgresql the index is only a partial on exported =
+    true, since indexing on the very common 'false' case is not that
+    effective. This gives us a big perf boost with minimal disk usage.
 
 * (PDB-85) Various fixes for report export and anonymization
 
 * (PDB-119) Pin to RSA ciphers for all jdk's to work-around Centos 6
-  EC failures
+    EC failures
 
-  We were seeing EC cipher failures for Centos 6 boxes, so we now pin
-  the ciphers to RSA only for all JDK's to work-around the
-  problem. The cipher suite is still customizable, so users can
-  override this is they wish.
+    We were seeing EC cipher failures for Centos 6 boxes, so we now pin
+    the ciphers to RSA only for all JDK's to work-around the
+    problem. The cipher suite is still customizable, so users can
+    override this is they wish.
 
 * Fixes to allow use of public/private key files generated by a wider
-  variety of tools, such as FreeIPA.
+    variety of tools, such as FreeIPA.
 
 * (#17555) Use systemd on recent Fedora and RHEL systems.
 
 * Documentation for `store-usage` and `temp-usage` MQ configuration
-  options.
+    options.
 
 * Travis-CI now automatically tests all pull requests against both
-  PostgreSQL and HSQLDB. We also run our full acceptance test suite on
-  incoming pull requests.
+    PostgreSQL and HSQLDB. We also run our full acceptance test suite on
+    incoming pull requests.
 
 * (PDB-102) Implement Prismatic Schema for configuration validation
 
-  In the past our configuration validation was fairly ad-hoc and imperative. By
-  implementing an internal schema mechanism (using Prismatic Schema) this should
-  provice a better and more declarative mechanism to validate users
-  configuration rather then letting mis-configurations "fall through" to
-  internal code throwing undecipherable Java exceptions.
+    In the past our configuration validation was fairly ad-hoc and imperative. By
+    implementing an internal schema mechanism (using Prismatic Schema) this should
+    provice a better and more declarative mechanism to validate users
+    configuration rather then letting mis-configurations "fall through" to
+    internal code throwing undecipherable Java exceptions.
 
-  This implementation also handles configuration variable coercion and
-  defaulting also, thus allowing us to remove a lot of the bespoke code we had
-  before that performed this activity.
+    This implementation also handles configuration variable coercion and
+    defaulting also, thus allowing us to remove a lot of the bespoke code we had
+    before that performed this activity.
 
 * (PDB-279) Sanitize report imports
 
-  Previously we had a bug PDB-85 that caused our exports on 1.5.x to fail. This
-  has been fixed, but alas people are trying to import those broken dumps into
-  1.6.x and finding it doesn't work.
+    Previously we had a bug PDB-85 that caused our exports on 1.5.x to fail. This
+    has been fixed, but alas people are trying to import those broken dumps into
+    1.6.x and finding it doesn't work.
 
-  This patch sanitizes our imports by only using select keys from the reports
-  model and dropping everything else.
+    This patch sanitizes our imports by only using select keys from the reports
+    model and dropping everything else.
 
 * (PDB-107) Support chained CA certificates
 
-  This patch makes puppetdb load all of the certificates in the CA .pem
-  file into the in-memory truststore. This allows users to use a
-  certificate chain (typically represented as a sequence of certs in a
-  single file) for trust.
+    This patch makes puppetdb load all of the certificates in the CA .pem
+    file into the in-memory truststore. This allows users to use a
+    certificate chain (typically represented as a sequence of certs in a
+    single file) for trust.
 
 1.5.2
 -----
@@ -302,7 +302,7 @@ PuppetDB 1.5.2 is a maintenance and bugfix release.
 Notable changes and fixes:
 
 * Improve handling of logfile names in our packaging, so that it's easier to
-  integrate with tools like logrotate.
+    integrate with tools like logrotate.
 
 * Better error logging when invoking subcommands.
 
@@ -313,11 +313,11 @@ Notable changes and fixes:
 * Add packaging support for Ubuntu `saucy`.
 
 * Add support for PEM private keys that are not generated by Puppet, and are not
-  represented as key pairs.
+    represented as key pairs.
 
 * Fix inconsistencies in names of `:sourcefile` / `:sourceline` parameters when
-  using `nodes/<node>/resources` version of `nodes` endpoint; these were always
-  being returned in the `v2` response format, even when using `/v3/nodes`.
+    using `nodes/<node>/resources` version of `nodes` endpoint; these were always
+    being returned in the `v2` response format, even when using `/v3/nodes`.
 
 1.5.1
 -----
@@ -329,64 +329,64 @@ publish release artifacts.
 1.5.0
 -----
 
-PuppetDB 1.5.0 is a new feature release.  (For detailed information about
+PuppetDB 1.5.0 is a new feature release.    (For detailed information about
 any of the API changes, please see the official documentation for PuppetDB 1.5.)
 
 Notable features and improvements:
 
 * (#21520) Configuration for soft failure when PuppetDB is unavailable
 
-  This feature adds a new option 'soft_write_failure' to the puppetdb
-  configuration.  If enabled the terminus behavior is changed so that if a
-  command or write fails, instead of throwing an exception and causing the agent
-  to stop it will simply log an error to the puppet master log.
+    This feature adds a new option 'soft_write_failure' to the puppetdb
+    configuration.  If enabled the terminus behavior is changed so that if a
+    command or write fails, instead of throwing an exception and causing the agent
+    to stop it will simply log an error to the puppet master log.
 
 * New v3 query API
 
-  New `/v3` URLs are available for all query endpoints.  The `reports` and
-  `events` endpoints, which were previously considered `experimental`, have
-  been moved into `/v3`.  Most of the other endpoints are 100% backwards-compatible
-  with `/v2`, but now offer additional functionality.  There are few minor
-  backwards-incompatible changes, detailed in the comments about individual
-  endpoints below.
+    New `/v3` URLs are available for all query endpoints.    The `reports` and
+    `events` endpoints, which were previously considered `experimental`, have
+    been moved into `/v3`.  Most of the other endpoints are 100% backwards-compatible
+    with `/v2`, but now offer additional functionality.  There are few minor
+    backwards-incompatible changes, detailed in the comments about individual
+    endpoints below.
 
 * Query paging
 
-  This feature adds a set of new HTTP query parameters that can be used with most
-  of the query endpoints (`fact_names`, `facts`, `resources`, `nodes`, `events`,
-  `reports`, `event-counts`) to allow paging through large result sets over
-  multiple queries.  The available HTTP query parameters are:
+    This feature adds a set of new HTTP query parameters that can be used with most
+    of the query endpoints (`fact_names`, `facts`, `resources`, `nodes`, `events`,
+    `reports`, `event-counts`) to allow paging through large result sets over
+    multiple queries.    The available HTTP query parameters are:
 
-     * `limit`: an integer specifying the maximum number of results to
-        return.
-     * `order-by`: a list of fields to sort by, in ascending or descending order.
-        The legal set of fields varies by endpoint; see the documentation for
-        individual endpoints for more info.
-     * `offset`: an integer specifying the first result in the result set that
-        should be returned.  This can be used in combination with `limit`
-        and `order-by` to page through a result set over multiple queries.
-     * `include-total`: a boolean flag which, if set, will cause the HTTP response
-       to contain an `X-Records` header indicating the total number of results that are
-       available that match the query.  (Mainly useful in combination with `limit`.)
+    * `limit`: an integer specifying the maximum number of results to
+           return.
+    * `order-by`: a list of fields to sort by, in ascending or descending order.
+           The legal set of fields varies by endpoint; see the documentation for
+           individual endpoints for more info.
+    * `offset`: an integer specifying the first result in the result set that
+           should be returned.  This can be used in combination with `limit`
+           and `order-by` to page through a result set over multiple queries.
+    * `include-total`: a boolean flag which, if set, will cause the HTTP response
+        to contain an `X-Records` header indicating the total number of results that are
+        available that match the query.    (Mainly useful in combination with `limit`.)
 
 * New features available on `events` endpoint
 
     * The `events` data now contains `file` and `line` fields.  These indicate
-      the location in the manifests where the resource was declared.  They can
-      be used as input to an `events` query.
+        the location in the manifests where the resource was declared.  They can
+        be used as input to an `events` query.
     * Add new `configuration-version` field, which contains the value that Puppet
-      supplied during the agent run.
+        supplied during the agent run.
     * New `containing-class` field: if the resource is declared inside of a
-      Puppet class, this field will contain the name of that class.
+        Puppet class, this field will contain the name of that class.
     * New `containment-path` field: this field is an array showing the full
-      path to the resource from the root of the catalog (contains an ordered
-      list of names of the classes/types that the resource is contained within).
+        path to the resource from the root of the catalog (contains an ordered
+        list of names of the classes/types that the resource is contained within).
     * New queryable timestamp fields:
-        * `run-start-time`: the time (on the agent node) that the run began
-        * `run-end-time`: the time (on the agent node) that the run completed
-        * `report-receive-time`: the time (on the puppetdb node) that the report was received by PuppetDB
+            * `run-start-time`: the time (on the agent node) that the run began
+            * `run-end-time`: the time (on the agent node) that the run completed
+            * `report-receive-time`: the time (on the puppetdb node) that the report was received by PuppetDB
     * Restrict results to only include events that occurred in the latest report
-      for a given node: `["=", "latest-report?", true]`
+        for a given node: `["=", "latest-report?", true]`
 
 * New `event-counts` endpoint
 
@@ -400,77 +400,77 @@ Notable features and improvements:
 
 * New `aggregate-event-counts` endpoint
 
-  This endpoint is similar to the `event-counts` endpoint, but rather than
-  aggregating the counts on a per-node, per-resource, or per-class basis,
-  it returns aggregate counts across your entire population.
+    This endpoint is similar to the `event-counts` endpoint, but rather than
+    aggregating the counts on a per-node, per-resource, or per-class basis,
+    it returns aggregate counts across your entire population.
 
 * New `server-time` endpoint
 
-  This endpoint simply returns a timestamp indicating the current time on
-  the PuppetDB server.  This can be used as input to time-based queries
-  against timestamp fields that are populated by PuppetDB.
+    This endpoint simply returns a timestamp indicating the current time on
+    the PuppetDB server.    This can be used as input to time-based queries
+    against timestamp fields that are populated by PuppetDB.
 
 * Minor changes to `resources` endpoint for `v3`
 
-  The `sourcefile` and `sourceline` fields have been renamed to `file` and `line`,
-  for consistency with other parts of the API.
+    The `sourcefile` and `sourceline` fields have been renamed to `file` and `line`,
+    for consistency with other parts of the API.
 
 * Minor changes relating to reports storage and query
 
-  * `store report` command has been bumped up to version `2`.
-  * Report data now includes a new `transaction-uuid` field; this is generated
-    by Puppet (as of Puppet 3.3) and can be used to definitively correlate a report
-    with the catalog that was used for the run.  This field is queryable on the
-    `reports` endpoint.
-  * Reports now support querying by the field `hash`; this allows you to retrieve
-    data about a given report based on the report hash for an event returned
-    by the `events` endpoint.
+    * `store report` command has been bumped up to version `2`.
+    * Report data now includes a new `transaction-uuid` field; this is generated
+        by Puppet (as of Puppet 3.3) and can be used to definitively correlate a report
+        with the catalog that was used for the run.  This field is queryable on the
+        `reports` endpoint.
+    * Reports now support querying by the field `hash`; this allows you to retrieve
+        data about a given report based on the report hash for an event returned
+        by the `events` endpoint.
 
 * Minor changes relating to catalog storage
 
-  * `store catalog` command has been bumped to version `3`.
-  * Catalog data now includes the new `transaction-uuid` field; see notes above.
+    * `store catalog` command has been bumped to version `3`.
+    * Catalog data now includes the new `transaction-uuid` field; see notes above.
 
 Bug fixes:
 
 * PuppetDB report processor was truncating microseconds from report timestamps;
-  all timestamp fields should now retain full precision.
+    all timestamp fields should now retain full precision.
 
 * Record resource failures even if Puppet doesn't generate an event for them in the
-  report: in rare cases, Puppet will generate a report that indicates a failure
-  on a resource but doesn't actually provide a failure event.  Prior to PuppetDB
-  1.5, the PuppetDB report processor was only checking for the existence of
-  events, so these resources would not show up in the PuppetDB report.  This is
-  really a bug in Puppet (which should be fixed as of Puppet 3.3), but the PuppetDB
-  report processor is now smart enough to detect this case and synthesize a failure
-  event for the resource, so that the failure is at least visible in the PuppetDB
-  report data.
+    report: in rare cases, Puppet will generate a report that indicates a failure
+    on a resource but doesn't actually provide a failure event.  Prior to PuppetDB
+    1.5, the PuppetDB report processor was only checking for the existence of
+    events, so these resources would not show up in the PuppetDB report.    This is
+    really a bug in Puppet (which should be fixed as of Puppet 3.3), but the PuppetDB
+    report processor is now smart enough to detect this case and synthesize a failure
+    event for the resource, so that the failure is at least visible in the PuppetDB
+    report data.
 
 * Filter out the well-known "Skipped Schedule" events: in versions of Puppet prior
-  to 3.3, every single agent report would include six events whose status was
-  `skipped` and whose resource type was `Schedule`.  (The titles were `never`,
-  `puppet`, `hourly`, `daily`, `weekly`, and `monthly`.)  These events were not
-  generally useful and caused a great deal of pollution in the PuppetDB database.
-  They are no longer generated as of Puppet 3.3, but for compatibility with
-  older versions of Puppet, the report terminus in PuppetDB 1.5 will filter
-  these events out before storing the report in PuppetDB.
+    to 3.3, every single agent report would include six events whose status was
+    `skipped` and whose resource type was `Schedule`.    (The titles were `never`,
+    `puppet`, `hourly`, `daily`, `weekly`, and `monthly`.)  These events were not
+    generally useful and caused a great deal of pollution in the PuppetDB database.
+    They are no longer generated as of Puppet 3.3, but for compatibility with
+    older versions of Puppet, the report terminus in PuppetDB 1.5 will filter
+    these events out before storing the report in PuppetDB.
 
 * Log a message when a request is blocked due to the certificate whitelist:
-  prior to 1.5, when a query or command was rejected due to PuppetDB's certificate
-  whitelist configuration, there was no logging on the server that could be used
-  to troubleshoot the cause of the rejection.  We now log a message, in hopes of
-  making it easier for administrators to track down the cause of connectivity
-  issues in this scenario.
+    prior to 1.5, when a query or command was rejected due to PuppetDB's certificate
+    whitelist configuration, there was no logging on the server that could be used
+    to troubleshoot the cause of the rejection.  We now log a message, in hopes of
+    making it easier for administrators to track down the cause of connectivity
+    issues in this scenario.
 
 * (#22122) Better log messages when puppetdb-ssl-setup is run before Puppet
-  certificates are available.
+    certificates are available.
 
 * (#22159) Fix a bug relating to anonymizing catalog edges in exported PuppetDB
-  data.
+    data.
 
 * (#22168) Add ability to configure maximum number of threads for Jetty (having too
-  low of a value for this setting on systems with large numbers of cores could
-  prevent Jetty from handling requests).
+    low of a value for this setting on systems with large numbers of cores could
+    prevent Jetty from handling requests).
 
 1.4.0
 -----
@@ -481,97 +481,97 @@ Notable features and improvements:
 
 * (#21732) Allow SSL configuration based on Puppet PEM files (Chris Price & Ken Barber)
 
-  This feature introduces some functions for reading keys and
-  certificates from PEM files, and dynamically constructing java
-  KeyStore instances in memory without requiring a .jks file on
-  disk.
+    This feature introduces some functions for reading keys and
+    certificates from PEM files, and dynamically constructing java
+    KeyStore instances in memory without requiring a .jks file on
+    disk.
 
-  It also introduces some new configuration options that may
-  be specified in the `jetty` section of the PuppetDB config
-  to initialize the web server SSL settings based on your
-  Puppet PEM files.
+    It also introduces some new configuration options that may
+    be specified in the `jetty` section of the PuppetDB config
+    to initialize the web server SSL settings based on your
+    Puppet PEM files.
 
-  The tool `puppetdb-ssl-setup` has been modified now to handle these new
-  parameters, but leave legacy configuration alone by default.
+    The tool `puppetdb-ssl-setup` has been modified now to handle these new
+    parameters, but leave legacy configuration alone by default.
 
 * (#20801) allow */* wildcard (Marc Fournier)
 
-  This allows you to use the default "Accept: */*" header to retrieve JSON
-  documents from PuppetDB without needed the extra "Accept: applicaiton/json"
-  header when using tools such as curl.
+    This allows you to use the default "Accept: */*" header to retrieve JSON
+    documents from PuppetDB without needed the extra "Accept: applicaiton/json"
+    header when using tools such as curl.
 
 * (#15369) Terminus for use with puppet apply (Ken Barber)
 
-  This patch provides a new terminus that is suitable for facts storage usage
-  with masterless or `puppet apply` usage. The idea is that it acts as a fact
-  cache terminus, intercepting the first save request and storing the values
-  in PuppetDB.
+    This patch provides a new terminus that is suitable for facts storage usage
+    with masterless or `puppet apply` usage. The idea is that it acts as a fact
+    cache terminus, intercepting the first save request and storing the values
+    in PuppetDB.
 
 * Avoid Array#find in Puppet::Resource::Catalog::Puppetdb#find_resource (Aman Gupta)
 
-  This patch provides performance improvements in the terminus, during the
-  synthesize_edges stage. For example, in cases with 10,000 resource (with
-  single relationships) we saw a reduction from 83 seconds to 6 seconds for a
-  full Puppet run after this patch was applied.
+    This patch provides performance improvements in the terminus, during the
+    synthesize_edges stage. For example, in cases with 10,000 resource (with
+    single relationships) we saw a reduction from 83 seconds to 6 seconds for a
+    full Puppet run after this patch was applied.
 
 * Portability fixes for OpenBSD (Jasper Lievisse Adriaanse)
 
-  This series of patches from Jasper improved the scripts in PuppetDB so they
-  are more portable to BSD based platforms like OpenBSD.
+    This series of patches from Jasper improved the scripts in PuppetDB so they
+    are more portable to BSD based platforms like OpenBSD.
 
 * Initial systemd service files (Niels Abspoel)
 
 * Updated spec file for suse support (Niels Abspoel)
 
-  This change wil make puppetdb rpm building possible on opensuse
-  with the same spec file as redhat.
+    This change wil make puppetdb rpm building possible on opensuse
+    with the same spec file as redhat.
 
 * (#21611) Allow rake commands to be ran on Ruby 2.0 (Ken Barber)
 
-  This allows rake commands to be ran on Ruby 2.0, for building on Fedora 19
-  to be made possible.
+    This allows rake commands to be ran on Ruby 2.0, for building on Fedora 19
+    to be made possible.
 
 * Add puppetdb-anonymize tool (Ken Barber)
 
-  This patch adds a new tool 'puppetdb-anonymize' which provides users with a
-  way to anonymize/scrub their puppetdb export files so they can be shared
-  with third parties.
+    This patch adds a new tool 'puppetdb-anonymize' which provides users with a
+    way to anonymize/scrub their puppetdb export files so they can be shared
+    with third parties.
 
 * (#21321) Configurable SSL protocols (Deepak Giridharagopal)
 
-  This patch adds an additional configuration option, `ssl-protocols`, to
-  the `[jetty]` section of the configuration file. This lets users specify
-  the exact list of SSL protocols they wish to support, such as in cases
-  where they're running PuppetDB in an environment with strict standards
-  for SSL usage.
+    This patch adds an additional configuration option, `ssl-protocols`, to
+    the `[jetty]` section of the configuration file. This lets users specify
+    the exact list of SSL protocols they wish to support, such as in cases
+    where they're running PuppetDB in an environment with strict standards
+    for SSL usage.
 
-  If the option is not supplied, we use the default set of protocols
-  enabled by the local JVM.
+    If the option is not supplied, we use the default set of protocols
+    enabled by the local JVM.
 
 * Create new conn-lifetime setting (Chuck Schweizer & Deepak Giridharagopal)
 
-  This creates a new option called `conn-lifetime` that governs how long
-  idle/active connections stick around.
+    This creates a new option called `conn-lifetime` that governs how long
+    idle/active connections stick around.
 
 * (#19174) Change query parameter to optional for facts & resources (Ken Barber)
 
-  Previously for the /v2/facts and /v2/resources end-point we had documented that
-  the query parameter was required, however a blank query parameter could be used
-  to return _all_ data, so this assertion wasn't quite accurate. However one
-  could never really drop the query parameter as it was considered mandatory and
-  without it you would get an error.
+    Previously for the /v2/facts and /v2/resources end-point we had documented that
+    the query parameter was required, however a blank query parameter could be used
+    to return _all_ data, so this assertion wasn't quite accurate. However one
+    could never really drop the query parameter as it was considered mandatory and
+    without it you would get an error.
 
-  To align with the need to return all results at times, and the fact that
-  making a query like '/v2/facts?query=' to do such a thing is wasteful, we have
-  decided to drop the mandatory need for the 'query' parameter.
+    To align with the need to return all results at times, and the fact that
+    making a query like '/v2/facts?query=' to do such a thing is wasteful, we have
+    decided to drop the mandatory need for the 'query' parameter.
 
-  This patch allows 'query' to be an optional parameter for /v2/facts & resources
-  by removing the validation check and updating the documentation to reflect this
-  this new behaviour.
+    This patch allows 'query' to be an optional parameter for /v2/facts & resources
+    by removing the validation check and updating the documentation to reflect this
+    this new behaviour.
 
-  To reduce the risk of memory bloat, the settings `resource-query-limit` still
-  apply, you should use this to set the maximum amount of resources in a single
-  query to provide safety from such out of memory problems.
+    To reduce the risk of memory bloat, the settings `resource-query-limit` still
+    apply, you should use this to set the maximum amount of resources in a single
+    query to provide safety from such out of memory problems.
 
 Bug fixes:
 
@@ -579,34 +579,34 @@ Bug fixes:
 
 * Capture request metrics on per-url/per-path basis (Deepak Giridharagopal)
 
-  When we migrated to versioned urls, we didn't update our metrics
-  middleware. Originally, we had urls like /resources, /commands, etc.
-  We configured the metrics middlware to only take the first component of
-  the path and create a metric for that, so we had metrics that tracked
-  all requests to /resources, /commands, etc. and all was right with the
-  world.
+    When we migrated to versioned urls, we didn't update our metrics
+    middleware. Originally, we had urls like /resources, /commands, etc.
+    We configured the metrics middlware to only take the first component of
+    the path and create a metric for that, so we had metrics that tracked
+    all requests to /resources, /commands, etc. and all was right with the
+    world.
 
-  When we moved to versioned urls, though, the first path component became
-  /v1, /v2, etc. This fix now allows the user to provide full URL paths to
-  query specific end-points, while still supporting the older mechanism of
-  passing 'commands', 'resources',  and 'metrics'.
+    When we moved to versioned urls, though, the first path component became
+    /v1, /v2, etc. This fix now allows the user to provide full URL paths to
+    query specific end-points, while still supporting the older mechanism of
+    passing 'commands', 'resources',    and 'metrics'.
 
 * (21450) JSON responses should be UTF-8 (Deepak Giridharagopal)
 
-  JSON is UTF-8, therefore our responses should also be UTF-8.
+    JSON is UTF-8, therefore our responses should also be UTF-8.
 
 Other important changes & refactors:
 
 * Upgrade internal components, including clojure (Deepak Giridharagopal)
 
-  - upgrade clojure to 1.5.1
-  - upgrade to latest cheshire, nrepl, libs, tools.namespace, clj-time, jmx,
-    ring, at-at, ring-mock, postgresql, log4j
+    - upgrade clojure to 1.5.1
+    - upgrade to latest cheshire, nrepl, libs, tools.namespace, clj-time, jmx,
+        ring, at-at, ring-mock, postgresql, log4j
 
 * Change default db conn keepalive to 45m (Deepak Giridharagopal)
 
-  This better matches up with the standard firewall or load balancer
-  idle connection timeouts in the wild.
+    This better matches up with the standard firewall or load balancer
+    idle connection timeouts in the wild.
 
 1.3.2
 -----
@@ -620,12 +620,12 @@ Bug fixes:
 
 * Size of column `puppet_version` in the database schema is insufficient
 
-  There is a field in the database that is used to store a string
-  representation of the puppet version along with each report.  Previously,
-  this column could contain a maximum of 40 characters, but for
-  certain builds of Puppet Enterprise, the version string could be
-  longer than that.  This change simply increases the maximum length of
-  the column.
+    There is a field in the database that is used to store a string
+    representation of the puppet version along with each report.    Previously,
+    this column could contain a maximum of 40 characters, but for
+    certain builds of Puppet Enterprise, the version string could be
+    longer than that.    This change simply increases the maximum length of
+    the column.
 
 1.3.1
 -----
@@ -643,33 +643,33 @@ Bug fixes:
 
 * (#19884) Intermittent SSL errors in Puppet master / PuppetDB communication
 
-  There is a bug in OpenJDK 7 (starting in 1.7 update 6) whereby SSL
-  communication using Diffie-Hellman ciphers will error out a small
-  percentage of the time.  In 1.3.1, we've made the list of SSL ciphers
-  that will be considered during SSL handshake configurable.  In addition,
-  if you're using an affected version of the JDK and you don't specify
-  a legal list of ciphers, we'll automatically default to a list that
-  does not include the Diffie-Hellman variants.  When this issue is
-  fixed in the JDK, we'll update the code to re-enable them on known
-  good versions.
+    There is a bug in OpenJDK 7 (starting in 1.7 update 6) whereby SSL
+    communication using Diffie-Hellman ciphers will error out a small
+    percentage of the time.  In 1.3.1, we've made the list of SSL ciphers
+    that will be considered during SSL handshake configurable.  In addition,
+    if you're using an affected version of the JDK and you don't specify
+    a legal list of ciphers, we'll automatically default to a list that
+    does not include the Diffie-Hellman variants.    When this issue is
+    fixed in the JDK, we'll update the code to re-enable them on known
+    good versions.
 
 * (#20563) Out of Memory error on PuppetDB export
 
-  Because the `puppetdb-export` tool used multiple threads to retrieve
-  data from PuppetDB and a single thread to write the data to the
-  export file, it was possible in certain hardware configurations to
-  exhaust all of the memory available to the JVM.  We've moved this
-  back to a single-threaded implementation for now, which may result
-  in a minor performance decrease for exports, but will prevent
-  the possibility of hitting an OOM error.
+    Because the `puppetdb-export` tool used multiple threads to retrieve
+    data from PuppetDB and a single thread to write the data to the
+    export file, it was possible in certain hardware configurations to
+    exhaust all of the memory available to the JVM.  We've moved this
+    back to a single-threaded implementation for now, which may result
+    in a minor performance decrease for exports, but will prevent
+    the possibility of hitting an OOM error.
 
 * Don't check for newer versions in the PE-PuppetDB dashboard
 
-  When running PuppetDB as part of a Puppet Enterprise installation, the
-  PuppetDB package should not be upgraded independently of Puppet Enterprise.
-  Therefore, the notification message that would appear in the PuppetDB
-  dashboard indicating that a newer version is available has been removed
-  for PE environments.
+    When running PuppetDB as part of a Puppet Enterprise installation, the
+    PuppetDB package should not be upgraded independently of Puppet Enterprise.
+    Therefore, the notification message that would appear in the PuppetDB
+    dashboard indicating that a newer version is available has been removed
+    for PE environments.
 
 
 1.3.0
@@ -691,23 +691,23 @@ Notable features:
 
 * Report queries
 
-  The query endpoint `experimental/event` has been augmented to support a
-  much more interesting set of queries against report data.  You can now query
-  for events by status (e.g. `success`, `failure`, `noop`), timestamp ranges,
-  resource types/titles/property name, etc.  This should make the report
-  storage feature of PuppetDB *much* more valuable!
+    The query endpoint `experimental/event` has been augmented to support a
+    much more interesting set of queries against report data.    You can now query
+    for events by status (e.g. `success`, `failure`, `noop`), timestamp ranges,
+    resource types/titles/property name, etc.    This should make the report
+    storage feature of PuppetDB *much* more valuable!
 
 * Import/export of PuppetDB reports
 
-  PuppetDB 1.2 added the command-line tools `puppetdb-export` and `puppetdb-import`,
-  which are useful for migrating catalog data between PuppetDB databases or
-  instances.  In PuppetDB 1.3, these tools now support importing
-  and exporting report data in addition to catalog data.
+    PuppetDB 1.2 added the command-line tools `puppetdb-export` and `puppetdb-import`,
+    which are useful for migrating catalog data between PuppetDB databases or
+    instances.  In PuppetDB 1.3, these tools now support importing
+    and exporting report data in addition to catalog data.
 
 Bug fixes:
 
 * `puppetdb-ssl-setup` is now smarter about not overwriting keystore
-  settings in `jetty.ini` during upgrades
+    settings in `jetty.ini` during upgrades
 
 * Add database index to `status` field for events to improve query performance
 
@@ -716,7 +716,7 @@ Bug fixes:
 * Upgrade to newer version of nrepl
 
 * Improvements to developer experience (remove dependency on `rake` for
-  building/running clojure code)
+    building/running clojure code)
 
 1.2.0
 -----
@@ -739,60 +739,60 @@ Notable features:
 
 * Automatic node purging
 
-  This is the first feature which allows data in PuppetDB to be deleted. The
-  new `node-purge-ttl` setting specifies a period of time to keep deactivated
-  nodes before deleting them. This can be used with the `puppet node
-  deactivate` command or the automatic node deactivation `node-ttl` setting.
-  This will also delete all facts, catalogs and reports for the purged nodes.
-  As always, if new data is received for a deactivated node, the node will be
-  reactivated, and thus exempt from purging until it is deactivated again. The
-  `node-purge-ttl` setting defaults to 0, which disables purging.
+    This is the first feature which allows data in PuppetDB to be deleted. The
+    new `node-purge-ttl` setting specifies a period of time to keep deactivated
+    nodes before deleting them. This can be used with the `puppet node
+    deactivate` command or the automatic node deactivation `node-ttl` setting.
+    This will also delete all facts, catalogs and reports for the purged nodes.
+    As always, if new data is received for a deactivated node, the node will be
+    reactivated, and thus exempt from purging until it is deactivated again. The
+    `node-purge-ttl` setting defaults to 0, which disables purging.
 
 * Import/export of PuppetDB data
 
-  Two new commands have been added, `puppetdb-export` and `puppetdb-import`.
-  These will respectively export and import the entire collection of catalogs
-  in your PuppetDB database. This can be useful for migrating from HSQL to
-  PostgreSQL, for instance.
+    Two new commands have been added, `puppetdb-export` and `puppetdb-import`.
+    These will respectively export and import the entire collection of catalogs
+    in your PuppetDB database. This can be useful for migrating from HSQL to
+    PostgreSQL, for instance.
 
-  There is also a new Puppet subcommand, `puppet storeconfigs export`. This
-  command will generate a similar export data from the ActiveRecord
-  storeconfigs database. Specifically, this includes only exported resources,
-  and is useful when first migrating to PuppetDB, in order to prevent failures
-  due to temporarily missing exported resources.
+    There is also a new Puppet subcommand, `puppet storeconfigs export`. This
+    command will generate a similar export data from the ActiveRecord
+    storeconfigs database. Specifically, this includes only exported resources,
+    and is useful when first migrating to PuppetDB, in order to prevent failures
+    due to temporarily missing exported resources.
 
 * Automatic dead-letter office compression
 
-  When commands fail irrecoverably or over a long period of time, they are
-  written to disk in what is called the dead-letter office (or DLO). Until now,
-  this directory had no automatic maintenance, and could rapidly grow in size.
-  Now there is a `dlo-compression-threshold` setting, which defaults to 1 day,
-  after which commands in the DLO will be compressed. There are also now
-  metrics collected about DLO usage, several of which (size, number of
-  messages, compression time) are visible from the PuppetDB dashboard.
+    When commands fail irrecoverably or over a long period of time, they are
+    written to disk in what is called the dead-letter office (or DLO). Until now,
+    this directory had no automatic maintenance, and could rapidly grow in size.
+    Now there is a `dlo-compression-threshold` setting, which defaults to 1 day,
+    after which commands in the DLO will be compressed. There are also now
+    metrics collected about DLO usage, several of which (size, number of
+    messages, compression time) are visible from the PuppetDB dashboard.
 
 * Package availability changes
 
-  Packages are now provided for Fedora 18, but are no longer provided for
-  Ubuntu 11.04 Natty Narwhal, which is end-of-life. Due to work being done to
-  integrate PuppetDB with Puppet Enterprise, new pe-puppetdb packages are not
-  available.
+    Packages are now provided for Fedora 18, but are no longer provided for
+    Ubuntu 11.04 Natty Narwhal, which is end-of-life. Due to work being done to
+    integrate PuppetDB with Puppet Enterprise, new pe-puppetdb packages are not
+    available.
 
 Bug fixes:
 
 * KahaDB journal corruption workaround
 
-  If the KahaDB journal, used by ActiveMQ (in turn used for asynchronous
-  message processing), becomes corrupted, PuppetDB would fail to start.
-  However, if the embedded ActiveMQ broker is restarted, it will cleanup the
-  corruption itself. Now, PuppetDB will recover from such a failure and restart
-  the broker automatically.
+    If the KahaDB journal, used by ActiveMQ (in turn used for asynchronous
+    message processing), becomes corrupted, PuppetDB would fail to start.
+    However, if the embedded ActiveMQ broker is restarted, it will cleanup the
+    corruption itself. Now, PuppetDB will recover from such a failure and restart
+    the broker automatically.
 
 * Terminus files conflict between puppetdb-terminus and puppet
 
-  There was a conflict between these two packages over ownership of certain
-  directories which could cause the puppetdb-terminus package to fail to
-  install in some cases. This has been resolved.
+    There was a conflict between these two packages over ownership of certain
+    directories which could cause the puppetdb-terminus package to fail to
+    install in some cases. This has been resolved.
 
 1.1.1
 -----
@@ -801,19 +801,19 @@ PuppetDB 1.1.1 is a bugfix release.  It contains the following fixes:
 
 * (#18934) Dashboard Inventory Service returns 404
 
-  Version 1.1.0 of the PuppetDB terminus package contained a faulty URL for
-  retrieving fact data for the inventory service.  This issue is fixed and
-  we've added better testing to ensure that this doesn't break again in the
-  future.
+    Version 1.1.0 of the PuppetDB terminus package contained a faulty URL for
+    retrieving fact data for the inventory service.  This issue is fixed and
+    we've added better testing to ensure that this doesn't break again in the
+    future.
 
 * (#18879) PuppetDB terminus 1.0.5 is incompatible with PuppetDB 1.1.0
 
-  Version 1.1.0 of the PuppetDB server package contained some API changes that
-  were not entirely backward-compatible with version 1.0.5 of the PuppetDB
-  terminus; this caused failures for some users if they upgraded the server
-  to 1.1.0 without simultaneously upgrading the terminus package.  Version 1.1.1
-  of the server is backward-compatible with terminus 1.0.5, allowing an easier
-  upgrade path for 1.0.x users.
+    Version 1.1.0 of the PuppetDB server package contained some API changes that
+    were not entirely backward-compatible with version 1.0.5 of the PuppetDB
+    terminus; this caused failures for some users if they upgraded the server
+    to 1.1.0 without simultaneously upgrading the terminus package.  Version 1.1.1
+    of the server is backward-compatible with terminus 1.0.5, allowing an easier
+    upgrade path for 1.0.x users.
 
 
 1.1.0
@@ -837,100 +837,100 @@ Notable features:
 
 * Enhanced query API
 
-  A substantially improved version 2 of the HTTP query API has been added. This
-  is located under the /v2 route. Detailed documentation on all the available
-  routes and query language can be found in the API documentation, but here are
-  a few of the noteworthy improvements:
+    A substantially improved version 2 of the HTTP query API has been added. This
+    is located under the /v2 route. Detailed documentation on all the available
+    routes and query language can be found in the API documentation, but here are
+    a few of the noteworthy improvements:
 
-  * Query based on regular expressions
+    * Query based on regular expressions
 
-    Regular expressions are now supported against most fields when querying
-    against resources, facts, and nodes, using the ~ operator. This makes it
-    easy to, for instance, find *all* IP addresses for a node, or apply a query
-    to some set of nodes.
+        Regular expressions are now supported against most fields when querying
+        against resources, facts, and nodes, using the ~ operator. This makes it
+        easy to, for instance, find *all* IP addresses for a node, or apply a query
+        to some set of nodes.
 
-  * More node information
+    * More node information
 
-    Queries against the /v2/nodes endpoint now return objects, rather than
-    simply a list of node names. These are effectively the same as what was
-    previously returned by the /status endpoint, containing the node name, its
-    deactivation time, as well as the timestamps of its latest catalog, facts,
-    and report.
+        Queries against the /v2/nodes endpoint now return objects, rather than
+        simply a list of node names. These are effectively the same as what was
+        previously returned by the /status endpoint, containing the node name, its
+        deactivation time, as well as the timestamps of its latest catalog, facts,
+        and report.
 
-  * Full fact query
+    * Full fact query
 
-    The /v2/facts endpoint supports the same type of query language available
-    when querying resources, where previously it could only be used to retrieve
-    the set of facts for a given node. This makes it easy to find the value of
-    some fact for all nodes, or to do more complex queries.
+        The /v2/facts endpoint supports the same type of query language available
+        when querying resources, where previously it could only be used to retrieve
+        the set of facts for a given node. This makes it easy to find the value of
+        some fact for all nodes, or to do more complex queries.
 
-  * Subqueries
+    * Subqueries
 
-    Queries can now contain subqueries through the `select-resources` and
-    `select-facts` operators. These operators perform queries equivalent to
-    using the /v2/resources and /v2/facts routes, respectively. The information
-    returned from them can then be correlated, to perform complex queries such
-    as "fetch the IP address of all nodes with `Class[apache]`", or "fetch the
-    `operatingsystemrelease` of all Debian nodes". These operators can also be
-    nested and correlated on any field, to answer virtually any question in a
-    single query.
+        Queries can now contain subqueries through the `select-resources` and
+        `select-facts` operators. These operators perform queries equivalent to
+        using the /v2/resources and /v2/facts routes, respectively. The information
+        returned from them can then be correlated, to perform complex queries such
+        as "fetch the IP address of all nodes with `Class[apache]`", or "fetch the
+        `operatingsystemrelease` of all Debian nodes". These operators can also be
+        nested and correlated on any field, to answer virtually any question in a
+        single query.
 
-  * Friendlier, RESTful query routes
+    * Friendlier, RESTful query routes
 
-    In addition to the standard query language, there are also now more
-    friendly, "RESTful" query routes. For instance, `/v2/nodes/foo.example.com`
-    will return information about the node foo.example.com. Similarly,
-    `/v2/facts/operatingsystem` will return the `operatingsystem` of every node, or
-    `/v2/nodes/foo.example.com/operatingsystem` can be used to just find the
-    `operatingsystem` of foo.example.com.
+        In addition to the standard query language, there are also now more
+        friendly, "RESTful" query routes. For instance, `/v2/nodes/foo.example.com`
+        will return information about the node foo.example.com. Similarly,
+        `/v2/facts/operatingsystem` will return the `operatingsystem` of every node, or
+        `/v2/nodes/foo.example.com/operatingsystem` can be used to just find the
+        `operatingsystem` of foo.example.com.
 
-    The same sort of routes are available for resources as well.
-    `/v2/resources/User` will return every User resource, `/v2/resources/User/joe`
-    will return every instance of the `User[joe]` resource, and
-    `/v2/nodes/foo.example.com/Package` will return every Package resource on
-    foo.example.com. These routes can also have a query parameter supplied, to
-    further query against their results, as with the standard query API.
+        The same sort of routes are available for resources as well.
+        `/v2/resources/User` will return every User resource, `/v2/resources/User/joe`
+        will return every instance of the `User[joe]` resource, and
+        `/v2/nodes/foo.example.com/Package` will return every Package resource on
+        foo.example.com. These routes can also have a query parameter supplied, to
+        further query against their results, as with the standard query API.
 
 * Improved catalog storage performance
 
-   Some improvements have been made to the way catalog hashes are computed for
-   deduplication, resulting in somewhat faster catalog storage, and a
-   significant decrease in the amount of time taken to store the first catalog
-   received after startup.
+     Some improvements have been made to the way catalog hashes are computed for
+     deduplication, resulting in somewhat faster catalog storage, and a
+     significant decrease in the amount of time taken to store the first catalog
+     received after startup.
 
 * Experimental report submission and storage
 
-  The 'puppetdb' report processor is now available, which can be used
-  (alongside any other reports) to submit reports to PuppetDB for storage. This
-  feature is considered experimental, which means the query API may change
-  significantly in the future. The ability to query reports is currently
-  limited and experimental, meaning it is accessed via /experimental/reports
-  rather than /v2/reports. Currently it is possible to get a list of reports
-  for a node, and to retrieve the contents of a single report. More advanced
-  querying (and integration with other query endpoints) will come in a future
-  release.
+    The 'puppetdb' report processor is now available, which can be used
+    (alongside any other reports) to submit reports to PuppetDB for storage. This
+    feature is considered experimental, which means the query API may change
+    significantly in the future. The ability to query reports is currently
+    limited and experimental, meaning it is accessed via /experimental/reports
+    rather than /v2/reports. Currently it is possible to get a list of reports
+    for a node, and to retrieve the contents of a single report. More advanced
+    querying (and integration with other query endpoints) will come in a future
+    release.
 
-  Unlike catalogs, reports are retained for a fixed time period (defaulting to
-  7 days), rather than only the most recent report being stored. This means
-  more data is available than just the latest, but also prevents the database
-  from growing unbounded. See the documentation for information on how to
-  configure the storage duration.
+    Unlike catalogs, reports are retained for a fixed time period (defaulting to
+    7 days), rather than only the most recent report being stored. This means
+    more data is available than just the latest, but also prevents the database
+    from growing unbounded. See the documentation for information on how to
+    configure the storage duration.
 
 * Tweakable settings for database connection and ActiveMQ storage
 
-  It is now possible to set the timeout for an idle database connection to be
-  terminated, as well as the keep alive interval for the connection, through
-  the `conn-max-age` and `conn-keep-alive` settings.
+    It is now possible to set the timeout for an idle database connection to be
+    terminated, as well as the keep alive interval for the connection, through
+    the `conn-max-age` and `conn-keep-alive` settings.
 
-  The settings `store-usage` and `temp-usage` can be used to set the amount of
-  disk space (in MB) for ActiveMQ to use for permanent and temporary message
-  storage. The main use for these settings is to lower the usage from the
-  default of 100GB and 50GB respectively, as ActiveMQ will issue a warning if
-  that amount of space is not available.
+    The settings `store-usage` and `temp-usage` can be used to set the amount of
+    disk space (in MB) for ActiveMQ to use for permanent and temporary message
+    storage. The main use for these settings is to lower the usage from the
+    default of 100GB and 50GB respectively, as ActiveMQ will issue a warning if
+    that amount of space is not available.
 
 Behavior changes:
 
-  * Messages received after a node is deactivated will be processed
+* Messages received after a node is deactivated will be processed
 
     Previously, commands which were initially received before a node was
     deactivated, but not processed until after (for instance, because the first
@@ -956,10 +956,10 @@ Fixes:
 
 * Drop a large, unused index on catalog_resources(tags)
 
-  This index was superseded by a GIN index on the same column, but the previous
-  index was kept around by mistake. This should result in a space savings of
-  10-20%, as well as a possible very minor improvement in catalog insert
-  performance.
+    This index was superseded by a GIN index on the same column, but the previous
+    index was kept around by mistake. This should result in a space savings of
+    10-20%, as well as a possible very minor improvement in catalog insert
+    performance.
 
 1.0.4
 -----
@@ -973,9 +973,9 @@ Fixes:
 
 * (#16554) Fix postgres query for numeric comparisons
 
-  This commit changes the regex that we are using for numeric
-  comparisons in postgres to a format that is compatible with both 8.4
-  and 9.1.
+    This commit changes the regex that we are using for numeric
+    comparisons in postgres to a format that is compatible with both 8.4
+    and 9.1.
 
 1.0.3
 -----
@@ -995,29 +995,29 @@ Fixes:
 
 * (#17216) Fix problems with UTF-8 transcoding
 
-  Certain 5 and 6 byte sequences were being incorrectly transcoded to
-  UTF-8 on Ruby 1.8.x systems. We now do two separate passes, one with
-  iconv and one with our hand-rolled transcoding algorithms. Better
-  safe than sorry!
+    Certain 5 and 6 byte sequences were being incorrectly transcoded to
+    UTF-8 on Ruby 1.8.x systems. We now do two separate passes, one with
+    iconv and one with our hand-rolled transcoding algorithms. Better
+    safe than sorry!
 
 * (#17498) Pretty-print JSON HTTP responses
 
-  We now output more nicely-formatted JSON when using the PuppetDB
-  HTTP API.
+    We now output more nicely-formatted JSON when using the PuppetDB
+    HTTP API.
 
 * (#17397) DB pool setup fails with numeric username or password
 
-  This bug happens during construction of the DB connection pool. If
-  the username or password is numeric, when parsing the configuration
-  file they're turned into numbers. When we go to actually create the
-  pool, we get an error because we're passing in numbers when strings
-  are expected.
+    This bug happens during construction of the DB connection pool. If
+    the username or password is numeric, when parsing the configuration
+    file they're turned into numbers. When we go to actually create the
+    pool, we get an error because we're passing in numbers when strings
+    are expected.
 
 * (#17524) Better logging and response handling for version checks
 
-  Errors when using the `version` endpoint are now caught, logged at a
-  more appropriate log level, and a reasonable HTTP response code is
-  returned to callers.
+    Errors when using the `version` endpoint are now caught, logged at a
+    more appropriate log level, and a reasonable HTTP response code is
+    returned to callers.
 
 
 1.0.2
@@ -1032,12 +1032,12 @@ Fixes:
 
 * (#17178) Update rubylib on debian/ubuntu installs
 
-  Previously the terminus would be installed to the 1.8 sitelibdir for ruby1.8 or
-  the 1.9.1 vendorlibdir on ruby1.9. The ruby1.9 code path was never used, so
-  platforms with ruby1.9 as the default (such as quantal and wheezy) would not be
-  able to load the terminus. Modern debian packages put version agnostic ruby
-  code in vendordir (/usr/lib/ruby/vendor_ruby), so this commit moves the
-  terminus install dir to be vendordir.
+    Previously the terminus would be installed to the 1.8 sitelibdir for ruby1.8 or
+    the 1.9.1 vendorlibdir on ruby1.9. The ruby1.9 code path was never used, so
+    platforms with ruby1.9 as the default (such as quantal and wheezy) would not be
+    able to load the terminus. Modern debian packages put version agnostic ruby
+    code in vendordir (/usr/lib/ruby/vendor_ruby), so this commit moves the
+    terminus install dir to be vendordir.
 
 1.0.1
 -----
@@ -1054,44 +1054,44 @@ Fixes:
 
 * (#16180) Properly handle edges between exported resources
 
-  This was previously failing when an edge referred to an exported
-  resource which was also collected, because it was incorrectly
-  assuming collected resources would always be marked as NOT
-  exported. However, in the case of a node collecting a resource which
-  it also exports, the resource is still marked exported. In that
-  case, it can be distinguished from a purely exported resource by
-  whether it's virtual. Purely virtual, non-exported resources never
-  appear in the catalog.
+    This was previously failing when an edge referred to an exported
+    resource which was also collected, because it was incorrectly
+    assuming collected resources would always be marked as NOT
+    exported. However, in the case of a node collecting a resource which
+    it also exports, the resource is still marked exported. In that
+    case, it can be distinguished from a purely exported resource by
+    whether it's virtual. Purely virtual, non-exported resources never
+    appear in the catalog.
 
-  Virtual, exported resources are not collected, whereas non-virtual,
-  exported resources are. The former will eventually be removed from
-  the catalog before being sent to the agent, and thus aren't eligible
-  for participation in a relationship. We now check whether the
-  resource is virtual rather than exported, for correct behavior.
+    Virtual, exported resources are not collected, whereas non-virtual,
+    exported resources are. The former will eventually be removed from
+    the catalog before being sent to the agent, and thus aren't eligible
+    for participation in a relationship. We now check whether the
+    resource is virtual rather than exported, for correct behavior.
 
 * (#16535) Properly find edges that point at an exec by an alias
 
-  During namevar aliasing, we end up changing the :alias parameter to
-  'alias' and using that for the duration (to distinguish "our"
-  aliases form the "original" aliases). However, in the case of exec,
-  we were bailing out early because execs aren't isomorphic, and not
-  adding 'alias'. Now we will always change :alias to 'alias', and
-  just won't add the namevar alias for execs.
+    During namevar aliasing, we end up changing the :alias parameter to
+    'alias' and using that for the duration (to distinguish "our"
+    aliases form the "original" aliases). However, in the case of exec,
+    we were bailing out early because execs aren't isomorphic, and not
+    adding 'alias'. Now we will always change :alias to 'alias', and
+    just won't add the namevar alias for execs.
 
 * (#16407) Handle trailing slashes when creating edges for file
-  resources
+    resources
 
-  We were failing to create relationships (edges) to File resources if
-  the relationship was specified with a different number of trailing
-  slashes in the title than the title of the original resource.
+    We were failing to create relationships (edges) to File resources if
+    the relationship was specified with a different number of trailing
+    slashes in the title than the title of the original resource.
 
 * (#16652) Replace dir with specific files for terminus package
 
-  Previously, the files section claimed ownership of Puppet's libdir,
-  which confuses rpm when both packages are installed. This commit
-  breaks out all of the files and only owns one directory, which
-  clearly belongs to puppetdb. This will allow rpm to correctly
-  identify files which belong to puppet vs puppetdb-terminus.
+    Previously, the files section claimed ownership of Puppet's libdir,
+    which confuses rpm when both packages are installed. This commit
+    breaks out all of the files and only owns one directory, which
+    clearly belongs to puppetdb. This will allow rpm to correctly
+    identify files which belong to puppet vs puppetdb-terminus.
 
 
 1.0.0
@@ -1115,87 +1115,87 @@ Notable features:
 
 * Additional database indexes for improved performance
 
-  Queries involving resources (type,title) or tags without much
-  additional filtering criteria are now much faster. Note that tag
-  queries cannot be sped up on PostgreSQL 8.1, as it doesn't have
-  support for GIN indexes on array columns.
+    Queries involving resources (type,title) or tags without much
+    additional filtering criteria are now much faster. Note that tag
+    queries cannot be sped up on PostgreSQL 8.1, as it doesn't have
+    support for GIN indexes on array columns.
 
 * Automatic generation of heap snapshots on OutOfMemoryError
 
-  In the unfortunate situation where PuppetDB runs out of memory, a
-  heap snapshot is automatically generated and saved in the log
-  directory. This helps us work with users to much more precisely
-  triangulate what's taking up the majority of the available heap
-  without having to work to reproduce the problem on a completely
-  different system (an often difficult proposition). This helps
-  keep PuppetDB lean for everyone.
+    In the unfortunate situation where PuppetDB runs out of memory, a
+    heap snapshot is automatically generated and saved in the log
+    directory. This helps us work with users to much more precisely
+    triangulate what's taking up the majority of the available heap
+    without having to work to reproduce the problem on a completely
+    different system (an often difficult proposition). This helps
+    keep PuppetDB lean for everyone.
 
 * Preliminary packaging support for Fedora 17 and Ruby 1.9
 
-  This hasn't been fully tested, nor integrated into our CI systems,
-  and therefore should be considered experimental. This fix adds
-  support for packaging for ruby 1.9 by modifying the @plibdir path
-  based on the ruby version. `RUBY_VER` can be passed in as an
-  environment variable, and if none is passed, `RUBY_VER` defaults to
-  the ruby on the local host as reported by facter. As is currently
-  the case, we use the sitelibdir in ruby 1.8, and with this commit
-  use vendorlibdir for 1.9. Fedora 17 ships with 1.9, so we use this
-  to test for 1.9 in the spec file. Fedora 17 also ships with open-jdk
-  1.7, so this commit updates the Requires to 1.7 for fedora 17.
+    This hasn't been fully tested, nor integrated into our CI systems,
+    and therefore should be considered experimental. This fix adds
+    support for packaging for ruby 1.9 by modifying the @plibdir path
+    based on the ruby version. `RUBY_VER` can be passed in as an
+    environment variable, and if none is passed, `RUBY_VER` defaults to
+    the ruby on the local host as reported by facter. As is currently
+    the case, we use the sitelibdir in ruby 1.8, and with this commit
+    use vendorlibdir for 1.9. Fedora 17 ships with 1.9, so we use this
+    to test for 1.9 in the spec file. Fedora 17 also ships with open-jdk
+    1.7, so this commit updates the Requires to 1.7 for fedora 17.
 
 * Resource tags semantics now match those of Puppet proper
 
-  In Puppet, tags are lower-case only. We now fail incoming catalogs that
-  contain mixed case tags, and we treat tags in queries as
-  case-insensitive comparisons.
+    In Puppet, tags are lower-case only. We now fail incoming catalogs that
+    contain mixed case tags, and we treat tags in queries as
+    case-insensitive comparisons.
 
 Notable fixes:
 
 * Properly escape resource query strings in our terminus
 
-  This fixes failures caused by storeconfigs queries that involve, for
-  example, resource titles whose names contain spaces.
+    This fixes failures caused by storeconfigs queries that involve, for
+    example, resource titles whose names contain spaces.
 
 * (#15947) Allow comments in puppetdb.conf
 
-  We now support whole-line comments in puppetdb.conf.
+    We now support whole-line comments in puppetdb.conf.
 
 * (#15903) Detect invalid UTF-8 multi-byte sequences
 
-  Prior to this fix, certain sequences of bytes used on certain
-  versions of Puppet with certain versions of Ruby would cause our
-  terminii to send malformed data to PuppetDB (which the daemon then
-  properly rejects with a checksum error, so no data corruption would
-  have taken place).
+    Prior to this fix, certain sequences of bytes used on certain
+    versions of Puppet with certain versions of Ruby would cause our
+    terminii to send malformed data to PuppetDB (which the daemon then
+    properly rejects with a checksum error, so no data corruption would
+    have taken place).
 
 * Don't remove puppetdb user during RPM package uninstall
 
-  We never did this on Debian systems, and most other packages seem
-  not to as well. Also, removing the user and not all files owned by
-  it can cause problems if another service later usurps the user id.
+    We never did this on Debian systems, and most other packages seem
+    not to as well. Also, removing the user and not all files owned by
+    it can cause problems if another service later usurps the user id.
 
 * Compatibility with legacy storeconfigs behavior for duplicate
-  resources
+    resources
 
-  Prior to this commit, the puppetdb resource terminus was not setting
-  a value for "collector_id" on collected resources.  This field is
-  used by puppet to detect duplicate resources (exported by multiple
-  nodes) and will cause a run to fail. Hence, the semantics around
-  duplicate resources were ill-specified and could cause
-  problems. This fix adds code to set the collector id based on node
-  name + resource title + resource type, and adds tests to verify that
-  a puppet run will fail if it collects duplicate instances of the
-  same resource from different exporters.
+    Prior to this commit, the puppetdb resource terminus was not setting
+    a value for "collector_id" on collected resources.  This field is
+    used by puppet to detect duplicate resources (exported by multiple
+    nodes) and will cause a run to fail. Hence, the semantics around
+    duplicate resources were ill-specified and could cause
+    problems. This fix adds code to set the collector id based on node
+    name + resource title + resource type, and adds tests to verify that
+    a puppet run will fail if it collects duplicate instances of the
+    same resource from different exporters.
 
 * Internal benchmarking suite fully functional again
 
-  Previous changes had broken the benchmark tool; functionality has
-  been restored.
+    Previous changes had broken the benchmark tool; functionality has
+    been restored.
 
 * Better version display
 
-  We now display the latest version info during daemon startup and on the
-  web dashboard.
+    We now display the latest version info during daemon startup and on the
+    web dashboard.
 
 0.10.0
 -----
@@ -1213,137 +1213,137 @@ Notable features:
 
 * Auto-deactivation of stale nodes
 
-  There is a new, optional setting you can add to the `[database]`
-  section of your configuration: `node-ttl-days`, which defines how
-  long, in days, a node can continue without seeing new activity (new
-  catalogs, new facts, etc) before it's automatically deactivated
-  during a garbage-collection run.
+    There is a new, optional setting you can add to the `[database]`
+    section of your configuration: `node-ttl-days`, which defines how
+    long, in days, a node can continue without seeing new activity (new
+    catalogs, new facts, etc) before it's automatically deactivated
+    during a garbage-collection run.
 
-  The default behavior, if that config setting is ommitted, is the
-  same as in previous releases: no automatic deactivation of anything.
+    The default behavior, if that config setting is ommitted, is the
+    same as in previous releases: no automatic deactivation of anything.
 
-  This feature is useful for those who have a non-trivial amount of
-  volatility in the lifecycles of their nodes, such as those who
-  regularly bring up nodes in a cloud environment and tear them down
-  shortly thereafter.
+    This feature is useful for those who have a non-trivial amount of
+    volatility in the lifecycles of their nodes, such as those who
+    regularly bring up nodes in a cloud environment and tear them down
+    shortly thereafter.
 
 * (#15696) Limit the number of results returned from a resource query
 
-  For sites with tens or even hundreds of thousands of resources, an
-  errant query could result in PuppetDB attempting to pull in a large
-  number of resources and parameters into memory before serializing
-  them over the wire. This can potentially trigger out-of-memory
-  conditions.
+    For sites with tens or even hundreds of thousands of resources, an
+    errant query could result in PuppetDB attempting to pull in a large
+    number of resources and parameters into memory before serializing
+    them over the wire. This can potentially trigger out-of-memory
+    conditions.
 
-  There is a new, optional setting you can add to the `[database]`
-  section of your configuration: `resource-query-limit`, which denotes
-  the maximum number of resources returnable via a resource query. If
-  the supplied query results in more than the indicated number of
-  resources, we return an HTTP 500.
+    There is a new, optional setting you can add to the `[database]`
+    section of your configuration: `resource-query-limit`, which denotes
+    the maximum number of resources returnable via a resource query. If
+    the supplied query results in more than the indicated number of
+    resources, we return an HTTP 500.
 
-  The default behavior is to limit resource queries to 20,000
-  resources.
+    The default behavior is to limit resource queries to 20,000
+    resources.
 
 * (#15696) Slow query logging
 
-  There is a new, optional setting you can add to the `[database]`
-  section of your configuration: `log-slow-statements`, which denotes
-  how many seconds a database query can take before the query is
-  logged at WARN level.
+    There is a new, optional setting you can add to the `[database]`
+    section of your configuration: `log-slow-statements`, which denotes
+    how many seconds a database query can take before the query is
+    logged at WARN level.
 
-  The default behavior for this setting is to log queries that take more than 10
-  seconds.
+    The default behavior for this setting is to log queries that take more than 10
+    seconds.
 
 * Add support for a --debug flag, and a debug-oriented startup script
 
-  This commit adds support for a new command-line flag: --debug.  For
-  now, this flag only affects logging: it forces a console logger and
-  ensures that the log level is set to DEBUG. The option is also
-  added to the main config hash so that it can potentially be used for
-  other purposes in the future.
+    This commit adds support for a new command-line flag: --debug.  For
+    now, this flag only affects logging: it forces a console logger and
+    ensures that the log level is set to DEBUG. The option is also
+    added to the main config hash so that it can potentially be used for
+    other purposes in the future.
 
-  This commit also adds a shell script, `puppetdb-foreground`, which
-  can be used to launch the services from the command line. This
-  script will be packaged (in /usr/sbin) along with the
-  puppetdb-ssl-setup script, and may be useful in helping users
-  troubleshoot problems on their systems (especially problems with
-  daemon startup).
+    This commit also adds a shell script, `puppetdb-foreground`, which
+    can be used to launch the services from the command line. This
+    script will be packaged (in /usr/sbin) along with the
+    puppetdb-ssl-setup script, and may be useful in helping users
+    troubleshoot problems on their systems (especially problems with
+    daemon startup).
 
 Notable fixes:
 
 * Update CONTRIBUTING.md to better reflect reality
 
-  The process previously described in CONTRIBUTING.md was largely
-  vestigial; we've now updated that documentation to reflect the
-  actual, current contribution process.
+    The process previously described in CONTRIBUTING.md was largely
+    vestigial; we've now updated that documentation to reflect the
+    actual, current contribution process.
 
 * Proper handling of composite namevars
 
-  Normally, as part of converting a catalog to the PuppetDB wire
-  format, we ensure that every resource has its namevar as one of its
-  aliases. This allows us to handle edges that refer to said resource
-  using its namevar instead of its title.
+    Normally, as part of converting a catalog to the PuppetDB wire
+    format, we ensure that every resource has its namevar as one of its
+    aliases. This allows us to handle edges that refer to said resource
+    using its namevar instead of its title.
 
-  However, Puppet implements `#namevar` for resources with composite
-  namevars in a strange way, only returning part of the composite
-  name. This can result in bugs in the generated catalog, where we
-  may have 2 resources with the same alias (because `#namevar` returns
-  the same thing for both of them).
+    However, Puppet implements `#namevar` for resources with composite
+    namevars in a strange way, only returning part of the composite
+    name. This can result in bugs in the generated catalog, where we
+    may have 2 resources with the same alias (because `#namevar` returns
+    the same thing for both of them).
 
-  Because resources with composite namevars can't be referred to by
-  anything other than their title when declaring relationships,
-  there's no real point to adding their aliases in anyways. So now we
-  don't bother.
+    Because resources with composite namevars can't be referred to by
+    anything other than their title when declaring relationships,
+    there's no real point to adding their aliases in anyways. So now we
+    don't bother.
 
 * Fix deb packaging so that the puppetdb service is restarted during
-  upgrades
+    upgrades
 
-  Prior to this commit, when you ran a debian package upgrade, the
-  puppetdb service would be stopped but would not be restarted.
+    Prior to this commit, when you ran a debian package upgrade, the
+    puppetdb service would be stopped but would not be restarted.
 
 * (#1406) Add curl-based query examples to docs
 
-  The repo now contains examples of querying PuppetDB via curl over
-  both HTTP and HTTPS.
+    The repo now contains examples of querying PuppetDB via curl over
+    both HTTP and HTTPS.
 
 * Documentation on how to configure PuppetDB to work with "puppet apply"
 
-  There are some extra steps necessary to get PuppetDB working
-  properly with Puppet apply, and there are limitations
-  thereafter. The repo now contains documentation around what those
-  limitations are, and what additional configuration is necessary.
+    There are some extra steps necessary to get PuppetDB working
+    properly with Puppet apply, and there are limitations
+    thereafter. The repo now contains documentation around what those
+    limitations are, and what additional configuration is necessary.
 
 * Upgraded testing during acceptance test runs
 
-  We now automatically test upgrades from the last published version
-  of PuppetDB to the currently-under-test version.
+    We now automatically test upgrades from the last published version
+    of PuppetDB to the currently-under-test version.
 
 * (#15281) Added postgres support to acceptance testing
 
-  Our acceptance tests now regularly run against both the embedded
-  database and PostgreSQL, automatically, on every commit.
+    Our acceptance tests now regularly run against both the embedded
+    database and PostgreSQL, automatically, on every commit.
 
 * (#15378) Improved behavior of acceptance tests in single-node
-  environment
+    environment
 
-  We have some acceptance tests that require multiple nodes in order
-  to execute successfully (mostly around exporting / collecting
-  resources). If you tried to run them in a single-node environment,
-  they would give a weird ruby error about 'nil' not defining a
-  certain method. Now, they will be skipped if you are running without
-  more than one host in your acceptance test-bed.
+    We have some acceptance tests that require multiple nodes in order
+    to execute successfully (mostly around exporting / collecting
+    resources). If you tried to run them in a single-node environment,
+    they would give a weird ruby error about 'nil' not defining a
+    certain method. Now, they will be skipped if you are running without
+    more than one host in your acceptance test-bed.
 
 * Spec tests now work against Puppet master branch
 
-  We now regularly and automatically run PuppetDB spec tests against
-  Puppet's master branch.
+    We now regularly and automatically run PuppetDB spec tests against
+    Puppet's master branch.
 
 * Acceptance testing for RPM-based systems
 
-  Previously we were running all of our acceptance tests solely
-  against Debian systems. We now run them all, automatically upon each
-  commit against RedHat machines as well.
+    Previously we were running all of our acceptance tests solely
+    against Debian systems. We now run them all, automatically upon each
+    commit against RedHat machines as well.
 
 * Added new `rake version` task
 
-  Does what it says on the tin.
+    Does what it says on the tin.


### PR DESCRIPTION
This commit brings over the relevant changes from commit eb20757, since PuppetDB
1.6 will stay around a while for PE customers. I applied them by hand rather
than cherry-picking, to ensure no 2.1-isms would sneak over.
