### PR TITLE
(docs) Fix glitches noticed while backporting recent revisions to 1.6.x

### DIFF
--- a/documentation/api/query/v3/catalogs.markdown
+++ b/documentation/api/query/v3/catalogs.markdown
@@ -11,13 +11,13 @@ canonical: "/puppetdb/latest/api/query/v3/catalogs.html"
 You can query catalogs by making an HTTP request to the
 `/catalogs` endpoint.
 
-### `GET /v3/catalogs/<NODE>`
+## `GET /v3/catalogs/<NODE>`
 
 This will return the most recent catalog for the given node.
 
 This endpoint does not use any URL parameters or query strings.
 
-## Response Format
+### Response Format
 
 Successful responses will be in `application/json`. Errors will be returned as
 non-JSON strings.

--- a/documentation/api/query/v3/events.markdown
+++ b/documentation/api/query/v3/events.markdown
@@ -24,7 +24,7 @@ Once this information is stored in PuppetDB, it can be queried in various ways.
 * You can query **data about individual events** by making an HTTP request to the `/events` endpoint.
 * You can query **summaries of event data** by making an HTTP request to the [`/event-counts`](./event-counts.html) or [`aggregate-event-counts`](./aggregate-event-counts.html) endpoints.
 
-### `GET /v3/events`
+## `GET /v3/events`
 
 This will return all resource events matching the given query.  (Resource events
 are generated from Puppet reports.)
@@ -127,7 +127,7 @@ is not supported by the regex match operator.
 ### Response Format
 
 The response is a JSON array of events that matched the input parameters.
-The events are sorted by their timestamps, from newest to oldest:
+The array is unordered.
 
     [
       {

--- a/documentation/api/query/v3/facts.markdown
+++ b/documentation/api/query/v3/facts.markdown
@@ -11,7 +11,7 @@ You can query facts by making an HTTP request to the `/facts` endpoint.
 
 
 
-### `GET /v3/facts`
+## `GET /v3/facts`
 
 This will return all facts matching the given query. Facts for
 deactivated nodes are not included in the response.

--- a/documentation/api/query/v3/nodes.markdown
+++ b/documentation/api/query/v3/nodes.markdown
@@ -73,7 +73,7 @@ than 30 days:
 ## `GET /v3/nodes/<NODE>`
 
 This will return status information for the given node, active or
-not. It behaves exactly like a call to `/v3/nodes` with a query string of `["=", "certname", "<NODE>"]`.
+not. It behaves exactly like a call to `/v3/nodes` with a query string of `["=", "name", "<NODE>"]`.
 
 ### URL Parameters / Query Operators / Query Fields
 
@@ -93,7 +93,7 @@ The response is a single hash, of the same form used for the plain `nodes` endpo
      "facts_timestamp": <timestamp>,
      "report_timestamp": <timestamp>}
 
-If a node of that certname doesn't exist, the response will instead be a hash of the form:
+If a node of that name doesn't exist, the response will instead be a hash of the form:
 
     {"error": "No information is known about <NODE>"}
 

--- a/documentation/api/query/v3/paging.markdown
+++ b/documentation/api/query/v3/paging.markdown
@@ -11,7 +11,7 @@ canonical: "/puppetdb/latest/api/query/v3/paging.html"
 Most of PuppetDB's [query endpoints][api] support a general set of HTTP URL parameters that
 can be used for paging results.
 
-> **Note:** The operators below apply to **version 3** of the query API.  It is not available in v2 queries.
+> **Note:** The operators below apply to **version 3** of the query API.  They are not available in v2 queries.
 
 ## URL Parameters for Paging Results
 

--- a/documentation/api/query/v3/reports.markdown
+++ b/documentation/api/query/v3/reports.markdown
@@ -8,7 +8,7 @@ canonical: "/puppetdb/latest/api/query/v3/reports.html"
 [operator]: ./operators.html
 [event]: ./events.html
 [paging]: ./paging.html
-[statuses]: ./puppet/latest/reference/format_report.html#puppettransactionreport
+[statuses]: /puppet/latest/reference/format_report.html#puppettransactionreport
 [query]: ./query.html
 
 Puppet agent nodes submit reports after their runs, and the puppet master forwards these to PuppetDB. Each report includes:

--- a/documentation/api/query/v3/resources.markdown
+++ b/documentation/api/query/v3/resources.markdown
@@ -49,8 +49,6 @@ See [the Operators page](./operators.html) for the full list of available operat
 
 * `line`: the line of the manifest on which the resource was declared.
 
-* `environment`: the environment of the node associated to the resource.
-
 
 ### Response format
 

--- a/documentation/api/query/v3/server-time.markdown
+++ b/documentation/api/query/v3/server-time.markdown
@@ -5,7 +5,6 @@ canonical: "/puppetdb/latest/api/query/v3/server-time.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
-[query]: ./query.html
 
 The `/server-time` endpoint can be used to retrieve the server time from the PuppetDB server.
 
@@ -34,4 +33,3 @@ current time on the PuppetDB server.
     curl -X GET http://localhost:8080/v3/server-time
 
     {"server-time": "2013-09-20T20:54:27.472Z"}
-

--- a/documentation/api/query/v3/version.markdown
+++ b/documentation/api/query/v3/version.markdown
@@ -9,7 +9,7 @@ canonical: "/puppetdb/latest/api/query/v3/version.html"
 The `/version` endpoint can be used to retrieve version information from the PuppetDB server.
 
 
-### `GET /v3/version`
+## `GET /v3/version`
 
 This query endpoint will return version information about the running PuppetDB
 server.

--- a/documentation/api/query/v4/events.markdown
+++ b/documentation/api/query/v4/events.markdown
@@ -132,7 +132,7 @@ is not supported by the regex match operator.
 ### Response Format
 
 The response is a JSON array of events that matched the input parameters.
-The events are sorted by their timestamps, from newest to oldest:
+The array is unordered.
 
     [
       {


### PR DESCRIPTION
- In 2.1 and up, the events endpoint is unsorted for v3 and v4.
- v3 doesn't support environments, but one line about them snuck in.
- Accidentally let "certname" (a v4-ism) slip into v3/nodes.
- Fix a busted URL and some glitchy header levels.
