### PR TITLE
(PDB-762) Fix broken export

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/export.clj
+++ b/src/com/puppetlabs/puppetdb/cli/export.clj
@@ -118,12 +118,12 @@
      {:pre  [(string? host)
              (integer? port)
              (string? report-hash)]
-      :post [vector? %]}
-     (when-let [body (parse-response
-                      (client/get
-                       (format
-                        "http://%s:%s/%s/events?query=%s"
-                        host port (name version) (url-encode (format "[\"=\",\"report\",\"%s\"]" report-hash)))))]
+      :post [(seq? %)]}
+     (let [body (parse-response
+                  (client/get
+                    (format
+                      "http://%s:%s/%s/events?query=%s"
+                      host port (name version) (url-encode (format "[\"=\",\"report\",\"%s\"]" report-hash)))))]
        (sort-by
         #(mapv % [:timestamp :resource-type :resource-title :property])
         (map


### PR DESCRIPTION
This pull request fixes a malformed post-assertion in the events-for-report-hash
function that caused exports to fail on unchanged reports. Inserting proper
parentheses made it apparent that a seq, rather than a vector, should be the
expected return type.
