### PR TITLE
Allow empty arrays and hashes in structured facts

### DIFF
--- a/src/com/puppetlabs/puppetdb/facts.clj
+++ b/src/com/puppetlabs/puppetdb/facts.clj
@@ -112,18 +112,20 @@
   ([data mem path]
      (if (coll? data)
        ;; Branch
-       (let [idv (if (map? data)
-                   (into [] data)
-                   (map vector (iterate inc 0) data))]
-         (loop [[k v] (first idv)
-                remaining (next idv)
-                fp mem]
-           (let [new-fp (factmap-to-paths* v fp (conj path k))]
-             (if (empty? remaining)
-               new-fp
-               (recur (first remaining)
-                      (next remaining)
-                      new-fp)))))
+       (if (empty? data)
+           mem
+           (let [idv (if (map? data)
+                       (into [] data)
+                       (map vector (iterate inc 0) data))]
+             (loop [[k v] (first idv)
+                    remaining (next idv)
+                    fp mem]
+               (let [new-fp (factmap-to-paths* v fp (conj path k))]
+                 (if (empty? remaining)
+                   new-fp
+                   (recur (first remaining)
+                          (next remaining)
+                          new-fp))))))
        ;; Leaf
        (let [type-id (value-type-id data)
              initial-map {:path (factpath-to-string path)

--- a/test/com/puppetlabs/puppetdb/test/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/facts.clj
@@ -24,7 +24,9 @@
                                                     {"ipaddresses" ["1.1.1.1", "2.2.2.2"]}}
                                                    "os"
                                                    {"operatingsystem" "Linux"}
-                                                   "avgload" 5.64}))
+                                                   "avgload" 5.64
+                                                   "empty_hash" {}
+                                                   "empty_array" []}))
            [{:path "os#~operatingsystem"
              :depth 1
              :value_type_id 0


### PR DESCRIPTION
We were getting validation errors in factmap-to-paths code due to the lack
of proper handling for empty hashes and arrays. This patch drops those branches
quickly and now moves onto the next element.

Signed-off-by: Ken Barber ken@bob.sh
