### PR TITLE
(PDB-713) Modify anonymization to support structured facts

### DIFF
--- a/src/com/puppetlabs/puppetdb/utils.clj
+++ b/src/com/puppetlabs/puppetdb/utils.clj
@@ -104,3 +104,10 @@
   [c :- Character]
   (and (>= 0 (compare \0 c))
        (>= 0 (compare c \9))))
+
+(defn update-vals
+  "This function is like update-in, except the vector argument contains top-level
+  keys rather than nested.  Applies function f to values corresponding to keys
+  ks in map m."
+  [m ks f]
+    (reduce #(update-in %1 [%2] f) m ks))

--- a/test/com/puppetlabs/puppetdb/test/anonymizer.clj
+++ b/test/com/puppetlabs/puppetdb/test/anonymizer.clj
@@ -125,20 +125,28 @@
     (is (string? (anonymize-leaf-memoize :parameter-name "good old string")))
     (is (= 10 (count (anonymize-leaf-memoize :parameter-name "good old string"))))))
 
-(deftest test-anonymize-leaf-parameter-value
+(deftest test-anonymize-leaf-value
   (testing "should return the same string twice"
     (is (= (anonymize-leaf-memoize :parameter-value "test string") (anonymize-leaf-memoize :parameter-value "test string"))))
+  (testing "should return the same string twice"
+    (is  (=  (anonymize-leaf-memoize :fact-value  {"a" "b"})  (anonymize-leaf-memoize :fact-value  {"a" "b"}))))
   (testing "should return a string 30 chars long when passed a string"
-    (is (= 30 (count (anonymize-leaf-parameter-value "good old string"))))
-    (is (string? (anonymize-leaf-parameter-value "some string"))))
+    (is (= 30 (count (anonymize-leaf-value "good old string"))))
+    (is (string? (anonymize-leaf-value "some string"))))
   (testing "should return a boolean when passed a boolean"
-    (is (boolean? (anonymize-leaf-parameter-value true))))
+    (is (boolean? (anonymize-leaf-value true))))
   (testing "should return an integer when passed an integer"
-    (is (integer? (anonymize-leaf-parameter-value 100))))
+    (is (integer? (anonymize-leaf-value 100))))
+  (testing "should return an float when passed an float"
+    (is (float? (anonymize-leaf-value 3.14))))
   (testing "should return a vector when passed a vector"
-    (is (vector? (anonymize-leaf-parameter-value ["asdf" "asdf"]))))
+    (is (vector? (anonymize-leaf-value ["asdf" "asdf"]))))
   (testing "should return a map when passed a map"
-    (is (map? (anonymize-leaf-parameter-value {"foo" "bar"})))))
+    (is (map? (anonymize-leaf-value {"foo" "bar"}))))
+  (testing "maps should retain their child types"
+    (let [mymap {"a" {"b" 1} "c" 3.14 "d" [1 2] "e" 3}]
+      (is (= (sort (map (comp str type) mymap))
+             (sort (map (comp str type) (anonymize-leaf-value mymap))))))))
 
 (deftest test-anonymize-leaf-message
   (testing "should return a string 50 characters long"


### PR DESCRIPTION
This pull request modifies the PuppetDB anonymization tool to retain some
structure in anonymization of structured facts. Top-level values are now anonymized
random values of matching type.  Maps are anonymized to a maps containing a
random string.
