### PR TITLE
Ensure factsets endpoint unescapes any delimiters

### DIFF
--- a/src/com/puppetlabs/puppetdb/facts.clj
+++ b/src/com/puppetlabs/puppetdb/facts.clj
@@ -115,7 +115,9 @@
   [^String s]
   (if-let [num (str->num s)]
     num
-    (unescape-string s)))
+    (-> s
+        unescape-string
+        unescape-delimiter)))
 
 (pls/defn-validated factpath-to-string :- s/Str
   "Converts a `fact-path` to an encoded string ready for database storage."

--- a/test/com/puppetlabs/puppetdb/test/http/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/facts.clj
@@ -811,7 +811,8 @@
                                        "e" "1"
                                        }
                 "domain" "testing.com"
-                "uptime_seconds" "4000"}
+                "uptime_seconds" "4000"
+                "test#~delimiter" "foo"}
           facts2 {
                  "my_structured_fact" {"a" 1
                                        "b" 3.14
@@ -892,7 +893,8 @@
                                       "e" "1"
                                       }
                 "domain" "testing.com"
-                "uptime_seconds" "4000"}
+                "uptime_seconds" "4000"
+                "test#~delimiter" "foo"}
                 "timestamp" (to-string current-time)
                 "environment" "DEV"
                 "certname" "foo1"}))
@@ -904,7 +906,8 @@
                                      "e" "1"
                                      }
                "domain" "testing.com"
-               "uptime_seconds" "4000"}
+               "uptime_seconds" "4000"
+               "test#~delimiter" "foo"}
                "timestamp" (to-string current-time)
                "environment" "DEV"
                "certname" "foo1"}


### PR DESCRIPTION
The delimiter #~ is reserved so we escape it on storage. Previously we had not
been removing the escaping from this field before returning it to the user,
this patch remedies that.

Signed-off-by: Ken Barber ken@bob.sh
