### PR TITLE
(maint) Switch confine for basic test during acc dependency installation

### DIFF
--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -66,7 +66,7 @@ step "Install rubygems and sqlite3 on master" do
   when :debian
     # Ubuntu has rubygems 1.3.5 which is known to not be reliable, so therefore
     # we skip.
-    confine :except, :platform => 'ubuntu-10.04-amd64' do
+    unless master['platform'].include? 'ubuntu-10.04-amd64'
       on master, "apt-get install -y rubygems libsqlite3-dev"
       on master, "gem install activerecord -v 3.2.17 --no-ri --no-rdoc -V --backtrace"
       on master, "gem install sqlite3 -v 1.3.9 --no-ri --no-rdoc -V --backtrace"


### PR DESCRIPTION
The way we were using confine was wrong, and since this is now more strict
in beaker it was throwing errors in the master smoke tests. This patch
just replaces it for a basic include? on the master platform instead.

Signed-off-by: Ken Barber ken@bob.sh
