### PR TITLE
(PDB-746) Add capability to use globs when querying fact-nodes

### DIFF
--- a/documentation/api/query/v4/fact-nodes.markdown
+++ b/documentation/api/query/v4/fact-nodes.markdown
@@ -106,6 +106,26 @@ which returns:
       "environment" : "foo"
     } ]
 
+With the globbing array operator, we can also provide some basic matches against all elements in a map, or all elements in an array. This can be useful to search across all values that might appear in different places of the tree.
+
+This example shows a query that extracts all macaddresses for all ethernet devices:
+
+    curl -G 'http://puppetdb:8080/v4/fact-nodes' --data-urlencode 'query=["*>", "path", ["networking","*","macaddresses","*"]]'
+
+which returns:
+
+    [ {
+      "certname" : "node-0",
+      "path" : [ "networking", "eth0", "macaddresses", 0 ],
+      "value" : "aa:bb:cc:dd:ee:00",
+      "environment" : "foo"
+    }, {
+      "certname" : "node-0",
+      "path" : [ "networking", "eth0", "macaddresses", 1 ],
+      "value" : "aa:bb:cc:dd:ee:01",
+      "environment" : "foo"
+    } ]
+
 ## Paging
 
 This query endpoint supports paged results via the common PuppetDB paging

--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -79,6 +79,16 @@ The following example would match if the `certname` field's actual value resembl
 > * [PostgreSQL regexp features](http://www.postgresql.org/docs/9.1/static/functions-matching.html#POSIX-SYNTAX-DETAILS)
 > * [HSQLDB (embedded database) regexp features](http://docs.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html)
 
+### `*>` (glob array match)
+
+**Works with:** paths
+
+**Matches if:** the array matches against the value, however in this form one may use an asterisk (*) as a means to glob a portion of a path element. The asterisk indicates one element can be any string or number, therefore allowing a user to define any key or value in an array or map represented by the path.
+
+The following example would match any network interface name, and its macaddress data:
+
+    ["*>", "path", ["networking","*","macaddress"]
+
 ### `null?` (is null)
 
 **Works with:** fields that may be null

--- a/src/com/puppetlabs/puppetdb/facts.clj
+++ b/src/com/puppetlabs/puppetdb/facts.clj
@@ -241,3 +241,27 @@
                   clj-edn/read-string
                   biginteger)
     value))
+
+(pls/defn-validated factpath-glob-elements-to-regexp :- fact-path
+  "Converts a field found in a factpath glob to its equivalent regexp"
+  [globarray :- fact-path]
+  (map (fn [element]
+         (if (= element "*")
+           ;; This may seem complicated, but the negative lookup ahead match
+           ;; is designed to not match against the delimiter, but happily
+           ;; match anything else. This ensures the single * is contained within
+           ;; one path element only.
+           (format "(?:(?!%s).)*" factpath-delimiter)
+           element))
+       globarray))
+
+(pls/defn-validated factpath-glob-to-regexp :- s/Str
+  "Converts a globbed array to a regexp for querying against the database.
+
+   Returns a string that contains a formatted regexp."
+  [globarray :- fact-path]
+  (str "^"
+       (-> globarray
+           factpath-glob-elements-to-regexp
+           factpath-to-string)
+       "$"))

--- a/test/com/puppetlabs/puppetdb/test/http/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/facts.clj
@@ -988,6 +988,32 @@
                [{"certname" "foo1", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
                 {"certname" "foo2", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
                 {"certname" "foo3", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "PROD"}]))
+        (is (= (into [] (response ["*>" "path" ["my_structured_fact" "c" "*"]]))
+               [{"certname" "foo1", "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
+                {"certname" "foo2", "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
+                {"certname" "foo3", "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "PROD"}
+                {"certname" "foo1", "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "DEV"}
+                {"certname" "foo2", "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "DEV"}
+                {"certname" "foo3", "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "PROD"}
+                {"certname" "foo1", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
+                {"certname" "foo2", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
+                {"certname" "foo3", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "PROD"}]))
+        (is (= (into [] (response ["*>" "path" ["my_structured_fact" "*" "n"]]))
+               [{"certname" "foo1", "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "DEV"}
+                {"certname" "foo2", "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "DEV"}
+                {"certname" "foo3", "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "PROD"}]))
+        (is (= (into [] (response ["*>" "path" ["my_structured_fact" "*"]]))
+               [{"certname" "foo1", "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
+                {"certname" "foo2", "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
+                {"certname" "foo3", "path" ["my_structured_fact" "a"], "value" 1, "environment" "PROD"}
+                {"certname" "foo1", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
+                {"certname" "foo2", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
+                {"certname" "foo3", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "PROD"}
+                {"certname" "foo1", "path" ["my_structured_fact" "e"], "value" "1", "environment" "DEV"}
+                {"certname" "foo2", "path" ["my_structured_fact" "e"], "value" "1", "environment" "DEV"}
+                {"certname" "foo3", "path" ["my_structured_fact" "e"], "value" "1", "environment" "PROD"}
+                {"certname" "foo1", "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
+                {"certname" "foo3", "path" ["my_structured_fact" "f"], "value" nil, "environment" "PROD"}]))
         (is (= (into [] (response ["=" "value" "a"]))
                [{"certname" "foo1", "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
                 {"certname" "foo2", "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}


### PR DESCRIPTION
This adds the new operator ~> which is a path glob operator that only works
against the `path` type. It works by internally converting the array of
literals and potential globs into a single regular expression for querying
the fact paths.

Signed-off-by: Ken Barber ken@bob.sh
