### PR TITLE
(PDB-772) Modify the facts endpoint to return structured facts

### DIFF
--- a/documentation/api/query/v3/facts.markdown
+++ b/documentation/api/query/v3/facts.markdown
@@ -113,7 +113,12 @@ this route.
 
 ## Paging
 
-This query endpoint supports paged results via the common PuppetDB paging
-URL parameters.  For more information, please see the documentation
-on [paging][paging].
+Unlike previously, the v3 /facts endpoint does not support ordering
+by value. An attempt to order the response by value will be silently ignored in
+the version 3 API and will generate an error in future versions. This change
+was made due to the lack of an obvious ordering for structured fact values.
+Ordering by value is supported on the fact-nodes endpoint.
 
+Aside from ordering by value, the v3 facts endpoint supports paged results via
+the common PuppetDB paging URL parameters. For more information, please see the
+documentation on [paging][paging].

--- a/documentation/api/query/v4/facts.markdown
+++ b/documentation/api/query/v4/facts.markdown
@@ -51,9 +51,12 @@ The result will be a JSON array, with one entry per fact. Each entry is of the f
       "environment": <facts environment>
     }
 
-The array is unsorted.
+The array is unsorted. Fact values can be strings, floats, integers, booleans,
+arrays, or maps. Map and array values can be any of the same types.
 
-If no facts match the query, an empty JSON array will be returned.
+If no facts match the query, an empty JSON array will be returned. Querying
+against `value` will return matches only at the top-level, rather than to
+individual fact nodes.
 
 ### Examples
 
@@ -89,12 +92,40 @@ this route.
 
 ### Examples
 
+Get the operating system fact for all nodes:
+
     curl -X GET http://puppetdb:8080/v4/facts/operatingsystem
 
     [{"certname": "a.example.com", "name": "operatingsystem", "value": "Debian"},
      {"certname": "b.example.com", "name": "operatingsystem", "value": "Redhat"},
      {"certname": "c.example.com", "name": "operatingsystem", "value": "Ubuntu"}]
 
+Get the structured partitions fact for a single node:
+
+    curl -X GET http://puppetdb:8080/v4/facts/partitions --data-urlencode 'query=["=", "certname", "a.example.com"]'
+
+    [ {
+      "value" : {
+        "sda3" : {
+          "size" : "174389248",
+          "mount" : "/home",
+          "uuid" : "26d79d9a-96b3-4cc7-960d-0d6558d7dc54"
+        },
+        "sda1" : {
+          "size" : "1048576",
+          "mount" : "/boot"
+        },
+        "sda2" : {
+          "mount" : "/",
+          "size" : "74629120",
+          "uuid" : "30d0108f-ec67-4557-8331-09ebc8b937f9"
+        }
+      },
+      "name" : "partitions",
+      "environment" : "production",
+      "certname" : "a.example.com"
+    } ]
+    
 ## `GET /v4/facts/<FACT NAME>/<VALUE>`
 
 This will return all facts with the given fact name and
@@ -121,7 +152,8 @@ this route.
 
 ## Paging
 
-This query endpoint supports paged results via the common PuppetDB paging
-URL parameters.  For more information, please see the documentation
-on [paging][paging].
+The v4 /facts endpoint does not allow ordering by fact value, but otherwise
+supports the common PuppetDB paging URL parameters. For more information,
+please see the documentation on [paging][paging]. Ordering by value is
+supported on the fact-nodes endpoint.
 

--- a/documentation/api/query/v4/paging.markdown
+++ b/documentation/api/query/v4/paging.markdown
@@ -36,7 +36,7 @@ lists of legal fields, please refer to the documentation for the specific query 
 
 [Using `curl` from localhost][curl]:
 
-    curl -X GET http://localhost:8080/v4/facts --data-urlencode 'order-by=[{"field": "value", "order": "desc"}, {"field": "name"}]'
+    curl -X GET http://localhost:8080/v4/facts --data-urlencode 'order-by=[{"field": "certname", "order": "desc"}, {"field": "name"}]'
 
 ### `limit`
 
@@ -72,4 +72,4 @@ should generally be used in conjunction with `order-by`.
 
 [Using `curl` from localhost][curl]:
 
-    curl -X GET http://localhost:8080/v4/facts --data-urlencode 'order-by=[{"field": "value"}]' --data-urlencode 'limit=5' --data-urlencode 'offset=5'
+    curl -X GET http://localhost:8080/v4/facts --data-urlencode 'order-by=[{"field": "certname"}]' --data-urlencode 'limit=5' --data-urlencode 'offset=5'

--- a/src/com/puppetlabs/puppetdb/http/facts.clj
+++ b/src/com/puppetlabs/puppetdb/http/facts.clj
@@ -2,7 +2,8 @@
   (:require [com.puppetlabs.puppetdb.http.query :as http-q]
             [com.puppetlabs.puppetdb.query.paging :as paging]
             [com.puppetlabs.http :as pl-http]
-            [com.puppetlabs.puppetdb.query.facts :as f]
+            [com.puppetlabs.puppetdb.query.facts :as facts]
+            [com.puppetlabs.puppetdb.facts :as f]
             [com.puppetlabs.cheshire :as json]
             [com.puppetlabs.puppetdb.query :as query]
             [net.cgrand.moustache :refer [app]]
@@ -10,6 +11,13 @@
                                                wrap-with-paging-options]]
             [com.puppetlabs.jdbc :as jdbc]
             [com.puppetlabs.puppetdb.http :as http]))
+
+(defn munge-result-rows
+  [version]
+  (fn [rows]
+    (if (empty? rows) []
+      (facts/structured-data-seq version rows f/factname-certname-pred
+                                 facts/collapse-facts facts/convert-types))))
 
 (defn produce-body
   "Given a query, and database connection, return a Ring response with the query
@@ -21,11 +29,14 @@
     (jdbc/with-transacted-connection db
       (let [parsed-query (json/parse-strict-string query true)
             {[sql & params] :results-query
-             count-query :count-query} (f/query->sql version parsed-query paging-options)
+             count-query :count-query} (facts/query->sql version parsed-query
+                                                      paging-options)
+            query-params (concat params params)
             resp (pl-http/stream-json-response
                   (fn [f]
                     (jdbc/with-transacted-connection db
-                      (query/streamed-query-result version sql params f))))]
+                      (query/streamed-query-result version sql query-params
+                                                   (comp f (munge-result-rows version))))))]
         (if count-query
           (http/add-headers resp {:count (jdbc/get-result-count count-query)})
           resp)))
@@ -68,12 +79,12 @@
     :v2 (build-facts-app
          (-> (query-app version)
              (validate-query-params
-              {:optional ["query"]})))
+               {:optional ["query"]})))
     (build-facts-app
-      (-> (query-app version)
-          (validate-query-params
+     (-> (query-app version)
+         (validate-query-params
            {:optional (cons "query" paging/query-params)})
-          wrap-with-paging-options))))
+         wrap-with-paging-options))))
 
 ;; Local Variables:
 ;; mode: clojure

--- a/src/com/puppetlabs/puppetdb/query/facts.clj
+++ b/src/com/puppetlabs/puppetdb/query/facts.clj
@@ -2,9 +2,125 @@
 
 (ns com.puppetlabs.puppetdb.query.facts
   (:require [com.puppetlabs.jdbc :as jdbc]
+            [schema.core :as s]
             [com.puppetlabs.puppetdb.query :as query]
+            [clojure.edn :as clj-edn]
+            [com.puppetlabs.puppetdb.schema :as pls]
             [com.puppetlabs.puppetdb.query.paging :as paging]
+            [com.puppetlabs.cheshire :as json]
+            [com.puppetlabs.puppetdb.facts :as f]
+            [clojure.string :as str]
             [com.puppetlabs.puppetdb.query-eng :as qe]))
+
+(def row-schema
+  {:certname String
+   (s/optional-key :environment) (s/maybe s/Str)
+   :path String
+   :name s/Str
+   :depth s/Int
+   :value s/Any
+   :type (s/maybe String)})
+
+(def converted-row-schema
+  {:certname s/Str
+   :path s/Str
+   :name s/Str
+   :value s/Any
+   (s/optional-key :environment) (s/maybe s/Str)})
+
+(def fact-schema
+  {:certname s/Str
+   :name s/Str
+   :value s/Any
+   (s/optional-key :environment) (s/maybe s/Str)})
+
+(defn convert-row-type
+  "Coerce the value of a row to the proper type."
+  [dissociated-fields row]
+  (let [conversion (case (:type row)
+                     "boolean" clj-edn/read-string
+                     "float" (comp double clj-edn/read-string)
+                     "integer" (comp biginteger clj-edn/read-string)
+                     ("string" "null") identity)]
+    (reduce #(dissoc %1 %2)
+            (update-in row [:value] conversion)
+            dissociated-fields)))
+
+(pls/defn-validated convert-types :- [converted-row-schema]
+  [rows :- [row-schema]]
+  (map (partial convert-row-type [:type :depth]) rows))
+
+(defn stringify-value
+  [value]
+  (if (string? value) value (json/generate-string value)))
+
+(pls/defn-validated collapse-facts :- fact-schema
+  "Aggregate all facts for a factname into a single structure."
+  [version
+   certname-rows :- [converted-row-schema]]
+  (let [first-row (first certname-rows)
+        facts (reduce f/recreate-fact-path {} certname-rows)
+        keyval (f/int-maps->vectors facts)
+        conversion (if (= version :v4) identity stringify-value)]
+    (assoc (select-keys first-row [:certname :environment :timestamp :name])
+      :value (conversion (first (vals keyval))))))
+
+(defn structured-data-seq
+  "Produce a lazy sequence of facts from a list of rows ordered by fact name"
+  ([version rows pred collapsing-fn conversion-fn]
+  (when (seq rows)
+    (let [[certname-facts more-rows] (split-with (pred rows) rows)]
+      (cons ((comp (partial collapsing-fn version) conversion-fn) certname-facts)
+            (lazy-seq (structured-data-seq version more-rows pred
+                                           collapsing-fn conversion-fn)))))))
+
+
+(defn facts-sql
+  "Return a vector with the facts SQL query string as the first element,
+  parameters needed for that query as the rest."
+  [operators query]
+  (if query
+    (let [[subselect & params] (query/fact-query->sql operators query)
+          sql (format "SELECT facts.certname, facts.environment, facts.name,
+                       facts.value, facts.path, facts.type, facts.depth
+                      FROM (%s) facts" subselect)]
+      (apply vector sql params))
+      ["SELECT fs.certname, fp.path as path, fp.name as name, fp.depth as depth,
+                        COALESCE(fv.value_string,
+                                cast(fv.value_integer as text),
+                                cast(fv.value_boolean as text),
+                                cast(fv.value_float as text)) as value,
+                        vt.type as type,
+                        env.name as environment
+                FROM factsets fs
+                      INNER JOIN facts as f on fs.id = f.factset_id
+                      INNER JOIN fact_values as fv on f.fact_value_id = fv.id
+                      INNER JOIN fact_paths as fp on fv.path_id = fp.id
+                      INNER JOIN value_types as vt on vt.id=fv.value_type_id
+                      LEFT OUTER JOIN environments as env on fs.environment_id = env.id
+        ORDER BY name, fs.certname"]))
+
+(defn query->sql
+  "Compile a query into an SQL expression."
+  [version query paging-options]
+  {:pre [((some-fn nil? sequential?) query) ]
+   :post [(map? %)
+          (string? (first (:results-query %)))
+          (every? (complement coll?) (rest (:results-query %)))]}
+  (let [augmented-paging-options (f/augment-paging-options paging-options)
+        columns (if (contains? #{:v2 :v3} version)
+                  (map keyword (keys query/fact-columns))
+                  (map keyword (keys (dissoc query/fact-columns "value"))))]
+    (paging/validate-order-by! columns paging-options)
+    (case version
+      (:v2 :v3)
+      (let [operators (query/fact-operators version)
+            [sql & params] (facts-sql operators query)]
+        (conj {:results-query (apply vector (jdbc/paged-sql sql augmented-paging-options true) params)}
+              (when (:count? augmented-paging-options)
+                [:count-query (apply vector (jdbc/count-sql true sql) params)])))
+      (qe/compile-user-query->sql
+        qe/facts-query query paging-options))))
 
 (defn flat-facts-by-node
   "Similar to `facts-for-node`, but returns facts in the form:
@@ -46,43 +162,3 @@
                    ORDER BY path"]
                  paging-options)]
       (update-in facts [:result] #(map :name %)))))
-
-(defn facts-sql
-  "Return a vector with the facts SQL query string as the first element, parameters
-   needed for that query as the rest."
-  [operators query paging-options]
-  (if query
-    (let [[subselect & params] (query/fact-query->sql operators query)
-          sql (format "SELECT facts.certname, facts.environment, facts.name, facts.value FROM (%s) facts" subselect)]
-      (apply vector sql params))
-    ["SELECT fs.certname,
-             fp.path as name,
-             COALESCE(fv.value_string,
-                      cast(fv.value_integer as text),
-                      cast(fv.value_boolean as text),
-                      cast(fv.value_float as text),
-                      '') as value
-             FROM factsets fs
-                  INNER JOIN facts as f on fs.id = f.factset_id
-                  INNER JOIN fact_values as fv on f.fact_value_id = fv.id
-                  INNER JOIN fact_paths as fp on fv.path_id = fp.id
-             WHERE fp.depth = 0"]))
-
-(defn query->sql
-  "Compile a query into an SQL expression."
-  [version query paging-options]
-  {:pre [((some-fn nil? sequential?) query) ]
-   :post [(map? %)
-          (string? (first (:results-query %)))
-          (every? (complement coll?) (rest (:results-query %)))]}
-  (paging/validate-order-by! (map keyword (keys query/fact-columns)) paging-options)
-  (case version
-    (:v2 :v3)
-    (let [operators (query/fact-operators version)
-          [sql & params] (facts-sql operators query paging-options)]
-      (conj {:results-query (apply vector (jdbc/paged-sql sql paging-options) params)}
-            (when (:count? paging-options)
-              [:count-query (apply vector (jdbc/count-sql sql) params)])))
-
-    (qe/compile-user-query->sql
-     qe/facts-query query paging-options)))

--- a/src/com/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/com/puppetlabs/puppetdb/scf/migrate.clj
@@ -755,6 +755,7 @@
                     ["id" "bigint NOT NULL PRIMARY KEY DEFAULT nextval('fact_paths_id_seq')"]
                     ["value_type_id" "bigint NOT NULL"]
                     ["depth" "int NOT NULL"]
+                    ["name" "varchar(1024)"]
                     ["path" "text NOT NULL"])
 
   (sql/do-commands
@@ -762,6 +763,7 @@
       UNIQUE (path, value_type_id)"
    "CREATE INDEX fact_paths_value_type_id ON fact_paths(value_type_id)"
    "CREATE INDEX fact_paths_depth ON fact_paths(depth)"
+   "CREATE INDEX fact_paths_name ON fact_paths(name)"
    "ALTER TABLE fact_paths ADD CONSTRAINT fact_paths_value_type_id
      FOREIGN KEY (value_type_id)
      REFERENCES value_types(id) ON UPDATE RESTRICT ON DELETE RESTRICT")

--- a/test/com/puppetlabs/puppetdb/test/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/facts.clj
@@ -1,5 +1,8 @@
 (ns com.puppetlabs.puppetdb.test.facts
   (:require [com.puppetlabs.puppetdb.facts :refer :all]
+            [com.puppetlabs.puppetdb.query.factsets :as fs]
+            [clojure.string :as string]
+            [com.puppetlabs.puppetdb.query.facts :refer :all]
             [clj-time.core :refer [now]]
             [clj-time.coerce :refer [to-timestamp]]
             [clojure.test :refer :all]))
@@ -38,7 +41,8 @@
              :value_string "Linux"
              :value_integer nil
              :value_float nil
-             :value_boolean nil}
+             :value_boolean nil
+             :name "os"}
             {:path "networking#~eth0#~ipaddresses#~1"
              :depth 3
              :value_type_id 0
@@ -46,7 +50,8 @@
              :value_string "2.2.2.2"
              :value_integer nil
              :value_float nil
-             :value_boolean nil}
+             :value_boolean nil
+             :name "networking"}
             {:path "avgload"
              :depth 0
              :value_type_id 2
@@ -54,7 +59,8 @@
              :value_string nil
              :value_integer nil
              :value_float 5.64
-             :value_boolean nil}
+             :value_boolean nil
+             :name "avgload"}
             {:path "networking#~eth0#~ipaddresses#~0"
              :depth 3
              :value_type_id 0
@@ -62,7 +68,8 @@
              :value_string "1.1.1.1"
              :value_integer nil
              :value_float nil
-             :value_boolean nil}]))))
+             :value_boolean nil
+             :name "networking"}]))))
 
 (deftest test-str->num
   (are [n s] (= n (str->num s))
@@ -112,3 +119,224 @@
     (doseq [[r l] data]
       (is (= (string-to-factpath r) l))
       (is (= r (factpath-to-string l))))))
+
+(deftest test-structured-data-seq
+  (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c" :value "abc" :type "string" :timestamp current-time}
+                   {:certname "foo.com" :environment "DEV" :path "a#~b#~d" :value "1" :type "integer" :timestamp current-time}
+                   {:certname "foo.com" :environment "DEV" :path "a#~b#~e" :value "true" :type "boolean" :timestamp current-time}
+                   {:certname "foo.com" :environment "DEV" :path "a#~b#~f" :value "3.14" :type "float" :timestamp current-time}]]
+    (is (= [{:certname "foo.com"
+             :environment "DEV"
+             :facts {"a" {"b" {"c" "abc"
+                               "d" 1
+                               "e" true
+                               "f" 3.14}}}
+             :timestamp current-time}]
+           (structured-data-seq :v4 test-rows create-certname-pred
+                                fs/collapse-factset fs/convert-types))))
+
+  (testing "laziness of the collapsing fns"
+    (let [ten-billion 10000000000]
+      (is (= 10
+             (count
+              (take 10
+                    (structured-data-seq :v4
+                     (mapcat (fn [certname]
+                               [{:certname certname :environment "DEV" :path "a#~b#~c"
+                                 :value "abc" :type "string" :timestamp current-time}
+                                {:certname certname :environment "DEV" :path "a#~b#~d"
+                                 :value "1" :type "integer" :timestamp current-time}
+                                {:certname certname :environment "DEV" :path "a#~b#~e"
+                                 :value "3.14" :type "float" :timestamp current-time}
+                                {:certname certname :environment "DEV" :path "a#~b#~f"
+                                 :value "true" :type "boolean" :timestamp current-time}])
+                             (map #(str "foo" % ".com") (range 0 ten-billion)))
+                    create-certname-pred fs/collapse-factset fs/convert-types)))))))
+
+  (testing "map with a nested vector"
+    (let [test-rows [{:certname "foo.com" :environment "DEV"
+                      :path "a#~b#~c" :value "abc" :type "string" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV"
+                      :path "a#~b#~d#~0" :value "1" :type "integer" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV"
+                      :path "a#~b#~d#~1" :value "3" :type "integer" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV"
+                      :path "a#~b#~e" :value "true" :type "boolean" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV"
+                      :path "a#~b#~f" :value "abf" :type "string" :timestamp current-time}]]
+
+      (is (= [{:certname "foo.com"
+               :environment "DEV"
+               :facts {"a" {"b" {"c" "abc"
+                                 "d" [1 3]
+                                 "e" true
+                                 "f" "abf"}}}
+               :timestamp current-time}]
+             (structured-data-seq :v4 test-rows create-certname-pred
+                                   fs/collapse-factset fs/convert-types)))))
+  (testing "map with a nested vector of maps"
+    (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c" :value "abc" :type "string" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~0#~e#~f#~0" :value "1" :type "integer" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~1#~e#~f#~0" :value "2" :type "integer" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~e" :value "abe" :type "string" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~f" :value "abf" :type "string" :timestamp current-time}]]
+      (is (= [{:certname "foo.com"
+               :environment "DEV"
+               :facts {"a" {"b" {"c" "abc"
+                                 "d" [{"e" {"f" [1]}}
+                                      {"e" {"f" [2]}}]
+                                 "e" "abe"
+                                 "f" "abf"}}}
+               :timestamp current-time}]
+             (structured-data-seq :v4 test-rows create-certname-pred
+                                  fs/collapse-factset fs/convert-types)))))
+
+  (testing "json numeric formats"
+    (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c" :value "10E10" :type "integer" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~\"0\"#~e#~f#~0" :value "3.14E10" :type "float" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~\"1\"#~e#~f#~0" :value "1.4e-5" :type "float" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~e" :value "-10E-5" :type "float" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~f" :value "-0.25e-5" :type "float" :timestamp current-time}]]
+      (is (= [{:certname "foo.com"
+               :environment "DEV"
+               :facts {"a" {"b" {"c" 100000000000
+                                 "d" {"0" {"e" {"f" [3.14E10]}}
+                                      "1" {"e" {"f" [1.4E-5]}}}
+                                 "e"  -1.0e-4
+                                 "f" -2.5E-6}}}
+               :timestamp current-time}]
+             (structured-data-seq :v4 test-rows create-certname-pred
+                                  fs/collapse-factset fs/convert-types)))))
+
+  (testing "map stringified integer keys"
+    (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c"
+                      :value "abc" :type "string" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~\"0\"#~e#~f#~0"
+                      :value "1" :type "integer" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV"
+                      :path "a#~b#~d#~\"1\"#~e#~f#~0" :value "2" :type "integer"
+                      :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~e"
+                      :value "abe" :type "string" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~j"
+                      :value nil :type "null" :timestamp current-time}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~f"
+                      :value "abf" :type "string" :timestamp current-time}]]
+
+      (is (= [{:certname "foo.com"
+               :environment "DEV"
+               :facts {"a" {"b" {"c" "abc"
+                                 "d" {"0" {"e" {"f" [1]}}
+                                      "1" {"e" {"f" [2]}}}
+                                 "e" "abe"
+                                 "f" "abf"
+                                 "j" nil}}}
+               :timestamp current-time}]
+             (structured-data-seq :v4 test-rows create-certname-pred
+                                  fs/collapse-factset fs/convert-types))))))
+
+(deftest test-facts-seq
+  (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c" :value "abc" :type "string" :name "a" :depth 2}
+                   {:certname "foo.com" :environment "DEV" :path "a#~b#~d" :value "1" :type "integer" :name "a" :depth 2}
+                   {:certname "foo.com" :environment "DEV" :path "a#~b#~e" :value "true" :type "boolean" :name "a" :depth 2}
+                   {:certname "foo.com" :environment "DEV" :path "a#~b#~f" :value "3.14" :type "float" :name "a" :depth 2}]]
+    (is (= [{:certname "foo.com"
+             :environment "DEV"
+             :value {"b" {"c" "abc"
+                               "d" 1
+                               "e" true
+                               "f" 3.14}}
+             :name "a"}]
+ 
+             (structured-data-seq :v4 test-rows factname-certname-pred
+                                  collapse-facts convert-types))))
+
+  (testing "laziness of the collapsing fns"
+    (let [ten-billion 10000000000]
+      (is (= 10
+             (count
+              (take 10
+                    (structured-data-seq :v4
+                     (mapcat (fn [certname]
+                               [{:certname certname :environment "DEV" :path "a#~b#~c" :value "abc" :type "string" :name "a" :depth 2}
+                                {:certname certname :environment "DEV" :path "a#~b#~d" :value "1" :type "integer" :name "a" :depth 2}
+                                {:certname certname :environment "DEV" :path "a#~b#~e" :value "3.14" :type "float" :name "a" :depth 2}
+                                {:certname certname :environment "DEV" :path "a#~b#~f" :value "true" :type "boolean" :name "a" :depth 2}])
+                             (map #(str "foo" % ".com") (range 0 ten-billion)))
+                     factname-certname-pred collapse-facts convert-types)))))))
+
+  (testing "map with a nested vector"
+    (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c" :value "abc" :type "string" :name "a" :depth 2}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~0" :value "1" :type "integer" :name "a" :depth 3}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~1" :value "3" :type "integer" :name "a" :depth 3}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~e" :value "true" :type "boolean" :name "a" :depth 2}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~f" :value "abf" :type "string" :name "a" :depth 2}]]
+
+      (is (= [{:certname "foo.com"
+               :environment "DEV"
+               :value {"b" {"c" "abc"
+                                 "d" [1 3]
+                                 "e" true
+                                 "f" "abf"}}
+               :name "a"}]
+             (structured-data-seq :v4 test-rows
+                                  factname-certname-pred collapse-facts
+                                  convert-types)))))
+  (testing "map with a nested vector of maps"
+    (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c" :value "abc" :type "string" :name "a" :depth 2}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~0#~e#~f#~0" :value "1" :type "integer" :name "a" :depth 6}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~1#~e#~f#~0" :value "2" :type "integer" :name "a" :depth 6}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~e" :value "abe" :type "string" :name "a" :depth 2}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~f" :value "abf" :type "string" :name "a" :depth 2}]]
+      (is (= [{:certname "foo.com"
+               :environment "DEV"
+               :value {"b" {"c" "abc"
+                                 "d" [{"e" {"f" [1]}}
+                                      {"e" {"f" [2]}}]
+                                 "e" "abe"
+                                 "f" "abf"}}
+               :name "a"}]
+
+             (structured-data-seq :v4 test-rows
+                                  factname-certname-pred collapse-facts
+                                  convert-types)))))
+
+  (testing "json numeric formats"
+    (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c" :value "10E10" :type "integer" :name "a" :depth 2}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~\"0\"#~e#~f#~0" :value "3.14E10" :type "float" :name "a" :depth 6}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~\"1\"#~e#~f#~0" :value "1.4e-5" :type "float" :name "a" :depth 6}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~e" :value "-10E-5" :type "float" :name "a" :depth 2}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~f" :value "-0.25e-5" :type "float" :name "a" :depth 2}]]
+      (is (= [{:certname "foo.com"
+               :environment "DEV"
+               :value {"b" {"c" 100000000000
+                                 "d" {"0" {"e" {"f" [3.14E10]}}
+                                      "1" {"e" {"f" [1.4E-5]}}}
+                                 "e"  -1.0e-4
+                                 "f" -2.5E-6}}
+               :name "a"}]
+             (structured-data-seq :v4 test-rows
+                                  factname-certname-pred collapse-facts
+                                  convert-types)))))
+
+  (testing "map stringified integer keys"
+    (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c" :value "abc" :type "string" :name "a" :depth 2}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~\"0\"#~e#~f#~0" :value "1" :type "integer" :name "a" :depth 6}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~\"1\"#~e#~f#~0" :value "2" :type "integer" :name "a" :depth 6}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~e" :value "abe" :type "string" :name "a" :depth 2}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~j" :value nil :type "null" :name "a" :depth 2}
+                     {:certname "foo.com" :environment "DEV" :path "a#~b#~f" :value "abf" :type "string" :name "a" :depth 2}]]
+
+      (is (= [{:certname "foo.com"
+               :environment "DEV"
+               :value {"b" {"c" "abc"
+                                 "d" {"0" {"e" {"f" [1]}}
+                                      "1" {"e" {"f" [2]}}}
+                                 "e" "abe"
+                                 "f" "abf"
+                                 "j" nil}}
+              :name "a" }]
+
+             (structured-data-seq :v4 test-rows
+                                  factname-certname-pred collapse-facts
+                                  convert-types))))))

--- a/test/com/puppetlabs/puppetdb/test/scf/migrate.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/migrate.clj
@@ -148,7 +148,7 @@
 
       (let [response
             (query-to-vec
-              "SELECT path,e.id AS environment_id,name AS environment,timestamp,value_string
+              "SELECT path,e.id AS environment_id, e.name AS environment,timestamp,value_string
                FROM
                environments e INNER JOIN factsets fs on e.id=fs.environment_id
                               INNER JOIN facts f on f.factset_id=fs.id

--- a/test/com/puppetlabs/puppetdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/storage.clj
@@ -26,7 +26,8 @@
             [clojure.math.combinatorics :refer [combinations subsets]]
             [clj-time.core :refer [ago from-now now days]]
             [clj-time.coerce :refer [to-timestamp to-string]]
-            [com.puppetlabs.jdbc :refer [query-to-vec with-transacted-connection convert-result-arrays]]
+            [com.puppetlabs.jdbc :refer [query-to-vec with-transacted-connection
+                                         convert-result-arrays]]
             [com.puppetlabs.puppetdb.fixtures :refer :all]))
 
 (use-fixtures :each with-test-db)
@@ -138,7 +139,8 @@
                                (:timestamp (last update-call))))
                         @updates)))
             (testing "should only insert uptime_seconds"
-              (is (some #{[:fact_paths {:value_type_id 0, :depth 0, :path "uptime_seconds"}]}
+              (is (some #{[:fact_paths {:name "uptime_seconds" :value_type_id 0,
+                                        :depth 0, :path "uptime_seconds"}]}
                         @adds))))))
 
       (testing "replacing all new facts"


### PR DESCRIPTION
This pull request causes the v4 facts endpoint to return typed and structured
facts while leaving the v3 responses stringified as before.  It also adds a
"name" column to the fact_paths table representing the first element of a
fact's path.  This column should be renamed to "fact" in the future to avoid
confusion with the many references to 'certname' as name.
