### PR TITLE
(maint) Fix fact-node globbing tests

### DIFF
--- a/src/com/puppetlabs/puppetdb/facts.clj
+++ b/src/com/puppetlabs/puppetdb/facts.clj
@@ -251,7 +251,7 @@
            ;; is designed to not match against the delimiter, but happily
            ;; match anything else. This ensures the single * is contained within
            ;; one path element only.
-           (format "(?:(?!%s).)*" factpath-delimiter)
+           (format "(?:(?!%s).)+" factpath-delimiter)
            element))
        globarray))
 

--- a/test/com/puppetlabs/puppetdb/test/http/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/facts.clj
@@ -828,7 +828,8 @@
                                       "c" ["a" "b" "c"]
                                       "d" {"n" ""}
                                       "e" "1"
-                                      "f" nil}
+                                      "f" nil
+                                      "" "g?"}
                 "domain" "testing.com"
                 "operatingsystem" "Darwin"}
         facts4 {"my_structured_fact" {"a" 1
@@ -1002,7 +1003,8 @@
                 {"certname" "foo2", "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "DEV"}
                 {"certname" "foo3", "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "PROD"}]))
         (is (= (into [] (response ["*>" "path" ["my_structured_fact" "*"]]))
-               [{"certname" "foo1", "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
+               [{"certname" "foo3", "path" ["my_structured_fact" ""], "value" "g?", "environment" "PROD"}
+                {"certname" "foo1", "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
                 {"certname" "foo2", "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
                 {"certname" "foo3", "path" ["my_structured_fact" "a"], "value" 1, "environment" "PROD"}
                 {"certname" "foo1", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}


### PR DESCRIPTION
The regular expression I provided for the glob replace wasn't sufficient for
PostgreSQL to work. This patch amends it to be so.

I've also put in a test for keys with blank strings, to make sure this change
doesn't affect that case as well.

Signed-off-by: Ken Barber ken@bob.sh
