### PR TITLE
(PDB-763) Provide trgm index handling for fact_paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: clojure
 lein: lein2
 env:
-  - T_TEST=java:oraclejdk7:embedded
-  - T_TEST=java:oraclejdk8:embedded
-  - T_TEST=java:openjdk7:embedded
+  - T_TEST=java:oraclejdk7:hsqldb
+  - T_TEST=java:oraclejdk8:hsqldb
+  - T_TEST=java:openjdk7:hsqldb
   - T_TEST=java:oraclejdk7:postgres
   - T_TEST=java:oraclejdk8:postgres
   - T_TEST=java:openjdk7:postgres

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -214,6 +214,12 @@ Before using the PostgreSQL backend, you must set up a PostgreSQL server, ensure
     $ createdb -E UTF8 -O puppetdb puppetdb
     $ exit
 
+If you are running PostgreSQL 9.3 or above you should install the regexp optimized index extension pg_trgm:
+
+    $ sudo -u postgres sh
+    $ psql puppetdb -c 'create extension pg_trgm'
+    $ exit
+
 Next you will most likely need to modify the `pg_hba.conf` file to allow for md5 authentication from at least localhost. To locate the file you can either issue a `locate pg_hba.conf` command (if your distribution supports it) or consult your distribution's documentation for the PostgreSQL `confdir`.
 
 The following example `pg_hba.conf` file allows md5 authentication from localhost for both IPv4 and IPv6 connections:

--- a/ext/templates/logback.xml.erb
+++ b/ext/templates/logback.xml.erb
@@ -27,7 +27,9 @@
     <!--
     <logger name="com.puppetlabs.puppetdb.scf.storage" level="debug"/>
     -->
-    <logger name="com.puppetlabs.puppetdb.scf.migrate" level="warn"/>
+
+    <!-- Info level provides migration and index creation information -->
+    <logger name="com.puppetlabs.puppetdb.scf.migrate" level="info"/>
 
     <root level="info">
         <!-- <appender-ref ref="STDOUT" /> -->

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -28,7 +28,7 @@ else
       PUPPETDB_DBPASSWORD= \
       lein2 test
     else
-      if [ $T_DB == "embedded" ]; then
+      if [ $T_DB == "hsqldb" ]; then
         PUPPETDB_DBTYPE=$T_DB \
         lein2 test
       else

--- a/project.clj
+++ b/project.clj
@@ -83,7 +83,7 @@
 
   :test-selectors {:default (fn [test-var-meta]
                               (let [dbtype (keyword (or (System/getenv "PUPPETDB_DBTYPE")
-                                                        "hsql"))]
+                                                        "hsqldb"))]
                                 (get test-var-meta dbtype true)))}
 
   :profiles {:dev {:resource-paths ["test-resources"],

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -15,7 +15,7 @@
     <!--
     <logger name="com.puppetlabs.puppetdb.scf.storage" level="debug"/>
     -->
-    <logger name="com.puppetlabs.puppetdb.scf.migrate" level="warn"/>
+    <logger name="com.puppetlabs.puppetdb.scf.migrate" level="info"/>
 
     <root level="info">
         <appender-ref ref="STDOUT" />

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -58,16 +58,16 @@
             [com.puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.trapperkeeper.core :refer [defservice main]]
-            [compojure.core :as compojure])
-  (:use [clojure.java.io :only [file]]
-        [clj-time.core :only [ago secs minutes days]]
-        [overtone.at-at :only (mk-pool interspaced)]
-        [com.puppetlabs.time :only [to-secs to-millis parse-period format-period period?]]
-        [com.puppetlabs.jdbc :only (with-transacted-connection)]
-        [com.puppetlabs.repl :only (start-repl)]
-        [com.puppetlabs.puppetdb.scf.migrate :only [migrate!]]
-        [com.puppetlabs.puppetdb.version :only [version update-info]]
-        [com.puppetlabs.puppetdb.command.constants :only [command-names]]))
+            [compojure.core :as compojure]
+            [clojure.java.io :refer [file]]
+            [clj-time.core :refer [ago]]
+            [overtone.at-at :refer [mk-pool interspaced]]
+            [com.puppetlabs.time :refer [to-secs to-millis parse-period format-period period?]]
+            [com.puppetlabs.jdbc :refer [with-transacted-connection]]
+            [com.puppetlabs.repl :refer [start-repl]]
+            [com.puppetlabs.puppetdb.scf.migrate :refer [migrate! indexes!]]
+            [com.puppetlabs.puppetdb.version :refer [version update-info]]
+            [com.puppetlabs.puppetdb.command.constants :refer [command-names]]))
 
 (def cli-description "Main PuppetDB daemon")
 
@@ -288,7 +288,8 @@
     ;; connection without creating anything.
     (sql/with-connection write-db
                          (scf-store/validate-database-version #(System/exit 1))
-                         (migrate!))
+                         (migrate!)
+                         (indexes!))
 
     ;; Initialize database-dependent metrics
     (pop/initialize-metrics write-db)


### PR DESCRIPTION
This patch adds a detection routine outside of the normal migration that will
nag the user if they don't have pg_trgm installed (or don't have a compatible
system for trgm and regexp performance, ie. pg 9.3 or above).

If trgm is working, it will manage installing the correct index on the
fact_paths table for regular expression query optimization.

Without a trgm index, globbing and regular expression queries will not use
an index and thus those queries become full table scans.

Signed-off-by: Ken Barber ken@bob.sh
