### PR TITLE
(maint) fix order on environments for facts

### DIFF
--- a/src/com/puppetlabs/jdbc.clj
+++ b/src/com/puppetlabs/jdbc.clj
@@ -160,8 +160,9 @@
           order-by-clause  (order-by->sql order-by)]
       (if structured?
         (format "SELECT paged_results.* FROM (%s) paged_results WHERE
-                (name,certname) IN (SELECT DISTINCT name,certname FROM (%s)
-                distinct_names %s%s%s) %s"
+                (name,certname,environment) IN
+                (SELECT DISTINCT name,certname,environment
+                FROM (%s) distinct_names %s%s%s) %s"
                 sql sql order-by-clause limit-clause offset-clause order-by-clause)
         (format "SELECT paged_results.* FROM (%s) paged_results%s%s%s"
                 sql

--- a/src/com/puppetlabs/puppetdb/query/facts.clj
+++ b/src/com/puppetlabs/puppetdb/query/facts.clj
@@ -109,7 +109,7 @@
           (every? (complement coll?) (rest (:results-query %)))]}
   (let [augmented-paging-options (f/augment-paging-options paging-options)
         columns (if (contains? #{:v2 :v3} version)
-                  (map keyword (keys query/fact-columns))
+                  (map keyword (keys (dissoc query/fact-columns "environment")))
                   (map keyword (keys (dissoc query/fact-columns "value"))))]
     (paging/validate-order-by! columns paging-options)
     (case version


### PR DESCRIPTION
this fixes an issue with ordering by environment on the facts endpoint and
patches the corresponding blind spot in our tests.
