### PR TITLE
(PDB-797) Add "name" field to fact-nodes response.

### DIFF
--- a/documentation/api/query/v4/fact-nodes.markdown
+++ b/documentation/api/query/v4/fact-nodes.markdown
@@ -47,7 +47,8 @@ See [the Operators page.](./operators.html)
 ### Query Fields
 
 * `certname` (string): the certname associated with the factset
-* `environment` (string): the environment associated with the fact
+* `environment` (string): the environment associated with the parent fact
+* `name` (string): the name of the parent fact
 * `path` (path): the path of traversal to get to this node
 * `value` (multi): the value of this node
 
@@ -62,6 +63,7 @@ the form:
     {
       "certname": <node name>,
       "environment": <node environment>,
+      "name": <fact name>,
       "path": <path to tree node>,
       "facts": <value of tree node>
     }
@@ -79,6 +81,7 @@ which returns:
     [ {
       "certname" : "node-0",
       "path" : [ "networking", "eth0", "macaddresses", 0 ],
+      "name" : "networking",
       "value" : "aa:bb:cc:dd:ee:00",
       "environment" : "foo"
     } ]
@@ -92,11 +95,13 @@ which returns:
     [ {
       "certname" : "node-0",
       "path" : [ "load_avg" ],
+      "name" : "load_avg",
       "value" : 3.16,
       "environment" : "foo"
     }, {
       "certname" : "node-0",
       "path" : [ "cpus" ],
+      "name" : "cpus",
       "value" : 6,
       "environment" : "foo"
     }, {
@@ -117,11 +122,13 @@ which returns:
     [ {
       "certname" : "node-0",
       "path" : [ "networking", "eth0", "macaddresses", 0 ],
+      "name" : "networking",
       "value" : "aa:bb:cc:dd:ee:00",
       "environment" : "foo"
     }, {
       "certname" : "node-0",
       "path" : [ "networking", "eth0", "macaddresses", 1 ],
+      "name" : "networking",
       "value" : "aa:bb:cc:dd:ee:01",
       "environment" : "foo"
     } ]

--- a/src/com/puppetlabs/puppetdb/query/fact_nodes.clj
+++ b/src/com/puppetlabs/puppetdb/query/fact_nodes.clj
@@ -12,6 +12,7 @@
   {:certname s/Str
    :environment (s/maybe s/Str)
    :path s/Str
+   :name s/Str
    :value (s/maybe s/Str)
    :type s/Str})
 
@@ -19,6 +20,7 @@
   {:certname s/Str
    :environment (s/maybe s/Str)
    :path f/fact-path
+   :name s/Str
    :value f/fact-value})
 
 (pls/defn-validated munge-result-row :- converted-row-schema

--- a/src/com/puppetlabs/puppetdb/query_eng.clj
+++ b/src/com/puppetlabs/puppetdb/query_eng.clj
@@ -115,14 +115,16 @@
   (map->Query {:project {"path" :path
                          "value" :multi
                          "certname" :string
+                         "name" :string
                          "environment" :string
                          "type" :string}
                :alias "fact_nodes"
-               :queryable-fields ["path" "value" "certname" "environment"]
+               :queryable-fields ["path" "value" "certname" "environment" "name"]
                :source-table "facts"
                :subquery? false
                :source "SELECT fs.certname,
                                fp.path,
+                               fp.name as name,
                                COALESCE(fv.value_string,
                                         CAST(fv.value_integer as text),
                                         CAST(fv.value_float as text),

--- a/test/com/puppetlabs/puppetdb/test/http/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/facts.clj
@@ -1213,75 +1213,81 @@
                            :body
                            #(get-response endpoint % {:order-by (json/generate-string [{:field "path"} {:field "certname"}])}))]
         (is (= (into {} (first (response ["=" "certname" "foo1"])))
-               {"certname" "foo1", "path" ["domain"], "value" "testing.com", "environment" "DEV"}))
+               {"certname" "foo1", "name" "domain" "path" ["domain"], "value" "testing.com", "environment" "DEV"}))
         (is (= (into [] (response ["=" "environment" "DEV"]))
-               [{"certname" "foo1", "path" ["domain"], "value" "testing.com", "environment" "DEV"}
-                {"certname" "foo2", "path" ["domain"], "value" "testing.com", "environment" "DEV"}
-                {"certname" "foo1", "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
-                {"certname" "foo1", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
-                {"certname" "foo1", "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
-                {"certname" "foo1", "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "DEV"}
-                {"certname" "foo1", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
-                {"certname" "foo1", "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "DEV"}
-                {"certname" "foo1", "path" ["my_structured_fact" "e"], "value" "1", "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "e"], "value" "1", "environment" "DEV"}
-                {"certname" "foo1", "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
-                {"certname" "foo1", "path" ["test#~delimiter"], "value" "foo", "environment" "DEV"}
-                {"certname" "foo1", "path" ["uptime_seconds"], "value" "4000", "environment" "DEV"}
-                {"certname" "foo2", "path" ["uptime_seconds"], "value" "6000", "environment" "DEV"}]))
+               [{"certname" "foo1", "name" "domain" "path" ["domain"], "value" "testing.com", "environment" "DEV"}
+                {"certname" "foo2", "name" "domain" "path" ["domain"], "value" "testing.com", "environment" "DEV"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "DEV"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "DEV"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "e"], "value" "1", "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "e"], "value" "1", "environment" "DEV"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
+                {"certname" "foo1", "name" "test#~delimiter" "path" ["test#~delimiter"], "value" "foo", "environment" "DEV"}
+                {"certname" "foo1", "name" "uptime_seconds" "path" ["uptime_seconds"], "value" "4000", "environment" "DEV"}
+                {"certname" "foo2", "name" "uptime_seconds" "path" ["uptime_seconds"], "value" "6000", "environment" "DEV"}]))
         (is (= (into [] (response ["=" "path" ["my_structured_fact" "c" 2]]))
-               [{"certname" "foo1", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
-                {"certname" "foo3", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "PROD"}]))
+               [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "PROD"}]))
         (is (= (into [] (response ["*>" "path" ["my_structured_fact" "c" "*"]]))
-               [{"certname" "foo1", "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
-                {"certname" "foo3", "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "PROD"}
-                {"certname" "foo1", "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "DEV"}
-                {"certname" "foo3", "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "PROD"}
-                {"certname" "foo1", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
-                {"certname" "foo3", "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "PROD"}]))
+               [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "PROD"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "PROD"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "PROD"}]))
         (is (= (into [] (response ["*>" "path" ["my_structured_fact" "*" "n"]]))
-               [{"certname" "foo1", "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "DEV"}
-                {"certname" "foo3", "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "PROD"}]))
+               [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "PROD"}]))
         (is (= (into [] (response ["*>" "path" ["my_structured_fact" "*"]]))
-               [{"certname" "foo3", "path" ["my_structured_fact" ""], "value" "g?", "environment" "PROD"}
-                {"certname" "foo1", "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
-                {"certname" "foo3", "path" ["my_structured_fact" "a"], "value" 1, "environment" "PROD"}
-                {"certname" "foo1", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
-                {"certname" "foo3", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "PROD"}
-                {"certname" "foo1", "path" ["my_structured_fact" "e"], "value" "1", "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "e"], "value" "1", "environment" "DEV"}
-                {"certname" "foo3", "path" ["my_structured_fact" "e"], "value" "1", "environment" "PROD"}
-                {"certname" "foo1", "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
-                {"certname" "foo3", "path" ["my_structured_fact" "f"], "value" nil, "environment" "PROD"}]))
+               [{"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" ""], "value" "g?", "environment" "PROD"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "PROD"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "PROD"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "e"], "value" "1", "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "e"], "value" "1", "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "e"], "value" "1", "environment" "PROD"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "PROD"}]))
         (is (= (into [] (response ["=" "value" "a"]))
-               [{"certname" "foo1", "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
-                {"certname" "foo3", "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "PROD"}]))
+               [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "PROD"}]))
         (is (= (into [] (response ["=" "value" 3.14]))
-               [{"certname" "foo1", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
-                {"certname" "foo3", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "PROD"}]))
+               [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "PROD"}]))
         (is (= (into [] (response [">" "value" 3.1]))
-               [{"certname" "foo1", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
-                {"certname" "foo2", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
-                {"certname" "foo3", "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "PROD"}]))
+               [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "PROD"}]))
         (is (= (into [] (response ["~" "value" "testing"]))
-               [{"certname" "foo1", "path" ["domain"], "value" "testing.com", "environment" "DEV"}
-                {"certname" "foo2", "path" ["domain"], "value" "testing.com", "environment" "DEV"}
-                {"certname" "foo3", "path" ["domain"], "value" "testing.com", "environment" "PROD"}]))
+               [{"certname" "foo1", "name" "domain" "path" ["domain"], "value" "testing.com", "environment" "DEV"}
+                {"certname" "foo2", "name" "domain" "path" ["domain"], "value" "testing.com", "environment" "DEV"}
+                {"certname" "foo3", "name" "domain" "path" ["domain"], "value" "testing.com", "environment" "PROD"}]))
         (is (= (into [] (response ["=" "value" nil]))
-               [{"certname" "foo1", "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
-                {"certname" "foo3", "path" ["my_structured_fact" "f"], "value" nil, "environment" "PROD"}]))))))
+               [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "PROD"}]))
+        (is (= (into [] (response ["~" "name" "#~"]))
+               [{"certname" "foo1", "path" ["test#~delimiter"], "name" "test#~delimiter", "value" "foo", "environment" "DEV"}]))
+        (is (= (into [] (response ["=", "name" "domain"]))
+               [{"certname" "foo1", "path" ["domain"], "name" "domain", "value" "testing.com", "environment" "DEV"}
+                {"certname" "foo2", "path" ["domain"], "name" "domain", "value" "testing.com", "environment" "DEV"}
+                {"certname" "foo3", "path" ["domain"], "name" "domain", "value" "testing.com", "environment" "PROD"}]))))))


### PR DESCRIPTION
This adds a "name" field to the fact-nodes response.  The field "name"
represents the name of the parent fact of the fact node and is drawn from a
new column in the fact_paths table.
