### PR TITLE
(PDB-798) Add capability to use regexp when querying fact-nodes path types

### DIFF
--- a/documentation/api/query/v4/fact-nodes.markdown
+++ b/documentation/api/query/v4/fact-nodes.markdown
@@ -113,7 +113,7 @@ which returns:
 
 With the globbing array operator, we can also provide some basic matches against all elements in a map, or all elements in an array. This can be useful to search across all values that might appear in different places of the tree.
 
-This example shows a query that extracts all macaddresses for all ethernet devices:
+This example shows a query that extracts all `macaddresses` for all networking devices:
 
     curl -G 'http://puppetdb:8080/v4/fact-nodes' --data-urlencode 'query=["*>", "path", ["networking","*","macaddresses","*"]]'
 
@@ -130,6 +130,31 @@ which returns:
       "path" : [ "networking", "eth0", "macaddresses", 1 ],
       "name" : "networking",
       "value" : "aa:bb:cc:dd:ee:01",
+      "environment" : "foo"
+    }, {
+      "certname" : "node-0",
+      "path" : [ "networking", "tun0", "macaddresses", 0 ],
+      "value" : "aa:bb:cc:dd:ee:02",
+      "environment" : "foo"
+    } ]
+
+Another operator that provides additional power, is the regexp array operator. This operator works a lot like the glob operator, but allows you to use full regexp to match an element for a path.
+
+The example shows a query that extracts all `macaddresses` for all ethernet devices (that is, devices starting with `eth`):
+
+    curl -G 'http://puppetdb:8080/v4/fact-nodes' --data-urlencode 'query=["~>", "path", ["networking","eth.*","macaddresses",".*"]]'
+
+which returns:
+
+    [ {
+      "certname" : "node-0",
+      "path" : [ "networking", "eth0", "macaddresses", 1 ],
+      "value" : "aa:bb:cc:dd:ee:01",
+      "environment" : "foo"
+    }, {
+      "certname" : "node-0",
+      "path" : [ "networking", "eth0", "macaddresses", 0 ],
+      "value" : "aa:bb:cc:dd:ee:00",
       "environment" : "foo"
     } ]
 

--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -89,6 +89,16 @@ The following example would match any network interface name, and its macaddress
 
     ["*>", "path", ["networking","*","macaddress"]
 
+### '~>' (regexp array match)
+
+**Works with:** paths
+
+**Matches if:** the array matches using the regular expressions provided within in each element.
+
+The following example would match any network interface names starting with eth:
+
+    ["~>", "path", ["networking", "eth.*", "macaddress"]]
+
 ### `null?` (is null)
 
 **Works with:** fields that may be null

--- a/src/com/puppetlabs/puppetdb/facts.clj
+++ b/src/com/puppetlabs/puppetdb/facts.clj
@@ -278,6 +278,24 @@
            factpath-to-string)
        "$"))
 
+(pls/defn-validated factpath-regexp-elements-to-regexp :- fact-path
+  "Converts a field found in a factpath regexp to its equivalent regexp"
+  [rearray :- fact-path]
+  (map (fn [element]
+         (format "(?:(?!%s)%s)" factpath-delimiter element))
+       rearray))
+
+(pls/defn-validated factpath-regexp-to-regexp :- s/Str
+  "Converts a regexp array to a single regexp for querying against the database.
+
+   Returns a string that contains a fomatted regexp."
+  [rearray :- fact-path]
+  (str "^"
+       (-> rearray
+           factpath-regexp-elements-to-regexp
+           factpath-to-string)
+       "$"))
+
 (defn augment-paging-options
   [{:keys [order-by] :as paging-options}]
   (if (nil? order-by)

--- a/test/com/puppetlabs/puppetdb/test/http/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/facts.clj
@@ -773,7 +773,8 @@
                             (:body (*app*(get-request endpoint nil
                                                       {:order-by
                                                        (json/generate-string
-                                                         [{"field" "value" "order" "ASC"}])})))))))))))
+                                                        [{"field" "value" "order" "ASC"}])})))))))))))
+
 (deftestseq facts-environment-paging
   [[version endpoint] facts-endpoints
    :when (and (not (contains? #{:v2 :v3} version)) (not= endpoint v4-facts-environment))]
@@ -830,7 +831,6 @@
                                                             {"field" "name" "order" name-order}])}})]
               (compare-structured-response (map unkeywordize-values actual)
                                            (remove-all-environments version expected) version)))))))
-
 
 (deftestseq fact-environment-queries
   [[version endpoint] facts-endpoints
@@ -1266,6 +1266,24 @@
                 {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "e"], "value" "1", "environment" "PROD"}
                 {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
                 {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "PROD"}]))
+        (is (= (into [] (response ["~>" "path" ["my_structured_fact" "f"]]))
+               [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "PROD"}]))
+        (is (= (into [] (response ["~>" "path" [".*structured.*" "a"]]))
+               [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "PROD"}]))
+        (is (= (into [] (response ["~>" "path" ["my_structured_fact" "[a-b]"]]))
+               [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "PROD"}
+                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
+                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
+                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "PROD"}]))
+        (is (= (into [] (response ["~>" "path" ["my_structured_fact"]]))
+               []))
+        (is (= (into [] (response ["~>" "path" ["my_structured_fact" "^a"]]))
+               []))
         (is (= (into [] (response ["=" "value" "a"]))
                [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
                 {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}


### PR DESCRIPTION
This adds the new operator ~> which is a path regexp operator that only works
against the `path` type. It works by internally converting the array of
regular expressions into a single regular expression for querying
fact paths.

Signed-off-by: Ken Barber ken@bob.sh
