### PR TITLE
(maint) Fix old acceptance test refspec issue

### DIFF
--- a/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
+++ b/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
@@ -17,7 +17,7 @@ step "Install development build of PuppetDB on the PuppetDB server" do
     on database, "rm -rf #{GitReposDir}/puppetdb"
     repo = extract_repo_info_from(test_config[:repo_puppetdb].to_s)
     install_from_git database, GitReposDir, repo,
-      :refspec => '+refs/pull/*:refs/remotes/origin/pr/*'
+      :refspec => '+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/*'
 
     if (test_config[:database] == :postgres)
       install_postgres(database)


### PR DESCRIPTION
The old refspec for acceptance testing source code only really worked for the
PR testing workflow. This patch makes it work for the command line or polling
based workflow as well.

Without it, it makes it hard to run beaker acceptance tests from the command
line.

Signed-off-by: Ken Barber ken@bob.sh
