### PR TITLE
(PDB-826) Fix pathing for puppetdb-legacy

### DIFF
--- a/ext/templates/puppetdb-legacy.erb
+++ b/ext/templates/puppetdb-legacy.erb
@@ -4,4 +4,7 @@ fullcommand="${0##*/}"
 subcommand="${fullcommand#puppetdb-}"
 echo "WARNING: ${fullcommand} style of executing puppetdb subcommands is deprecated, use 'puppetdb ${subcommand}' instead"
 
-exec puppetdb "${subcommand}" "$@"
+# The path is to allow for PE installations, where puppetdb may not be in the path but is
+# often installed alongside the legacy script in /opt/puppet/sbin.
+# We may require something more sophisticated in the future.
+PATH=$PATH:$(dirname $0) exec puppetdb "${subcommand}" "$@"


### PR DESCRIPTION
For PE the puppetdb-legacy scripts (such as puppetdb-ssl-setup) expect the
puppetdb script to be in the path. This assumption isn't always true, as we
install PE in a weird place.

This patch adjusts the PATH for this single exec so that it also includes
the path of the directory where the original script is found, which is usually
/opt/puppet/sbin.(PDB-826) Fix pathing for puppetdb-legacy

Signed-off-by: Ken Barber ken@bob.sh
