### PR TITLE
(QENG-1071) debian ec2 /etc/init.d/ec2-get-credentials...

### DIFF
--- a/config/image_templates/ec2.yaml
+++ b/config/image_templates/ec2.yaml
@@ -64,6 +64,11 @@ AMI:
       :pe: ami-4eea627e
     :region: us-west-2
 
+  debian-6-amd64-west-2:
+    :image:
+      :pe: ami-fd4401cd
+    :region: us-west-2
+
   debian-6-i386-west:
     :image:
       :pe: ami-fcf27fcc


### PR DESCRIPTION
... script corrupts authorized_keys
- add definition for repaired debian ami
