### PR TITLE
DO NOT MERGE: (PDB-820) Add the double asterisk matcher to the path glob operator

### DIFF
--- a/documentation/api/query/v4/fact-nodes.markdown
+++ b/documentation/api/query/v4/fact-nodes.markdown
@@ -138,6 +138,14 @@ which returns:
       "environment" : "foo"
     } ]
 
+The double asterisk (**) can be used with the path glob operator to define any number of element matches. For example if you wanted to see all fact-nodes with the parent `["networking","eth0"]`, the following query could be used:
+
+    curl -G 'http://puppetdb:8080/v4/fact-nodes' --data-urlencode 'query=["*>", "path", ["networking","eth0","**"]]'
+
+Or you could use the double asterisk match at the beginning, to match against a key that is at the bottom of a path, and you are uncertain of its depth:
+
+    curl -G 'http://puppetdb:8080/v4/fact-nodes' --data-urlencode 'query=["*>", "path", ["**","operatingsystem"]]'
+
 Another operator that provides additional power, is the regexp array operator. This operator works a lot like the glob operator, but allows you to use full regexp to match an element for a path.
 
 The example shows a query that extracts all `macaddresses` for all ethernet devices (that is, devices starting with `eth`):

--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -83,11 +83,34 @@ The following example would match if the `certname` field's actual value resembl
 
 **Works with:** paths
 
-**Matches if:** the array matches against the value, however in this form one may use an asterisk (*) as a means to glob a portion of a path element. The asterisk indicates one element can be any string or number, therefore allowing a user to define any key or value in an array or map represented by the path.
+**Matches if:** the array matches against the value, however in this form one may use an asterisk (*) as a means to match anything for a single path element. The asterisk indicates one element can be any string or a number, therefore allowing a user to define any key or value in an array or map represented by the path.
 
-The following example would match any network interface name, and its macaddress data:
+Given the following sample hash data:
 
-    ["*>", "path", ["networking","*","macaddress"]
+    {
+      "networking": {
+        "eth0": {
+          "macaddress": "aa:bb:cc:00:11:22"
+        },
+        "eth1": {
+          "macaddress": "aa:bb:cc:00:11:23"
+        }
+      }
+    }
+
+The following example would match both network interface names, and specifically match their macaddress data:
+
+    ["*>", "path", ["networking", "*", "macaddress"]
+
+The double asterisk may be used to match beyond one single element. For example if you wished to match all paths under `network` you could use:
+
+    ["*>", "path", ["networking", "**"]]
+
+Or alternatively if you knew you had a macaddress key as a leaf key, but you weren't sure where in the tree it was:
+
+    ["*>", "path", ["**", "macaddress"]]
+
+For greater matching power against parts of each element using regular expressions, use the `~>` operator.
 
 ### '~>' (regexp array match)
 

--- a/src/com/puppetlabs/puppetdb/facts.clj
+++ b/src/com/puppetlabs/puppetdb/facts.clj
@@ -258,12 +258,18 @@
   "Converts a field found in a factpath glob to its equivalent regexp"
   [globarray :- fact-path]
   (map (fn [element]
-         (if (= element "*")
+         (case element
+           "*"
            ;; This may seem complicated, but the negative lookup ahead match
            ;; is designed to not match against the delimiter, but happily
            ;; match anything else. This ensures the single * is contained within
            ;; one path element only.
            (format "(?:(?!%s).)+" factpath-delimiter)
+
+           ;; The double glob is simply an open search. Its intent is to be
+           ;; unbounded by delimiters but not greedy.
+           "**" ".*"
+
            element))
        globarray))
 

--- a/test/com/puppetlabs/puppetdb/test/http/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/facts.clj
@@ -1323,6 +1323,14 @@
                 {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "e"], "value" "1", "environment" "PROD"}
                 {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
                 {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "PROD"}]))
+        (is (= (into [] (response ["*>" "path" ["**" "n"]]))
+               [{"certname" "foo1", "path" ["my_structured_fact" "d" "n"], "name" "my_structured_fact", "value" "", "environment" "DEV"}
+                {"certname" "foo2", "path" ["my_structured_fact" "d" "n"], "name" "my_structured_fact", "value" "", "environment" "DEV"}
+                {"certname" "foo3", "path" ["my_structured_fact" "d" "n"], "name" "my_structured_fact", "value" "", "environment" "PROD"}]))
+        (is (= (into [] (response ["and" ["*>" "path" ["my_structured_fact" "**"]] ["=" "value" 3.14]]))
+               [{"certname" "foo1", "path" ["my_structured_fact" "b"], "name" "my_structured_fact", "value" 3.14, "environment" "DEV"}
+                {"certname" "foo2", "path" ["my_structured_fact" "b"], "name" "my_structured_fact", "value" 3.14, "environment" "DEV"}
+                {"certname" "foo3", "path" ["my_structured_fact" "b"], "name" "my_structured_fact", "value" 3.14, "environment" "PROD"}]))
         (is (= (into [] (response ["~>" "path" ["my_structured_fact" "f"]]))
                [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
                 {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "PROD"}]))


### PR DESCRIPTION
DO NOT MERGE - this whole matter is still under design consideration.

This adds the double asterisk (*_) which allows you to match against multiple
elements in a path, instead of just one like the single asterisk (_).

Signed-off-by: Ken Barber ken@bob.sh
