### PR TITLE
(PDB-822) Change acceptance tests to incorporate structured facts.

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -729,6 +729,14 @@ EOS
     JSON.parse(File.read(cat_path))
   end
 
+  def parse_json_with_error(input)
+      begin
+          facts = JSON.parse(input)
+      rescue Exception => e
+          facts = "#{e.message} on input '#{input}'"
+      end
+      return facts
+  end
 
   ############################################################################
   # NOTE: This code was merged into beaker, however it does not work as desired.

--- a/acceptance/tests/inventory/basic_fact_retrieval.rb
+++ b/acceptance/tests/inventory/basic_fact_retrieval.rb
@@ -1,10 +1,18 @@
 require 'json'
 
-test_name "facts should be available through facts terminus" do
+test_name "structured and trusted facts should be available through facts terminus" do
+
+  structured_data = {"foo"=>[1, 2, 3],
+                     "bar"=>{"f" => [3.14, 2.71], "*" => "**","#~" => ""},
+                     "baz" => [{"a"=>1},{"b"=>2}]}
 
   with_puppet_running_on master, {
     'master' => {
       'autosign' => 'true',
+      'trusted_node_data' => 'true'
+    },
+    'main' => {
+      'stringify_facts' => 'false'
     }} do
 
     step "Run agent once to populate database" do
@@ -19,9 +27,37 @@ test_name "facts should be available through facts terminus" do
       hosts.each do |host|
         result = on master, "puppet facts find #{host.node_name} --terminus puppetdb"
         facts = JSON.parse(result.stdout.strip)
-        assert_equal(host.node_name, facts['name'], "Failed to retrieve facts for '#{host.node_name}' via inventory service!")
-
+        assert_equal(host.node_name, facts['name'],
+                     "Failed to retrieve facts for '#{host.node_name}' via inventory service!")
       end
+    end
+
+    step "Query the database for trusted facts" do
+      query = CGI.escape('["=","name","trusted"]')
+      result = on database, %Q|curl -G 'http://localhost:8080/v4/facts' --data 'query=#{query}'|
+      facts = parse_json_with_error(result.stdout)
+      assert_equal("remote", facts.first["value"]["authenticated"])
+    end
+
+    step "create a custom structured fact" do
+      payload = <<-EOM
+      -H "Accept: application/json" -H "Content-Type: application/json" \
+      -d '{"command":"replace facts","version":3, \
+      "payload":{"environment":"DEV","name":"#{master}", \
+      "values":{"my_structured_fact":#{JSON.generate(structured_data)}}}}' http://localhost:8080/v4/commands
+      EOM
+      on database, %Q|curl -X POST #{payload}|
+    end
+
+    # Wait until all the commands have been processed
+    sleep_until_queue_empty database
+
+
+    step "Ensure that the structured fact is passed through properly" do
+      query = CGI.escape('["=","name","my_structured_fact"]')
+      result = on database, %Q|curl -G 'http://localhost:8080/v4/facts' --data 'query=#{query}'|
+      facts = parse_json_with_error(result.stdout)
+      assert_equal(structured_data, facts.first["value"])
     end
   end
 end


### PR DESCRIPTION
This patch augments our basic_fact_retrieval and import_export acceptance tests
to include structured facts, and also bumps the version of the nodes query in
the facts/find indirector so structured facts are returned when puppet facts
find is issued to the PDB terminus.
