### PR TITLE
(PDB-820) Remove glob operator

### DIFF
--- a/documentation/api/query/v4/fact-nodes.markdown
+++ b/documentation/api/query/v4/fact-nodes.markdown
@@ -111,34 +111,9 @@ which returns:
       "environment" : "foo"
     } ]
 
-With the globbing array operator, we can also provide some basic matches against all elements in a map, or all elements in an array. This can be useful to search across all values that might appear in different places of the tree.
+For matching against a path element, we have added a new operator: `~>`. We call it the regexp array operator.
 
-This example shows a query that extracts all `macaddresses` for all networking devices:
-
-    curl -G 'http://puppetdb:8080/v4/fact-nodes' --data-urlencode 'query=["*>", "path", ["networking","*","macaddresses","*"]]'
-
-which returns:
-
-    [ {
-      "certname" : "node-0",
-      "path" : [ "networking", "eth0", "macaddresses", 0 ],
-      "name" : "networking",
-      "value" : "aa:bb:cc:dd:ee:00",
-      "environment" : "foo"
-    }, {
-      "certname" : "node-0",
-      "path" : [ "networking", "eth0", "macaddresses", 1 ],
-      "name" : "networking",
-      "value" : "aa:bb:cc:dd:ee:01",
-      "environment" : "foo"
-    }, {
-      "certname" : "node-0",
-      "path" : [ "networking", "tun0", "macaddresses", 0 ],
-      "value" : "aa:bb:cc:dd:ee:02",
-      "environment" : "foo"
-    } ]
-
-Another operator that provides additional power, is the regexp array operator. This operator works a lot like the glob operator, but allows you to use full regexp to match an element for a path.
+This operator allows you to match against path elements using an array of regular expressions that individually match against the stored paths for each fact-node.
 
 The example shows a query that extracts all `macaddresses` for all ethernet devices (that is, devices starting with `eth`):
 

--- a/documentation/api/query/v4/facts.markdown
+++ b/documentation/api/query/v4/facts.markdown
@@ -125,7 +125,7 @@ Get the structured partitions fact for a single node:
       "environment" : "production",
       "certname" : "a.example.com"
     } ]
-    
+
 ## `GET /v4/facts/<FACT NAME>/<VALUE>`
 
 This will return all facts with the given fact name and

--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -79,25 +79,19 @@ The following example would match if the `certname` field's actual value resembl
 > * [PostgreSQL regexp features](http://www.postgresql.org/docs/9.1/static/functions-matching.html#POSIX-SYNTAX-DETAILS)
 > * [HSQLDB (embedded database) regexp features](http://docs.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html)
 
-### `*>` (glob array match)
-
-**Works with:** paths
-
-**Matches if:** the array matches against the value, however in this form one may use an asterisk (*) as a means to glob a portion of a path element. The asterisk indicates one element can be any string or number, therefore allowing a user to define any key or value in an array or map represented by the path.
-
-The following example would match any network interface name, and its macaddress data:
-
-    ["*>", "path", ["networking","*","macaddress"]
-
 ### '~>' (regexp array match)
 
 **Works with:** paths
 
-**Matches if:** the array matches using the regular expressions provided within in each element.
+**Matches if:** the array matches using the regular expressions provided within in each element. Array indexes are coerced to strings.
 
 The following example would match any network interface names starting with eth:
 
     ["~>", "path", ["networking", "eth.*", "macaddress"]]
+
+If you want to match any index for an array path element, you can use regular expressions to do this as the element acts like a string:
+
+    ["~>", "path", ["array_fact", ".*"]]
 
 ### `null?` (is null)
 

--- a/src/com/puppetlabs/puppetdb/facts.clj
+++ b/src/com/puppetlabs/puppetdb/facts.clj
@@ -254,30 +254,6 @@
                   biginteger)
     value))
 
-(pls/defn-validated factpath-glob-elements-to-regexp :- fact-path
-  "Converts a field found in a factpath glob to its equivalent regexp"
-  [globarray :- fact-path]
-  (map (fn [element]
-         (if (= element "*")
-           ;; This may seem complicated, but the negative lookup ahead match
-           ;; is designed to not match against the delimiter, but happily
-           ;; match anything else. This ensures the single * is contained within
-           ;; one path element only.
-           (format "(?:(?!%s).)+" factpath-delimiter)
-           element))
-       globarray))
-
-(pls/defn-validated factpath-glob-to-regexp :- s/Str
-  "Converts a globbed array to a regexp for querying against the database.
-
-   Returns a string that contains a formatted regexp."
-  [globarray :- fact-path]
-  (str "^"
-       (-> globarray
-           factpath-glob-elements-to-regexp
-           factpath-to-string)
-       "$"))
-
 (pls/defn-validated factpath-regexp-elements-to-regexp :- fact-path
   "Converts a field found in a factpath regexp to its equivalent regexp"
   [rearray :- fact-path]

--- a/src/com/puppetlabs/puppetdb/query_eng.clj
+++ b/src/com/puppetlabs/puppetdb/query_eng.clj
@@ -496,10 +496,10 @@
                                          col-type))
                   (throw (IllegalArgumentException. (format "Query operators >,>=,<,<= are not allowed on field %s" field)))))
 
-              [[(:or "~>" "*>") field _]]
+              [["~>" field _]]
               (let [col-type (get-in query-context [:project field])]
                 (when-not (contains? #{:path} col-type)
-                  (throw (IllegalArgumentException. (format "Query operators *>,~> are not allowed on field %s" field)))))
+                  (throw (IllegalArgumentException. (format "Query operator ~> is not allowed on field %s" field)))))
 
               ;;This validation check is added to fix a failing facts
               ;;test. The facts test is checking that you can't submit
@@ -621,13 +621,6 @@
 
                 (map->RegexExpression {:column column
                                        :value value})))
-
-            [["*>" column value]]
-            (let [col-type (get-in query-rec [:project column])]
-              (case col-type
-                :path
-                (map->RegexExpression {:column column
-                                       :value (facts/factpath-glob-to-regexp value)})))
 
             [["~>" column value]]
             (let [col-type (get-in query-rec [:project column])]

--- a/test/com/puppetlabs/puppetdb/test/http/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/facts.clj
@@ -1296,33 +1296,6 @@
                [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
                 {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
                 {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "PROD"}]))
-        (is (= (into [] (response ["*>" "path" ["my_structured_fact" "c" "*"]]))
-               [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
-                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
-                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "PROD"}
-                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "DEV"}
-                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "DEV"}
-                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 1], "value" "b", "environment" "PROD"}
-                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
-                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "DEV"}
-                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 2], "value" "c", "environment" "PROD"}]))
-        (is (= (into [] (response ["*>" "path" ["my_structured_fact" "*" "n"]]))
-               [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "DEV"}
-                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "DEV"}
-                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "d" "n"], "value" "", "environment" "PROD"}]))
-        (is (= (into [] (response ["*>" "path" ["my_structured_fact" "*"]]))
-               [{"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" ""], "value" "g?", "environment" "PROD"}
-                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
-                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "DEV"}
-                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "a"], "value" 1, "environment" "PROD"}
-                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
-                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "DEV"}
-                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "b"], "value" 3.14, "environment" "PROD"}
-                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "e"], "value" "1", "environment" "DEV"}
-                {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "e"], "value" "1", "environment" "DEV"}
-                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "e"], "value" "1", "environment" "PROD"}
-                {"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
-                {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "PROD"}]))
         (is (= (into [] (response ["~>" "path" ["my_structured_fact" "f"]]))
                [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
                 {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "PROD"}]))


### PR DESCRIPTION
This removes the glob operator, leaving the regexp operator as the main way of
matching paths in a complex way.

Signed-off-by: Ken Barber ken@bob.sh
