### PR TITLE
(PDB-821) Facilitate facts subqueries against fact nodes.

### DIFF
--- a/documentation/api/query/v4/facts.markdown
+++ b/documentation/api/query/v4/facts.markdown
@@ -68,7 +68,7 @@ Get the operatingsystem fact for all nodes:
 
     [{"certname": "a.example.com", "name": "operatingsystem", "value": "Debian"},
      {"certname": "b.example.com", "name": "operatingsystem", "value": "RedHat"},
-     {"certname": "c.example.com", "name": "operatingsystem", "value": "Darwin"},
+     {"certname": "c.example.com", "name": "operatingsystem", "value": "Darwin"}]
 
 Get all facts for a single node:
 
@@ -77,6 +77,22 @@ Get all facts for a single node:
     [{"certname": "a.example.com", "name": "operatingsystem", "value": "Debian"},
      {"certname": "a.example.com", "name": "ipaddress", "value": "192.168.1.105"},
      {"certname": "a.example.com", "name": "uptime_days", "value": "26 days"}]
+
+Subquery against `/fact-nodes` to get all remotely-authenticated trusted facts:
+
+    curl -X GET http://localhost:8080/v4/facts --data-urlencode 'query=["in", ["name","certname"],
+      ["extract",["name","certname"],
+        ["select-fact-nodes", ["~>", "path", [".*", "authenticated"]]]]]'
+
+    [ {
+        "value" : {
+            "certname" : "desktop.localdomain",
+            "authenticated" : "remote"
+        },
+        "name" : "trusted",
+        "environment" : "production",
+        "certname" : "desktop.localdomain"
+    } ]
 
 ## `GET /v4/facts/<FACT NAME>`
 

--- a/test/com/puppetlabs/puppetdb/test/http/events.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/events.clj
@@ -324,6 +324,33 @@
         :timestamp "2011-01-01T15:00:02.000Z"
         :configuration-version "a81jasj123"
         :certname "basic.catalogs.com"
+        :message nil}}
+
+     ;; test vector-valued field
+     ["and"
+      ["=" "containing-class" "Foo"]
+      ["in" ["certname", "environment"]
+       ["extract" ["certname", "environment"]
+        ["select-resources" ["=" "title" "foobar"]]]]]
+
+     #{{:containment-path ["Foo" "" "Bar[Baz]"]
+        :new-value nil
+        :containing-class "Foo"
+        :report-receive-time "2014-04-16T12:44:40.978Z"
+        :report "e52935c051785ec6f3eeb67877aed320c90c2a88"
+        :resource-title "hi"
+        :property nil
+        :file "bar"
+        :old-value nil
+        :run-start-time "2011-01-01T15:00:00.000Z"
+        :line 2
+        :status "skipped"
+        :run-end-time "2011-01-01T15:10:00.000Z"
+        :resource-type "Notify"
+        :environment "DEV"
+        :timestamp "2011-01-01T15:00:02.000Z"
+        :configuration-version "a81jasj123"
+        :certname "basic.catalogs.com"
         :message nil}})))
 
 (deftestseq valid-subqueries


### PR DESCRIPTION
This patch modifies the v4 IN and EXTRACT operators to accept multiple fields at once.
This allows the following...

```
["and" ["in", "name",
         ["extract", "name", [select-fact-nodes ["=","value",10]]]]
       ["in", "certname",
         ["extract", "certname", [select-fact-nodes ["=", "value", 10]]]]]
```

to be re-written as

```
["in", ["name","certname"],
  ["extract", ["name", "certname"], ["select-fact-nodes", ["=", "value", 10]]]]
```

As written, this will affect in and extract for all v4 endpoints, while throwing an
exception on v2/v3 to explain that vector fields are not allowed.
