### PR TITLE
(maint) Remove more dead code from facts.clj

### DIFF
--- a/src/com/puppetlabs/puppetdb/facts.clj
+++ b/src/com/puppetlabs/puppetdb/facts.clj
@@ -39,26 +39,6 @@
 
 ;; FUNCS
 
-(pls/defn-validated flatten-fact-value :- s/Str
-  "Flatten a fact value to a string either using JSON or coercement depending on
-  the type."
-  [value :- s/Any]
-  (cond
-   (string? value) value
-   (kitchensink/boolean? value) (str value)
-   (integer? value) (str value)
-   (float? value) (str value)
-   (map? value) (json/generate-string value)
-   (coll? value) (json/generate-string value)
-   :else (throw (IllegalArgumentException. (str "Value " value " is not valid for flattening")))))
-
-(pls/defn-validated flatten-fact-set :- {s/Str s/Str}
-  "Flatten a map of facts depending on the type of the value."
-  [factset :- fact-set]
-  (reduce-kv (fn [acc k v]
-               (assoc acc k (flatten-fact-value v)))
-             {} factset))
-
 (pls/defn-validated escape-delimiter :- s/Str
   "Escape the delimiter from a string"
   [element :- s/Str]

--- a/test/com/puppetlabs/puppetdb/test/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/facts.clj
@@ -2,21 +2,6 @@
   (:require [com.puppetlabs.puppetdb.facts :refer :all]
             [clojure.test :refer :all]))
 
-(deftest test-flatten-fact-value
-  (testing "check basic types work"
-    (is (= (flatten-fact-value "foo") "foo"))
-    (is (= (flatten-fact-value 3) "3"))
-    (is (= (flatten-fact-value true) "true"))
-    (is (= (flatten-fact-value {:a :b}) "{\"a\":\"b\"}"))
-    (is (= (flatten-fact-value [:a :b]) "[\"a\",\"b\"]"))))
-
-(deftest test-flatten-fact-set
-  (testing "ensure we get back a flattened set of values"
-    (is (= (flatten-fact-set {"networking"
-                              {"eth0"
-                               {"ipaddresses" ["192.168.1.1"]}}})
-           {"networking" "{\"eth0\":{\"ipaddresses\":[\"192.168.1.1\"]}}"}))))
-
 (deftest test-factmap-to-paths
   (testing "should convert a conventional factmap to a set of paths"
     (is (= (sort-by :value_hash


### PR DESCRIPTION
This removes some older facts flattening code that is no longer used.

Signed-off-by: Ken Barber ken@bob.sh
