### PR TITLE
(PDB-830) Regexp array operator is too greedy

### DIFF
--- a/src/com/puppetlabs/puppetdb/facts.clj
+++ b/src/com/puppetlabs/puppetdb/facts.clj
@@ -204,10 +204,14 @@
     value))
 
 (pls/defn-validated factpath-regexp-elements-to-regexp :- fact-path
-  "Converts a field found in a factpath regexp to its equivalent regexp"
+  "Converts a field found in a factpath regexp to its equivalent regexp."
   [rearray :- fact-path]
   (map (fn [element]
-         (format "(?:(?!%s)%s)" factpath-delimiter element))
+         (-> element
+             ;; This ensures that any of the more wildcard searches do not cross
+             ;; delimiter boundaries, by wrapping them with a negative lookup
+             ;; ahead for the delimiter.
+             (str/replace #"\.(\*|\+|\{.+\})" (format "(?:(?!%s).)$1" factpath-delimiter))))
        rearray))
 
 (pls/defn-validated factpath-regexp-to-regexp :- s/Str

--- a/test/com/puppetlabs/puppetdb/test/http/facts.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/facts.clj
@@ -1336,6 +1336,21 @@
                []))
         (is (= (into [] (response ["~>" "path" ["my_structured_fact" "^a"]]))
                []))
+        (is (= (into [] (response ["and" ["~>" "path" ["my_structured_fact" ".*"]] ["=" "certname" "foo1"]]))
+               [{"certname" "foo1", "path" ["my_structured_fact" "a"], "name" "my_structured_fact", "value" 1, "environment" "DEV"}
+                {"certname" "foo1", "path" ["my_structured_fact" "b"], "name" "my_structured_fact", "value" 3.14, "environment" "DEV"}
+                {"certname" "foo1", "path" ["my_structured_fact" "e"], "name" "my_structured_fact", "value" "1", "environment" "DEV"}
+                {"certname" "foo1", "path" ["my_structured_fact" "f"], "name" "my_structured_fact", "value" nil, "environment" "DEV"}]))
+        (is (= (into [] (response ["and" ["~>" "path" ["my_structured_fact" ".+"]] ["=" "certname" "foo1"]]))
+               [{"certname" "foo1", "path" ["my_structured_fact" "a"], "name" "my_structured_fact", "value" 1, "environment" "DEV"}
+                {"certname" "foo1", "path" ["my_structured_fact" "b"], "name" "my_structured_fact", "value" 3.14, "environment" "DEV"}
+                {"certname" "foo1", "path" ["my_structured_fact" "e"], "name" "my_structured_fact", "value" "1", "environment" "DEV"}
+                {"certname" "foo1", "path" ["my_structured_fact" "f"], "name" "my_structured_fact", "value" nil, "environment" "DEV"}]))
+        (is (= (into [] (response ["and" ["~>" "path" ["my_structured_fact" ".{1,20}"]] ["=" "certname" "foo1"]]))
+               [{"certname" "foo1", "path" ["my_structured_fact" "a"], "name" "my_structured_fact", "value" 1, "environment" "DEV"}
+                {"certname" "foo1", "path" ["my_structured_fact" "b"], "name" "my_structured_fact", "value" 3.14, "environment" "DEV"}
+                {"certname" "foo1", "path" ["my_structured_fact" "e"], "name" "my_structured_fact", "value" "1", "environment" "DEV"}
+                {"certname" "foo1", "path" ["my_structured_fact" "f"], "name" "my_structured_fact", "value" nil, "environment" "DEV"}]))
         (is (= (into [] (response ["=" "value" "a"]))
                [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}
                 {"certname" "foo2", "name" "my_structured_fact" "path" ["my_structured_fact" "c" 0], "value" "a", "environment" "DEV"}


### PR DESCRIPTION
This changes the regular expression, and moves the delimiter lookahead guard
so it is only introduced when a wildcard/style search is introduced.

Signed-off-by: Ken Barber ken@bob.sh
