### PR TITLE
(PDB-769) Deprecate PostgreSQL 9.2 and older

### DIFF
--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -1120,14 +1120,17 @@
   "Returns a string with an deprecation message if the DB is deprecated,
    nil otherwise."
   []
-  (when (sutils/pg-8-4?)
-    "PostgreSQL DB 8.4 is deprecated and won't be supported in the future."))
+  (when (and (sutils/postgres?)
+             (sutils/db-version-newer-than? [8 3])
+             (sutils/db-version-older-than? [9 3]))
+    "PostgreSQL DB versions 8.4 - 9.2 are deprecated and won't be supported in the future."))
 
 (defn db-unsupported?
   "Returns a string with an unsupported message if the DB is not supported,
    nil otherwise."
   []
-  (when (sutils/pg-older-than-8-4?)
+  (when (and (sutils/postgres?)
+             (sutils/db-version-older-than? [8 4]))
     "PostgreSQL DB versions 8.3 and older are no longer supported. Please upgrade Postgres and restart PuppetDB."))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/com/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -68,24 +68,6 @@
   [version :- db-version]
   (pos? (compare (sql-current-connection-database-version) version)))
 
-(pls/defn-validated pg-older-than-8-4? :- s/Bool
-  "Returns true if connected to a Postgres instance that is older than 8.4"
-  []
-  (and (postgres?)
-       (db-version-older-than? [8 4])))
-
-(pls/defn-validated pg-8-4? :- s/Bool
-  "Returns true if connected to a version 8.4 PostgreSQL instance"
-  []
-  (and (postgres?)
-       (db-version? [8 4])))
-
-(pls/defn-validated pg-newer-than-8-4? :- s/Bool
-  "Returns true if connected to a Postgres instance that is newer than 8.4"
-  []
-  (and (postgres?)
-       (db-version-newer-than? [8 4])))
-
 (defn sql-current-connection-table-names
   "Return all of the table names that are present in the database based on the
   current connection.  This is most useful for debugging / testing  purposes

--- a/test/com/puppetlabs/puppetdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/storage.clj
@@ -1196,10 +1196,10 @@
       (with-db-version db version
         (fn []
           (is (= result (db-deprecated?)))))
-      "PostgreSQL" [8 4] "PostgreSQL DB 8.4 is deprecated and won't be supported in the future."
-      "PostgreSQL" [9 0] nil
-      "PostgreSQL" [9 1] nil
-      "PostgreSQL" [9 2] nil
+      "PostgreSQL" [8 4] "PostgreSQL DB versions 8.4 - 9.2 are deprecated and won't be supported in the future."
+      "PostgreSQL" [9 0] "PostgreSQL DB versions 8.4 - 9.2 are deprecated and won't be supported in the future."
+      "PostgreSQL" [9 1] "PostgreSQL DB versions 8.4 - 9.2 are deprecated and won't be supported in the future."
+      "PostgreSQL" [9 2] "PostgreSQL DB versions 8.4 - 9.2 are deprecated and won't be supported in the future."
       "PostgreSQL" [9 3] nil
       "PostgreSQL" [9 4] nil)))
 


### PR DESCRIPTION
This patch deprecates PostgreSQL 9.2 and older.

Signed-off-by: Ken Barber ken@bob.sh
