### PR TITLE
(PDB-810) WIP  Load test structured facts indices.

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/com/puppetlabs/puppetdb/cli/benchmark.clj
@@ -42,6 +42,7 @@
             [com.puppetlabs.puppetdb.catalogs :as cat]
             [com.puppetlabs.puppetdb.catalog.utils :as catutils]
             [puppetlabs.trapperkeeper.logging :as logutils]
+            [clojure.java.jdbc :as sql]
             [com.puppetlabs.puppetdb.command :as command]
             [com.puppetlabs.http :as pl-http]
             [com.puppetlabs.cheshire :as json]
@@ -51,7 +52,9 @@
             [com.puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.kitchensink.core :as kitchensink]
             [clj-time.core :as time]
+            [com.puppetlabs.random :refer [random-string random-bool]]
             [com.puppetlabs.puppetdb.command.constants :refer [command-names]]
+            [com.puppetlabs.puppetdb.cli.import :refer [submit-facts]]
             [slingshot.slingshot :refer [try+]]))
 
 (def cli-description "Development-only benchmarking tool")
@@ -103,6 +106,55 @@
   "Grabs one of the mutate-fns randomly and returns it"
   []
   (rand-nth mutate-fns))
+
+(defn random-fact-value
+  "Given a type, generate a random fact value"
+  [kind]
+  (case kind
+    :int (rand-int 300)
+    :float (rand)
+    :bool (random-bool)
+    :string (random-string 4)
+    :vector (into [] (take (rand-int 10)
+                           (repeatedly #(random-fact-value
+                                          (rand-nth [:string :int :float :bool])))))))
+
+(defn random-structured-fact
+  "Create a 'random' structured fact.
+  Parameters are fact depth and number of child facts.  Depth 0 implies one child."
+  ([]
+   (random-structured-fact (rand-nth [0 1 2 3]) (rand-nth [1 2 3 4])))
+  ([depth children]
+   (let [kind (rand-nth [:int :float :bool :string :vector])]
+     (if (zero? depth)
+       {(random-string 10) (random-fact-value kind)}
+       {(random-string 10) (zipmap (take children (repeatedly #(random-string 10)))
+                                   (take children (repeatedly
+                                                    #(random-structured-fact
+                                                       (rand-nth (range depth))
+                                                       (rand-nth (range children))))))}))))
+
+(defn populate-database-with-facts
+  "This will populate a database with semi-random structured facts.
+  Aside from database host, port, and fact command version, arguments are
+
+  *nodes : number of nodes to be submitted
+  *dup-rate : target duplication rated defined as 1 - (#distinct fact values)/(#facts)
+  *facts-per-node : number of facts per node
+
+  This function is only suitable for *rough* load testing, as its output has
+  not been compared to real user data."
+  [host port facts-version nodes dup-rate facts-per-node]
+  (let [name-pool (take (Math/round (* dup-rate facts-per-node)) (repeatedly #(random-string 10)))
+        facts-pool (take (* dup-rate facts-per-node) (repeatedly #(random-structured-fact)))]
+    (doseq [[certname env] (take nodes (repeatedly #(vector (random-string 10) (random-string 10))))]
+      (let [fact-payload {:environment env
+                          :name certname
+                          :values (apply merge (take facts-per-node
+                                                     (repeatedly #(if (< (rand) dup-rate)
+                                                                    (rand-nth facts-pool)
+                                                                    (random-structured-fact)))))}]
+        (submit-facts host port facts-version (json/generate-string fact-payload))))))
 
 (defn maybe-tweak-catalog
   "Slightly tweak the given catalog, returning a new catalog, `rand-percentage`

--- a/src/com/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/com/puppetlabs/puppetdb/scf/migrate.clj
@@ -793,10 +793,7 @@
      ON UPDATE RESTRICT ON DELETE RESTRICT"
    "ALTER TABLE fact_values ADD CONSTRAINT fact_values_value_type_id_fk
      FOREIGN KEY (value_type_id) REFERENCES value_types (id) MATCH SIMPLE
-     ON UPDATE RESTRICT ON DELETE RESTRICT"
-   ;; For efficient operator querying with <, >, <= and >=
-   "CREATE INDEX fact_values_value_integer_idx ON fact_values(value_integer)"
-   "CREATE INDEX fact_values_value_float_idx ON fact_values(value_float)")
+     ON UPDATE RESTRICT ON DELETE RESTRICT")
 
   ;; --------
   ;; FACTSETS
@@ -940,7 +937,8 @@
   (when-not (scf-utils/index-exists? "fact_paths_path_trgm")
     (log/info "Creating additional index `fact_paths_path_trgm`")
     (sql/do-commands
-     "CREATE INDEX fact_paths_path_trgm ON fact_paths USING gist (path gist_trgm_ops)")))
+     "CREATE INDEX fact_paths_path_trgm ON fact_paths USING gist (path gist_trgm_ops)"
+     "CREATE INDEX fact_values_string_trgm ON fact_values USING gist (value_string gist_trgm_ops)")))
 
 (defn indexes!
   "Create missing indexes for applicable database platforms."

--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -738,7 +738,7 @@
   []
   (time! (:gc-fact-paths metrics)
          (sql/delete-rows :fact_values
-            ["ID NOT IN (SELECT fact_value_id FROM facts)"])
+            ["ID NOT IN (SELECT DISTINCT fact_value_id FROM facts)"])
          (sql/delete-rows :fact_paths
             ["ID NOT IN (SELECT path_id FROM fact_values)"])))
 


### PR DESCRIPTION
This patch addresses some performance issues for structured facts
- deletes the index of fact_values value_integer and value_float.  These
  indices were dead weight since a coalesce causes them to be disregarded.
  This is a stopgap solution to be augmented by PDB-811
- creates a trgm index on fact_values column value_string, so that our trgm
  indexes are now on fact_paths and value_string. This greatly speeds
  up queries on value_string and only moderately affects the table size. See
  https://gist.githubusercontent.com/wkalt/42792c53a5dc9f0840c4/raw/29f261316bc7e39d888250401f0b1f1c8c28a87b/gistfile1.txt
  for some comparisons on a 2000 node dataset with 100 facts per node.
- put a DISTINCT clause in our garbage collection on fact_paths.  This incurs a
  minor performance cost in small datasets, but yields a tremendous benefit in
  large and highly duplicated sets by reducing the load on the accompanying IN.
  (see https://gist.github.com/wkalt/09225b71588c35674827)
- still need to confirm that the depth index is used.
