### PR TITLE
Deprecate PG 9.1 instead, and remove nagging about 9.3 for PE users

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -289,7 +289,7 @@
     (sql/with-connection write-db
                          (scf-store/validate-database-version #(System/exit 1))
                          (migrate!)
-                         (indexes!))
+                         (indexes! (:product-name globals)))
 
     ;; Initialize database-dependent metrics
     (pop/initialize-metrics write-db)

--- a/src/com/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/com/puppetlabs/puppetdb/scf/migrate.clj
@@ -944,7 +944,7 @@
 
 (defn indexes!
   "Create missing indexes for applicable database platforms."
-  []
+  [product-name]
   (if (and (scf-utils/postgres?)
            (scf-utils/db-version-newer-than? [9 2]))
     (sql/transaction
@@ -958,9 +958,10 @@
          "    CREATE EXTENSION pg_trgm;\n\n"
          "as the database super user on the PuppetDB database to correct\n"
          "this, then restart PuppetDB.\n"))))
-    (log/warn
-     (str
-      "Unable to install optimal indexing\n\n"
-      "We are unable to create optimal indexes for your database.\n"
-      "For maximum index performance, we recommend using PostgreSQL 9.3 or\n"
-      "greater.\n"))))
+    (when (= product-name "puppetdb")
+      (log/warn
+       (str
+        "Unable to install optimal indexing\n\n"
+        "We are unable to create optimal indexes for your database.\n"
+        "For maximum index performance, we recommend using PostgreSQL 9.3 or\n"
+        "greater.\n")))))

--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -1122,8 +1122,8 @@
   []
   (when (and (sutils/postgres?)
              (sutils/db-version-newer-than? [8 3])
-             (sutils/db-version-older-than? [9 3]))
-    "PostgreSQL DB versions 8.4 - 9.2 are deprecated and won't be supported in the future."))
+             (sutils/db-version-older-than? [9 2]))
+    "PostgreSQL DB versions 8.4 - 9.1 are deprecated and won't be supported in the future."))
 
 (defn db-unsupported?
   "Returns a string with an unsupported message if the DB is not supported,

--- a/test/com/puppetlabs/puppetdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/storage.clj
@@ -1196,10 +1196,10 @@
       (with-db-version db version
         (fn []
           (is (= result (db-deprecated?)))))
-      "PostgreSQL" [8 4] "PostgreSQL DB versions 8.4 - 9.2 are deprecated and won't be supported in the future."
-      "PostgreSQL" [9 0] "PostgreSQL DB versions 8.4 - 9.2 are deprecated and won't be supported in the future."
-      "PostgreSQL" [9 1] "PostgreSQL DB versions 8.4 - 9.2 are deprecated and won't be supported in the future."
-      "PostgreSQL" [9 2] "PostgreSQL DB versions 8.4 - 9.2 are deprecated and won't be supported in the future."
+      "PostgreSQL" [8 4] "PostgreSQL DB versions 8.4 - 9.1 are deprecated and won't be supported in the future."
+      "PostgreSQL" [9 0] "PostgreSQL DB versions 8.4 - 9.1 are deprecated and won't be supported in the future."
+      "PostgreSQL" [9 1] "PostgreSQL DB versions 8.4 - 9.1 are deprecated and won't be supported in the future."
+      "PostgreSQL" [9 2] nil
       "PostgreSQL" [9 3] nil
       "PostgreSQL" [9 4] nil)))
 


### PR DESCRIPTION
This changes the deprecation to 9.1 and below. It also removes the nagging about
upgrading for PE users, who will still be on 9.2 it looks like.

Signed-off-by: Ken Barber ken@bob.sh
