### PR TITLE
(PDB-810) Load test structured facts indices.

### DIFF
--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -23,17 +23,22 @@ Each of these operators accepts two arguments: a **field,** and a
 
 The available fields for each endpoint are listed in that endpoint's documentation.
 
+**Note**
+In past API versions PuppetDB has supported comparisons between strings in the
+database and numerical values.  For example, equality and inequality queries for 0
+would match database values of "0". This behavior is not supported on the v4 API,
+since typed and structured facts allow us to distinguish the two in the database.
+Instead, binary operators must be predicated on the same type as the desired
+database value.
+
 ### `=` (equality)
 
 **Works with:** strings, numbers, timestamps, booleans, arrays, multi, path
 
 **Matches if:** the field's actual value is exactly the same as the provided value.
 
-Note that this operator **will** coerce values if the provided value is numeric and the target field is coercible (i.e. fact values), but will not coerce if the provided value is a string.
-
 * Most fields are strings.
 * Some fields are booleans.
-* Numbers in resource parameters from Puppet are usually stored as strings, but can be coerced to numbers by PuppetDB... as long as you compare them to numbers. (For example: if the value of `someparam` were `"0"`, then `["=", "someparam", "0.0"]` wouldn't match, but `["=", "someparam", 0.0]` would.)
 * Arrays match if any **one** of their elements match.
 * Path matches are a special kind of array, and must be exactly matched with this operator.
 
@@ -41,25 +46,25 @@ Note that this operator **will** coerce values if the provided value is numeric 
 
 **Works with:** numbers, timestamps, multi
 
-**Matches if:** the field is greater than the provided value. If the column is coercible (such as fact values), it will coerce both the field and value to floats or integers.
+**Matches if:** the field is greater than the provided value.
 
 ### `<` (less than)
 
 **Works with:** numbers, timestamps, multi
 
-**Matches if:** the field is greater than the provided value. If the column is coercible (such as fact values), it will coerce both the field and value to floats or integers.
+**Matches if:** the field is greater than the provided value.
 
 ### `>=` (less than or equal to)
 
 **Works with:** numbers, timestamps, multi
 
-**Matches if:** the field is greater than the provided value. If the column is coercible (such as fact values), it will coerce both the field and value to floats or integers.
+**Matches if:** the field is greater than the provided value.
 
 ### `<=` (greater than or equal to)
 
 **Works with:** numbers, timestamps, multi
 
-**Matches if:** the field is greater than the provided value. If the column is coercible (such as fact values), it will coerce both the field and value to floats or integers.
+**Matches if:** the field is greater than the provided value.
 
 ### `~` (regexp match)
 

--- a/src/com/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/com/puppetlabs/puppetdb/cli/benchmark.clj
@@ -42,6 +42,7 @@
             [com.puppetlabs.puppetdb.catalogs :as cat]
             [com.puppetlabs.puppetdb.catalog.utils :as catutils]
             [puppetlabs.trapperkeeper.logging :as logutils]
+            [clojure.java.jdbc :as sql]
             [com.puppetlabs.puppetdb.command :as command]
             [com.puppetlabs.http :as pl-http]
             [com.puppetlabs.cheshire :as json]
@@ -51,7 +52,9 @@
             [com.puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.kitchensink.core :as kitchensink]
             [clj-time.core :as time]
+            [com.puppetlabs.random :refer [random-string random-bool]]
             [com.puppetlabs.puppetdb.command.constants :refer [command-names]]
+            [com.puppetlabs.puppetdb.cli.import :refer [submit-facts]]
             [slingshot.slingshot :refer [try+]]))
 
 (def cli-description "Development-only benchmarking tool")
@@ -103,6 +106,55 @@
   "Grabs one of the mutate-fns randomly and returns it"
   []
   (rand-nth mutate-fns))
+
+(defn random-fact-value
+  "Given a type, generate a random fact value"
+  [kind]
+  (case kind
+    :int (rand-int 300)
+    :float (rand)
+    :bool (random-bool)
+    :string (random-string 4)
+    :vector (into [] (take (rand-int 10)
+                           (repeatedly #(random-fact-value
+                                          (rand-nth [:string :int :float :bool])))))))
+
+(defn random-structured-fact
+  "Create a 'random' structured fact.
+  Parameters are fact depth and number of child facts.  Depth 0 implies one child."
+  ([]
+   (random-structured-fact (rand-nth [0 1 2 3]) (rand-nth [1 2 3 4])))
+  ([depth children]
+   (let [kind (rand-nth [:int :float :bool :string :vector])]
+     (if (zero? depth)
+       {(random-string 10) (random-fact-value kind)}
+       {(random-string 10) (zipmap (take children (repeatedly #(random-string 10)))
+                                   (take children (repeatedly
+                                                    #(random-structured-fact
+                                                       (rand-nth (range depth))
+                                                       (rand-nth (range children))))))}))))
+
+(defn populate-database-with-facts
+  "This will populate a database with semi-random structured facts.
+  Aside from database host, port, and fact command version, arguments are
+
+  *nodes : number of nodes to be submitted
+  *dup-rate : target duplication rated defined as 1 - (#distinct fact values)/(#facts)
+  *facts-per-node : number of facts per node
+
+  This function is only suitable for *rough* load testing, as its output has
+  not been compared to real user data."
+  [host port facts-version nodes dup-rate facts-per-node]
+  (let [name-pool (take (Math/round (* dup-rate facts-per-node)) (repeatedly #(random-string 10)))
+        facts-pool (take (* dup-rate facts-per-node) (repeatedly #(random-structured-fact)))]
+    (doseq [[certname env] (take nodes (repeatedly #(vector (random-string 10) (random-string 10))))]
+      (let [fact-payload {:environment env
+                          :name certname
+                          :values (apply merge (take facts-per-node
+                                                     (repeatedly #(if (< (rand) dup-rate)
+                                                                    (rand-nth facts-pool)
+                                                                    (random-structured-fact)))))}]
+        (submit-facts host port facts-version (json/generate-string fact-payload))))))
 
 (defn maybe-tweak-catalog
   "Slightly tweak the given catalog, returning a new catalog, `rand-percentage`

--- a/src/com/puppetlabs/puppetdb/facts.clj
+++ b/src/com/puppetlabs/puppetdb/facts.clj
@@ -235,8 +235,8 @@
   [dissociated-fields row]
   (let [conversion (case (:type row)
                      "boolean" clj-edn/read-string
-                     "float" (comp double clj-edn/read-string)
-                     "integer" (comp biginteger clj-edn/read-string)
+                     "float" (constantly (:value_float row))
+                     "integer" (constantly (:value_integer row))
                      "json" json/parse-string
                      ("string" "null") identity)]
     (reduce #(dissoc %1 %2)

--- a/src/com/puppetlabs/puppetdb/query.clj
+++ b/src/com/puppetlabs/puppetdb/query.clj
@@ -193,13 +193,15 @@
 
 ;; This map's keys are the queryable fields for facts, and the values are the
 ;;  corresponding table names where the fields reside
-(def fact-columns {"certname" "facts"
-                   "name"     "facts"
-                   "value"    "facts"
-                   "depth"    "facts"
-                   "type"     "facts"
-                   "path"     "facts"
-                   "environment" "facts"})
+(def fact-columns {"certname"         "facts"
+                   "name"             "facts"
+                   "value"            "facts"
+                   "depth"            "facts"
+                   "value_integer"    "facts"
+                   "value_float"      "facts"
+                   "type"             "facts"
+                   "path"             "facts"
+                   "environment"      "facts"})
 
 ;; This map's keys are the queryable fields for factsets, and the values are the
 ;;  corresponding table names where the fields reside
@@ -401,11 +403,13 @@
                              fp.path as path,
                              fp.name as name,
                              fp.depth as depth,
+                             fv.value_integer as value_integer,
+                             fv.value_float as value_float,
                              COALESCE(fv.value_string,
                                       fv.value_json,
                                       cast(fv.value_integer as text),
-                                      cast(fv.value_boolean as text),
-                                      cast(fv.value_float as text)) as value,
+                                      cast(fv.value_float as text),
+                                      cast(fv.value_boolean as text)) as value,
                              vt.type as type,
                              env.name as environment
                       FROM factsets fs

--- a/src/com/puppetlabs/puppetdb/query/fact_contents.clj
+++ b/src/com/puppetlabs/puppetdb/query/fact_contents.clj
@@ -10,6 +10,8 @@
    :path s/Str
    :name s/Str
    :value (s/maybe s/Str)
+   :value_integer (s/maybe s/Int)
+   :value_float (s/maybe s/Num)
    :type s/Str})
 
 (def converted-row-schema
@@ -24,9 +26,10 @@
    an array structure."
   [row :- row-schema]
   (-> row
-      (update-in [:value] #(f/unstringify-value (:type row) %))
+      (update-in [:value] #(or (:value_integer row) (:value_float row)
+                               (f/unstringify-value (:type row) %)))
       (update-in [:path] f/string-to-factpath)
-      (dissoc :type)))
+      (dissoc :type :value_integer :value_float)))
 
 (defn munge-result-rows
   "Munge resulting rows for fact-contents endpoint."

--- a/src/com/puppetlabs/puppetdb/query/factsets.clj
+++ b/src/com/puppetlabs/puppetdb/query/factsets.clj
@@ -14,6 +14,8 @@
    :environment (s/maybe s/Str)
    :path String
    :value s/Any
+   :value_float (s/maybe s/Num)
+   :value_integer (s/maybe s/Int)
    :type (s/maybe String)
    :timestamp pls/Timestamp})
 
@@ -42,7 +44,7 @@
 
 (pls/defn-validated convert-types :- [converted-row-schema]
   [rows :- [row-schema]]
-  (map (partial facts/convert-row-type [:type]) rows))
+  (map (partial facts/convert-row-type [:type :value_integer :value_float]) rows))
 
 (defn int-map->vector
   "Convert a map of form {1 'a' 0 'b' ...} to vector ['b' 'a' ...]"

--- a/src/com/puppetlabs/puppetdb/query/nodes.clj
+++ b/src/com/puppetlabs/puppetdb/query/nodes.clj
@@ -62,7 +62,6 @@
          (if (:count? paging-options)
            (assoc result :count-query (apply vector (jdbc/count-sql subselect) params))
            result))
-
        (qe/compile-user-query->sql
         qe/nodes-query query paging-options))))
 

--- a/src/com/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/com/puppetlabs/puppetdb/scf/migrate.clj
@@ -763,7 +763,6 @@
    "ALTER TABLE fact_paths ADD CONSTRAINT fact_paths_path_type_id_key
       UNIQUE (path, value_type_id)"
    "CREATE INDEX fact_paths_value_type_id ON fact_paths(value_type_id)"
-   "CREATE INDEX fact_paths_depth ON fact_paths(depth)"
    "CREATE INDEX fact_paths_name ON fact_paths(name)"
    "ALTER TABLE fact_paths ADD CONSTRAINT fact_paths_value_type_id
      FOREIGN KEY (value_type_id)
@@ -940,7 +939,8 @@
   (when-not (scf-utils/index-exists? "fact_paths_path_trgm")
     (log/info "Creating additional index `fact_paths_path_trgm`")
     (sql/do-commands
-     "CREATE INDEX fact_paths_path_trgm ON fact_paths USING gist (path gist_trgm_ops)")))
+     "CREATE INDEX fact_paths_path_trgm ON fact_paths USING gist (path gist_trgm_ops)"
+     "CREATE INDEX fact_values_string_trgm ON fact_values USING gist (value_string gist_trgm_ops)")))
 
 (defn indexes!
   "Create missing indexes for applicable database platforms."

--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -738,7 +738,7 @@
   []
   (time! (:gc-fact-paths metrics)
          (sql/delete-rows :fact_values
-            ["ID NOT IN (SELECT fact_value_id FROM facts)"])
+            ["ID NOT IN (SELECT DISTINCT fact_value_id FROM facts)"])
          (sql/delete-rows :fact_paths
             ["ID NOT IN (SELECT path_id FROM fact_values)"])))
 

--- a/src/com/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -166,14 +166,14 @@ must be supplied as the value to be matched."
 
 (defmethod sql-as-numeric "PostgreSQL"
   [column]
-  (format (str "CASE WHEN %s~E'^\\\\d+$' THEN %s::integer "
+  (format (str "CASE WHEN %s~E'^\\\\d+$' THEN %s::bigint "
                "WHEN %s~E'^\\\\d+\\\\.\\\\d+$' THEN %s::float "
                "ELSE NULL END")
           column column column column))
 
 (defmethod sql-as-numeric "HSQL Database Engine"
   [column]
-  (format (str "CASE WHEN REGEXP_MATCHES(%s, '^\\d+$') THEN CAST(%s AS INTEGER) "
+  (format (str "CASE WHEN REGEXP_MATCHES(%s, '^\\d+$') THEN CAST(%s AS BIGINT) "
                "WHEN REGEXP_MATCHES(%s, '^\\d+\\.\\d+$') THEN CAST(%s AS FLOAT) "
                "ELSE NULL END")
           column column column column))

--- a/test/com/puppetlabs/puppetdb/test/http/nodes.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/nodes.clj
@@ -119,7 +119,9 @@
     (testing "basic equality works for facts, and is based on string equality"
       (is-query-result endpoint ["=" ["fact" "operatingsystem"] "Debian"] [db web1 web2])
       (is-query-result endpoint ["=" ["fact" "uptime_seconds"] 10000] [web1])
-      (is-query-result endpoint ["=" ["fact" "uptime_seconds"] "10000"] [web1])
+      (is-query-result endpoint ["=" ["fact" "uptime_seconds"] "10000"] (case version
+                                                                          (:v2 :v3) [web1]
+                                                                          []))
       (is-query-result endpoint ["=" ["fact" "uptime_seconds"] 10000.0] (case version
                                                                           (:v2 :v3) []
                                                                           [web1]))

--- a/test/com/puppetlabs/puppetdb/test/query/factsets.clj
+++ b/test/com/puppetlabs/puppetdb/test/query/factsets.clj
@@ -8,13 +8,17 @@
 
 (deftest test-structured-data-seq
   (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c"
-                    :value "abc" :type "string" :timestamp current-time}
+                    :value "abc" :type "string" :timestamp current-time :value_integer nil
+                    :value_float nil}
                    {:certname "foo.com" :environment "DEV" :path "a#~b#~d"
-                    :value "1" :type "integer" :timestamp current-time}
+                    :value nil :type "integer" :timestamp current-time
+                    :value_integer 1 :value_float nil}
                    {:certname "foo.com" :environment "DEV" :path "a#~b#~e"
-                    :value "true" :type "boolean" :timestamp current-time}
+                    :value "true" :type "boolean" :timestamp current-time
+                    :value_integer nil :value_float nil}
                    {:certname "foo.com" :environment "DEV" :path "a#~b#~f"
-                    :value "3.14" :type "float" :timestamp current-time}]]
+                    :value_float 3.14 :type "float" :timestamp current-time
+                    :value_integer nil :value nil}]]
     (is (= [{:certname "foo.com"
              :environment "DEV"
              :facts {"a" {"b" {"c" "abc"
@@ -32,26 +36,35 @@
                     (structured-data-seq :v4
                      (mapcat (fn [certname]
                                [{:certname certname :environment "DEV" :path "a#~b#~c"
-                                 :value "abc" :type "string" :timestamp current-time}
+                                 :value "abc" :type "string" :timestamp current-time
+                                 :value_integer nil :value_float nil}
                                 {:certname certname :environment "DEV" :path "a#~b#~d"
-                                 :value "1" :type "integer" :timestamp current-time}
+                                 :value_integer 1 :type "integer" :timestamp current-time
+                                 :value nil :value_float nil}
                                 {:certname certname :environment "DEV" :path "a#~b#~e"
-                                 :value "3.14" :type "float" :timestamp current-time}
+                                 :value_float 3.14 :type "float" :timestamp current-time
+                                 :value_integer nil :value nil}
                                 {:certname certname :environment "DEV" :path "a#~b#~f"
-                                 :value "true" :type "boolean" :timestamp current-time}])
+                                 :value "true" :type "boolean" :timestamp current-time
+                                 :value_integer nil :value_float nil}])
                              (map #(str "foo" % ".com") (range 0 ten-billion))))))))))
 
   (testing "map with a nested vector"
     (let [test-rows [{:certname "foo.com" :environment "DEV"
-                      :path "a#~b#~c" :value "abc" :type "string" :timestamp current-time}
+                      :path "a#~b#~c" :value "abc" :type "string" :timestamp current-time
+                      :value_integer nil :value_float nil}
                      {:certname "foo.com" :environment "DEV"
-                      :path "a#~b#~d#~0" :value "1" :type "integer" :timestamp current-time}
+                      :path "a#~b#~d#~0" :value_integer 1 :type "integer" :timestamp current-time
+                      :value nil :value_float nil}
                      {:certname "foo.com" :environment "DEV"
-                      :path "a#~b#~d#~1" :value "3" :type "integer" :timestamp current-time}
+                      :path "a#~b#~d#~1" :value_integer 3 :type "integer" :timestamp current-time
+                      :value nil :value_float nil}
                      {:certname "foo.com" :environment "DEV"
-                      :path "a#~b#~e" :value "true" :type "boolean" :timestamp current-time}
+                      :path "a#~b#~e" :value "true" :type "boolean" :timestamp current-time
+                      :value_integer nil :value_float nil}
                      {:certname "foo.com" :environment "DEV"
-                      :path "a#~b#~f" :value "abf" :type "string" :timestamp current-time}]]
+                      :path "a#~b#~f" :value "abf" :type "string" :timestamp current-time
+                      :value_integer nil :value_float nil}]]
 
       (is (= [{:certname "foo.com"
                :environment "DEV"
@@ -64,15 +77,20 @@
 
   (testing "map with a nested vector of maps"
     (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c"
-                      :value "abc" :type "string" :timestamp current-time}
+                      :value "abc" :type "string" :timestamp current-time
+                      :value_integer nil :value_float nil}
                      {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~0#~e#~f#~0"
-                      :value "1" :type "integer" :timestamp current-time}
+                      :value_integer 1 :type "integer" :timestamp current-time
+                      :value nil :value_float nil}
                      {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~1#~e#~f#~0"
-                      :value "2" :type "integer" :timestamp current-time}
+                      :value_integer 2 :type "integer" :timestamp current-time
+                      :value nil :value_float nil}
                      {:certname "foo.com" :environment "DEV" :path "a#~b#~e"
-                      :value "abe" :type "string" :timestamp current-time}
+                      :value "abe" :type "string" :timestamp current-time
+                      :value_integer nil :value_float nil}
                      {:certname "foo.com" :environment "DEV" :path "a#~b#~f"
-                      :value "abf" :type "string" :timestamp current-time}]]
+                      :value "abf" :type "string" :timestamp current-time
+                      :value_integer nil :value_float nil}]]
       (is (= [{:certname "foo.com"
                :environment "DEV"
                :facts {"a" {"b" {"c" "abc"
@@ -85,15 +103,20 @@
 
   (testing "json numeric formats"
     (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c"
-                      :value "10E10" :type "integer" :timestamp current-time}
+                      :value_integer 100000000000 :type "integer" :timestamp current-time
+                      :value nil :value_float nil}
                      {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~\"0\"#~e#~f#~0"
-                      :value "3.14E10" :type "float" :timestamp current-time}
+                      :value_float 3.14E10 :type "float" :timestamp current-time
+                      :value_integer nil :value nil}
                      {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~\"1\"#~e#~f#~0"
-                      :value "1.4e-5" :type "float" :timestamp current-time}
+                      :value_float 1.4e-5 :type "float" :timestamp current-time
+                      :value_integer nil :value nil}
                      {:certname "foo.com" :environment "DEV" :path "a#~b#~e"
-                      :value "-10E-5" :type "float" :timestamp current-time}
+                      :value_float -10E-5 :type "float" :timestamp current-time
+                      :value_integer nil :value nil}
                      {:certname "foo.com" :environment "DEV" :path "a#~b#~f"
-                      :value "-0.25e-5" :type "float" :timestamp current-time}]]
+                      :value_float -0.25e-5 :type "float" :timestamp current-time
+                      :value_integer nil :value nil}]]
       (is (= [{:certname "foo.com"
                :environment "DEV"
                :facts {"a" {"b" {"c" 100000000000
@@ -106,18 +129,23 @@
 
   (testing "map stringified integer keys"
     (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c"
-                      :value "abc" :type "string" :timestamp current-time}
+                      :value "abc" :type "string" :timestamp current-time
+                      :value_integer nil :value_float nil}
                      {:certname "foo.com" :environment "DEV" :path "a#~b#~d#~\"0\"#~e#~f#~0"
-                      :value "1" :type "integer" :timestamp current-time}
+                      :value_integer 1 :type "integer" :timestamp current-time
+                      :value nil :value_float nil}
                      {:certname "foo.com" :environment "DEV"
-                      :path "a#~b#~d#~\"1\"#~e#~f#~0" :value "2" :type "integer"
-                      :timestamp current-time}
+                      :path "a#~b#~d#~\"1\"#~e#~f#~0" :value_integer 2 :type "integer"
+                      :timestamp current-time :value nil :value_float nil}
                      {:certname "foo.com" :environment "DEV" :path "a#~b#~e"
-                      :value "abe" :type "string" :timestamp current-time}
+                      :value "abe" :type "string" :timestamp current-time
+                      :value_integer nil :value_float nil}
                      {:certname "foo.com" :environment "DEV" :path "a#~b#~j"
-                      :value nil :type "null" :timestamp current-time}
+                      :value nil :type "null" :timestamp current-time
+                      :value_integer nil :value_float nil}
                      {:certname "foo.com" :environment "DEV" :path "a#~b#~f"
-                      :value "abf" :type "string" :timestamp current-time}]]
+                      :value "abf" :type "string" :timestamp current-time
+                      :value_integer nil :value_float nil}]]
 
       (is (= [{:certname "foo.com"
                :environment "DEV"


### PR DESCRIPTION
This patch addresses some performance issues for structured facts
- changes a coalesce that was causing the value_integer and value_float indices
  to be disregarded.  They are verified to work.
- deletes the index on fact path depth, since it was not getting used.
- creates a trgm index on fact_values column value_string, so that our trgm
  indexes are now on fact_paths and value_string. This greatly speeds
  up queries on value_string and only moderately affects the table size. See
  https://gist.githubusercontent.com/wkalt/42792c53a5dc9f0840c4/raw/29f261316bc7e39d888250401f0b1f1c8c28a87b/gistfile1.txt
  for some comparisons on a 2000 node dataset with 100 facts per node.
- put a DISTINCT clause in our garbage collection on fact_paths.  This incurs a
  minor performance cost in small datasets, but yields a tremendous benefit in
  large and highly duplicated sets by reducing the load on the accompanying IN.
- changes stringified numerical comparisons on the lower endpoints to use
  bigints instead of ints. 
- Changes the /v4 endpoint to make the equality
  operator type sensitive, i.e a value query for "24" will not match 24 like it
  does on the lower endpoints. Inequality operators will also fail on strings.
  On the old endpoints the old behavior is preserved.
- adds some rough load testing fuctions to benchmark.clj
- all structured facts indices have been verified to work.
