### PR TITLE
Correct v4 checking to include future versions of the API

### DIFF
--- a/src/com/puppetlabs/puppetdb/http.clj
+++ b/src/com/puppetlabs/puppetdb/http.clj
@@ -38,13 +38,16 @@
     (add-headers (dissoc query-result :result))))
 
 (defn remove-status
-  "Status is only for the v4 version of the reports response"
+  "Status is only for the v4 or newer version of the reports response"
   [result-map version]
-  (if-not (= :v4 version)
-    (dissoc result-map :status)
+  (case version
+    (:v2 :v3) (dissoc result-map :status)
     result-map))
 
-(defn v4?
-  "Returns a function that always returns true if `version` is :v4"
+(defn v4-or-newer?
+  "Returns a function that always returns true if `version` is newer than :v4"
   [version]
-  (constantly (= :v4 version)))
+  (constantly
+   (case version
+     (:v2 :v3) false
+     true)))

--- a/src/com/puppetlabs/puppetdb/query.clj
+++ b/src/com/puppetlabs/puppetdb/query.clj
@@ -63,7 +63,7 @@
 (ns com.puppetlabs.puppetdb.query
   (:require [clojure.string :as string]
             [clojure.set :as set]
-            [com.puppetlabs.puppetdb.http :refer [v4?]]
+            [com.puppetlabs.puppetdb.http :refer [v4-or-newer?]]
             [puppetlabs.kitchensink.core :as kitchensink]
             [com.puppetlabs.jdbc :as jdbc]
             [clj-time.coerce :refer [to-timestamp]]
@@ -532,7 +532,7 @@
            {:where  "catalogs.certname = ?"
             :params [value]}
 
-           ["environment" :guard (v4? version)]
+           ["environment" :guard (v4-or-newer? version)]
            {:where  "catalog_resources.environment = ?"
             :params [value]}
 
@@ -578,7 +578,7 @@
            {:where  (sql-regexp-match "catalogs.certname")
             :params [value]}
 
-           ["environment" :guard (v4? version)]
+           ["environment" :guard (v4-or-newer? version)]
            {:where  (sql-regexp-match "catalog_resources.environment")
             :params [value]}
 
@@ -611,7 +611,7 @@
            {:where "facts.certname = ?"
             :params [value]}
 
-           ["environment" :guard (v4? version)]
+           ["environment" :guard (v4-or-newer? version)]
            {:where "facts.environment = ?"
             :params [value]}
 
@@ -639,7 +639,7 @@
              ["certname"]
              (query "facts.certname")
 
-             ["environment" :guard (v4? version)]
+             ["environment" :guard (v4-or-newer? version)]
              (query "facts.environment")
 
              ["name"]
@@ -851,7 +851,7 @@ args))))))
              {:where (format "resource_events.report %s (SELECT latest_reports.report FROM latest_reports)"
                              (if value "IN" "NOT IN"))}
 
-             ["environment" :guard (v4? version)]
+             ["environment" :guard (v4-or-newer? version)]
              {:where "environments.name = ?"
               :params [value]}
 
@@ -893,7 +893,7 @@ args))))))
              {:where (sql-regexp-match "reports.certname")
               :params [pattern]}
 
-             ["environment" :guard (v4? version)]
+             ["environment" :guard (v4-or-newer? version)]
              {:where (sql-regexp-match "environments.name")
               :params [pattern]}
 
@@ -933,11 +933,11 @@ args))))))
            {:where "reports.hash = ?"
             :params [value]}
 
-           ["environment" :guard (v4? version)]
+           ["environment" :guard (v4-or-newer? version)]
            {:where "environments.name = ?"
             :params [value]}
 
-           ["status" :guard (v4? version)]
+           ["status" :guard (v4-or-newer? version)]
            {:where "report_statuses.status = ?"
             :params [value]}
 

--- a/src/com/puppetlabs/puppetdb/query/reports.clj
+++ b/src/com/puppetlabs/puppetdb/query/reports.clj
@@ -1,7 +1,7 @@
 (ns com.puppetlabs.puppetdb.query.reports
   (:require [puppetlabs.kitchensink.core :as kitchensink]
             [clojure.string :as string]
-            [com.puppetlabs.puppetdb.http :refer [remove-status v4?]]
+            [com.puppetlabs.puppetdb.http :refer [remove-status]]
             [clojure.core.match :refer [match]]
             [com.puppetlabs.jdbc :as jdbc]
             [com.puppetlabs.puppetdb.query :as query]


### PR DESCRIPTION
The v4? check was only pinning on :v4 versions of the API. This patch now
allows for future versions to match also, and so I've renamed it to v4-and-newer?

Also, remove-status was pinned to :v4, and is now future compatible.

Signed-off-by: Ken Barber ken@bob.sh
