### PR TITLE
(PDB-707) Fix bonecp 57P01 handling

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -413,6 +413,17 @@ module PuppetDBExtensions
     apply_manifest_on(host, manifest)
   end
 
+  # Restart postgresql using Puppet, by notifying the postgresql::server::service
+  # class, which should cause the service to restart.
+  def restart_postgres(host)
+    manifest = add_el5_postgres(host, "class { 'puppetdb::database::postgresql': }\n")
+    manifest += <<-EOS
+      notify { 'restarting postgresql': }~>
+      Class['postgresql::server::service']
+    EOS
+    apply_manifest_on(host, manifest)
+  end
+
   def install_puppetdb_via_rake(host)
     os = PuppetDBExtensions.config[:os_families][host.name]
     case os

--- a/acceptance/tests/db_resilience/postgres_restart.rb
+++ b/acceptance/tests/db_resilience/postgres_restart.rb
@@ -1,0 +1,33 @@
+if (test_config[:database] == :postgres)
+  test_name "test postgresql database restart handling to ensure we recover from a restart" do
+    step "clear puppetdb database" do
+      clear_and_restart_puppetdb(database)
+    end
+
+    with_puppet_running_on master, {
+      'master' => {
+        'autosign' => 'true'
+      }} do
+      step "Run agents once to activate nodes" do
+        run_agent_on agents, "--test --server #{master}"
+      end
+    end
+
+    step "Verify that the number of active nodes is what we expect" do
+      result = on database, %Q|curl -G http://localhost:8080/v3/nodes|
+      result_node_statuses = JSON.parse(result.stdout)
+      assert_equal(agents.length, result_node_statuses.length, "Expected query to return '#{agents.length}' active nodes; returned '#{result_node_statuses.length}'")
+    end
+
+    restart_postgres(database)
+
+    # Avoid a restart race condition
+    sleep(1)
+
+    step "Verify that the number of active nodes is what we expect" do
+      result = on database, %Q|curl -G http://localhost:8080/v3/nodes|
+      result_node_statuses = JSON.parse(result.stdout)
+      assert_equal(agents.length, result_node_statuses.length, "Expected query to return '#{agents.length}' active nodes; returned '#{result_node_statuses.length}'")
+    end
+  end
+end

--- a/test/com/puppetlabs/puppetdb/fixtures.clj
+++ b/test/com/puppetlabs/puppetdb/fixtures.clj
@@ -1,4 +1,5 @@
 (ns com.puppetlabs.puppetdb.fixtures
+  (:import [java.io ByteArrayInputStream])
   (:require [clojure.java.jdbc :as sql]
             [clojure.java.jdbc.internal :as jint]
             [com.puppetlabs.puppetdb.http.server :as server]
@@ -7,11 +8,10 @@
             [com.puppetlabs.puppetdb.config :as cfg]
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
             [clojure.tools.macro :as tmacro]
-            [clojure.test :refer [join-fixtures use-fixtures]])
-  (:import [java.io ByteArrayInputStream])
-  (:use [com.puppetlabs.puppetdb.testutils :only [clear-db-for-testing! test-db with-test-broker]]
-        [puppetlabs.trapperkeeper.logging :only [reset-logging]]
-        [com.puppetlabs.puppetdb.scf.migrate :only [migrate!]]))
+            [clojure.test :refer [join-fixtures use-fixtures]]
+            [com.puppetlabs.puppetdb.testutils :refer [clear-db-for-testing! test-db with-test-broker]]
+            [puppetlabs.trapperkeeper.logging :refer [reset-logging]]
+            [com.puppetlabs.puppetdb.scf.migrate :refer [migrate!]]))
 
 (def ^:dynamic *db* nil)
 (def ^:dynamic *mq* nil)

--- a/test/com/puppetlabs/puppetdb/test/cli/import_export_roundtrip.clj
+++ b/test/com/puppetlabs/puppetdb/test/cli/import_export_roundtrip.clj
@@ -63,7 +63,8 @@
    results are returned from the body of the macro"
   [n & body]
   `(future
-     (block-until-results-fn ~n
+     (block-until-results-fn
+      ~n
       (fn []
         (try
           (do ~@body)
@@ -191,8 +192,8 @@
                     (assoc :name "foo.local"))]
     (jutils/puppetdb-instance
       (assoc-in (jutils/create-config) [:command-processing :max-frame-size] "1024")
-       (fn []
+      (fn []
         (is (empty? (export/get-nodes "localhost" jutils/*port*)))
         (submit-command :replace-catalog 5 catalog)
         (is (thrown-with-msg? java.util.concurrent.ExecutionException #"Results not found"
-              @(block-until-results 5 (json/parse-string (export/catalog-for-node "localhost" jutils/*port* "foo.local")))))))))
+                              @(block-until-results 5 (json/parse-string (export/catalog-for-node "localhost" jutils/*port* "foo.local")))))))))


### PR DESCRIPTION
This patch adds retry handling for 57P01 failures, which result in an
PSQLException with a status code of 08003. The patch has been made
forward compatible by catching all SQLExceptions with this status code.

Version 0.8.0-RELEASE of Bonecp does not throw the correct sql state code
today, however a patch has been raised to make this happen so we can
upgrade to this version in the future.

Signed-off-by: Ken Barber ken@bob.sh
