### PR TITLE
Add thread names to logging

### DIFF
--- a/ext/templates/logback.xml.erb
+++ b/ext/templates/logback.xml.erb
@@ -1,7 +1,7 @@
 <configuration scan="true">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+            <pattern>%d %-5p [%thread] [%c{2}] %m%n</pattern>
         </encoder>
     </appender>
 
@@ -9,7 +9,7 @@
         <file><%= @log_dir -%>/<%= @name -%>.log</file>
         <append>true</append>
         <encoder>
-            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+            <pattern>%d %-5p [%thread] [%c{2}] %m%n</pattern>
         </encoder>
     </appender>
 

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration scan="true">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+            <pattern>%d %-5p [%thread] [%c{2}] %m%n</pattern>
         </encoder>
     </appender>
 

--- a/test-resources/logback-test.xml
+++ b/test-resources/logback-test.xml
@@ -1,7 +1,7 @@
 <configuration scan="true">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+            <pattern>%d %-5p [%thread] [%c{2}] %m%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
This patch adds thread names to the various logback.xml configuration files
in this project. This provides us with better traceability when attempting
to understand where a log message came from.

Signed-off-by: Ken Barber ken@bob.sh
