### PR TITLE
(maint) fix commands API examples

### DIFF
--- a/documentation/api/commands.markdown
+++ b/documentation/api/commands.markdown
@@ -213,7 +213,7 @@ To post a `replace facts` command you can use the following curl command:
     curl -X POST \
       -H "Accept: application/json" \
       -H "Content-Type: application/json" \
-      -d '{"command":"replace facts","version":2,"payload":{"name":"test1","values":{"myfact":"myvalue"}}}' \
+      -d '{"command":"replace facts","version":3,"payload":{"name":"test1","environment":"DEV","values":{"myfact":"myvalue"}}}' \
       http://localhost:8080/v3/commands
 
 An example of `deactivate node`:
@@ -223,4 +223,3 @@ An example of `deactivate node`:
       -H "Content-Type: application/json" \
       -d '{"command":"deactivate node","version":2,"payload":"test1"}' \
       http://localhost:8080/v3/commands
-=======


### PR DESCRIPTION
This includes an environment key in the replace-facts example so it works when copy pasted.
