### PR TITLE
(PDB-653) metrics update on PDB start

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -290,8 +290,10 @@
                          (migrate!)
                          (indexes! (:product-name globals)))
 
-    ;; Initialize database-dependent metrics
+    ;; Initialize database-dependent metrics and dlo metrics if existent.
     (pop/initialize-metrics write-db)
+    (when (.exists discard-dir)
+      (dlo/create-metrics-for-dlo! discard-dir))
 
     (let [broker (try
                    (log/info "Starting broker")

--- a/src/puppetlabs/puppetdb/command/dlo.clj
+++ b/src/puppetlabs/puppetdb/command/dlo.clj
@@ -59,7 +59,7 @@
        (sort)
        (last)))
 
-(defn- create-metrics-for-dlo!
+(defn create-metrics-for-dlo!
   "Creates the standard set of global metrics."
   [dir]
   (when-not (:global @metrics)


### PR DESCRIPTION
Previously the DLO metrics only updated on a failed command submission, which
meant restarting PDB would blank the metrics until the next failure. This patch
initializes DLO metrics on PDB startup if the DLO directory, which is created
on first failure, already exists.
