### PR TITLE
Changed our acceptance test setup to pin on facter 2.1.0

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -909,7 +909,7 @@ EOS
 
       case os
       when :debian
-        on host, "apt-get install -y puppet puppetmaster-common"
+        on host, "apt-get install -y puppet puppetmaster-common facter=2.1.0-1puppetlabs1"
       when :redhat, :fedora
         on host, "yum install -y puppet"
       else


### PR DESCRIPTION
Facter 2.2.0 changed the value returned from the 'lsbmajdistrelease'
fact that causes the postgresql module to break on Ubuntu 10.04. Pinning
facter to 2.1.0 avoids the problem until the module can be released.
