### PR TITLE
Allow beaker rake task to accept proper preserve-hosts options

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -166,7 +166,7 @@ namespace :test do
     args.with_defaults(:test_files => 'acceptance/tests/')
     config = ENV["BEAKER_CONFIG"] || "vbox-el6-64mda"
     options = ENV["BEAKER_OPTIONS"] || "postgres"
-    preserve_hosts = ENV["BEAKER_PRESERVE_HOSTS"] == "true" ? true : false
+    preserve_hosts = ENV["BEAKER_PRESERVE_HOSTS"] || "never"
     color = ENV["BEAKER_COLOR"] == "false" ? false : true
     xml = ENV["BEAKER_XML"] == "true" ? true : false
     type = ENV["BEAKER_TYPE"] || "git"
@@ -177,9 +177,9 @@ namespace :test do
        "--debug " +
        "--tests " + args[:test_files] + " " +
        "--options-file 'acceptance/options/#{options}.rb' " +
-       "--root-keys"
+       "--root-keys " +
+       "--preserve-hosts #{preserve_hosts}"
 
-    beaker += " --preserve-hosts" if preserve_hosts
     beaker += " --no-color" unless color
     beaker += " --xml" if xml
 

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -155,7 +155,7 @@ These files are listed in the directory `acceptance/options`, so you should look
 
 ###`BEAKER_PRESERVE_HOSTS`
 
-When this setting is `true` it will stop the removal of the virtual machine once the task has been completed.
+When this setting is `always` it will stop the removal of the virtual machine once the task has been completed. `onfail` will leave them behind only if they have failed. The default is `never`.
 
 ####`BEAKER_COLOR`
 


### PR DESCRIPTION
In the past it just allowed true/false, but the current beaker accepts a series
of options, including 'onfail' which is what I was after. This change passes
throught the value specified in the env var only now.

Signed-off-by: Ken Barber ken@bob.sh
