### PR TITLE
(PDB-865) PDB 2.2 migration fails when nodes have no facts

### DIFF
--- a/src/com/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/com/puppetlabs/puppetdb/scf/migrate.clj
@@ -719,15 +719,16 @@
                        (query-to-vec "SELECT * FROM certname_facts WHERE certname = ?")
                        (reduce #(assoc %1 (:name %2) (:value %2)) {}))
             environment (->> environment_id
-                          (query-to-vec "SELECT name FROM environments WHERE id = ?")
-                          first
-                          :name)]
-        (scf-store/add-facts!
-          {:name (str certname)
-           :values facts
-           :timestamp timestamp
-           :environment environment
-           :producer-timestamp nil})))))
+                             (query-to-vec "SELECT name FROM environments WHERE id = ?")
+                             first
+                             :name)]
+        (when-not (empty? facts)
+          (scf-store/add-facts!
+            {:name (str certname)
+             :values facts
+             :timestamp timestamp
+             :environment environment
+             :producer-timestamp nil}))))))
 
 (defn structured-facts []
   ;; -----------


### PR DESCRIPTION
This patch handles an error that occurs if a user attempts the 2.2 upgrade
with nodes that have no associated facts in the database, and adds some
additional testing around the migration.
