### PR TITLE
(PDB-873) Revert "Changed our acceptance test setup to pin on facter 2.1.0"

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -909,7 +909,7 @@ EOS
 
       case os
       when :debian
-        on host, "apt-get install -y puppet puppetmaster-common facter=2.1.0-1puppetlabs1"
+        on host, "apt-get install -y puppet puppetmaster-common"
       when :redhat, :fedora
         on host, "yum install -y puppet"
       else


### PR DESCRIPTION
This reverts commit 72a1588fd5019de9c9801974b9ef4c25625dcc48.

The tests should now use puppetlabs/puppetdb 4.0.0. The 4.0.0 module
depends on puppetlabs/postgresql 4.0.0, which has a fix for the facter
issue, so we no longer need to pin on an older facter.
