### PR TITLE
(testing) Remove open_postgres_port usage from puppetdb class

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -291,7 +291,6 @@ module PuppetDBExtensions
     class { 'puppetdb':
       database             => '#{db}',
       open_ssl_listen_port => false,
-      open_postgres_port   => false,
       puppetdb_version     => '#{get_package_version(host, version)}',
     }")
 


### PR DESCRIPTION
This option is now deprecated, so we shouldn't use it in our tests.

Signed-off-by: Ken Barber ken@bob.sh
