### PR TITLE
(PDB-868) Add exponential back offs for db retry logic

### DIFF
--- a/acceptance/tests/db_resilience/postgres_restart.rb
+++ b/acceptance/tests/db_resilience/postgres_restart.rb
@@ -21,9 +21,6 @@ if (test_config[:database] == :postgres)
 
     restart_postgres(database)
 
-    # Avoid a restart race condition
-    sleep(1)
-
     step "Verify that the number of active nodes is what we expect" do
       result = on database, %Q|curl -G http://localhost:8080/v3/nodes|
       result_node_statuses = JSON.parse(result.stdout)

--- a/project.clj
+++ b/project.clj
@@ -31,6 +31,7 @@
                  [cheshire "5.3.1"]
                  [org.clojure/core.match "0.2.0-rc5"]
                  [org.clojure/math.combinatorics "0.0.4"]
+                 [org.clojure/math.numeric-tower "0.0.4"]
                  [org.clojure/tools.logging "0.2.6"]
                  [org.clojure/tools.nrepl "0.2.3"]
                  [puppetlabs/tools.namespace "0.2.4.1"]


### PR DESCRIPTION
This patch provides greater amount of retries, and exponential backoff logic
to avoid the case where the database is still throwing errors for a short
period of time. This commonly occurs during database restarts, and so this
logic is specifically targeted to handle smaller transient failures (not
large ones).

Signed-off-by: Ken Barber ken@bob.sh
