### PR TITLE
Add VPC support for acceptance test hosts for PuppetDB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,5 +42,5 @@ group :test do
 end
 
 group :acceptance do
-  gem 'beaker', '~> 1.11'
+  gem 'beaker', '~> 2.2'
 end

--- a/acceptance/config/ec2-west-debian6-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-debian6-64mda-64a.cfg
@@ -10,6 +10,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
   debian6-64-2:
     roles:
       - agent
@@ -18,6 +20,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443

--- a/acceptance/config/ec2-west-debian7-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-debian7-64mda-64a.cfg
@@ -10,6 +10,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
   debian7-64-2:
     roles:
       - agent
@@ -18,6 +20,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443

--- a/acceptance/config/ec2-west-el5-64mda-el5-64a.cfg
+++ b/acceptance/config/ec2-west-el5-64mda-el5-64a.cfg
@@ -10,6 +10,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
   el5-64-2:
     roles:
       - agent
@@ -18,6 +20,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443

--- a/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
@@ -10,6 +10,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
   el5-64-1:
     roles:
       - agent
@@ -18,6 +20,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
   ubuntu-12.04-64-1:
     roles:
       - agent
@@ -26,6 +30,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443

--- a/acceptance/config/ec2-west-el6-64mda-el6-64a.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-el6-64a.cfg
@@ -10,6 +10,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
   el6-64-2:
     roles:
       - agent
@@ -18,6 +20,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443

--- a/acceptance/config/ec2-west-el6-64mda.cfg
+++ b/acceptance/config/ec2-west-el6-64mda.cfg
@@ -10,6 +10,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
 
 CONFIG:
   nfs_server: none

--- a/acceptance/config/ec2-west-el7-64mda-el7-64a.cfg
+++ b/acceptance/config/ec2-west-el7-64mda-el7-64a.cfg
@@ -10,6 +10,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
   el7-64-2:
     roles:
       - agent
@@ -18,6 +20,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443

--- a/acceptance/config/ec2-west-f20-64mda-f20-64a.cfg
+++ b/acceptance/config/ec2-west-f20-64mda-f20-64a.cfg
@@ -10,6 +10,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
   fedora-20-2:
     roles:
       - agent
@@ -18,6 +20,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
 
 CONFIG:
   nfs_server: none

--- a/acceptance/config/ec2-west-ubuntu1004-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1004-64mda-64a.cfg
@@ -10,6 +10,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
   ubuntu-1004-64-2:
     roles:
       - agent
@@ -18,6 +20,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443

--- a/acceptance/config/ec2-west-ubuntu1204-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1204-64mda-64a.cfg
@@ -10,6 +10,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
   ubuntu-1204-64-2:
     roles:
       - agent
@@ -18,6 +20,8 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
+    subnet_id: subnet-92dd65f7
+    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443


### PR DESCRIPTION
This changes all the templates to provide the correct vpc/subnet ids
and pins our beaker gem to use my test branch (at least until this is
merged).

Signed-off-by: Ken Barber <ken@bob.sh>