### PR TITLE
Switch to using c3.large testing instances

### DIFF
--- a/acceptance/config/ec2-west-debian6-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-debian6-64mda-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: debian6-amd64-west
     platform: debian-6-amd64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
   debian6-64-2:
@@ -15,7 +15,7 @@ HOSTS:
       - agent
     vmname: debian6-amd64-west
     platform: debian-6-amd64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
 CONFIG:

--- a/acceptance/config/ec2-west-el5-64mda-el5-64a.cfg
+++ b/acceptance/config/ec2-west-el5-64mda-el5-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: el-5-x86_64-west
     platform: el-5-x86_64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
   el5-64-2:
@@ -15,7 +15,7 @@ HOSTS:
       - agent
     vmname: el-5-x86_64-west
     platform: el-5-x86_64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
 CONFIG:

--- a/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: el-6-x86_64-west
     platform: el-6-x86_64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
   el5-64-1:
@@ -15,7 +15,7 @@ HOSTS:
       - agent
     vmname: el-5-x86_64-west
     platform: el-5-x86_64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
   ubuntu-12.04-64-1:
@@ -23,7 +23,7 @@ HOSTS:
       - agent
     vmname: ubuntu-12.04-amd64-west
     platform: ubuntu-12.04-amd64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
 CONFIG:

--- a/acceptance/config/ec2-west-el6-64mda-el6-64a.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-el6-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: el-6-x86_64-west
     platform: el-6-x86_64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
   el6-64-2:
@@ -15,7 +15,7 @@ HOSTS:
       - agent
     vmname: el-6-x86_64-west
     platform: el-6-x86_64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
 CONFIG:

--- a/acceptance/config/ec2-west-el6-64mda.cfg
+++ b/acceptance/config/ec2-west-el6-64mda.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - database
     vmname: el-6-x86_64-west
     platform: el-6-x86_64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
 

--- a/acceptance/config/ec2-west-f20-64mda-f20-64a.cfg
+++ b/acceptance/config/ec2-west-f20-64mda-f20-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - database
     vmname: fedora-20-x86_64-west
     platform: fedora-20-x86_64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
   fedora-20-2:
@@ -15,7 +15,7 @@ HOSTS:
       - agent
     vmname: fedora-20-x86_64-west
     platform: fedora-20-x86_64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
 

--- a/acceptance/config/ec2-west-ubuntu1004-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1004-64mda-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: ubuntu-10.04-amd64-west
     platform: ubuntu-10.04-amd64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
   ubuntu-1004-64-2:
@@ -15,7 +15,7 @@ HOSTS:
       - agent
     vmname: ubuntu-10.04-amd64-west
     platform: ubuntu-10.04-amd64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
 CONFIG:

--- a/acceptance/config/ec2-west-ubuntu1204-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1204-64mda-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: ubuntu-12.04-amd64-west
     platform: ubuntu-12.04-amd64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
   ubuntu-1204-64-2:
@@ -15,7 +15,7 @@ HOSTS:
       - agent
     vmname: ubuntu-12.04-amd64-west
     platform: ubuntu-12.04-amd64
-    amisize: c1.medium
+    amisize: c3.large
     hypervisor: ec2
     snapshot: foss
 CONFIG:


### PR DESCRIPTION
This switches us over to the newer c3.large instance types in EC2. After some
testing I've found these boxes are much faster and can complete our tests at
a faster rate. Not only that for pricing they are priced at $0.105 versus
$0.130 (c1.medium) per instance hour.

And since c1.medium are now in the 'previous generation' bucket, best to switch
away anyway.

Signed-off-by: Ken Barber ken@bob.sh
