### PR TITLE
(PDB-900) Make performance improvements to fact_values GC process

### DIFF
--- a/src/com/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/com/puppetlabs/puppetdb/scf/migrate.clj
@@ -844,6 +844,36 @@
    "DROP TABLE certname_facts"
    "DROP TABLE certname_facts_metadata"))
 
+(defn structured-facts-deferrable-constraints []
+
+  ;;This migration is switching from a GC background thread to
+  ;;removing fact values as they are orphaned. Before switching to
+  ;;that model (which only cleans up the specific fact values it
+  ;;orphans) we need to clean up any ones that have appeared between
+  ;;the last run and the current run.
+  (sql/delete-rows :fact_values
+                   ["ID NOT IN (SELECT DISTINCT fact_value_id FROM facts)"])
+  (sql/delete-rows :fact_paths
+                   ["ID NOT IN (SELECT path_id FROM fact_values)"])
+
+  (when (scf-utils/postgres?)
+    (sql/do-commands
+
+     "ALTER TABLE fact_values DROP CONSTRAINT fact_values_path_id_fk"
+     (str "ALTER TABLE fact_values ADD CONSTRAINT fact_values_path_id_fk
+           FOREIGN KEY (path_id) REFERENCES fact_paths (id) MATCH SIMPLE
+           ON UPDATE NO ACTION ON DELETE NO ACTION
+           DEFERRABLE")
+
+     "ALTER TABLE facts DROP CONSTRAINT fact_value_id_fk"
+     (str "ALTER TABLE facts ADD CONSTRAINT fact_value_id_fk
+           FOREIGN KEY (fact_value_id) REFERENCES fact_values(id)
+           ON UPDATE NO ACTION  ON DELETE NO ACTION
+           DEFERRABLE")))
+
+  (sql/do-commands
+   "CREATE INDEX fact_value_id_idx ON facts(fact_value_id)"))
+
 ;; The available migrations, as a map from migration version to migration function.
 (def migrations
   {1 initialize-store
@@ -870,7 +900,8 @@
    22 add-environments
    23 add-report-status
    24 add-producer-timestamps
-   25 structured-facts})
+   25 structured-facts
+   26 structured-facts-deferrable-constraints})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -733,15 +733,6 @@
 
 ;; ## Database compaction
 
-(defn delete-unassociated-fact-paths!
-  "Remove fact paths that are not associated with a fact"
-  []
-  (time! (:gc-fact-paths metrics)
-         (sql/delete-rows :fact_values
-            ["ID NOT IN (SELECT DISTINCT fact_value_id FROM facts)"])
-         (sql/delete-rows :fact_paths
-            ["ID NOT IN (SELECT path_id FROM fact_values)"])))
-
 (defn delete-unassociated-params!
   "Remove any resources that aren't associated with a catalog"
   []
@@ -777,9 +768,7 @@
          (sql/transaction
           (delete-unassociated-environments!))
          (sql/transaction
-          (delete-unassociated-statuses!))
-         (sql/transaction
-           (delete-unassociated-fact-paths!))))
+          (delete-unassociated-statuses!))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Facts
@@ -988,10 +977,48 @@
   ([factset :- s/Int
     fact-ids :- #{s/Int}]
      (when (seq fact-ids)
-       (sql/delete-rows :facts
-                        (into [(str "factset_id=? and fact_value_id "
-                                    (jdbc/in-clause fact-ids)) factset]
-                              fact-ids)))))
+       (let [in-list (jdbc/in-clause fact-ids)]
+         (sql/transaction
+
+          (when (sutils/postgres?)
+            (sql/do-commands "SET CONSTRAINTS ALL DEFERRED")
+
+
+            (sql/do-prepared (format "DELETE FROM fact_paths fp
+                                      WHERE fp.id in ( SELECT fp.id
+                                                       FROM fact_paths fp inner join fact_values fv on fp.id = fv.path_id
+                                                       WHERE fp.id in ( select fv.path_id from fact_values fv where fv.id %s )
+                                                       GROUP BY fp.id
+                                                       HAVING COUNT(fv.id) = 1)" in-list)
+                             fact-ids)
+
+            (sql/do-prepared (format "DELETE FROM fact_values WHERE id in (
+                                          SELECT fact_value_id FROM facts where factset_id = ? and fact_value_id %s
+                                          EXCEPT
+                                          SELECT fact_value_id FROM facts where factset_id <> ? and fact_value_id %s)" in-list in-list)
+                             (concat (cons factset fact-ids)
+                                     (cons factset fact-ids))))
+
+          (sql/delete-rows :facts
+                           (into [(str "factset_id=? and fact_value_id "
+                                       in-list) factset]
+                                 fact-ids))
+
+          ;; HSQLDB doesn't support delayed constraints. This query
+          ;; achieves the same goals as the DELETE FROM fact_values
+          ;; above, but does so in a less efficient manner. Having
+          ;; these two separated allows Postgres queries to execute
+          ;; faster, but still support HSQLDB
+          (when-not (sutils/postgres?)
+            (sql/do-prepared (format "DELETE FROM fact_values WHERE id in (
+                                        SELECT fv.id
+                                        FROM fact_values fv left join facts f on fv.id = f.fact_value_id
+                                        WHERE f.fact_value_id is NULL and fv.id %s )" in-list)
+                             fact-ids)
+            (sql/do-prepared (format "DELETE FROM fact_paths fp
+                                      WHERE fp.id in ( SELECT fp.id
+                                                       FROM fact_paths fp left join fact_values fv on fp.id = fv.path_id
+                                                       WHERE fv.path_id is NULL )"))))))))
 
 (pls/defn-validated update-facts!
   "Given a certname, querys the DB for existing facts for that


### PR DESCRIPTION
Switched from a background thread to cleanup orphaned fact_values to one
that deletes as it goes. Switching to deferred constraints also
significantly improved performance on PostgreSQL. The same facilities are
not available in HSQLDB, but I have alternate queries that work, though
will likely not be as fast.
