### PR TITLE
Drain queues where appropriate to avoid race conditions

### DIFF
--- a/acceptance/tests/db_garbage_collection/node_ttl.rb
+++ b/acceptance/tests/db_garbage_collection/node_ttl.rb
@@ -28,6 +28,10 @@ test_name "validate that nodes are deactivated and deleted based on ttl settings
     end
   end
 
+  step "ensure the queue is drained" do
+    sleep_until_queue_empty database
+  end
+
   step "Verify that the number of active nodes is what we expect" do
     result = on database, %Q|curl -G http://localhost:8080/v3/nodes|
     result_node_statuses = JSON.parse(result.stdout)

--- a/acceptance/tests/storeconfigs/deactivated_nodes.rb
+++ b/acceptance/tests/storeconfigs/deactivated_nodes.rb
@@ -74,6 +74,10 @@ MANIFEST
       end
     end
 
+    step "ensure the queue is drained" do
+      sleep_until_queue_empty database
+    end
+
     step "resources should be collected before deactivation" do
       test_collection.call collectors, "not_deactivated", %w[from_exporter]
     end


### PR DESCRIPTION
We have a theory that these two places require checks to ensure the queue is
drained/processed before continuing, to avoid a potential race.

Signed-off-by: Ken Barber ken@bob.sh
