### PR TITLE
More clarification around using an IP address for ssl-host and host

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -469,7 +469,9 @@ The `[jetty]` section configures HTTP for PuppetDB.
 
 ### `host`
 
-This sets the hostname to listen on for _unencrypted_ HTTP traffic. If not supplied, we bind to `localhost`, which will reject connections from anywhere but the PuppetDB server itself. To listen on all available interfaces, use `0.0.0.0`.
+This sets the IP interface to listen on for _unencrypted_ HTTP traffic. If not supplied, we bind to `localhost`, which will reject connections from anywhere but the PuppetDB server itself. To listen on all available interfaces, use `0.0.0.0`.
+
+To avoid DNS resolution confusion, it is recommended that if you wish to set this to something other than `localhost` an IP address should be used instead of a hostname.
 
 > **Note:** Unencrypted HTTP is the only way to view the [performance dashboard][dashboard], since PuppetDB uses host verification for SSL. However, it can also be used to make any call to PuppetDB's API, including inserting exported resources and retrieving arbitrary data about your Puppet-managed nodes. **If you enable cleartext HTTP, you MUST configure your firewall to protect unverified access to PuppetDB.**
 
@@ -485,7 +487,9 @@ This sets the maximum number of threads assigned to responding to HTTP and HTTPS
 
 ### `ssl-host`
 
-This sets the hostname to listen on for _encrypted_ HTTPS traffic. If not supplied, we bind to `localhost`. To listen on all available interfaces, use `0.0.0.0`.
+This sets IP interface to listen on for _encrypted_ HTTPS traffic. If not supplied, we bind to `localhost`. To listen on all available interfaces, use `0.0.0.0`.
+
+To avoid DNS resolution confusion, it is recommended that if you wish to set this to something other than `localhost` an IP address should be used instead of a hostname.
 
 ### `ssl-port`
 

--- a/ext/templates/jetty.ini.erb
+++ b/ext/templates/jetty.ini.erb
@@ -1,5 +1,7 @@
 [jetty]
-# Hostname or IP address to listen for clear-text HTTP.  Default is localhost
+# IP address or hostname to listen for clear-text HTTP. To avoid resolution
+# issues, IP addresses are recommended over hostnames.
+# Default is `localhost`.
 # host = <host>
 
 # Port to listen on for clear-text HTTP.
@@ -11,7 +13,9 @@ port = 8080
 # automatically with the tool `puppetdb ssl-setup`, which is normally
 # ran during package installation.
 
-# The host or IP address to listen on for HTTPS connections
+# IP address to listen on for HTTPS connections. Hostnames can also be used
+# but are not recommended to avoid DNS resolution issues. To listen on all
+# interfaces, use `0.0.0.0`.
 # ssl-host = <host>
 
 # The port to listen on for HTTPS connections


### PR DESCRIPTION
Setting `ssl-host` and `host` to a hostname often causes problems due to
resolution failing, pointing at the wrong thing or sometimes even resolving
first to an IPv6 address instead of an IPv4.

This patch fixes some documentation and the comment in the configuration
file to forewarn users of this scenario, so they can avoid it.

Signed-off-by: Ken Barber ken@bob.sh
