### PR TITLE
(PDB-489) return producer timestamp

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -23,7 +23,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
     {
       :transaction_uuid => request.options[:transaction_uuid],
       :environment => request.environment,
-      :producer_timestamp => request.options[:producer_timestamp] || Time.now.iso8601,
+      :producer_timestamp => request.options[:producer_timestamp] || Time.now.iso8601(5),
     }
   end
 

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -31,7 +31,7 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
           # when we attempt to use ActiveSupport 2.3.16 on RHEL 5 with
           # legacy storeconfigs.
           "environment" => request.options[:environment] || request.environment.to_s,
-          "producer-timestamp" => request.options[:producer_timestamp] || Time.now.iso8601,
+          "producer-timestamp" => request.options[:producer_timestamp] || Time.now.iso8601(5),
         }
       end
 

--- a/src/puppetlabs/puppetdb/cli/export.clj
+++ b/src/puppetlabs/puppetdb/cli/export.clj
@@ -52,7 +52,7 @@
                                   (format
                                    "http://%s:%s/%s/catalogs/%s"
                                    host port (name version) node)
-                                  { :accept :json})]
+                                  {:accept :json})]
        (when (= status 200) body))))
 
 (pls/defn-validated catalog->tar :- utils/tar-item
@@ -94,7 +94,8 @@
                                {:accept :json})))]
        {:name node
         :values (:facts facts)
-        :environment (:environment facts)})))
+        :environment (:environment facts)
+        :producer-timestamp (:producer-timestamp facts)})))
 
 (pls/defn-validated facts->tar :- utils/tar-item
   "Creates a tar-item map for the collection of facts"

--- a/src/puppetlabs/puppetdb/http/catalogs.clj
+++ b/src/puppetlabs/puppetdb/http/catalogs.clj
@@ -4,15 +4,16 @@
             [puppetlabs.puppetdb.query.catalogs :as c]
             [puppetlabs.puppetdb.catalogs :as cats]
             [puppetlabs.puppetdb.middleware :as middleware]
+            [schema.core :as s]
             [puppetlabs.puppetdb.jdbc :refer [with-transacted-connection]]
             [net.cgrand.moustache :refer [app]]))
 
 (defn produce-body
   "Produce a response body for a request to retrieve the catalog for `node`."
-  [version node db]
+  [api-version node db]
   (if-let [catalog (with-transacted-connection db
-                     (c/catalog-for-node version node))]
-    (http/json-response (cats/canonical->wire-format version catalog))
+                     (c/catalog-for-node api-version node))]
+    (http/json-response (s/validate (c/catalog-response-schema api-version) catalog))
     (http/json-response {:error (str "Could not find catalog for " node)} http/status-not-found)))
 
 (defn routes

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -206,7 +206,8 @@
 ;;  corresponding table names where the fields reside
 (def factset-columns {"certname" "factsets"
                       "environment" "factsets"
-                      "timestamp" "factsets"})
+                      "timestamp" "factsets"
+                      "producer-timestamp" "factsets"})
 
 ;; This map's keys are the queryable fields for resources, and the values are the
 ;;  corresponding table names where the fields reside

--- a/src/puppetlabs/puppetdb/query/factsets.clj
+++ b/src/puppetlabs/puppetdb/query/factsets.clj
@@ -16,6 +16,7 @@
    :value s/Any
    :value_float (s/maybe s/Num)
    :value_integer (s/maybe s/Int)
+   :producer-timestamp (s/maybe pls/Timestamp)
    :type (s/maybe String)
    :timestamp pls/Timestamp})
 
@@ -24,12 +25,14 @@
    :environment (s/maybe s/Str)
    :path String
    :value s/Any
+   :producer-timestamp (s/maybe pls/Timestamp)
    :timestamp pls/Timestamp})
 
 (def factset-schema
   {:certname String
    :environment (s/maybe s/Str)
    :timestamp pls/Timestamp
+   :producer-timestamp (s/maybe pls/Timestamp)
    :facts {s/Str s/Any}})
 
 ;; FUNCS
@@ -81,7 +84,7 @@
    certname-rows :- [converted-row-schema]]
   (let [first-row (first certname-rows)
         facts (reduce recreate-fact-path {} certname-rows)]
-    (assoc (select-keys first-row [:certname :environment :timestamp])
+    (assoc (select-keys first-row [:certname :environment :timestamp :producer-timestamp])
       :facts (int-maps->vectors facts))))
 
 (pls/defn-validated structured-data-seq

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -277,9 +277,10 @@
                          "value_float" :number
                          "value_integer" :number
                          "environment" :string
+                         "\"producer-timestamp\"" :timestamp
                          "type" :string}
                :alias "factsets"
-               :queryable-fields ["certname" "environment" "timestamp"]
+               :queryable-fields ["certname" "environment" "timestamp" "producer-timestamp"]
                :entity :factsets
                :source-table "factsets"
                :subquery? false
@@ -290,6 +291,7 @@
                                fact_values.value_integer as value_integer,
                                fact_values.value_float as value_float,
                                factsets.certname,
+                               factsets.producer_timestamp as \"producer-timestamp\",
                                environments.name as environment,
                                value_types.type
                         FROM factsets
@@ -756,9 +758,13 @@
   "Convert field names with dashes to underscores"
   [node state]
   (cm/match [node]
+            [[(op :guard binary-operators) (field :guard #(contains?
+                                                            #{"producer-timestamp"
+                                                             :producer-timestamp} %)) value]]
+            {:node (with-meta [op (str \" (name field) \") value] (meta node)) :state state}
             [[(op :guard binary-operators) (field :guard string?) value]]
             {:node (with-meta [op (jdbc/dashes->underscores field) value]
-                     (meta node))
+                              (meta node))
              :state state}
             :else {:node node :state state}))
 

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -77,7 +77,7 @@
    Moving the more restrictive resource/edge schemas into puppetdb.catalogs is TODO. Upstream
    code needs to assume a map of resources (not a vector) and tests need to be update to adhere
    to the new format."
-  (assoc (cat/catalog-schema :all)
+  (assoc (cat/catalog-wireformat :all)
     :resources resource-ref->resource-schema
     :edges #{edge-schema}))
 

--- a/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
+++ b/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
@@ -16,6 +16,7 @@
             [puppetlabs.puppetdb.testutils.reports :as tur]
             [clojure.walk :as walk]
             [clj-time.core :refer [now]]
+            [clj-time.coerce :refer [to-string]]
             [puppetlabs.puppetdb.archive :as archive]
             [puppetlabs.puppetdb.utils :as utils]
             [clojure.tools.logging.impl :as li]
@@ -90,7 +91,8 @@
                :values {:foo "the foo"
                         :bar "the bar"
                         :baz "the baz"
-                        :biz {:a [3.14 2.71] :b "the b" :c [1 2 3] :d {:e nil}}}}
+                        :biz {:a [3.14 2.71] :b "the b" :c [1 2 3] :d {:e nil}}}
+               :producer-timestamp (to-string (now))}
         export-out-file (testutils/temp-file "export-test" ".tar.gz")
         catalog (-> (get-in wire-catalogs [5 :empty])
                     (assoc :name "foo.local"))
@@ -104,7 +106,7 @@
 
       (block-on-node (:name facts))
 
-      (is (= (tuc/munge-catalog-for-comparison :v5 (dissoc catalog :producer-timestamp))
+      (is (= (tuc/munge-catalog-for-comparison :v5 catalog)
              (tuc/munge-catalog-for-comparison :v5 (json/parse-string (export/catalog-for-node "localhost" jutils/*port* (:name catalog))))))
 
       (is (= (tur/munge-report-for-comparison (tur/munge-example-report-for-storage report))
@@ -122,7 +124,7 @@
 
       (block-on-node (:name facts))
 
-      (is (= (tuc/munge-catalog-for-comparison :v5 (dissoc catalog :producer-timestamp))
+      (is (= (tuc/munge-catalog-for-comparison :v5 catalog)
              (tuc/munge-catalog-for-comparison :v5 (json/parse-string (export/catalog-for-node "localhost" jutils/*port* (:name catalog))))))
       (is (= (tur/munge-report-for-comparison (tur/munge-example-report-for-storage report))
              (tur/munge-report-for-comparison (-> (export/reports-for-node "localhost" jutils/*port* (:certname report))
@@ -149,7 +151,8 @@
   (let [facts {:name "foo.local"
                :values {:foo "the foo"
                         :bar "the bar"
-                        :baz "the baz"}}
+                        :baz "the baz"}
+               :producer-timestamp nil}
         export-out-file (testutils/temp-file "export-test" ".tar.gz")
         catalog (assoc-in (get-in wire-catalogs [2 :empty])
                           [:data :name] "foo.local")

--- a/test/puppetlabs/puppetdb/query/catalogs_test.clj
+++ b/test/puppetlabs/puppetdb/query/catalogs_test.clj
@@ -11,14 +11,15 @@
 (use-fixtures :each with-test-db)
 
 (deftest catalog-query
-  (let [catalog-str      (slurp (resource "puppetlabs/puppetdb/cli/export/tiny-catalog.json"))
-        {:strs [name version transaction-uuid environment] :as catalog}    (json/parse-string catalog-str)]
+  (let [catalog-str (slurp (resource "puppetlabs/puppetdb/cli/export/tiny-catalog.json"))
+        {:strs [name version transaction-uuid environment] :as catalog} (json/parse-string
+                                                                          catalog-str)]
     (testcat/replace-catalog catalog-str)
-    (doseq [cmd-version [:v3 :v4]]
+    (doseq [api-version [:v3 :v4]]
       (testing "get-catalog-info"
         (is (= (str version)  (:version (c/get-catalog-info name))))
         (is (= transaction-uuid (:transaction-uuid (c/get-catalog-info name))))
         (is (= environment (:environment (c/get-catalog-info name)))))
       (testing "catalog-for-node"
-        (is (= (testcat/munged-canonical->wire-format cmd-version (json/parse-string catalog-str true))
-               (testcat/munged-canonical->wire-format cmd-version (c/catalog-for-node cmd-version name))))))))
+        (is (= (testcat/munged-canonical->wire-format api-version (json/parse-string catalog-str true))
+               (testcat/munged-canonical->wire-format api-version (c/catalog-for-node api-version name))))))))


### PR DESCRIPTION
This exposes our "producer-timestamp" field on the factsets and catalogs
endpoints.  On factsets the field is queryable and orderable. The next step
will be to push the generation of this field back to the agent.
