### PR TITLE
Add Centos 7 acceptance tests

### DIFF
--- a/acceptance/config/ec2-west-el7-64mda-el7-64a.cfg
+++ b/acceptance/config/ec2-west-el7-64mda-el7-64a.cfg
@@ -1,0 +1,23 @@
+HOSTS:
+  el7-64-1:
+    roles:
+      - master
+      - database
+      - dashboard
+      - agent
+    vmname: el-7-x86_64-west
+    platform: el-7-x86_64
+    amisize: c3.large
+    hypervisor: ec2
+    snapshot: foss
+  el7-64-2:
+    roles:
+      - agent
+    vmname: el-7-x86_64-west
+    platform: el-7-x86_64
+    amisize: c3.large
+    hypervisor: ec2
+    snapshot: foss
+CONFIG:
+  nfs_server: none
+  consoleport: 443

--- a/config/image_templates/ec2.yaml
+++ b/config/image_templates/ec2.yaml
@@ -1,8 +1,8 @@
 AMI:
-  debian-7-amd64-west:
+  el-7-x86_64-west:
     :image:
-      :pe: ami-99e0ada9
-      :foss: ami-99e0ada9
+      :pe: ami-bd420e8d
+      :foss: ami-bd420e8d
     :region: us-west-2
 
   el-6-x86_64-west:
@@ -17,16 +17,22 @@ AMI:
       :foss: ami-4a6df87a
     :region: us-west-2
 
+  ubuntu-12.04-amd64-west:
+    :image:
+      :pe: ami-d6e860e6
+      :foss: ami-d6e860e6
+    :region: us-west-2
+
   ubuntu-10.04-amd64-west:
     :image:
       :pe: ami-52ea6262
       :foss: ami-52ea6262
     :region: us-west-2
 
-  ubuntu-12.04-amd64-west:
+  debian-7-amd64-west:
     :image:
-      :pe: ami-d6e860e6
-      :foss: ami-d6e860e6
+      :pe: ami-99e0ada9
+      :foss: ami-99e0ada9
     :region: us-west-2
 
   debian6-amd64-west:


### PR DESCRIPTION
This includes a new test AMI for Centos 7 to test against.

Signed-off-by: Ken Barber ken@bob.sh
