### PR TITLE
Upgrade distros to ensure all packages are the latest

### DIFF
--- a/acceptance/setup/pre_suite/12_upgrade_distros.rb
+++ b/acceptance/setup/pre_suite/12_upgrade_distros.rb
@@ -1,0 +1,21 @@
+def upgrade_pkgs_on_host(host, os)
+  case os
+  when :debian
+    on host, "apt-get update"
+    on host, "DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=\"--force-confnew\" --force-yes -fuy dist-upgrade"
+  when :redhat
+    on host, "yum clean all -y"
+    on host, "yum upgrade -y"
+  when :fedora
+    on host, "yum clean all -y"
+    on host, "yum upgrade -y"
+  else
+    raise ArgumentError, "Unsupported OS '#{os}'"
+  end
+end
+
+step "Upgrade each host" do
+  hosts.each do |host|
+    upgrade_pkgs_on_host(host, test_config[:os_families][host.name])
+  end
+end


### PR DESCRIPTION
Without this we are seeing elements fall behind, such as the new SSL changes
to the EPEL mirror which are no longer compatible with the SSL setup on older
RHEL6/7 boxes.

Signed-off-by: Ken Barber ken@bob.sh
