### PR TITLE
(PDB-100) Convert terminus to internally use a URL connecting to PDB

### DIFF
--- a/documentation/connect_puppet_master.markdown
+++ b/documentation/connect_puppet_master.markdown
@@ -58,19 +58,20 @@ You will need to edit (or create) three files in this directory:
 The [puppetdb.conf][puppetdb_conf] file will probably not exist yet. Create it, and add the PuppetDB server's hostname and port:
 
     [main]
-    server = puppetdb.example.com
-    port = 8081
+    server_urls = https://puppetdb.example.com:8081/
 
-PuppetDB's port for secure traffic defaults to 8081. Puppet _requires_ use of PuppetDB's secure, HTTPS port. You cannot use the unencrypted, plain HTTP port.
+PuppetDB's port for secure traffic defaults to 8081 and the 'url_prefix' defaults to '/'. Puppet _requires_ use of PuppetDB's secure, HTTPS port. You cannot use the unencrypted, plain HTTP port. Note that a comma separated list of the URLs can be provided if there is more than one PuppetDB instance available.
 
 For availability reasons there is a setting named `soft_write_failure` that will cause the PuppetDB terminus to fail in a soft-manner if PuppetDB is not accessable for command submission. This will mean that users who are either not using storeconfigs, or only exporting resources will still have their catalogs compile during a PuppetDB outage.
 
 You may also, optionally, specify a setting named `url_prefix` if you have configured your PuppetDB server to run the web application at a URL other than "/".  This should not be necessary in most cases, and should only be used if you have modified the corresponding [`url-prefix` setting in your PuppetDB configuration][url_prefix_setting].
 
+The `server_url_timeout` field sets the maximum amount of time (in seconds) the PuppetDB terminus will wait for an HTTP request to be responded to by PuppetDB. If the user has specified more than one PuppetDB URL and a timeout has occurred, it will attempt the same request in the next server in the list.
+
 If no puppetdb.conf file exists, the following default values will be used:
 
-    server = puppetdb
-    port = 8081
+    server_urls = https://puppetdb:8081/
+    server_url_timeout = 120
     soft_write_failure = false
 
 ### 2. Edit puppet.conf

--- a/puppet/lib/puppet/face/node/status.rb
+++ b/puppet/lib/puppet/face/node/status.rb
@@ -17,14 +17,11 @@ Puppet::Face.define(:node, '0.0.1') do
       opts = args.pop
       raise ArgumentError, "Please provide at least one node" if args.empty?
 
-      server = Puppet::Util::Puppetdb.server
-      port = Puppet::Util::Puppetdb.port
-
-      http = Puppet::Network::HttpPool.http_instance(server, port)
-
       args.map do |node|
         begin
-          response = http.get(Puppet::Util::Puppetdb.url_path("/v3/nodes/#{CGI.escape(node)}"), headers)
+          response = Puppet::Util::Puppetdb::Http.action("/v3/nodes/#{CGI.escape(node)}") do |http_instance, path|
+             http_instance.get(path, headers)
+          end
           if response.is_a? Net::HTTPSuccess
             result = JSON.parse(response.body)
           elsif response.is_a? Net::HTTPNotFound

--- a/puppet/lib/puppet/indirector/resource/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/resource/puppetdb.rb
@@ -26,10 +26,12 @@ class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
       query_param = CGI.escape(expr.to_json)
 
       begin
-        url = Puppet::Util::Puppetdb.url_path("/v3/resources?query=#{query_param}")
-        response = profile "Resources query: #{URI.unescape(url)}" do
-          http_get(request, url, headers)
+        response = Http.action("/v3/resources?query=#{query_param}") do |http_instance, path|
+          profile "Resources query: #{URI.unescape(path)}" do
+            http_instance.get(path, headers)
+          end
         end
+
         log_x_deprecation_header(response)
 
         unless response.is_a? Net::HTTPSuccess

--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -10,41 +10,9 @@ require 'fileutils'
 
 module Puppet::Util::Puppetdb
 
-  def self.server
-    config.server
-  end
-
-  def self.port
-    config.port
-  end
-
-  def self.url_path(path)
-    unless path.start_with?("/")
-      path = "/" + path
-    end
-    config.url_prefix + path
-  end
-
   def self.config
     @config ||= Puppet::Util::Puppetdb::Config.load
     @config
-  end
-
-  # This magical stuff is needed so that the indirector termini will make requests to
-  # the correct host/port, because this module gets mixed in to our indirector
-  # termini.
-  module ClassMethods
-    def server
-      Puppet::Util::Puppetdb.server
-    end
-
-    def port
-      Puppet::Util::Puppetdb.port
-    end
-  end
-
-  def self.included(child)
-    child.extend ClassMethods
   end
 
   # Given an instance of ruby's Time class, this method converts it to a String

--- a/puppet/lib/puppet/util/puppetdb/http.rb
+++ b/puppet/lib/puppet/util/puppetdb/http.rb
@@ -1,0 +1,70 @@
+require 'uri'
+require 'puppet/network/http_pool'
+require 'net/http'
+require 'timeout'
+
+module Puppet::Util::Puppetdb
+  class Http
+    # Concat two url snippets, taking into account a trailing/leading slash to
+    # ensure a correct url is constructed
+    #
+    # @param snippet1 [String] first URL snippet
+    # @param snippet2 [String] second URL snippet
+    # @return [String] returns http response
+    # @api private
+    def self.concat_url_snippets(snippet1, snippet2)
+      if snippet1.end_with?('/') and snippet2.start_with?('/')
+        snippet1 + snippet2[1..-1]
+      elsif !snippet1.end_with?('/') and !snippet2.start_with?('/')
+        snippet1 + '/' + snippet2
+      else
+        snippet1 + snippet2
+      end
+    end
+
+    # Setup an http connection, provide a block that will do something with that http
+    # connection. The block should be a two argument block, accepting the connection (which
+    # you can call get or post on for example) and the properly constructed path, which
+    # will be the concatenated version of any url_prefix and the path passed in.
+    #
+    # @param path_suffix [String] path for the get/post of the http action
+    # @param http_callback [Proc] proc containing the code calling the action on the http connection
+    # @return [Response] returns http response
+    def self.action(path_suffix, &http_callback)
+
+      response = nil
+
+      for url in Puppet::Util::Puppetdb.config.server_urls
+        begin
+          route = concat_url_snippets(url.request_uri, path_suffix)
+          http = Puppet::Network::HttpPool.http_instance(url.host, url.port)
+          request_timeout = Puppet::Util::Puppetdb.config.server_url_timeout
+
+          response = timeout(request_timeout) do
+            http_callback.call(http, route)
+          end
+
+          if response.is_a? Net::HTTPServerError
+            Puppet.warning("Attempted to connect #{url.host} on #{url.port} at route #{route} and failed with code #{response.code} and error message #{response.message}. Failing to next PuppetDB url in the 'server_urls' list.")
+            response = nil
+          else
+            break
+          end
+        rescue Timeout::Error => e
+          Puppet.warning("Request to #{url.host} on #{url.port} at route #{route} timed out after #{request_timeout}. Failing over to the next PuppetDB urls in the 'server_urls' list")
+
+        rescue SystemCallError, Net::ProtocolError, IOError => e
+          Puppet.warning("Error connecting to #{url.host} on #{url.port} at route #{route}, error message received was '#{e.message}'. Failing over to the next PuppetDB urls in the 'server_urls' list")
+        end
+      end
+
+      if response.nil?
+        server_url_strings = Puppet::Util::Puppetdb.config.server_urls.map {|url| url.to_s}.join(',')
+        raise Puppet::Error, "Failed to execute '#{path_suffix}' on any of the following 'server_urls' #{server_url_strings}"
+      end
+
+      response
+
+    end
+  end
+end

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -5,20 +5,23 @@ require 'puppet/indirector/facts/puppetdb'
 require 'puppet/util/puppetdb/command_names'
 require 'json'
 
+
 describe Puppet::Node::Facts::Puppetdb do
 
   CommandReplaceFacts = Puppet::Util::Puppetdb::CommandNames::CommandReplaceFacts
 
+  let(:http) {stub 'http'}
+
   before :each do
-    Puppet::Util::Puppetdb.stubs(:server).returns 'localhost'
-    Puppet::Util::Puppetdb.stubs(:port).returns 0
+    Puppet::Util::Puppetdb.config.stubs(:server_urls).returns [URI("https://localhost:8282")]
     Puppet::Node::Facts.indirection.stubs(:terminus).returns(subject)
+
+    Puppet::Network::HttpPool.stubs(:http_instance).returns(http)
   end
 
   describe "#save" do
     let(:response) { Net::HTTPOK.new('1.1', 200, 'OK') }
     let(:facts)    { Puppet::Node::Facts.new('foo') }
-    let(:http)     { mock 'http' }
 
     let(:options) {{
       :producer_timestamp => 'a test',
@@ -26,7 +29,6 @@ describe Puppet::Node::Facts::Puppetdb do
     }}
 
     before :each do
-      Puppet::Network::HttpPool.expects(:http_instance).returns http
       response.stubs(:body).returns '{"uuid": "a UUID"}'
     end
 
@@ -121,7 +123,7 @@ describe Puppet::Node::Facts::Puppetdb do
       response = Net::HTTPOK.new('1.1', 200, 'OK')
       response.stubs(:body).returns body
 
-      subject.stubs(:http_get).returns response
+      http.stubs(:get).with("/v3/nodes/some_node/facts",  subject.headers).returns response
 
       result = find_facts
       result.should be_a(Puppet::Node::Facts)
@@ -135,7 +137,7 @@ describe Puppet::Node::Facts::Puppetdb do
       response = Net::HTTPOK.new('1.1', 200, 'OK')
       response.stubs(:body).returns body
 
-      subject.stubs(:http_get).returns response
+      http.stubs(:get).with("/v3/nodes/some_node/facts",  subject.headers).returns response
 
       find_facts.should be_nil
     end
@@ -144,7 +146,7 @@ describe Puppet::Node::Facts::Puppetdb do
       response = Net::HTTPForbidden.new('1.1', 403, "Forbidden")
       response.stubs(:body).returns ''
 
-      subject.stubs(:http_get).returns response
+      http.stubs(:get).with("/v3/nodes/some_node/facts",  subject.headers).returns response
 
       expect {
         find_facts
@@ -152,7 +154,7 @@ describe Puppet::Node::Facts::Puppetdb do
     end
 
     it "should fail if an error occurs" do
-      subject.stubs(:http_get).raises Puppet::Error, "Everything is terrible!"
+      http.stubs(:get).with("/v3/nodes/some_node/facts",  subject.headers).raises Puppet::Error, "Everything is terrible!"
 
       expect {
         find_facts
@@ -167,7 +169,7 @@ describe Puppet::Node::Facts::Puppetdb do
 
       response.stubs(:body).returns body
 
-      subject.stubs(:http_get).returns response
+      http.stubs(:get).with("/v3/nodes/some_node/facts",  subject.headers).returns(response)
 
       Puppet.expects(:deprecation_warning).with do |msg|
         msg =~ /This is deprecated!/
@@ -192,7 +194,9 @@ describe Puppet::Node::Facts::Puppetdb do
       response.stubs(:body).returns '[{"name": "foo", "deactivated": null, "catalog_timestamp": null, "facts_timestamp": null, "report_timestamp": null},
                                       {"name": "bar", "deactivated": null, "catalog_timestamp": null, "facts_timestamp": null, "report_timestamp": null},
                                       {"name": "baz", "deactivated": null, "catalog_timestamp": null, "facts_timestamp": null, "report_timestamp": null}]'
-      subject.stubs(:http_get).returns response
+
+      query = CGI.escape("[\"and\",[\"=\",[\"fact\",\"kernel\"],\"Linux\"]]")
+      http.stubs(:get).with("/v3/nodes?query=#{query}",  subject.headers).returns(response)
 
       search_facts(args).should == ['foo', 'bar', 'baz']
     end
@@ -219,9 +223,7 @@ describe Puppet::Node::Facts::Puppetdb do
 
       response.stubs(:body).returns '[]'
 
-      subject.expects(:http_get).with do |_,url,_|
-        url.should == "/v3/nodes?query=#{query}"
-      end.returns response
+      http.stubs(:get).with("/v3/nodes?query=#{query}",  subject.headers).returns(response)
 
       search_facts(args)
     end
@@ -235,9 +237,7 @@ describe Puppet::Node::Facts::Puppetdb do
 
       response.stubs(:body).returns '[]'
 
-      subject.expects(:http_get).with do |_,url,_|
-        url.should == "/v3/nodes?query=#{query}"
-      end.returns response
+      http.stubs(:get).with("/v3/nodes?query=#{query}",  subject.headers).returns(response)
 
       search_facts(args)
     end
@@ -251,9 +251,7 @@ describe Puppet::Node::Facts::Puppetdb do
 
       response.stubs(:body).returns '[]'
 
-      subject.expects(:http_get).with do |_,url,_|
-        url.should == "/v3/nodes?query=#{query}"
-      end.returns response
+      http.stubs(:get).with("/v3/nodes?query=#{query}",  subject.headers).returns(response)
 
       search_facts(args)
     end
@@ -273,9 +271,7 @@ describe Puppet::Node::Facts::Puppetdb do
 
         response.stubs(:body).returns '[]'
 
-        subject.expects(:http_get).with do |_,url,_|
-          url.should == "/v3/nodes?query=#{query}"
-        end.returns response
+        http.stubs(:get).with("/v3/nodes?query=#{query}",  subject.headers).returns(response)
 
         search_facts(args)
       end
@@ -285,18 +281,21 @@ describe Puppet::Node::Facts::Puppetdb do
       response = Net::HTTPBadRequest.new('1.1', 400, 'Bad Request')
       response.stubs(:body).returns 'Something bad happened!'
 
-      subject.stubs(:http_get).returns response
+      query = CGI.escape(["and"].to_json)
+      http.stubs(:get).with("/v3/nodes?query=#{query}",  subject.headers).returns(response)
 
       expect do
         search_facts(nil)
-      end.to raise_error(Puppet::Error, /Could not perform inventory search from PuppetDB at localhost:0: \[400 Bad Request\] Something bad happened!/)
+      end.to raise_error(Puppet::Error, /Could not perform inventory search from PuppetDB at localhost:8282: \[400 Bad Request\] Something bad happened!/)
+
     end
 
     it "should log a deprecation warning if one is returned from PuppetDB" do
       response['x-deprecation'] = "This is deprecated!"
       response.stubs(:body).returns '[]'
 
-      subject.stubs(:http_get).returns response
+      query = CGI.escape(["and"].to_json)
+      http.stubs(:get).with("/v3/nodes?query=#{query}",  subject.headers).returns(response)
 
       Puppet.expects(:deprecation_warning).with do |msg|
         msg =~ /This is deprecated!/

--- a/puppet/spec/unit/util/puppetdb/command_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/command_spec.rb
@@ -59,8 +59,14 @@ describe Puppet::Util::Puppetdb::Command do
       let(:httpok) { Net::HTTPOK.new('1.1', 200, '') }
 
       it "should make a request to the correct url" do
-        config = Puppet::Util::Puppetdb.config
-        config.stubs(:url_prefix).returns "/puppetdb"
+        tempconfig = Tempfile.new('config')
+        File.open(tempconfig.path, 'w') {|f| f.write('[main]
+url_prefix = /puppetdb
+server = puppetdb
+port = 8081
+soft_write_failure = false
+ignore_blacklisted_events = true') }
+        config = Puppet::Util::Puppetdb::Config.load(tempconfig.path)
         Puppet::Util::Puppetdb.expects(:config).at_least_once.returns(config)
 
         httpok.stubs(:body).returns '{"uuid": "a UUID"}'

--- a/puppet/spec/unit/util/puppetdb/http_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/http_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+require 'puppet/util/puppetdb/http'
+
+describe Puppet::Util::Puppetdb::Http do
+
+  describe "#concat_url_snippets" do
+    it "should avoid a double slash" do
+      described_class.concat_url_snippets('/foo/', '/bar/').should == '/foo/bar/'
+    end
+    it "should add a slash if needed" do
+      described_class.concat_url_snippets('/foo', 'bar/').should == '/foo/bar/'
+      described_class.concat_url_snippets('/foo', 'bar/').should == '/foo/bar/'
+    end
+    it "should do the right thing if only one snippet has a slash" do
+      described_class.concat_url_snippets('/foo', '/bar/').should == '/foo/bar/'
+      described_class.concat_url_snippets('/foo/', 'bar/').should == '/foo/bar/'
+    end
+  end
+
+  before :each do
+      Puppet::Util::Puppetdb.stubs(:config).returns config
+  end
+
+  let(:config) do
+    config = stub 'config'
+    config.stubs(:server_urls).returns [URI("https://server1:8080/foo"), URI("https://server2:8181/bar")]
+    config.stubs(:server_url_timeout).returns 30
+    config
+  end
+  let(:http1) {stub 'http'}
+  let(:http2) {stub 'http'}
+
+
+  describe "#action" do
+    it "call the proc argument with a correct path" do
+
+      Puppet::Network::HttpPool.expects(:http_instance).returns(http1)
+      http1.expects(:get).with("/foo/bar/baz", {}).returns Net::HTTPOK.new('1.1', 200, 'OK')
+
+      described_class.action("/bar/baz") do |http_instance, path|
+        http_instance.get(path, {})
+      end
+    end
+
+    it "should not fail over when the first url works" do
+      Puppet::Network::HttpPool.expects(:http_instance).with("server1", 8080).returns(http1)
+      Puppet::Network::HttpPool.expects(:http_instance).with("server2", 8181).never
+
+      http1.expects(:get).with("/foo/baz", {}).returns Net::HTTPOK.new('1.1', 200, 'OK')
+
+      response = described_class.action("/baz") do |http_instance, path|
+        http_instance.get(path, {})
+      end
+
+      response.code.should == 200
+      response.message.should == 'OK'
+
+    end
+
+
+    it "fails over to the next url when it can't connect" do
+      Puppet::Network::HttpPool.expects(:http_instance).with("server1", 8080).returns(http1)
+      Puppet::Network::HttpPool.expects(:http_instance).with("server2", 8181).returns(http2)
+
+      http1.expects(:get).with("/foo/baz", {}).raises SystemCallError, "Connection refused"
+      http2.expects(:get).with("/bar/baz", {}).returns Net::HTTPOK.new('1.1', 200, 'OK')
+
+      response = described_class.action("/baz") do |http_instance, path|
+        http_instance.get(path, {})
+      end
+
+      response.code.should == 200
+      response.message.should == 'OK'
+
+    end
+
+    it "fails over to the next url on a server error" do
+      Puppet::Network::HttpPool.expects(:http_instance).with("server1", 8080).returns(http1)
+      Puppet::Network::HttpPool.expects(:http_instance).with("server2", 8181).returns(http2)
+
+      http1.expects(:get).with("/foo/baz", {}).returns Net::HTTPServiceUnavailable.new('1.1', 503, "Unavailable")
+      http2.expects(:get).with("/bar/baz", {}).returns Net::HTTPOK.new('1.1', 200, 'OK')
+
+      response = described_class.action("/baz") do |http_instance, path|
+        http_instance.get(path, {})
+      end
+
+      response.code.should == 200
+      response.message.should == 'OK'
+    end
+
+    it "raises an exception when all urls fail" do
+      Puppet::Network::HttpPool.expects(:http_instance).with("server1", 8080).returns(http1)
+      Puppet::Network::HttpPool.expects(:http_instance).with("server2", 8181).returns(http2)
+
+      http1.expects(:get).with("/foo/baz", {}).returns Net::HTTPServiceUnavailable.new('1.1', 503, "Unavailable")
+      http2.expects(:get).with("/bar/baz", {}).returns Net::HTTPServiceUnavailable.new('1.1', 503, "Unavailable")
+
+
+      expect {
+         described_class.action("/baz") do |http_instance, path|
+           http_instance.get(path, {})
+         end
+      }.to raise_error Puppet::Error, /Failed to execute/
+    end
+
+    it "fails over after IOError" do
+      Puppet::Network::HttpPool.expects(:http_instance).with("server1", 8080).returns(http1)
+      Puppet::Network::HttpPool.expects(:http_instance).with("server2", 8181).returns(http2)
+
+      http1.expects(:get).with("/foo/baz", {}).raises IOError
+      http2.expects(:get).with("/bar/baz", {}).returns Net::HTTPOK.new('1.1', 200, 'OK')
+
+      response = described_class.action("/baz") do |http_instance, path|
+        http_instance.get(path, {})
+      end
+
+      response.code.should == 200
+      response.message.should == 'OK'
+    end
+
+    it "times out and rolls to the next url" do
+      Puppet::Network::HttpPool.expects(:http_instance).with("server1", 8080).returns(http1)
+      Puppet::Network::HttpPool.expects(:http_instance).with("server2", 8181).returns(http2)
+
+      http1.expects(:get).with("/foo/baz", {}).raises Timeout::Error
+      http2.expects(:get).with("/bar/baz", {}).returns Net::HTTPOK.new('1.1', 200, 'OK')
+
+      response = described_class.action("/baz") do |http_instance, path|
+        http_instance.get(path, {})
+      end
+
+      response.code.should == 200
+      response.message.should == 'OK'
+    end
+  end
+end


### PR DESCRIPTION
There purely a refactor of terminus' HTTP code to use URLs rather than
the existing server + port combination internally. The user still
specifies server+port and we convert this internally to URLs. This is
step one in getting connection failover for the terminus.

This is my first significant change to the terminus code and would appreciate some feedback on the new API, style etc.
