### PR TITLE
(PDB-964) Switch to using curl --tlsv1 everywhere

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -551,11 +551,11 @@ EOS
 
   def curl_with_retries(desc, host, curl_args, desired_exit_codes, max_retries = 60, retry_interval = 1, expected_output = /.*/)
     desired_exit_codes = [desired_exit_codes].flatten
-    result = on host, "curl #{curl_args}", :acceptable_exit_codes => (0...127)
+    result = on host, "curl --tlsv1 #{curl_args}", :acceptable_exit_codes => (0...127)
     num_retries = 0
     until desired_exit_codes.include?(exit_code) and (result.stdout =~ expected_output)
       sleep retry_interval
-      result = on host, "curl #{curl_args}", :acceptable_exit_codes => (0...127)
+      result = on host, "curl --tlsv1 #{curl_args}", :acceptable_exit_codes => (0...127)
       num_retries += 1
       if (num_retries > max_retries)
         fail("Unable to #{desc}")

--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -41,7 +41,7 @@ deb http://s3-us-west-2.amazonaws.com/puppetdb-jdk/jpkg/ pljdk main
       which_result = on database, "which lein", :acceptable_exit_codes => [0,1]
       needs_lein = which_result.exit_code == 1
       if (needs_lein)
-        on database, "curl -k https://raw.githubusercontent.com/technomancy/leiningen/2.3.4/bin/lein -o /usr/local/bin/lein"
+        on database, "curl --tlsv1 -k https://raw.githubusercontent.com/technomancy/leiningen/2.3.4/bin/lein -o /usr/local/bin/lein"
         on database, "chmod +x /usr/local/bin/lein"
         on database, "LEIN_ROOT=true lein"
       end

--- a/acceptance/tests/security/cert_whitelist.rb
+++ b/acceptance/tests/security/cert_whitelist.rb
@@ -20,7 +20,7 @@ test_name "certificate whitelisting" do
     create_remote_file database, "#{confd}/whitelist", whitelist
     on database, "chmod 644 #{confd}/whitelist"
     restart_puppetdb database
-    on database, "curl -sL -w '%{http_code}\\n' " +
+    on database, "curl --tlsv1 -sL -w '%{http_code}\\n' " +
                  "--cacert #{ssldir}/certs/ca.pem " +
                  "--cert #{ssldir}/certs/#{dbname}.pem " +
                  "--key #{ssldir}/private_keys/#{dbname}.pem "+


### PR DESCRIPTION
This works around the problems where sites are dropping SSLv3
support so our tests continue to work.

Signed-off-by: Ken Barber ken@bob.sh
