### PR TITLE
Correct the ssl-protocols rewrite for the master branch

### DIFF
--- a/acceptance/tests/security/cert_whitelist_legacy.rb
+++ b/acceptance/tests/security/cert_whitelist_legacy.rb
@@ -20,7 +20,7 @@ test_name "certificate whitelisting using legacy location in [jetty]" do
     create_remote_file database, "#{confd}/whitelist", whitelist
     on database, "chmod 644 #{confd}/whitelist"
     restart_puppetdb database
-    on database, "curl -sL -w '%{http_code}\\n' " +
+    on database, "curl --tlsv1 -sL -w '%{http_code}\\n' " +
                  "--cacert #{ssldir}/certs/ca.pem " +
                  "--cert #{ssldir}/certs/#{dbname}.pem " +
                  "--key #{ssldir}/private_keys/#{dbname}.pem "+

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -351,7 +351,7 @@
    at this point may or may not be setup, so warning via *err* and logging is done."
   [config-data]
   (when-let [protocol-str (get-in config-data [:jetty :ssl-protocols])]
-    (when (re-matches #"(?i).*sslv3.*" protocol-str)
+    (when (some #(re-matches #"(?i).*sslv3.*" %) protocol-str)
       (binding [*out* *err*]
         (let [warn-str "`ssl-protocols` contains SSLv3, a protocol with known vulnerabilities and should be removed from the `ssl-protocols` list"]
           (println warn-str)
@@ -364,7 +364,7 @@
   [config-data]
   (if (get-in config-data [:jetty :ssl-protocols])
     (warn-if-sslv3 config-data)
-    (assoc-in config-data [:jetty :ssl-protocols] "TLSv1, TLSv1.1, TLSv1.2")))
+    (assoc-in config-data [:jetty :ssl-protocols] ["TLSv1" "TLSv1.1" "TLSv1.2"])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -210,13 +210,13 @@
 (deftest sslv3-warn-test
   (testing "output to log"
     (tu-log/with-log-output log-output
-      (let [bad-config {:jetty {:ssl-protocols "SSLv3, TLSv1, TLSv1.1, TLSv1.2"}}]
+      (let [bad-config {:jetty {:ssl-protocols ["SSLv3" "TLSv1" "TLSv1.1" "TLSv1.2"]}}]
         (is (= bad-config
                (default-ssl-protocols bad-config)))
         (is (.contains (last (first @log-output)) "contains SSLv3")))))
 
   (testing "output to standard out"
-    (let [bad-config {:jetty {:ssl-protocols "SSLv3, TLSv1, TLSv1.1, TLSv1.2"}}
+    (let [bad-config {:jetty {:ssl-protocols ["SSLv3" "TLSv1" "TLSv1.1" "TLSv1.2"]}}
           out-str (with-out-str
                     (binding [*err* *out*]
                       (default-ssl-protocols bad-config)))]
@@ -224,7 +224,7 @@
 
   (testing "defaulted-config"
     (tu-log/with-log-output log-output
-      (is (= {:jetty {:ssl-protocols "TLSv1, TLSv1.1, TLSv1.2"}}
+      (is (= {:jetty {:ssl-protocols ["TLSv1" "TLSv1.1" "TLSv1.2"]}}
              (default-ssl-protocols {})))
       (is (empty? @log-output))
       (is (str/blank?


### PR DESCRIPTION
Right now tk-webserver-jetty9 0.7.5 requires a list to be passed to it for
the setting `ssl-protocols` but our rewrite still provides a comma separated
string.

While this is a bug in-and-of-itself, its causing our tests to fail. This
patch gets us back to passing. We'll look at the configuration issue as a
part of the fixes going into TK that might resolve this.

Signed-off-by: Ken Barber ken@bob.sh
