### PR TITLE
DOCUMENT-211: Greater than or equal to and less than or equal to swapped

### DIFF
--- a/documentation/api/query/v2/operators.markdown
+++ b/documentation/api/query/v2/operators.markdown
@@ -42,12 +42,12 @@ they can't be coerced, the operator will not match.
 **Matches if:** the field is less than the provided value. Coerces both the field and value to floats or integers; if
 they can't be coerced, the operator will not match.
 
-### `>=` (less than or equal to)
+### `<=` (less than or equal to)
 
 **Matches if:** the field is greater than or equal to the provided value. Coerces both the field and value to floats or integers; if
 they can't be coerced, the operator will not match.
 
-### `<=` (greater than or equal to)
+### `>=` (greater than or equal to)
 
 **Matches if:** the field is less than or equal to the provided value. Coerces both the field and value to floats or integers; if
 they can't be coerced, the operator will not match.

--- a/documentation/api/query/v3/operators.markdown
+++ b/documentation/api/query/v3/operators.markdown
@@ -44,12 +44,12 @@ they can't be coerced, the operator will not match.
 **Matches if:** the field is less than the provided value. Coerces both the field and value to floats or integers; if
 they can't be coerced, the operator will not match.
 
-### `>=` (less than or equal to)
+### `<=` (less than or equal to)
 
 **Matches if:** the field is greater than or equal to the provided value. Coerces both the field and value to floats or integers; if
 they can't be coerced, the operator will not match.
 
-### `<=` (greater than or equal to)
+### `>=` (greater than or equal to)
 
 **Matches if:** the field is less than or equal to the provided value. Coerces both the field and value to floats or integers; if
 they can't be coerced, the operator will not match.

--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -54,13 +54,13 @@ database value.
 
 **Matches if:** the field is greater than the provided value.
 
-### `>=` (less than or equal to)
+### `<=` (less than or equal to)
 
 **Works with:** numbers, timestamps, multi
 
 **Matches if:** the field is greater than the provided value.
 
-### `<=` (greater than or equal to)
+### `>=` (greater than or equal to)
 
 **Works with:** numbers, timestamps, multi
 


### PR DESCRIPTION
The greater than or equal to (>=) and less than or equal to (<=) signs were swapped. Now they aren't.

This fix should also get into master.
