### PR TITLE
(PDB-880) Errors on PDB shutdown

### DIFF
--- a/documentation/api/query/v2/metrics.markdown
+++ b/documentation/api/query/v2/metrics.markdown
@@ -9,7 +9,10 @@ canonical: "/puppetdb/latest/api/query/v2/metrics.html"
 Querying PuppetDB metrics is accomplished by making an HTTP request
 to paths under the `/v2/metrics` REST endpoint.
 
-> **Note:** The v2 API is deprecated. We recommend that you use the v3 API instead.
+**Note:** The v2 API is deprecated. We recommend that you use the v3 API instead.
+
+**Note** In most cases PuppetDB is simply a conduit for mbeans made available
+by its components. PuppetDB makes no guarantee about the stability of mbean names.
 
 ## Listing available metrics
 

--- a/documentation/api/query/v3/metrics.markdown
+++ b/documentation/api/query/v3/metrics.markdown
@@ -9,6 +9,9 @@ canonical: "/puppetdb/latest/api/query/v3/metrics.html"
 Querying PuppetDB metrics is accomplished by making an HTTP request
 to paths under the `/v3/metrics` REST endpoint.
 
+**Note** In most cases PuppetDB is simply a conduit for mbeans made available
+by its components. PuppetDB makes no guarantee about the stability of mbean names.
+
 ## Listing available metrics
 
 ### Request format

--- a/documentation/api/query/v4/metrics.markdown
+++ b/documentation/api/query/v4/metrics.markdown
@@ -9,7 +9,10 @@ canonical: "/puppetdb/latest/api/query/v4/metrics.html"
 Querying PuppetDB metrics is accomplished by making an HTTP request
 to paths under the `/v4/metrics` REST endpoint.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, it is recommended that you use the v3 API instead.
+**Note:** The v4 API is experimental and may change without notice. For stability, it is recommended that you use the v3 API instead.
+
+**Note** In most cases PuppetDB is simply a conduit for mbeans made available
+by its components. PuppetDB makes no guarantee about the stability of mbean names.
 
 ## Listing available metrics
 

--- a/project.clj
+++ b/project.clj
@@ -57,7 +57,7 @@
                  [clojureql "1.0.3"]
                  ;; MQ connectivity
                  [clamq/clamq-activemq "0.4" :exclusions [org.slf4j/slf4j-api]]
-                 [org.apache.activemq/activemq-core "5.6.0" :exclusions [org.slf4j/slf4j-api org.fusesource.fuse-extra/fusemq-leveldb]]
+                 [org.apache.activemq/activemq-core "5.7.0" :exclusions [org.slf4j/slf4j-api org.fusesource.fuse-extra/fusemq-leveldb]]
                  ;; bridge to allow some spring/activemq stuff to log over slf4j
                  [org.slf4j/jcl-over-slf4j "1.7.6"]
                  ;; WebAPI support libraries.


### PR DESCRIPTION
This patch bumps activemq to 5.7.0.  This seems to prevent two errors that
would sometimes occur on shutdown, one where the broker was stopped before its consumers
were removed and another where KahaDB batching fails to reset due to the PageFile
not being loaded.
