### PR TITLE
(maint) Allow factset hashes to be null in db

### DIFF
--- a/src/puppetlabs/puppetdb/query/factsets.clj
+++ b/src/puppetlabs/puppetdb/query/factsets.clj
@@ -14,7 +14,7 @@
    :environment (s/maybe s/Str)
    :path String
    :value s/Any
-   :hash s/Str
+   :hash (s/maybe s/Str)
    :value_float (s/maybe s/Num)
    :value_integer (s/maybe s/Int)
    :producer-timestamp (s/maybe pls/Timestamp)
@@ -25,7 +25,7 @@
   {:certname String
    :environment (s/maybe s/Str)
    :path String
-   :hash s/Str
+   :hash (s/maybe s/Str)
    :value s/Any
    :producer-timestamp (s/maybe pls/Timestamp)
    :timestamp pls/Timestamp})
@@ -35,7 +35,7 @@
    :environment (s/maybe s/Str)
    :timestamp pls/Timestamp
    :producer-timestamp (s/maybe pls/Timestamp)
-   :hash s/Str
+   :hash (s/maybe s/Str)
    :facts {s/Str s/Any}})
 
 ;; FUNCS

--- a/test/puppetlabs/puppetdb/query/factsets_test.clj
+++ b/test/puppetlabs/puppetdb/query/factsets_test.clj
@@ -122,6 +122,17 @@
                :hash "1234"}]
              (structured-data-seq :v4 test-rows)))))
 
+  (testing "ensure that nil-valued hashes are legal"
+    (let [test-row [{:certname "foo.com" :environment "DEV" :path "a#~b#~c"
+                      :value "abc" :type "string" :timestamp current-time
+                      :value_integer nil :value_float nil
+                      :producer-timestamp current-time :hash nil}]]
+      (is (= [{:facts {"a" {"b" {"c" "abc"}}}
+               :producer-timestamp current-time
+               :timestamp current-time :environment "DEV"
+               :certname "foo.com", :hash nil}]
+             (structured-data-seq :v4 test-row)))))
+
   (testing "json numeric formats"
     (let [test-rows [{:certname "foo.com" :environment "DEV" :path "a#~b#~c"
                       :value_integer 100000000000 :type "integer" :timestamp current-time


### PR DESCRIPTION
This is necessary for factsets to function after the PDB-898 migration,
since preexisting factsets are not being hashed.
