### PR TITLE
(PDB-911) change to TK WebroutingService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ pom.xml
 *#
 /pkg/
 test-resources/config/local.clj
+checkouts
 ext/packaging/*
 /scripts
 Gemfile.lock

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
            (s/trim out)
            "0.0-dev-build"))))))
 
-(def tk-version "0.5.1")
+(def tk-version "0.5.2")
 (def tk-jetty9-version "0.9.0")
 (def ks-version "0.7.2")
 

--- a/resources/bootstrap.cfg
+++ b/resources/bootstrap.cfg
@@ -5,6 +5,7 @@
 
 # Load the web server service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 
 # Load the PuppetDB service
 puppetlabs.puppetdb.cli.services/puppetdb-service

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -171,7 +171,7 @@
             db-config
             (-> db-config
                 (assoc :node-ttl (or (maybe-days (:node-ttl-days db-config))
-                                     (pl-time/parse-period "0s")))  ))
+                                     (pl-time/parse-period "0s")))))
           :node-ttl-days))
 
 (defn convert-write-db-config
@@ -366,6 +366,11 @@
     (warn-if-sslv3 config-data)
     (assoc-in config-data [:jetty :ssl-protocols] ["TLSv1" "TLSv1.1" "TLSv1.2"])))
 
+(defn add-web-routing-config
+  [config-data]
+  (let [prefix (get-in config-data [:global :url-prefix] "/")]
+    (assoc-in config-data [:web-router-service
+                           :puppetlabs.puppetdb.cli.services/puppetdb-service] prefix)))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
@@ -377,7 +382,8 @@
   (let [config (f args)]
     (-> config
         fix-tk-config
-        default-ssl-protocols)))
+        default-ssl-protocols
+        add-web-routing-config)))
 
 (defn process-config!
   "Accepts a map containing all of the user-provided configuration values

--- a/test/puppetlabs/puppetdb/testutils/jetty.clj
+++ b/test/puppetlabs/puppetdb/testutils/jetty.clj
@@ -4,6 +4,7 @@
             [puppetlabs.trapperkeeper.app :as tka]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tkbs]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
+            [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :refer [webrouting-service]]
             [puppetlabs.puppetdb.cli.services :refer [puppetdb-service]]
             [puppetlabs.puppetdb.mq-listener :refer [message-listener-service]]
             [puppetlabs.puppetdb.command :refer [command-service]]
@@ -19,7 +20,8 @@
    :global {:vardir (temp-dir)}
    :jetty {:port 0}
    :database (fixt/create-db-map)
-   :command-processing {}})
+   :command-processing {}
+   :web-router-service {:puppetlabs.puppetdb.cli.services/puppetdb-service "/"}})
 
 (defn current-url
   "Uses the dynamically bound port to create a v4 URL to the
@@ -45,7 +47,7 @@
   ([f] (puppetdb-instance (create-config) f))
   ([config f]
      (tkbs/with-app-with-config server
-       [jetty9-service puppetdb-service message-listener-service command-service]
+       [jetty9-service puppetdb-service message-listener-service command-service webrouting-service]
        config
        (binding [*port* (current-port server)]
          (f)))))


### PR DESCRIPTION
This commit switches us from the TK WebserverService to the TK
WebroutingService. This will allow us to attach commercial-only routes by
modifying the config file before consumption by TK.
