### PR TITLE
WIP: (PDB-950) Catch and express postgresql regexp failures as better errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
 script: ./ext/travisci/test.sh
 notifications:
   email: false
+addons:
+  postgresql: "9.3"
 services: postgresql
 before_install:
   - rvm use 1.9.3

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -16,7 +16,16 @@
             [puppetlabs.puppetdb.query :as query]
             [net.cgrand.moustache :refer [app]]
             [puppetlabs.puppetdb.jdbc :as jdbc]
-            [puppetlabs.puppetdb.http :as http]))
+            [puppetlabs.puppetdb.http :as http]
+            [clojure.tools.logging :as log]))
+
+(defmacro process-psql-invalid-regexp-or-rethrow
+  [e & body]
+  `(if (= (.getSQLState ~e) "2201B")
+    (do
+      (log/debug ~e "Caught PSQL processing exception")
+      ~@body)
+    (throw ~e)))
 
 (defn ignore-engine-params
   "Query engine munge functions should take two arguments, a version
@@ -51,11 +60,24 @@
              count-query :count-query
              projections :projections} (query->sql version query
                                                    paging-options)
+             query-error (promise)
              resp (output-fn
                    (fn [f]
-                     (jdbc/with-transacted-connection db
-                       (query/streamed-query-result version sql params
-                                                    (comp f (munge-fn version projections))))))]
+                     (try
+                       (jdbc/with-transacted-connection db
+                         (query/streamed-query-result version sql params
+                           (comp
+                             f
+                             #(do
+                                (first %)
+                                (deliver query-error nil)
+                                %)
+                             (munge-fn version projections))))
+                       (catch java.sql.SQLException e
+                         (deliver query-error e)
+                         nil))))]
+        (when @query-error
+          (throw @query-error))
         (if count-query
           (http/add-headers resp {:count (jdbc/get-result-count count-query entity)})
           resp)))))
@@ -71,4 +93,7 @@
     (catch com.fasterxml.jackson.core.JsonParseException e
       (pl-http/error-response e))
     (catch IllegalArgumentException e
-      (pl-http/error-response e))))
+      (pl-http/error-response e))
+    (catch org.postgresql.util.PSQLException e
+      (process-psql-invalid-regexp-or-rethrow e
+        (pl-http/error-response (.getMessage e))))))

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -71,9 +71,10 @@
            (fn [f]
              (f
               (fn [result-set]
-                (reset! before-slurp? (realized? result-set))
+                ;; We evaluate a first element from lazy-seq just to check if DB query was successful or not
+                (reset! before-slurp? (and (realized? result-set) (realized? (rest result-set))))
                 (reset! results result-set)
-                (reset! after-slurp? (realized? result-set))))))
+                (reset! after-slurp? (and (realized? result-set) (realized? (rest result-set))))))))
     (is (false? @before-slurp?))
     (check-result @results)
     (is (false? @after-slurp?))))

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -320,6 +320,21 @@
         (is (re-find msg body))
         (is (= status http/status-bad-request))))))
 
+(def pg-versioned-invalid-regexps
+  (omap/ordered-map
+    "/v4/facts" (omap/ordered-map
+                  ["~" "certname" "*abc"]
+                  #".*invalid regular expression.*")))
+
+(deftestseq ^{:hsqldb false} pg-invalid-regexps
+  [[version endpoint] facts-endpoints]
+
+  (doseq [[query msg] (get pg-versioned-invalid-regexps endpoint)]
+    (testing (str "query: " query " should fail with msg: " msg)
+      (let [{:keys [status body] :as result} (get-response endpoint query)]
+        (is (re-find msg body))
+        (is (= status http/status-bad-request))))))
+
 (def common-well-formed-tests
   (omap/ordered-map
    ["=" "name" "domain"]


### PR DESCRIPTION
This commit adds a validation for regexps in queries as was proposed in PDB-950