### PR TITLE
(PDB-971) retire facts.strip_internal

### DIFF
--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -20,7 +20,6 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
     profile "facts#save" do
       payload = profile "Encode facts command submission payload" do
         facts = request.instance.dup
-        facts.values = facts.strip_internal
         if Puppet[:trusted_node_data]
           facts.values[:trusted] = get_trusted_info(request.node)
         end

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -39,7 +39,7 @@ describe Puppet::Node::Facts::Puppetdb do
     it "should POST the facts as a JSON string" do
       f = {
         "name" => facts.name,
-        "values" => facts.strip_internal,
+        "values" => facts.values,
         "environment" => "my_environment",
         "producer-timestamp" => "a test",
       }
@@ -64,7 +64,7 @@ describe Puppet::Node::Facts::Puppetdb do
 
       f = {
         "name" => facts.name,
-        "values" => facts.strip_internal.merge({"trusted" => trusted_data}),
+        "values" => facts.values.merge({"trusted" => trusted_data}),
         "environment" => "my_environment",
         "producer-timestamp" => "a test",
       }


### PR DESCRIPTION
This patch replaces calls to Facts#strip_internal with calls to Facts#values.
strip_internal is a deprecated method, and it is no longer necessary anyway
since the _timestamp fact is gone.
