### PR TITLE
(PDB-1012) Make spec tests use correct Puppet version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
+puppet_branch = ENV['puppet_branch'] || "latest"
+oldest_supported_puppet = "3.5.1"
 
 gem 'facter'
 
@@ -14,7 +16,15 @@ group :test do
   gem 'rspec', '2.13.0'
   gem 'puppetlabs_spec_helper', '0.4.1', :require => false
 
-  gem 'puppet', '>= 3.5.1', :require => false
+  case puppet_branch
+  when "latest"
+    gem 'puppet', ">= #{oldest_supported_puppet}", :require => false
+  when "oldest"
+    gem 'puppet', oldest_supported_puppet, :require => false
+  else
+    gem 'puppet', :git => 'git://github.com/puppetlabs/puppet.git',
+      :branch => puppet_branch, :require => false
+  end
 
   gem 'mocha', '~> 1.0'
 

--- a/ext/jenkins/terminus-rspec.sh
+++ b/ext/jenkins/terminus-rspec.sh
@@ -25,17 +25,7 @@ echo ""
 echo "PUPPETDB_BRANCH: ${PUPPETDB_BRANCH}"
 echo "**********************************************"
 
-(
-  cd vendor
-  git clone --depth 1 git://github.com/puppetlabs/facter.git
-
-  # Checkout Puppet branch
-  git clone --depth 1 --branch ${puppet_branch} git://github.com/puppetlabs/puppet.git
-
-  git clone --depth 1 git://github.com/puppetlabs/puppetlabs_spec_helper.git
-)
-
-export RUBYLIB=$RUBYLIB:`pwd`/vendor/facter/lib/:`pwd`/vendor/puppet/lib/:`pwd`/vendor/puppetlabs_spec_helper/lib
+export RUBYLIB=$RUBYLIB:`pwd`/puppet/lib
 
 cat >/tmp/force_gc.rb <<RUBY
 def GC.disable; end


### PR DESCRIPTION
This patch parameterizes the branch of puppet our Gemfile installs so that we
can use specific puppet versions in our spec tests.
