### PR TITLE
(PDB-1011) Allow querying of PDB directly via a TK service

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -68,7 +68,8 @@
             [puppetlabs.puppetdb.repl :refer [start-repl]]
             [puppetlabs.puppetdb.scf.migrate :refer [migrate! indexes!]]
             [puppetlabs.puppetdb.version :refer [version update-info]]
-            [puppetlabs.puppetdb.command.constants :refer [command-names]]))
+            [puppetlabs.puppetdb.command.constants :refer [command-names]]
+            [puppetlabs.puppetdb.query-eng :as qeng]))
 
 (def cli-description "Main PuppetDB daemon")
 
@@ -329,7 +330,8 @@
       (assoc context :shared-globals globals))))
 
 (defprotocol PuppetDBServer
-  (shared-globals [this]))
+  (shared-globals [this])
+  (query [this query-obj version query-expr query-row-callback-fn]))
 
 (defservice puppetdb-service
   "Defines a trapperkeeper service for PuppetDB; this service is responsible
@@ -345,7 +347,15 @@
   (stop [this context]
         (stop-puppetdb context))
   (shared-globals [this]
-                  (:shared-globals (service-context this))))
+                  (:shared-globals (service-context this)))
+  (query [this query-obj version query-expr query-row-callback-fn]
+         (qeng/stream-query-result
+          query-obj
+          version
+          query-expr
+          nil
+          (get-in (service-context this) [:shared-globals :scf-read-db])
+          query-row-callback-fn)))
 
 (defn -main
   "Calls the trapperkeeper main argument to initialize tk.

--- a/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
+++ b/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
@@ -1,7 +1,6 @@
 (ns puppetlabs.puppetdb.cli.import-export-roundtrip-test
   (:require [puppetlabs.puppetdb.cli.export :as export]
             [puppetlabs.puppetdb.cli.import :as import]
-            [puppetlabs.trapperkeeper.core :as tk]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.testutils :as testutils]
             [fs.core :as fs]

--- a/test/puppetlabs/puppetdb/testutils/jetty.clj
+++ b/test/puppetlabs/puppetdb/testutils/jetty.clj
@@ -39,6 +39,8 @@
       first
       .getLocalPort))
 
+(def ^:dynamic *server*)
+
 (defn puppetdb-instance
   "Stands up a puppetdb instance with `config`, tears down once `f` returns.
    If the port is assigned by Jetty, use *port* to get the currently running port."
@@ -47,7 +49,8 @@
      (tkbs/with-app-with-config server
        [jetty9-service puppetdb-service message-listener-service command-service]
        config
-       (binding [*port* (current-port server)]
+       (binding [*port* (current-port server)
+                 *server* server]
          (f)))))
 
 (defmacro with-puppetdb-instance


### PR DESCRIPTION
This commit adds a function to the PuppetDBServer service to execute a
query and return the results as a Clojure data structure (rather than
streaming JSON over HTTP). A function can be passed in that will accept
a lazy seq to consume the rows
