### PR TITLE
(PDB-995) retire to_pson_data_hash in spec tests to conform to latest pu...

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -29,11 +29,9 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
 
   def munge_catalog(catalog, extra_request_data = {})
     profile "Munge catalog" do
-      hash = profile "Convert catalog to PSON data hash" do
-        catalog.to_pson_data_hash
+      data = profile "Convert catalog to JSON data hash" do
+        catalog.to_data_hash
       end
-
-      data = hash['data']
 
       add_parameters_if_missing(data)
       add_namevar_aliases(data, catalog)
@@ -239,7 +237,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
           # exported resources which haven't been also collected will appears as
           # exported and virtual (collected ones will only be exported). They will
           # eventually be removed from the catalog, so we can't add edges involving
-          # them. Puppet::Resource#to_pson_data_hash omits 'virtual', so we have to
+          # them. Puppet::Resource#to_data_hash omits 'virtual', so we have to
           # look it up in the catalog to find that information. This isn't done in
           # a separate step because we don't actually want to send the field (it
           # will always be false). See ticket #16472.

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -71,7 +71,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
     # create the catalog based on that manifest simply by asking for it.
     def catalog_data_hash
       Puppet[:code] = resource.to_manifest
-      catalog.to_pson_data_hash['data']
+      catalog.to_data_hash
     end
 
     describe "#add_transaction_uuid" do
@@ -117,7 +117,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
           notify { $foo: }
         MANIFEST
 
-        hash = catalog.to_pson_data_hash['data']
+        hash = catalog.to_data_hash
         result = subject.stringify_titles(hash)
 
         result['resources'].should be_any { |res|
@@ -166,7 +166,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
             #  way to accomplish this...
             Puppet[:code] = file_resource.to_manifest
 
-            hash = subject.add_parameters_if_missing(catalog.to_pson_data_hash['data'])
+            hash = subject.add_parameters_if_missing(catalog.to_data_hash)
             result = subject.add_namevar_aliases(hash, catalog)
 
             resource = result['resources'].find do |res|
@@ -314,7 +314,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         other_resource = Puppet::Resource.new(:notify, 'noone', :parameters => {:require => "Notify[anyone]"})
         Puppet[:code] = [resource, other_resource].map(&:to_manifest).join
 
-        hash = catalog.to_pson_data_hash['data']
+        hash = catalog.to_data_hash
         subject.add_parameters_if_missing(hash)
         result = subject.synthesize_edges(hash, catalog)
 
@@ -330,7 +330,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         Puppet[:code] = [resource, other_resource].map(&:to_manifest).join
         Puppet[:code] << "Notify[anyone] -> Notify[noone]"
 
-        hash = catalog.to_pson_data_hash['data']
+        hash = catalog.to_data_hash
         subject.add_parameters_if_missing(hash)
         result = subject.synthesize_edges(hash, catalog)
 
@@ -524,7 +524,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         resource[:require] = 'Notify[another_thing]'
         Puppet[:code] = [resource, other_resource].map(&:to_manifest).join
 
-        hash = catalog.to_pson_data_hash['data']
+        hash = catalog.to_data_hash
         subject.add_parameters_if_missing(hash)
         subject.add_namevar_aliases(hash, catalog)
         result = subject.synthesize_edges(hash, catalog)

--- a/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
@@ -75,7 +75,7 @@ describe Puppet::Resource::Puppetdb do
 
         res = Puppet::Type.type(:file).new(:title => File.expand_path(name),
                                            :ensure => :present,
-                                           :mode => 0777)
+                                           :mode => "0777")
         params = res.to_hash
         res_hash = metadata.merge(:type => res.type, :title => res.title)
         res_hash.merge(:parameters => params)


### PR DESCRIPTION
...ppet

This commit changes calls of to_pson_data_hash to to_data_hash so that our tests
pass on the current master branch of puppet.
