### PR TITLE
(PDB-971) retire facts.strip_internal

### DIFF
--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -16,11 +16,19 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
     trusted.to_h
   end
 
+  def maybe_strip_internal(facts)
+    if Puppet::Node::Facts.method_defined? :strip_internal
+      facts.strip_internal
+    else
+      facts.values
+    end
+  end
+
   def save(request)
     profile "facts#save" do
       payload = profile "Encode facts command submission payload" do
         facts = request.instance.dup
-        facts.values = facts.strip_internal
+        facts.values = maybe_strip_internal(facts)
         if Puppet[:trusted_node_data]
           facts.values[:trusted] = get_trusted_info(request.node)
         end

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -39,7 +39,7 @@ describe Puppet::Node::Facts::Puppetdb do
     it "should POST the facts as a JSON string" do
       f = {
         "name" => facts.name,
-        "values" => facts.strip_internal,
+        "values" => subject.maybe_strip_internal(facts),
         "environment" => "my_environment",
         "producer-timestamp" => "a test",
       }
@@ -64,7 +64,7 @@ describe Puppet::Node::Facts::Puppetdb do
 
       f = {
         "name" => facts.name,
-        "values" => facts.strip_internal.merge({"trusted" => trusted_data}),
+        "values" => subject.maybe_strip_internal(facts).merge({"trusted" => trusted_data}),
         "environment" => "my_environment",
         "producer-timestamp" => "a test",
       }


### PR DESCRIPTION
This patch adds a maybe_strip_internal method to Puppet::Node::Facts::Puppetdb
that will call Facts#strip_internal if the method exists, but Facts#values if
not. This will allow our terminus to remain backwards compatible when Puppet
retires the strip_internal method and the _timestamp fact.
