### PR TITLE
(PUP-3512) Use new Profiler API

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -8,7 +8,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   include Puppet::Util::Puppetdb::CommandNames
 
   def save(request)
-    profile "catalog#save" do
+    profile("catalog#save", [:puppetdb, :catalog, :save, request.key]) do
       catalog = munge_catalog(request.instance, extract_extra_request_data(request))
       submit_command(request.key, catalog, CommandReplaceCatalog, 5)
     end
@@ -28,8 +28,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   end
 
   def munge_catalog(catalog, extra_request_data = {})
-    profile "Munge catalog" do
-      data = profile "Convert catalog to JSON data hash" do
+    profile("Munge catalog", [:puppetdb, :catalog, :munge]) do
+      data = profile("Convert catalog to JSON data hash", [:puppetdb, :catalog, :convert_to_hash]) do
         catalog.to_data_hash
       end
 
@@ -109,7 +109,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
 
   def stringify_titles(hash)
     resources = hash['resources']
-    profile "Stringify titles (resource count: #{resources.count})" do
+    profile("Stringify titles (resource count: #{resources.count})",
+            [:puppetdb, :titles, :stringify]) do
       resources.each do |resource|
         resource['title'] = resource['title'].to_s
       end
@@ -120,7 +121,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
 
   def add_parameters_if_missing(hash)
     resources = hash['resources']
-    profile "Add parameters if missing (resource count: #{resources.count})" do
+    profile("Add parameters if missing (resource count: #{resources.count})",
+            [:puppetdb, :parameters, :add_missing]) do
       resources.each do |resource|
         resource['parameters'] ||= {}
       end
@@ -131,7 +133,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
 
   def add_namevar_aliases(hash, catalog)
     resources = hash['resources']
-    profile "Add namevar aliases (resource count: #{resources.count})" do
+    profile("Add namevar aliases (resource count: #{resources.count})",
+            [:puppetdb, :namevar_aliases, :add]) do
       resources.each do |resource|
         real_resource = catalog.resource(resource['type'], resource['title'])
 
@@ -173,7 +176,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
 
   def sort_unordered_metaparams(hash)
     resources = hash['resources']
-    profile "Sort unordered metaparams (resource count: #{resources.count})" do
+    profile("Sort unordered metaparams (resource count: #{resources.count})",
+            [:puppetdb, :metaparams, :sort]) do
       resources.each do |resource|
         params = resource['parameters']
         UnorderedMetaparams.each do |metaparam|
@@ -190,7 +194,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
 
   def munge_edges(hash)
     edges = hash['edges']
-    profile "Munge edges (edge count: #{edges.count})" do
+    profile("Munge edges (edge count: #{edges.count})",
+            [:puppetdb, :edges, :munge]) do
       edges.each do |edge|
         %w[source target].each do |vertex|
           edge[vertex] = resource_ref_to_hash(edge[vertex]) if edge[vertex].is_a?(String)
@@ -206,7 +211,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
     resources = hash['resources']
     aliases = {}
 
-    profile "Map aliases to title (resource count: #{resources.count})" do
+    profile("Map aliases to title (resource count: #{resources.count})",
+            [:puppetdb, :aliases, :map_to_title]) do
       resources.each do |resource|
         names = resource['parameters']['alias'] || []
         resource_hash = {'type' => resource['type'], 'title' => resource['title']}
@@ -221,17 +227,20 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   end
 
   def synthesize_edges(hash, catalog)
-    profile "Synthesize edges" do
+    profile("Synthesize edges",
+            [:puppetdb, :edges, :synthesize]) do
       aliases = map_aliases_to_title(hash)
 
       resource_table = {}
-      profile "Build up resource_table" do
+      profile("Build up resource_table",
+              [:puppetdb, :edges, :synthesize, :resource_table, :build]) do
         hash['resources'].each do |resource|
           resource_table[ [resource['type'], resource['title']] ] = resource
         end
       end
 
-      profile "Primary synthesis" do
+      profile("Primary synthesis",
+              [:puppetdb, :edges, :synthesize, :primary_synthesis])do
         hash['resources'].each do |resource|
           # Standard virtual resources don't appear in the catalog. However,
           # exported resources which haven't been also collected will appears as
@@ -326,7 +335,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
         end
       end
 
-      profile "Make edges unique" do
+      profile("Make edges unique",
+              [:puppetdb, :edges, :synthesize, :make_unique]) do
         hash['edges'].uniq!
       end
 
@@ -335,7 +345,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   end
 
   def filter_keys(hash)
-    profile "Filter extraneous keys from the catalog" do
+    profile("Filter extraneous keys from the catalog",
+            [:puppetdb, :keys, :filter_extraneous]) do
       hash.delete_if do |k,v|
         ! ['name', 'version', 'edges', 'resources'].include?(k)
       end

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -25,8 +25,9 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
   end
 
   def save(request)
-    profile "facts#save" do
-      payload = profile "Encode facts command submission payload" do
+    profile("facts#save", [:puppetdb, :facts, :save, request.key]) do
+      payload = profile("Encode facts command submission payload",
+                        [:puppetdb, :facts, :encode]) do
         facts = request.instance.dup
         facts.values = maybe_strip_internal(facts)
         if Puppet[:trusted_node_data]
@@ -48,17 +49,18 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
   end
 
   def find(request)
-    profile "facts#find" do
+    profile("facts#find", [:puppetdb, :facts, :find, request.key]) do
       begin
         response = Http.action("/v3/nodes/#{CGI.escape(request.key)}/facts") do |http_instance, path|
-          profile "Query for nodes facts: #{path}" do
+          profile("Query for nodes facts: #{path}", [:puppetdb, :facts, :find, request.key, :query_nodes]) do
             http_instance.get(path, headers)
           end
         end
         log_x_deprecation_header(response)
 
         if response.is_a? Net::HTTPSuccess
-          profile "Parse fact query response (size: #{response.body.size})" do
+          profile("Parse fact query response (size: #{response.body.size})",
+                  [:puppetdb, :facts, :find, request.key, :parse_response]) do
             result = JSON.parse(response.body)
             # Note: the Inventory Service API appears to expect us to return nil here
             # if the node isn't found.  However, PuppetDB returns an empty array in
@@ -96,7 +98,7 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
   # `operator` may be one of {eq, ne, lt, gt, le, ge}, and will default to 'eq'
   # if unspecified.
   def search(request)
-    profile "facts#search" do
+    profile("facts#search", [:puppetdb, :facts, :search, request.key]) do
       return [] unless request.options
       operator_map = {
         'eq' => '=',
@@ -121,14 +123,16 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
 
       begin
         response = Http.action("/v3/nodes?query=#{query_param}") do |http_instance, path|
-          profile "Fact query request: #{URI.unescape(path)}" do
+          profile("Fact query request: #{URI.unescape(path)}",
+                  [:puppetdb, :facts, :search, request.key, :query_request]) do
             http_instance.get(path, headers)
           end
         end
         log_x_deprecation_header(response)
 
         if response.is_a? Net::HTTPSuccess
-          profile "Parse fact query response (size: #{response.body.size})" do
+          profile("Parse fact query response (size: #{response.body.size})",
+                  [:puppetdb, :facts, :search, request.key, :parse_query_response]) do
             JSON.parse(response.body).collect {|s| s["name"]}
           end
         else

--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -18,7 +18,7 @@ Puppet::Reports.register_report(:puppetdb) do
   #
   # @return [void]
   def process
-    profile "report#process" do
+    profile("report#process", [:puppetdb, :report, :process]) do
       submit_command(self.host, report_to_hash, CommandStoreReport, 4)
     end
 
@@ -31,7 +31,8 @@ Puppet::Reports.register_report(:puppetdb) do
   # @return Hash[<String, Object>]
   # @api private
   def report_to_hash
-    profile "Convert report to wire format hash" do
+    profile("Convert report to wire format hash",
+            [:puppetdb, :report, :convert_to_wire_format_hash]) do
       if environment.nil?
         raise Puppet::Error, "Environment is nil, unable to submit report. This may be due a bug with Puppet. Ensure you are running the latest revision, see PUP-2508 for more details."
       end
@@ -54,7 +55,8 @@ Puppet::Reports.register_report(:puppetdb) do
   # @return Array[Hash]
   # @api private
   def build_events_list
-    profile "Build events list (count: #{resource_statuses.count})" do
+    profile("Build events list (count: #{resource_statuses.count})",
+            [:puppetdb, :events_list, :build]) do
       filter_events(resource_statuses.inject([]) do |events, status_entry|
         _, status = *status_entry
         if ! (status.events.empty?)
@@ -133,7 +135,8 @@ Puppet::Reports.register_report(:puppetdb) do
   # @api private
   def filter_events(events)
     if config.ignore_blacklisted_events?
-      profile "Filter blacklisted events" do
+      profile("Filter blacklisted events",
+              [:puppetdb, :events, :filter_blacklisted]) do
         events.select { |e| ! config.is_event_blacklisted?(e) }
       end
     else

--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -57,7 +57,8 @@ module Puppet::Util::Puppetdb
   # @param version [Number] version number of command
   # @return [Hash <String, String>]
   def submit_command(certname, payload, command_name, version)
-    profile "Submitted command '#{command_name}' version '#{version}'" do
+    profile("Submitted command '#{command_name}' version '#{version}'",
+            [:puppetdb, :command, :submit, command_name, version]) do
       command = Puppet::Util::Puppetdb::Command.new(command_name, version, certname, payload)
       command.submit
     end
@@ -71,11 +72,12 @@ module Puppet::Util::Puppetdb
   # in the profiled hierachy.
   #
   # @param message [String] A description of the profiled event
+  # @param metric_id [Array] A list of strings making up the ID of a metric to profile
   # @param block [Block] The segment of code to profile
   # @api public
-  def profile(message, &block)
+  def profile(message, metric_id, &block)
     message = "PuppetDB: " + message
-    Puppet::Util::Profiler.profile(message, &block)
+    Puppet::Util::Profiler.profile(message, metric_id, &block)
   end
 
   # @!group Private instance methods

--- a/puppet/lib/puppet/util/puppetdb/command.rb
+++ b/puppet/lib/puppet/util/puppetdb/command.rb
@@ -27,7 +27,7 @@ class Puppet::Util::Puppetdb::Command
     @command = command
     @version = version
     @certname = certname
-    profile "Format payload" do
+    profile("Format payload", [:puppetdb, :payload, :format]) do
       @payload = self.class.format_payload(command, version, payload)
     end
   end
@@ -43,7 +43,8 @@ class Puppet::Util::Puppetdb::Command
     for_whom = " for #{certname}" if certname
 
     begin
-      response = profile "Submit command HTTP post" do
+      response = profile("Submit command HTTP post",
+                         [:puppetdb, :command, :submit]) do
         Http.action("#{CommandsUrl}?checksum=#{checksum}") do |http_instance, path|
           http_instance.post(path, payload, headers)
         end


### PR DESCRIPTION
This PR modifies PuppetDB to use the new Puppet Profiler API instead of the old one, in preparation for the removal of the old API.
