### PR TITLE
(PUP-3512) Use new Profiler API

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -8,7 +8,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   include Puppet::Util::Puppetdb::CommandNames
 
   def save(request)
-    profile "catalog#save" do
+    profile("catalog#save", [:puppetdb, :catalog, :save, request.key]) do
       catalog = munge_catalog(request.instance, extract_extra_request_data(request))
       submit_command(request.key, catalog, CommandReplaceCatalog, 5)
     end
@@ -28,8 +28,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   end
 
   def munge_catalog(catalog, extra_request_data = {})
-    profile "Munge catalog" do
-      data = profile "Convert catalog to JSON data hash" do
+    profile("Munge catalog", [:puppetdb, :catalog, :munge]) do
+      data = profile("Convert catalog to JSON data hash", [:puppetdb, :catalog, :convert_to_hash]) do
         catalog.to_data_hash
       end
 
@@ -109,7 +109,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
 
   def stringify_titles(hash)
     resources = hash['resources']
-    profile "Stringify titles (resource count: #{resources.count})" do
+    profile("Stringify titles (resource count: #{resources.count})",
+            [:puppetdb, :titles, :stringify]) do
       resources.each do |resource|
         resource['title'] = resource['title'].to_s
       end
@@ -120,7 +121,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
 
   def add_parameters_if_missing(hash)
     resources = hash['resources']
-    profile "Add parameters if missing (resource count: #{resources.count})" do
+    profile("Add parameters if missing (resource count: #{resources.count})",
+            [:puppetdb, :parameters, :add_missing]) do
       resources.each do |resource|
         resource['parameters'] ||= {}
       end
@@ -131,7 +133,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
 
   def add_namevar_aliases(hash, catalog)
     resources = hash['resources']
-    profile "Add namevar aliases (resource count: #{resources.count})" do
+    profile("Add namevar aliases (resource count: #{resources.count})",
+            [:puppetdb, :namevar_aliases, :add]) do
       resources.each do |resource|
         real_resource = catalog.resource(resource['type'], resource['title'])
 
@@ -173,7 +176,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
 
   def sort_unordered_metaparams(hash)
     resources = hash['resources']
-    profile "Sort unordered metaparams (resource count: #{resources.count})" do
+    profile("Sort unordered metaparams (resource count: #{resources.count})",
+            [:puppetdb, :metaparams, :sort]) do
       resources.each do |resource|
         params = resource['parameters']
         UnorderedMetaparams.each do |metaparam|
@@ -190,7 +194,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
 
   def munge_edges(hash)
     edges = hash['edges']
-    profile "Munge edges (edge count: #{edges.count})" do
+    profile("Munge edges (edge count: #{edges.count})",
+            [:puppetdb, :edges, :munge]) do
       edges.each do |edge|
         %w[source target].each do |vertex|
           edge[vertex] = resource_ref_to_hash(edge[vertex]) if edge[vertex].is_a?(String)
@@ -206,7 +211,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
     resources = hash['resources']
     aliases = {}
 
-    profile "Map aliases to title (resource count: #{resources.count})" do
+    profile("Map aliases to title (resource count: #{resources.count})",
+            [:puppetdb, :aliases, :map_to_title]) do
       resources.each do |resource|
         names = resource['parameters']['alias'] || []
         resource_hash = {'type' => resource['type'], 'title' => resource['title']}
@@ -221,17 +227,20 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   end
 
   def synthesize_edges(hash, catalog)
-    profile "Synthesize edges" do
+    profile("Synthesize edges",
+            [:puppetdb, :edges, :synthesize]) do
       aliases = map_aliases_to_title(hash)
 
       resource_table = {}
-      profile "Build up resource_table" do
+      profile("Build up resource_table",
+              [:puppetdb, :edges, :synthesize, :resource_table, :build]) do
         hash['resources'].each do |resource|
           resource_table[ [resource['type'], resource['title']] ] = resource
         end
       end
 
-      profile "Primary synthesis" do
+      profile("Primary synthesis",
+              [:puppetdb, :edges, :synthesize, :primary_synthesis])do
         hash['resources'].each do |resource|
           # Standard virtual resources don't appear in the catalog. However,
           # exported resources which haven't been also collected will appears as
@@ -326,7 +335,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
         end
       end
 
-      profile "Make edges unique" do
+      profile("Make edges unique",
+              [:puppetdb, :edges, :synthesize, :make_unique]) do
         hash['edges'].uniq!
       end
 
@@ -335,7 +345,8 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   end
 
   def filter_keys(hash)
-    profile "Filter extraneous keys from the catalog" do
+    profile("Filter extraneous keys from the catalog",
+            [:puppetdb, :keys, :filter_extraneous]) do
       hash.delete_if do |k,v|
         ! ['name', 'version', 'edges', 'resources'].include?(k)
       end

--- a/puppet/lib/puppet/indirector/resource/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/resource/puppetdb.rb
@@ -7,7 +7,8 @@ class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
   include Puppet::Util::Puppetdb
 
   def search(request)
-    profile "resource#search" do
+    profile("resource#search",
+            [:puppetdb, :resource, :search, request.key]) do
       type   = request.key
       host   = request.options[:host]
       filter = request.options[:filter]
@@ -27,7 +28,8 @@ class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
 
       begin
         url = Puppet::Util::Puppetdb.url_path("/v3/resources?query=#{query_param}")
-        response = profile "Resources query: #{URI.unescape(url)}" do
+        response = profile("Resources query: #{URI.unescape(url)}",
+                           [:puppetdb, :resource, :search, :query, request.key]) do
           http_get(request, url, headers)
         end
         log_x_deprecation_header(response)
@@ -40,11 +42,13 @@ class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
         raise Puppet::Error, "Could not retrieve resources from the PuppetDB at #{self.class.server}:#{self.class.port}: #{e}"
       end
 
-      resources = profile "Parse resource query response (size: #{response.body.size})" do
+      resources = profile("Parse resource query response (size: #{response.body.size})",
+                          [:puppetdb, :resource, :search, :parse_query_response, request.key]) do
         JSON.load(response.body)
       end
 
-      profile "Build up collected resource objects (count: #{resources.count})" do
+      profile("Build up collected resource objects (count: #{resources.count})",
+              [:puppetdb, :resource, :search, :build_up_collected_objects, request.key]) do
         resources.map do |res|
           params = res['parameters'] || {}
           params = params.map do |name,value|

--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -18,7 +18,7 @@ Puppet::Reports.register_report(:puppetdb) do
   #
   # @return [void]
   def process
-    profile "report#process" do
+    profile("report#process", [:puppetdb, :report, :process]) do
       submit_command(self.host, report_to_hash, CommandStoreReport, 4)
     end
 
@@ -31,7 +31,8 @@ Puppet::Reports.register_report(:puppetdb) do
   # @return Hash[<String, Object>]
   # @api private
   def report_to_hash
-    profile "Convert report to wire format hash" do
+    profile("Convert report to wire format hash",
+            [:puppetdb, :report, :convert_to_wire_format_hash]) do
       if environment.nil?
         raise Puppet::Error, "Environment is nil, unable to submit report. This may be due a bug with Puppet. Ensure you are running the latest revision, see PUP-2508 for more details."
       end
@@ -54,7 +55,8 @@ Puppet::Reports.register_report(:puppetdb) do
   # @return Array[Hash]
   # @api private
   def build_events_list
-    profile "Build events list (count: #{resource_statuses.count})" do
+    profile("Build events list (count: #{resource_statuses.count})",
+            [:puppetdb, :events_list, :build]) do
       filter_events(resource_statuses.inject([]) do |events, status_entry|
         _, status = *status_entry
         if ! (status.events.empty?)
@@ -133,7 +135,8 @@ Puppet::Reports.register_report(:puppetdb) do
   # @api private
   def filter_events(events)
     if config.ignore_blacklisted_events?
-      profile "Filter blacklisted events" do
+      profile("Filter blacklisted events",
+              [:puppetdb, :events, :filter_blacklisted]) do
         events.select { |e| ! config.is_event_blacklisted?(e) }
       end
     else

--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -76,7 +76,8 @@ module Puppet::Util::Puppetdb
   # @param version [Number] version number of command
   # @return [Hash <String, String>]
   def submit_command(certname, payload, command_name, version)
-    profile "Submitted command '#{command_name}' version '#{version}'" do
+    profile("Submitted command '#{command_name}' version '#{version}'",
+            [:puppetdb, :command, :submit, command_name, version]) do
       command = Puppet::Util::Puppetdb::Command.new(command_name, version, certname, payload)
       command.submit
     end
@@ -90,11 +91,12 @@ module Puppet::Util::Puppetdb
   # in the profiled hierachy.
   #
   # @param message [String] A description of the profiled event
+  # @param metric_id [Array] A list of strings making up the ID of a metric to profile
   # @param block [Block] The segment of code to profile
   # @api public
-  def profile(message, &block)
+  def profile(message, metric_id, &block)
     message = "PuppetDB: " + message
-    Puppet::Util::Profiler.profile(message, &block)
+    Puppet::Util::Profiler.profile(message, metric_id, &block)
   end
 
   # @!group Private instance methods

--- a/puppet/lib/puppet/util/puppetdb/command.rb
+++ b/puppet/lib/puppet/util/puppetdb/command.rb
@@ -27,7 +27,7 @@ class Puppet::Util::Puppetdb::Command
     @command = command
     @version = version
     @certname = certname
-    profile "Format payload" do
+    profile("Format payload", [:puppetdb, :payload, :format]) do
       @payload = self.class.format_payload(command, version, payload)
     end
   end
@@ -43,7 +43,7 @@ class Puppet::Util::Puppetdb::Command
     for_whom = " for #{certname}" if certname
 
     begin
-      response = profile "Submit command HTTP post" do
+      response = profile("Submit command HTTP post", [:puppetdb, :command, :submit]) do
         http = Puppet::Network::HttpPool.http_instance(config.server, config.port)
         http.post(Puppet::Util::Puppetdb.url_path(CommandsUrl + "?checksum=#{checksum}"),
                   payload, headers)


### PR DESCRIPTION
Change the `profile` function in PuppetDB to use the new Puppet
Profiler API in preparation for removing the old API from Puppet.
Modify all calls to the `profile` function in PuppetDB to pass in
a metric ID.
