### PR TITLE
(PDB-1029) Provide an arity detection for backwards compatibility for profiling

### DIFF
--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -96,7 +96,13 @@ module Puppet::Util::Puppetdb
   # @api public
   def profile(message, metric_id, &block)
     message = "PuppetDB: " + message
-    Puppet::Util::Profiler.profile(message, metric_id, &block)
+    arity = Puppet::Util::Profiler.method(:profile).arity
+    case arity
+    when 1
+      Puppet::Util::Profiler.profile(message, &block)
+    when 2, -2
+      Puppet::Util::Profiler.profile(message, metric_id, &block)
+    end
   end
 
   # @!group Private instance methods


### PR DESCRIPTION
This patch fixes the arity problem on the oldest version of Puppet we support
by adding a compatibility layer that uses the correct argument list based
on the methods arity available.

Signed-off-by: Ken Barber ken@bob.sh
