### PR TITLE
Fixes needed for running tests against puppet's master branch

### DIFF
--- a/puppet/lib/puppet/face/storeconfigs.rb
+++ b/puppet/lib/puppet/face/storeconfigs.rb
@@ -1,177 +1,192 @@
+require 'puppet/util/puppetdb'
 require 'puppet/face'
-require 'tmpdir'
 
-Puppet::Face.define(:storeconfigs, '0.0.1') do
-  copyright "Puppet Labs", 2011
-  license   "Apache 2 license"
+if Puppet::Util::Puppetdb.puppet3compat?
+  require 'tmpdir'
 
-  summary "Interact with the storeconfigs database"
-  description <<-DESC
+  Puppet::Face.define(:storeconfigs, '0.0.1') do
+    copyright "Puppet Labs", 2011
+    license   "Apache 2 license"
+
+    summary "Interact with the storeconfigs database"
+    description <<-DESC
     This subcommand interacts with the ActiveRecord storeconfigs database, and
     can be used to export a dump of that data which is suitable for import by
     PuppetDB.
   DESC
 
-  action :export do
-    summary "Export the storeconfigs database"
-    description <<-DESC
+    action :export do
+      summary "Export the storeconfigs database"
+      description <<-DESC
       Generate a dump of all catalogs from the storeconfigs database, as a
       tarball which can be imported by PuppetDB. Only exported resources are
       included; non-exported resources, edges, facts, or other data are
       omitted. Returns the location of the output.
     DESC
 
-    when_invoked do |options|
+      when_invoked do |options|
 
-      require 'puppet/rails'
+        require 'puppet/rails'
 
-      tmpdir = Dir.mktmpdir
-      workdir = File.join(tmpdir, 'puppetdb-bak')
-      Dir.mkdir(workdir)
+        tmpdir = Dir.mktmpdir
+        workdir = File.join(tmpdir, 'puppetdb-bak')
+        Dir.mkdir(workdir)
 
-      begin
-        Puppet::Rails.connect
+        begin
+          Puppet::Rails.connect
 
-        # Fetch all nodes, including exported resources and their params
-        nodes = Puppet::Rails::Host.all(:include => {:resources => [:param_values, :puppet_tags]},
-                                        :conditions => {:resources => {:exported => true}})
+          # Fetch all nodes, including exported resources and their params
+          nodes = Puppet::Rails::Host.all(:include => {:resources => [:param_values, :puppet_tags]},
+                                          :conditions => {:resources => {:exported => true}})
 
-        catalogs = nodes.map { |node| node_to_catalog_hash(node) }
+          catalogs = nodes.map { |node| node_to_catalog_hash(node) }
 
-        catalog_dir = File.join(workdir, 'catalogs')
-        FileUtils.mkdir(catalog_dir)
+          catalog_dir = File.join(workdir, 'catalogs')
+          FileUtils.mkdir(catalog_dir)
 
-        catalogs.each do |catalog|
-          filename = File.join(catalog_dir, "#{catalog[:data][:name]}.json")
+          catalogs.each do |catalog|
+            filename = File.join(catalog_dir, "#{catalog[:data][:name]}.json")
 
-          File.open(filename, 'w') do |file|
-            file.puts catalog.to_pson
+            File.open(filename, 'w') do |file|
+              file.puts catalog.to_pson
+            end
           end
-        end
 
-        node_names = nodes.map(&:name).sort
+          node_names = nodes.map(&:name).sort
 
-        timestamp = Time.now
+          timestamp = Time.now
 
-        File.open(File.join(workdir, 'export-metadata.json'), 'w') do |file|
-          metadata = {
-            'timestamp' => timestamp,
-            'command-versions' => {
-              'replace-catalog' => 2,
+          File.open(File.join(workdir, 'export-metadata.json'), 'w') do |file|
+            metadata = {
+              'timestamp' => timestamp,
+              'command-versions' => {
+                'replace-catalog' => 2,
+              }
             }
-          }
 
-          file.puts metadata.to_pson
-        end
-
-        tarfile = destination_file(timestamp)
-
-        if tar = Puppet::Util.which('tar')
-          execute("cd #{tmpdir} && #{tar} -cf #{tarfile} puppetdb-bak")
-
-          FileUtils.rm_rf(workdir)
-
-          if gzip = Puppet::Util.which('gzip')
-            execute("#{gzip} #{tarfile}")
-            "#{tarfile}.gz"
-          else
-            Puppet.warning "Can't find the `gzip` command to compress the tarball; output will not be compressed"
-            tarfile
+            file.puts metadata.to_pson
           end
-        else
-          Puppet.warning "Can't find the `tar` command to produce a tarball; output will remain in the temporary working directory"
-          workdir
+
+          tarfile = destination_file(timestamp)
+
+          if tar = Puppet::Util.which('tar')
+            execute("cd #{tmpdir} && #{tar} -cf #{tarfile} puppetdb-bak")
+
+            FileUtils.rm_rf(workdir)
+
+            if gzip = Puppet::Util.which('gzip')
+              execute("#{gzip} #{tarfile}")
+              "#{tarfile}.gz"
+            else
+              Puppet.warning "Can't find the `gzip` command to compress the tarball; output will not be compressed"
+              tarfile
+            end
+          else
+            Puppet.warning "Can't find the `tar` command to produce a tarball; output will remain in the temporary working directory"
+            workdir
+          end
+        rescue => e
+          # Clean up if something goes wrong. We don't want to ensure this,
+          # because we want the directory to stick around in the case where they
+          # don't have tar.
+          FileUtils.rm_rf(workdir)
+          raise
         end
-      rescue => e
-        # Clean up if something goes wrong. We don't want to ensure this,
-        # because we want the directory to stick around in the case where they
-        # don't have tar.
-        FileUtils.rm_rf(workdir)
-        raise
+      end
+
+      when_rendering :console do |filename|
+        "Exported storeconfigs data to #{filename}"
       end
     end
 
-    when_rendering :console do |filename|
-      "Exported storeconfigs data to #{filename}"
+    # Returns the location to leave the output. This is really only here for testing. :/
+    def destination_file(timestamp)
+      File.expand_path("storeconfigs-#{timestamp.strftime('%Y%m%d%H%M%S')}.tar")
     end
-  end
 
-  # Returns the location to leave the output. This is really only here for testing. :/
-  def destination_file(timestamp)
-    File.expand_path("storeconfigs-#{timestamp.strftime('%Y%m%d%H%M%S')}.tar")
-  end
+    # Execute a command using Puppet's execution static method.
+    #
+    # @param command [Array<String>, String] the command to execute. If it is
+    #   an Array the first element should be the executable and the rest of the
+    #   elements should be the individual arguments to that executable.
+    # @return [Puppet::Util::Execution::ProcessOutput] output as specified by options
+    # @raise [Puppet::ExecutionFailure] if the executed chiled process did not exit with status == 0 and `failonfail` is
+    #   `true`.
+    def execute(command)
+      Puppet::Util::Execution.execute(command)
+    end
 
-  # Execute a command using Puppet's execution static method.
-  #
-  # @param command [Array<String>, String] the command to execute. If it is
-  #   an Array the first element should be the executable and the rest of the
-  #   elements should be the individual arguments to that executable.
-  # @return [Puppet::Util::Execution::ProcessOutput] output as specified by options
-  # @raise [Puppet::ExecutionFailure] if the executed chiled process did not exit with status == 0 and `failonfail` is
-  #   `true`.
-  def execute(command)
-    Puppet::Util::Execution.execute(command)
-  end
+    def node_to_catalog_hash(node)
+      resources = node.resources.map { |resource| resource_to_hash(resource) }
+      edges = node.resources.map { |resource| resource_to_edge_hash(resource) }
 
-  def node_to_catalog_hash(node)
-    resources = node.resources.map { |resource| resource_to_hash(resource) }
-    edges = node.resources.map { |resource| resource_to_edge_hash(resource) }
+      {
+        :metadata => {
+          :api_version => 1,
+        },
+        :data => {
+          :name => node.name,
+          :version => node.last_compile || Time.now,
+          :edges => edges,
+          :resources => resources + [stage_main_hash],
+        },
+      }
+    end
 
-    {
-      :metadata => {
-        :api_version => 1,
-      },
-      :data => {
-        :name => node.name,
-        :version => node.last_compile || Time.now,
-        :edges => edges,
-        :resources => resources + [stage_main_hash],
-      },
-    }
-  end
-
-  def resource_to_hash(resource)
-    parameters = resource.param_values.inject({}) do |params,param_value|
-      if params.has_key?(param_value.param_name.name)
-        value = [params[param_value.param_name.name],param_value.value].flatten
-      else
-        value = param_value.value
+    def resource_to_hash(resource)
+      parameters = resource.param_values.inject({}) do |params,param_value|
+        if params.has_key?(param_value.param_name.name)
+          value = [params[param_value.param_name.name],param_value.value].flatten
+        else
+          value = param_value.value
+        end
+        params.merge(param_value.param_name.name => value)
       end
-      params.merge(param_value.param_name.name => value)
+
+      tags = resource.puppet_tags.map(&:name).uniq.sort
+
+      hash = {
+        :type       => resource.restype,
+        :title      => resource.title,
+        :exported   => true,
+        :parameters => parameters,
+        :tags       => tags,
+      }
+
+      hash[:file] = resource.file if resource.file
+      hash[:line] = resource.line if resource.line
+
+      hash
     end
 
-    tags = resource.puppet_tags.map(&:name).uniq.sort
+    # The catalog *must* have edges, so everything is contained by Stage[main]!
+    def resource_to_edge_hash(resource)
+      {
+        'source' => {'type' => 'Stage', 'title' => 'main'},
+        'target' => {'type' => resource.restype, 'title' => resource.title},
+        'relationship' => 'contains',
+      }
+    end
 
-    hash = {
-      :type       => resource.restype,
-      :title      => resource.title,
-      :exported   => true,
-      :parameters => parameters,
-      :tags       => tags,
-    }
-
-    hash[:file] = resource.file if resource.file
-    hash[:line] = resource.line if resource.line
-
-    hash
+    def stage_main_hash
+      {
+        :type       => 'Stage',
+        :title      => 'main',
+        :exported   => false,
+        :parameters => {},
+        :tags       => ['stage', 'main'],
+      }
+    end
   end
+else
+  Puppet::Face.define(:storeconfigs, '0.0.1') do
+    copyright "Puppet Labs", 2011
+    license   "Apache 2 license"
 
-  # The catalog *must* have edges, so everything is contained by Stage[main]!
-  def resource_to_edge_hash(resource)
-    {
-      'source' => {'type' => 'Stage', 'title' => 'main'},
-      'target' => {'type' => resource.restype, 'title' => resource.title},
-      'relationship' => 'contains',
-    }
-  end
-
-  def stage_main_hash
-    {
-      :type       => 'Stage',
-      :title      => 'main',
-      :exported   => false,
-      :parameters => {},
-      :tags       => ['stage', 'main'],
-    }
+    summary "storeconfigs is not supported on Puppet 4.0.0+"
+    description <<-DESC
+    Users needing this feature should migrate using Puppet 3.7.2 or a more recent
+    3.7 release.
+  DESC
   end
 end

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -21,8 +21,9 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
       payload = profile("Encode facts command submission payload",
                         [:puppetdb, :facts, :encode]) do
         facts = request.instance.dup
-        facts.values = facts.strip_internal
-        if Puppet[:trusted_node_data]
+        facts.values = facts.strip_internal.dup
+
+        if ! Puppet::Util::Puppetdb.puppet3compat? || Puppet[:trusted_node_data]
           facts.values[:trusted] = get_trusted_info(request.node)
         end
         {

--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -30,6 +30,10 @@ module Puppet::Util::Puppetdb
     @config
   end
 
+  def self.puppet3compat?
+    defined?(Puppet::Parser::AST::HashOrArrayAccess)
+  end
+
   # This magical stuff is needed so that the indirector termini will make requests to
   # the correct host/port, because this module gets mixed in to our indirector
   # termini.

--- a/puppet/spec/unit/face/storeconfigs_spec.rb
+++ b/puppet/spec/unit/face/storeconfigs_spec.rb
@@ -1,198 +1,204 @@
 #!/usr/bin/env ruby
 
-require 'spec_helper'
-require 'puppet/face/storeconfigs'
-require 'json'
+require 'puppet/util/puppetdb'
 
-describe Puppet::Face[:storeconfigs, '0.0.1'], :if => (Puppet.features.sqlite? and Puppet.features.rails?) do
-  def setup_scratch_database
-    Puppet::Rails.stubs(:database_arguments).returns(
-      :adapter => 'sqlite3',
-      :log_level => Puppet[:rails_loglevel],
-      :database => ':memory:'
-    )
-    Puppet[:railslog]     = '/dev/null'
-    Puppet::Rails.init
-  end
+if Puppet::Util::Puppetdb.puppet3compat?
+  require 'spec_helper'
+  require 'puppet/face/storeconfigs'
+  require 'json'
+  require 'puppet/util/feature'
+  require 'puppet/util/puppetdb'
 
-  before :all do
-    # We have to have this block to require this file, so they get loaded on
-    # platforms where we are going to run the tests, but not on Ruby 1.8.5.
-    # Unfortunately, rspec will evaluate the describe block (but not the before
-    # block or tests) even if the conditions fail. The lack of a sqlite3 gem
-    # for Ruby 1.8.5 ensures that the condition will always be false on Ruby
-    # 1.8.5, so at this point it's safe to require this.
-    require 'puppet/indirector/catalog/active_record'
-  end
+  describe Puppet::Face[:storeconfigs, '0.0.1'], :if => (Puppet.features.rails? && Puppet.features.sqlite?) do
+    def setup_scratch_database
+      Puppet::Rails.stubs(:database_arguments).returns(
+        :adapter => 'sqlite3',
+        :log_level => Puppet[:rails_loglevel],
+        :database => ':memory:'
+      )
+      Puppet[:railslog]     = '/dev/null'
+      Puppet::Rails.init
+    end
 
-  before :each do
-    setup_scratch_database
-    Puppet[:storeconfigs] = true
-    Puppet[:storeconfigs_backend] = :active_record
-  end
-
-  describe "export action" do
-    after :each do
-      FileUtils.rm_rf(@path)
+    before :all do
+      # We have to have this block to require this file, so they get loaded on
+      # platforms where we are going to run the tests, but not on Ruby 1.8.5.
+      # Unfortunately, rspec will evaluate the describe block (but not the before
+      # block or tests) even if the conditions fail. The lack of a sqlite3 gem
+      # for Ruby 1.8.5 ensures that the condition will always be false on Ruby
+      # 1.8.5, so at this point it's safe to require this.
+      require 'puppet/indirector/catalog/active_record'
     end
 
     before :each do
-      tempfile = Tempfile.new('export')
-      @path = tempfile.path
-      tempfile.close!
-
-      Dir.mkdir(@path)
-
-      subject.stubs(:destination_file).returns File.join(@path, 'storeconfigs-test.tar')
+      setup_scratch_database
+      Puppet[:storeconfigs] = true
+      Puppet[:storeconfigs_backend] = :active_record
     end
 
-    # Turn the filename of a gzipped tar into a hash from filename to content.
-    def tgz_to_hash(filename)
-      # List the files in the archive, ignoring directories (whose names end
-      # with /), and stripping the leading puppetdb-bak.
-      files = `tar tf #{filename}`.lines.map(&:chomp).reject { |fname| fname[-1,1] == '/'}.map {|fname| fname.sub('puppetdb-bak/', '') }
-
-      # Get the content of the files, one per line. Thank goodness they're a
-      # single line each.
-      content = `tar xf #{filename} -O`.lines.to_a
-
-      # Build a hash from filename to content. Ruby 1.8.5 doesn't like
-      # Hash[array_of_pairs], so we have to jump through hoops by flattening
-      # and splatting this list.
-      Hash[*files.zip(content).flatten]
-    end
-
-    describe "with nodes present" do
-      def notify(title, exported=false)
-        Puppet::Resource.new(:notify, title, :parameters => {:message => title}, :exported => exported)
-      end
-
-      def user(name)
-        Puppet::Resource.new(:user, name,
-                             :parameters => {:groups => ['foo', 'bar', 'baz'],
-                                             :profiles => ['stuff', 'here'] #<-- Uses an ordered list
-                             }, :exported => true)
-      end
-
-      def save_catalog(catalog)
-        request = Puppet::Resource::Catalog.indirection.request(:save, catalog.name, catalog)
-        Puppet::Resource::Catalog::ActiveRecord.new.save(request)
+    describe "export action" do
+      after :each do
+        FileUtils.rm_rf(@path)
       end
 
       before :each do
-        catalog = Puppet::Resource::Catalog.new('foo')
+        tempfile = Tempfile.new('export')
+        @path = tempfile.path
+        tempfile.close!
 
-        catalog.add_resource notify('not exported')
-        catalog.add_resource notify('exported', true)
-        catalog.add_resource user('someuser')
-        save_catalog(catalog)
+        Dir.mkdir(@path)
+
+        subject.stubs(:destination_file).returns File.join(@path, 'storeconfigs-test.tar')
       end
 
-      it "should have the right structure" do
+      # Turn the filename of a gzipped tar into a hash from filename to content.
+      def tgz_to_hash(filename)
+        # List the files in the archive, ignoring directories (whose names end
+        # with /), and stripping the leading puppetdb-bak.
+        files = `tar tf #{filename}`.lines.map(&:chomp).reject { |fname| fname[-1,1] == '/'}.map {|fname| fname.sub('puppetdb-bak/', '') }
+
+        # Get the content of the files, one per line. Thank goodness they're a
+        # single line each.
+        content = `tar xf #{filename} -O`.lines.to_a
+
+        # Build a hash from filename to content. Ruby 1.8.5 doesn't like
+        # Hash[array_of_pairs], so we have to jump through hoops by flattening
+        # and splatting this list.
+        Hash[*files.zip(content).flatten]
+      end
+
+      describe "with nodes present" do
+        def notify(title, exported=false)
+          Puppet::Resource.new(:notify, title, :parameters => {:message => title}, :exported => exported)
+        end
+
+        def user(name)
+          Puppet::Resource.new(:user, name,
+                               :parameters => {:groups => ['foo', 'bar', 'baz'],
+                                               :profiles => ['stuff', 'here'] #<-- Uses an ordered list
+                                              }, :exported => true)
+        end
+
+        def save_catalog(catalog)
+          request = Puppet::Resource::Catalog.indirection.request(:save, catalog.name, catalog)
+          Puppet::Resource::Catalog::ActiveRecord.new.save(request)
+        end
+
+        before :each do
+          catalog = Puppet::Resource::Catalog.new('foo')
+
+          catalog.add_resource notify('not exported')
+          catalog.add_resource notify('exported', true)
+          catalog.add_resource user('someuser')
+          save_catalog(catalog)
+        end
+
+        it "should have the right structure" do
+          filename = subject.export
+
+          results = tgz_to_hash(filename)
+
+          results.keys.should =~ ['export-metadata.json', 'catalogs/foo.json']
+
+          metadata = JSON.load(results['export-metadata.json'])
+
+          metadata.keys.should =~ ['timestamp', 'command-versions']
+          metadata['command-versions'].should == {'replace-catalog' => 2}
+
+          catalog = JSON.load(results['catalogs/foo.json'])
+
+          catalog.keys.should =~ ['metadata', 'data']
+
+          catalog['metadata'].should == {'api_version' => 1}
+
+          data = catalog['data']
+
+          data.keys.should =~ ['name', 'version', 'edges', 'resources']
+
+          data['name'].should == 'foo'
+          data['edges'].to_set.should == [{
+                                            'source' => {'type' => 'Stage', 'title' => 'main'},
+                                            'target' => {'type' => 'Notify', 'title' => 'exported'},
+                                            'relationship' => 'contains'},
+                                          {"source"=>{"type"=>"Stage", "title"=>"main"},
+                                           "target"=>{"type"=>"User", "title"=>"someuser"},
+                                           "relationship"=>"contains"}].to_set
+
+          data['resources'].should include({
+                                             'type'       => 'Stage',
+                                             'title'      => 'main',
+                                             'exported'   => false,
+                                             'tags'       => ['stage', 'main'],
+                                             'parameters' => {},
+                                           })
+
+          data['resources'].should include({
+                                             'type'       => 'Notify',
+                                             'title'      => 'exported',
+                                             'exported'   => true,
+                                             'tags'       => ['exported', 'notify'],
+                                             'parameters' => {
+                                               'message' => 'exported',
+                                             },
+                                           })
+
+          data['resources'].should include({
+                                             'type'       => 'User',
+                                             'title'      => 'someuser',
+                                             'exported'   => true,
+                                             'tags'       => ['someuser', 'user'],
+                                             'parameters' => {
+                                               'groups'   => ['foo', 'bar', 'baz'],
+                                               'profiles' => ['stuff', 'here']
+                                             },
+                                           })
+        end
+
+        it "should only include exported resources and Stage[main]" do
+          filename = subject.export
+
+          results = tgz_to_hash(filename)
+
+          results.keys.should =~ ['export-metadata.json', 'catalogs/foo.json']
+
+          catalog = JSON.load(results['catalogs/foo.json'])
+
+          data = catalog['data']
+          data['name'].should == 'foo'
+
+          data['edges'].map do |edge|
+            [edge['source']['type'], edge['source']['title'], edge['relationship'], edge['target']['type'], edge['target']['title']]
+          end.to_set.should == [['Stage', 'main', 'contains', 'Notify', 'exported'],
+                                ['Stage', 'main', 'contains', 'User', 'someuser']].to_set
+
+          data['resources'].map { |resource| [resource['type'], resource['title']] }.to_set.should == [['Notify', 'exported'], ["User", "someuser"], ['Stage', 'main']].to_set
+
+          notify = data['resources'].find {|resource| resource['type'] == 'Notify'}
+
+          notify['exported'].should == true
+        end
+
+        it "should exclude nodes with no exported resources" do
+          catalog = Puppet::Resource::Catalog.new('bar')
+
+          catalog.add_resource notify('also not exported')
+
+          save_catalog(catalog)
+
+          filename = subject.export
+
+          results = tgz_to_hash(filename)
+
+          results.keys.should =~ ['export-metadata.json', 'catalogs/foo.json']
+        end
+      end
+
+      it "should do nothing if there are no nodes" do
         filename = subject.export
 
         results = tgz_to_hash(filename)
-
-        results.keys.should =~ ['export-metadata.json', 'catalogs/foo.json']
-
-        metadata = JSON.load(results['export-metadata.json'])
-
-        metadata.keys.should =~ ['timestamp', 'command-versions']
-        metadata['command-versions'].should == {'replace-catalog' => 2}
-
-        catalog = JSON.load(results['catalogs/foo.json'])
-
-        catalog.keys.should =~ ['metadata', 'data']
-
-        catalog['metadata'].should == {'api_version' => 1}
-
-        data = catalog['data']
-
-        data.keys.should =~ ['name', 'version', 'edges', 'resources']
-
-        data['name'].should == 'foo'
-        data['edges'].to_set.should == [{
-          'source' => {'type' => 'Stage', 'title' => 'main'},
-          'target' => {'type' => 'Notify', 'title' => 'exported'},
-          'relationship' => 'contains'},
-         {"source"=>{"type"=>"Stage", "title"=>"main"},
-          "target"=>{"type"=>"User", "title"=>"someuser"},
-          "relationship"=>"contains"}].to_set
-
-        data['resources'].should include({
-          'type'       => 'Stage',
-          'title'      => 'main',
-          'exported'   => false,
-          'tags'       => ['stage', 'main'],
-          'parameters' => {},
-        })
-
-        data['resources'].should include({
-          'type'       => 'Notify',
-          'title'      => 'exported',
-          'exported'   => true,
-          'tags'       => ['exported', 'notify'],
-          'parameters' => {
-            'message' => 'exported',
-          },
-        })
-
-        data['resources'].should include({
-          'type'       => 'User',
-          'title'      => 'someuser',
-          'exported'   => true,
-          'tags'       => ['someuser', 'user'],
-          'parameters' => {
-            'groups'   => ['foo', 'bar', 'baz'],
-            'profiles' => ['stuff', 'here']
-          },
-        })
+        results.keys.should == ['export-metadata.json']
       end
-
-      it "should only include exported resources and Stage[main]" do
-        filename = subject.export
-
-        results = tgz_to_hash(filename)
-
-        results.keys.should =~ ['export-metadata.json', 'catalogs/foo.json']
-
-        catalog = JSON.load(results['catalogs/foo.json'])
-
-        data = catalog['data']
-        data['name'].should == 'foo'
-
-        data['edges'].map do |edge|
-          [edge['source']['type'], edge['source']['title'], edge['relationship'], edge['target']['type'], edge['target']['title']]
-        end.to_set.should == [['Stage', 'main', 'contains', 'Notify', 'exported'],
-                              ['Stage', 'main', 'contains', 'User', 'someuser']].to_set
-
-        data['resources'].map { |resource| [resource['type'], resource['title']] }.to_set.should == [['Notify', 'exported'], ["User", "someuser"], ['Stage', 'main']].to_set
-
-        notify = data['resources'].find {|resource| resource['type'] == 'Notify'}
-
-        notify['exported'].should == true
-      end
-
-      it "should exclude nodes with no exported resources" do
-        catalog = Puppet::Resource::Catalog.new('bar')
-
-        catalog.add_resource notify('also not exported')
-
-        save_catalog(catalog)
-
-        filename = subject.export
-
-        results = tgz_to_hash(filename)
-
-        results.keys.should =~ ['export-metadata.json', 'catalogs/foo.json']
-      end
-    end
-
-    it "should do nothing if there are no nodes" do
-      filename = subject.export
-
-      results = tgz_to_hash(filename)
-      results.keys.should == ['export-metadata.json']
     end
   end
 end

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 
 require 'puppet/indirector/catalog/puppetdb'
+require 'puppet/util/puppetdb'
 require 'puppet/util/puppetdb/command_names'
 require 'json'
 
@@ -111,18 +112,20 @@ describe Puppet::Resource::Catalog::Puppetdb do
     end
 
     describe "#stringify_titles" do
-      it "should make all resource titles strings if they aren't" do
-        Puppet[:code] = <<-MANIFEST
+      if Puppet::Util::Puppetdb.puppet3compat?
+        it "should make all resource titles strings if they aren't" do
+          Puppet[:code] = <<-MANIFEST
           $foo = true
           notify { $foo: }
         MANIFEST
 
-        hash = catalog.to_data_hash
-        result = subject.stringify_titles(hash)
+          hash = catalog.to_data_hash
+          result = subject.stringify_titles(hash)
 
-        result['resources'].should be_any { |res|
-          res['type'] == 'Notify' and res['title'] == 'true'
-        }
+          result['resources'].should be_any { |res|
+            res['type'] == 'Notify' and res['title'] == 'true'
+          }
+        end
       end
     end
 

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -1,7 +1,9 @@
 #!/usr/bin/env rspec
 require 'spec_helper'
 
+require 'puppet/util/feature'
 require 'puppet/indirector/facts/puppetdb'
+require 'puppet/util/puppetdb'
 require 'puppet/util/puppetdb/command_names'
 require 'json'
 
@@ -35,6 +37,7 @@ describe Puppet::Node::Facts::Puppetdb do
     end
 
     it "should POST the facts as a JSON string" do
+      Puppet::Util::Puppetdb.stubs(:puppet3compat?).returns(true)
       f = {
         "name" => facts.name,
         "values" => facts.strip_internal,
@@ -56,7 +59,11 @@ describe Puppet::Node::Facts::Puppetdb do
     end
 
     it "should POST the trusted data we tell it to" do
-      Puppet[:trusted_node_data] = true
+
+      if Puppet::Util::Puppetdb.puppet3compat?
+        Puppet[:trusted_node_data] = true
+      end
+
       trusted_data = {"foo" => "foobar", "certname" => "testing_posting"}
       subject.stubs(:get_trusted_info).returns trusted_data
 
@@ -103,7 +110,11 @@ describe Puppet::Node::Facts::Puppetdb do
   describe "#get_trusted_info" do
 
     it 'should return trusted data' do
-      Puppet[:trusted_node_data] = true
+
+      if Puppet::Util::Puppetdb.puppet3compat?
+        Puppet[:trusted_node_data] = true
+      end
+
       node = Puppet::Node.new("my_certname")
       expect(subject.get_trusted_info(node)).to eq({"authenticated"=>"local", "certname"=>"testing", "extensions"=>{}})
     end


### PR DESCRIPTION
Specifically this commit
- Adds specific checks for puppet 3 when loading storeconfig code
  storeconfig does not work against current master and will be removed
  as part of Puppet 4.0.0. We want to maintain backward compatibility,
  so the code supports both
- Removes references to Puppet[:trusted_node_data] when on Puppet
  4 (essentially assuming it is always true on 4). Like above we will
  look for it when on Puppet 3.y.z and ignore it (assuming true) when
  on Puppet 4.y.z
