### PR TITLE
WIP: (PDB-950) Added upfront validation for regexps in queries in API v4 for HSQLDB

### DIFF
--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -89,3 +89,31 @@
   (is (thrown-with-msg? IllegalArgumentException
                         #"'foo' is not a queryable object for resources, known queryable objects are.*"
                         (compile-user-query->sql resources-query ["=" "foo" "bar"]))))
+
+(deftest ^{:postgres false} test-valid-query-regexps
+  (is (thrown-with-msg? IllegalArgumentException
+        #"Invalid regexp:.*"
+        (compile-user-query->sql facts-query ["~" "name" 1])))
+
+  (is (thrown-with-msg? IllegalArgumentException
+        #"Invalid regexp:.*"
+        (compile-user-query->sql facts-query ["~" "name" true])))
+
+  (is (thrown-with-msg? IllegalArgumentException
+        #"Invalid regexp:.*"
+        (compile-user-query->sql facts-query ["~" "name" "*.bar"])))
+
+  (is (thrown-with-msg? IllegalArgumentException
+        #"Invalid regexp:.*"
+        (compile-user-query->sql fact-paths-query ["~>" "path" [".*" "*.bar"]])))
+
+  (is (thrown-with-msg? IllegalArgumentException
+        #"Invalid regexp:.*"
+        (compile-user-query->sql
+          facts-query
+          ["and"
+           ["=" ["node" "active"] "true"]
+           ["and"
+            ["=" "certname" "somename"]
+            ["=" ["node" "active"] "true"]
+            ["~" "name" "*.bar"]]]))))


### PR DESCRIPTION
This comes from [PR-1142](https://github.com/puppetlabs/puppetdb/pull/1142) to simplify merge/discussion.

This PR adds a simple validation for regexps in queries in all APIs v4.
It validates regexps using Java rules, so there might be some constructions that pass this validation but won't be valid in Postgres.
Here is an example of such construction:
curl -v 'http://localhost:8080/v4/fact-contents?query=\["~","name","\\p\{Alnum\}"\]'

Those regexp differences are discussed in original [PR-1142](https://github.com/puppetlabs/puppetdb/pull/1142).