### PR TITLE
(PDB-722) Added missing validation for fields in vector forms for 'in' and 'extract' operators in API v4

### DIFF
--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -404,15 +404,23 @@
 (def versioned-invalid-subqueries
   (omap/ordered-map
    "/v4/events" (omap/ordered-map
-                 ;; Extract using an invalid field should throw an error
+                 ;; Extract using invalid fields should throw an error
                  ["in" "certname" ["extract" "nothing" ["select-resources"
                                                         ["=" "type" "Class"]]]]
                  #"Can't extract unknown 'resources' field 'nothing'.*Acceptable fields are.*"
 
+                 ["in" "certname" ["extract" ["nothing" "nothing2" "certname"] ["select-resources"
+                                                                                ["=" "type" "Class"]]]]
+                 #"Can't extract unknown 'resources' fields: 'nothing', 'nothing2'.*Acceptable fields are.*"
+
                  ;; In-query for invalid fields should throw an error
                  ["in" "nothing" ["extract" "certname" ["select-resources"
                                                         ["=" "type" "Class"]]]]
-                 #"Can't match on unknown 'events' field 'nothing' for 'in'.*Acceptable fields are.*")))
+                 #"Can't match on unknown 'events' field 'nothing' for 'in'.*Acceptable fields are.*"
+
+                 ["in" ["certname" "nothing" "nothing2"] ["extract" "certname" ["select-resources"
+                                                                                ["=" "type" "Class"]]]]
+                 #"Can't match on unknown 'events' fields: 'nothing', 'nothing2' for 'in'.*Acceptable fields are.*")))
 
 (deftestseq invalid-subqueries
   [[version endpoint] endpoints]

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -281,7 +281,25 @@
                 ;; In-queries for invalid fields should throw an error
                 ["in" "nothing" ["extract" "certname" ["select-resources"
                                                        ["=" "type" "Class"]]]]
-                "Can't match on unknown fact field 'nothing' for 'in'. Acceptable fields are: certname, depth, environment, name, path, type, value, value_float, value_integer")))
+                "Can't match on unknown fact field 'nothing' for 'in'. Acceptable fields are: certname, depth, environment, name, path, type, value, value_float, value_integer")
+   "/v4/facts" (omap/ordered-map
+                ;; Extract using invalid fields should throw an error
+                ["in" "certname" ["extract" "nothing" ["select-resources"
+                                                        ["=" "type" "Class"]]]]
+                "Can't extract unknown 'resources' field 'nothing'. Acceptable fields are: [\"certname\",\"environment\",\"resource\",\"type\",\"title\",\"tag\",\"exported\",\"file\",\"line\",\"parameters\"]"
+
+                ["in" "certname" ["extract" ["nothing" "nothing2" "certname"] ["select-resources"
+                                                                               ["=" "type" "Class"]]]]
+                "Can't extract unknown 'resources' fields: 'nothing', 'nothing2'. Acceptable fields are: [\"certname\",\"environment\",\"resource\",\"type\",\"title\",\"tag\",\"exported\",\"file\",\"line\",\"parameters\"]"
+
+                ;; In-query for invalid fields should throw an error
+                ["in" "nothing" ["extract" "certname" ["select-resources"
+                                                        ["=" "type" "Class"]]]]
+                "Can't match on unknown 'facts' field 'nothing' for 'in'. Acceptable fields are: [\"name\",\"certname\",\"environment\",\"value\"]"
+
+                ["in" ["name" "nothing" "nothing2"] ["extract" "certname" ["select-resources"
+                                                                            ["=" "type" "Class"]]]]
+                "Can't match on unknown 'facts' fields: 'nothing', 'nothing2' for 'in'. Acceptable fields are: [\"name\",\"certname\",\"environment\",\"value\"]")))
 
 (def common-well-formed-tests
   (omap/ordered-map


### PR DESCRIPTION
Previously such validation was only implemented for if field is passed as a string.
So, I added a validation for both when it is passed as a string and when as a vector of strings.

Original problem described in PDB-722 seems to be already fixed, so that was the only related issue that we found.
