### PR TITLE
(PDB-885) Include a new namespace for ezbake to use for service startup

### DIFF
--- a/src/puppetlabs/puppetdb/main.clj
+++ b/src/puppetlabs/puppetdb/main.clj
@@ -1,0 +1,11 @@
+(ns puppetlabs.puppetdb.main
+  "Starts the PuppetDB service, bypassing the subcommand handling.
+
+   Used by our main startup scripts, to avoid having to variabilize the
+   sub-command within ezbake."
+  (:require [puppetlabs.puppetdb.core :as core])
+  (:gen-class))
+
+(defn -main
+  [& args]
+  (core/run-command #(System/exit 0) #(System/exit 1) (cons "services" args)))


### PR DESCRIPTION
This provides a new namespace: puppetlabs.puppetdb.main that will be used to
startup the PuppetDB service. This avoids the need to include the sub-command
'services' in the ezbake configuration templates, avoiding the need for
a new parameter to be added to ezbake to support this 1 edge case.

The new namespace contains a single function -main, that effectively wraps
the sub-command 'services'.

Signed-off-by: Ken Barber ken@bob.sh
