### PR TITLE
Ensure we use our own vendored directory for gems

### DIFF
--- a/ext/jenkins/beaker-tests.sh
+++ b/ext/jenkins/beaker-tests.sh
@@ -29,7 +29,14 @@ export PUPPETDB_PACKAGE_BUILD_VERSION=$PACKAGE_BUILD_VERSION
 [[ -s "/usr/local/rvm/scripts/rvm" ]] && source /usr/local/rvm/scripts/rvm
 rvm use ruby-1.9.3-p484
 
-bundle install --without test
+# Remove old vendor directory to ensure we have a clean slate
+if [ -d "vendor" ];
+then
+  rm -rf vendor
+fi
+mkdir vendor
+
+bundle install --path vendor/bundle --without test
 
 # Now run our tests
 bundle exec rake beaker:acceptance


### PR DESCRIPTION
We were using the global gemset which is a bad thing, this patch fixes that.

This was causing issues when a fog-core gem that was bad had been permanently
'cached' due to the use of a global gemset. This will slow the build down
and create another potential place of failure, but it is more correct.

Signed-off-by: Ken Barber ken@bob.sh
