### PR TITLE
(PDB-863) Remove com. from jmx and mq endpoints

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -552,7 +552,7 @@ module PuppetDBExtensions
   end
 
   def sleep_until_queue_empty(host, timeout=60)
-    metric = "org.apache.activemq:BrokerName=localhost,Type=Queue,Destination=com.puppetlabs.puppetdb.commands"
+    metric = "org.apache.activemq:BrokerName=localhost,Type=Queue,Destination=puppetlabs.puppetdb.commands"
     queue_size = nil
 
     begin
@@ -570,7 +570,7 @@ module PuppetDBExtensions
   # Queries the metrics endpoint for command processing results, return a hash
   # of results.
   def command_processing_stats(host, counter = "processed")
-    metric = "com.puppetlabs.puppetdb.command:type=global,name=discarded"
+    metric = "puppetlabs.puppetdb.command:type=global,name=discarded"
 
     result = on host, %Q(curl http://localhost:8080/v3/metrics/mbean/#{CGI.escape(metric)})
 

--- a/documentation/api/query/v4/metrics.markdown
+++ b/documentation/api/query/v4/metrics.markdown
@@ -48,13 +48,13 @@ Responses return a JSON Object mapping strings to (strings/numbers/booleans).
 
 ### Population metrics
 
-* `com.puppetlabs.puppetdb.query.population:type=default,name=num-nodes`:
+* `puppetlabs.puppetdb.query.population:type=default,name=num-nodes`:
   The number of nodes in your population.
-* `com.puppetlabs.puppetdb.query.population:type=default,name=num-resources`:
+* `puppetlabs.puppetdb.query.population:type=default,name=num-resources`:
   The number of resources in your population.
-* `com.puppetlabs.puppetdb.query.population:type=default,name=avg-resources-per-node`:
+* `puppetlabs.puppetdb.query.population:type=default,name=avg-resources-per-node`:
   The average number of resources per node in your population.
-* `com.puppetlabs.puppetdb.query.population:type=default,name=pct-resource-dupes`:
+* `puppetlabs.puppetdb.query.population:type=default,name=pct-resource-dupes`:
   The percentage of resources that exist on more than one node.
 
 ### Database metrics
@@ -81,16 +81,16 @@ statistics for each version independently.
 
 Metrics available for each command:
 
-* `com.puppetlabs.puppetdb.command:type=<name>,name=discarded`: stats
+* `puppetlabs.puppetdb.command:type=<name>,name=discarded`: stats
   about commands we've discarded (we've retried them as many times as
   we can, to no avail)
-* `com.puppetlabs.puppetdb.command:type=<name>,name=fatal`: stats about
+* `puppetlabs.puppetdb.command:type=<name>,name=fatal`: stats about
   commands we failed to process.
-* `com.puppetlabs.puppetdb.command:type=<name>,name=processed`: stats
+* `puppetlabs.puppetdb.command:type=<name>,name=processed`: stats
   about commands we've successfully processed
-* `com.puppetlabs.puppetdb.command:type=<name>,name=processing-time`:
+* `puppetlabs.puppetdb.command:type=<name>,name=processing-time`:
   stats about how long it takes to process commands
-* `com.puppetlabs.puppetdb.command:type=<name>,name=retried`: stats about
+* `puppetlabs.puppetdb.command:type=<name>,name=retried`: stats about
   commands that have been submitted for retry (due to transient
   errors)
 
@@ -122,22 +122,22 @@ see the stats for all `200` responses for the `resources`
 endpoint. This allows you to see, per endpoint and per response,
 independent counters and statistics.
 
-* `com.puppetlabs.puppetdb.http.server:type=<name>,name=service-time`:
+* `puppetlabs.puppetdb.http.server:type=<name>,name=service-time`:
   stats about how long it takes to service all HTTP requests to this endpoint
-* `com.puppetlabs.puppetdb.http.server:type=<name>,name=<status code>`:
+* `puppetlabs.puppetdb.http.server:type=<name>,name=<status code>`:
   stats about how often we're returning this response code
 
 ### Storage metrics
 
 Metrics involving the PuppetDB storage subsystem all begin with the
-`com.puppetlabs.puppetdb.scf.storage:type=default,name=` prefix. There are
+`puppetlabs.puppetdb.scf.storage:type=default,name=` prefix. There are
 a number of metrics concerned with individual storage operations (storing
 resources, storing edges, etc.). Metrics of particular note include:
 
-* `com.puppetlabs.puppetdb.scf.storage:type=default,name=duplicate-pct`:
+* `puppetlabs.puppetdb.scf.storage:type=default,name=duplicate-pct`:
   the percentage of catalogs that PuppetDB determines to be
   duplicates of existing catalogs.
-* `com.puppetlabs.puppetdb.scf.storage:type=default,name=gc-time`: state
+* `puppetlabs.puppetdb.scf.storage:type=default,name=gc-time`: state
   about how long it takes to do storage compaction
 
 ### JVM Metrics
@@ -147,7 +147,7 @@ resources, storing edges, etc.). Metrics of particular note include:
 
 ### MQ Metrics
 
-* `org.apache.activemq:BrokerName=localhost,Type=Queue,Destination=com.puppetlabs.puppetdb.commands`:
+* `org.apache.activemq:BrokerName=localhost,Type=Queue,Destination=puppetlabs.puppetdb.commands`:
   stats about the command processing queue: queue depth, how long messages remain in the queue, etc.
 
 ## Example

--- a/resources/ext/config/logback.xml
+++ b/resources/ext/config/logback.xml
@@ -27,11 +27,6 @@
     <logger name="org.apache.activemq.store.kahadb.MessageDatabase"
         level="info"/>
 
-    <!-- turn on to see verbose storage activity -->
-    <!--
-    <logger name="com.puppetlabs.puppetdb.scf.storage" level="debug"/>
-    -->
-
     <root level="info">
         <appender-ref ref="${logappender:-DUMMY}" />
         <appender-ref ref="F1" />

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -11,11 +11,6 @@
         level="info"/>
     <logger name="org.springframework.jms.connection" level="warn"/>
 
-    <!-- turn on to see verbose storage activity -->
-    <!--
-    <logger name="puppetlabs.puppetdb.scf.storage" level="debug"/>
-    -->
-
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>

--- a/resources/public/dashboard/index.html
+++ b/resources/public/dashboard/index.html
@@ -123,7 +123,7 @@ body {
   };
 
   function setVersion() {
-    d3.json("../v3/version", function (res) {
+    d3.json("../v4/version", function (res) {
       if (res != null && res.version != null) {
         d3.select('#version').html('v' + res.version);
       }
@@ -134,7 +134,7 @@ body {
   };
 
   function checkForUpdates() {
-    d3.json("../v3/version/latest", function (res) {
+    d3.json("../v4/version/latest", function (res) {
       console.log(res);
       if (res != null && res.newer) {
         d3.select('#latest-version').html('v' + res.version);
@@ -155,7 +155,7 @@ body {
   var height = getParameter("height") || 60;
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/java.lang:type=Memory")
+  .url("../v4/metrics/mbean/java.lang:type=Memory")
   .snag(function(res) { return res["HeapMemoryUsage"]["used"]; })
   .format(d3.format(",.3s"))
   .description("JVM Heap")
@@ -168,7 +168,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.query.population:type=default,name=num-nodes")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.query.population:type=default,name=num-nodes")
   .snag(function(res) { return res["Value"]; })
   .format(d3.format(","))
   .description("Nodes")
@@ -181,7 +181,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.query.population:type=default,name=num-resources")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.query.population:type=default,name=num-resources")
   .snag(function(res) { return res["Value"]; })
   .format(d3.format(","))
   .description("Resources")
@@ -194,7 +194,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.query.population:type=default,name=pct-resource-dupes")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.query.population:type=default,name=pct-resource-dupes")
   .snag(function(res) { return res["Value"]; })
   .format(d3.format(",.1%"))
   .description("Resource duplication")
@@ -207,7 +207,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.scf.storage:type=default,name=duplicate-pct")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.scf.storage:type=default,name=duplicate-pct")
   .snag(function(res) { return res["Value"]; })
   .format(d3.format(",.1%"))
   .description("Catalog duplication")
@@ -220,7 +220,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/org.apache.activemq:BrokerName=localhost,Type=Queue,Destination=com.puppetlabs.puppetdb.commands")
+  .url("../v4/metrics/mbean/org.apache.activemq:BrokerName=localhost,Type=Queue,Destination=puppetlabs.puppetdb.commands")
   .snag(function(res) { return res["QueueSize"]; })
   .format(d3.format(",s"))
   .description("Command Queue")
@@ -233,7 +233,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.command:type=global,name=processing-time")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.command:type=global,name=processing-time")
   .snag(function(res) { return res["50thPercentile"] / 1000; })
   .format(d3.format(",.3s"))
   .description("Command Processing")
@@ -246,7 +246,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.command:type=global,name=processed")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.command:type=global,name=processed")
   .snag(function(res) { return res["FiveMinuteRate"]; })
   .format(clampToZero(d3.format(",.3s"), 0.001))
   .description("Command Processing")
@@ -259,7 +259,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.command:type=global,name=processed")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.command:type=global,name=processed")
   .snag(function(res) { return res["Count"]; })
   .format(d3.format(","))
   .description("Processed")
@@ -272,7 +272,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.command:type=global,name=retried")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.command:type=global,name=retried")
   .snag(function(res) { return res["Count"]; })
   .format(d3.format(","))
   .description("Retried")
@@ -285,7 +285,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.command:type=global,name=discarded")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.command:type=global,name=discarded")
   .snag(function(res) { return res["Count"]; })
   .format(d3.format(","))
   .description("Discarded")
@@ -298,7 +298,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.command:type=global,name=fatal")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.command:type=global,name=fatal")
   .snag(function(res) { return res["Count"]; })
   .format(d3.format(","))
   .description("Rejected")
@@ -311,7 +311,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.http.server:type=../v3/commands,name=service-time")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.http.server:type=../v4/commands,name=service-time")
   .snag(function(res) { return res["50thPercentile"] / 1000; })
   .format(d3.format(",.3s"))
   .description("Enqueueing")
@@ -324,7 +324,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.http.server:type=../v3/resources,name=service-time")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.http.server:type=../v4/resources,name=service-time")
   .snag(function(res) { return res["50thPercentile"] / 1000; })
   .format(d3.format(",.3s"))
   .description("Collection Queries")
@@ -337,7 +337,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.scf.storage:type=default,name=gc-time")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.scf.storage:type=default,name=gc-time")
   .snag(function(res) { return res["50thPercentile"] / 1000; })
   .format(d3.format(",.3s"))
   .description("DB Compaction")
@@ -350,7 +350,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.command.dlo:type=global,name=compression")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.command.dlo:type=global,name=compression")
   .snag(function(res) { return res["50thPercentile"] / 1000; })
   .format(d3.format(",.3s"))
   .description("DLO Compression")
@@ -363,7 +363,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.command.dlo:type=global,name=filesize")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.command.dlo:type=global,name=filesize")
   .snag(function(res) { return res["Value"]; })
   .format(d3.format(",.3s"))
   .description("DLO Size on Disk")
@@ -376,7 +376,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../v3/metrics/mbean/com.puppetlabs.puppetdb.command.dlo:type=global,name=messages")
+  .url("../v4/metrics/mbean/puppetlabs.puppetdb.command.dlo:type=global,name=messages")
   .snag(function(res) { return res["Value"]; })
   .format(d3.format(","))
   .description("Discarded Messages")

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -78,7 +78,7 @@
 ;; PuppetDB components.
 
 (def mq-addr "vm://localhost?jms.prefetchPolicy.all=1&create=false")
-(def mq-endpoint "com.puppetlabs.puppetdb.commands")
+(def mq-endpoint "puppetlabs.puppetdb.commands")
 (def send-command! (partial command/enqueue-command! mq-addr mq-endpoint))
 
 (defn auto-deactivate-nodes!

--- a/src/puppetlabs/puppetdb/command/dlo.clj
+++ b/src/puppetlabs/puppetdb/command/dlo.clj
@@ -14,7 +14,7 @@
             [puppetlabs.puppetdb.time :refer [period?]]))
 
 ;; This is pinned for JMX, for backwards compatibility with old namespace
-(def ns-str "com.puppetlabs.puppetdb.command.dlo")
+(def ns-str "puppetlabs.puppetdb.command.dlo")
 
 (def metrics (atom {}))
 

--- a/src/puppetlabs/puppetdb/http/metrics.clj
+++ b/src/puppetlabs/puppetdb/http/metrics.clj
@@ -72,16 +72,16 @@
           ;; we documented as supported, but we broke when we
           ;; went to versioned apis.
           name' (cond
-                 (.startsWith name "com.puppetlabs.puppetdb.http.server:type=metrics")
+                 (.startsWith name "puppetlabs.puppetdb.http.server:type=metrics")
                  (s/replace name #"type=metrics" "type=/v2/metrics")
 
-                 (.startsWith name "com.puppetlabs.puppetdb.http.server:type=commands")
+                 (.startsWith name "puppetlabs.puppetdb.http.server:type=commands")
                  (s/replace name #"type=commands" "type=/v2/commands")
 
-                 (.startsWith name "com.puppetlabs.puppetdb.http.server:type=facts")
+                 (.startsWith name "puppetlabs.puppetdb.http.server:type=facts")
                  (s/replace name #"type=facts" "type=/v2/facts")
 
-                 (.startsWith name "com.puppetlabs.puppetdb.http.server:type=resources")
+                 (.startsWith name "puppetlabs.puppetdb.http.server:type=resources")
                  (s/replace name #"type=resources" "type=/v2/resources")
 
                  :else

--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -250,9 +250,7 @@
   cannot contain ':', '=', or ',' characters. They will be replaced
   with '_'."
   [app storage normalize-uri]
-  ;; This is pinned to the old namespace for backwards compatibility
-  `(let [prefix# ~(str "com." *ns*)]
-     (wrap-with-metrics* ~app prefix# ~storage ~normalize-uri)))
+  `(wrap-with-metrics* ~app (str *ns*) ~storage ~normalize-uri))
 
 (defn payload-to-body-string
   "Middleware to move the payload from the body or the payload param into the

--- a/src/puppetlabs/puppetdb/mq_listener.clj
+++ b/src/puppetlabs/puppetdb/mq_listener.clj
@@ -66,7 +66,7 @@
 
 (def metrics (atom {}))
 ;; This is pinned to the old namespace for backwards compatibility
-(def ns-str "com.puppetlabs.puppetdb.command")
+(def ns-str "puppetlabs.puppetdb.command")
 
 (defn create-metrics-for-command!
   "Create a subtree of metrics for the given command and version (if

--- a/src/puppetlabs/puppetdb/query/population.clj
+++ b/src/puppetlabs/puppetdb/query/population.clj
@@ -59,7 +59,7 @@
 ;; ## Population-wide metrics
 
 ;; This is pinned to the old namespace for backwards compatibility
-(def ns-str "com.puppetlabs.puppetdb.query.population")
+(def ns-str "puppetlabs.puppetdb.query.population")
 (def metrics (atom nil))
 
 (defn population-gauges

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -124,7 +124,7 @@
 ;;; Metrics
 
 ;; This is pinned to the old namespace for backwards compatibility
-(def ns-str "com.puppetlabs.puppetdb.scf.storage")
+(def ns-str "puppetlabs.puppetdb.scf.storage")
 
 ;; ## Performance metrics
 ;;

--- a/test/puppetlabs/puppetdb/fixtures.clj
+++ b/test/puppetlabs/puppetdb/fixtures.clj
@@ -54,7 +54,7 @@
   [f]
   (with-test-broker "test" conn
     (binding [*mq*   {:connection-string "vm://test"
-                      :endpoint          "com.puppetlabs.puppetdb.commands"}
+                      :endpoint          "puppetlabs.puppetdb.commands"}
               *conn* conn]
       (f))))
 

--- a/test/puppetlabs/puppetdb/http/command_test.clj
+++ b/test/puppetlabs/puppetdb/http/command_test.clj
@@ -101,7 +101,7 @@
     (fixt/*app* (request good-payload good-checksum))
     (fixt/*app* (request bad-payload bad-checksum))
 
-    (let [[good-msg bad-msg] (mq/bounded-drain-into-vec! fixt/*conn* "com.puppetlabs.puppetdb.commands" 2)
+    (let [[good-msg bad-msg] (mq/bounded-drain-into-vec! fixt/*conn* "puppetlabs.puppetdb.commands" 2)
           good-command       (json/parse-string (:body good-msg) true)]
       (testing "should be timestamped when parseable"
         (let [timestamp (get-in good-msg [:headers :received])]

--- a/test/puppetlabs/puppetdb/testutils/jetty.clj
+++ b/test/puppetlabs/puppetdb/testutils/jetty.clj
@@ -65,6 +65,6 @@
 (defn current-queue-depth
   "Return the queue depth currently running PuppetDB instance (see `puppetdb-instance` for launching PuppetDB)"
   []
-  (-> (format "%smetrics/mbean/org.apache.activemq:BrokerName=localhost,Type=Queue,Destination=com.puppetlabs.puppetdb.commands" (current-url))
+  (-> (format "%smetrics/mbean/org.apache.activemq:BrokerName=localhost,Type=Queue,Destination=puppetlabs.puppetdb.commands" (current-url))
       (client/get {:as :json})
       (get-in [:body :QueueSize])))


### PR DESCRIPTION
This PR removes the com. from the jmx and mq endpoints so that these
endpoints use the new puppetlabs.puppetdb namespace. In order to change
all the outstanding references to the old namespace, this PR also
updates the dashboard index.html to reference the v4 metrics api.
