### PR TITLE
(PDB-158) Added option to disable update checking.

### DIFF
--- a/config.sample.ini
+++ b/config.sample.ini
@@ -8,6 +8,13 @@ vardir = /var/lib/puppetdb
 # Use an external logback config file
 # logging-config = /path/to/logback.xml
 
+[puppetdb]
+# List of certificate names from which to allow incoming HTTPS requests:
+# certificate-whitelist = /path/to/certname/whitelist
+
+# Whether we should check for more recent PuppetDB versions.  Defaults to 'false':
+# disable-update-checking = true
+
 [database]
 # For the embedded DB: org.hsqldb.jdbcDriver
 # For PostgreSQL: org.postgresql.Driver

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -98,6 +98,10 @@ An example configuration file:
     subprotocol = postgresql
     subname = //localhost:5432/puppetdb
 
+    [puppetdb]
+    certificate-whitelist = /path/to/file/containing/certnames
+    disable-update-checking = false
+
     [jetty]
     port = 8080
 
@@ -191,6 +195,10 @@ The `[puppetdb]` section is used to configure PuppetDB application specific beha
 Optional. This describes the path to a file that contains a list of certificate names, one per line.  Incoming HTTPS requests will have their certificates validated against this list of names and only those with an _exact_ matching entry will be allowed through. (For a puppet master, this compares against the value of the `certname` setting, rather than the `dns_alt_names` setting.)
 
 If not supplied, PuppetDB uses standard HTTPS without any additional authorization. All HTTPS clients must still supply valid, verifiable SSL client certificates.
+
+### `disable-update-checking`
+
+Optional.  Setting this to `true` disables checking for updated versions of PuppetDB.  Defaults to `false`.
 
 
 `[database]` Settings

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -11,6 +11,27 @@
             [clojure.string :as str]
             [fs.core :as fs]))
 
+(deftest puppetdb-configuration
+  (testing "puppetdb-configuration"
+    (testing "should throw an exception if unrecognized config options are specified"
+      (is (thrown? clojure.lang.ExceptionInfo (configure-puppetdb {:puppetdb {:foo "foo"}}))))
+
+    (testing "should convert disable-update-checking value to boolean, if it is specified"
+      (let [config (configure-puppetdb {:puppetdb {:disable-update-checking "true"}})]
+        (is (= (get-in config [:puppetdb :disable-update-checking]) true)))
+      (let [config (configure-puppetdb {:puppetdb {:disable-update-checking "false"}})]
+        (is (= (get-in config [:puppetdb :disable-update-checking]) false)))
+      (let [config (configure-puppetdb {:puppetdb {:disable-update-checking "some-string"}})]
+        (is (= (get-in config [:puppetdb :disable-update-checking]) false))))
+
+    (testing "should throw exception if disable-update-checking cannot be converted to boolean"
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (configure-puppetdb {:puppetdb {:disable-update-checking 1337}}))))
+
+    (testing "disable-update-checking should default to 'false' if left unspecified"
+      (let [config (configure-puppetdb {})]
+        (is (= (get-in config [:puppetdb :disable-update-checking]) false))))))
+
 (deftest commandproc-configuration
   (testing "should throw an error on unrecognized config options"
     (is (thrown? clojure.lang.ExceptionInfo (configure-command-params {:command-processing {:foo "foo"}}))))


### PR DESCRIPTION
- Updated documentation and sample config file.
- Added `disable-update-checking` configuration parameter with a default
  value of `false`.  If set to `true`, then PuppetDB will not spawn a
  future thread to check whether an updated version is available.
- Removed :updater from post-condition check, in case it's nil.
- Added check to skip adding nil :updater to context.
- Added new parameter to puppetdb-config-in schema, created -out schema, and
  converted input to output configuration.
- Added test code to check for proper config conversion, expected exceptions,
  and correct default value.
