### PR TITLE
(maint) Switch to new el5 image for acceptance tests

### DIFF
--- a/config/image_templates/ec2.yaml
+++ b/config/image_templates/ec2.yaml
@@ -13,8 +13,8 @@ AMI:
 
   el-5-x86_64-west:
     :image:
-      :pe: ami-4a6df87a
-      :foss: ami-4a6df87a
+      :pe: ami-85693fb5
+      :foss: ami-85693fb5
     :region: us-west-2
 
   ubuntu-12.04-amd64-west:


### PR DESCRIPTION
The old image had CentosPlus enabled, which pulled in an odd postfix version
that pulled in a conflicting 'postgresql' package. This new image no longer
uses the CentosPlus repository, since we weren't using it before this anyway
it probably won't matter.

Signed-off-by: Ken Barber ken@bob.sh
