### PR TITLE
(PDB-644) Retire node-ttl-days

### DIFF
--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -52,8 +52,7 @@
          {(s/optional-key :gc-interval) (pls/defaulted-maybe s/Int 60)
           (s/optional-key :report-ttl) (pls/defaulted-maybe String "14d")
           (s/optional-key :node-purge-ttl) (pls/defaulted-maybe String "0s")
-          (s/optional-key :node-ttl) String
-          (s/optional-key :node-ttl-days) (s/maybe s/Int)}))
+          (s/optional-key :node-ttl) (pls/defaulted-maybe String "0s")}))
 
 (def database-config-out
   "Schema for parsed/processed database config"
@@ -82,7 +81,7 @@
          {:gc-interval Minutes
           :report-ttl Period
           :node-purge-ttl Period
-          (s/optional-key :node-ttl) (s/either Period Days)}))
+          :node-ttl Period}))
 
 (defn half-the-cores*
   "Function for computing half the cores of the system, useful
@@ -163,22 +162,11 @@
     (s/validate database-config-out db-config)
     (assoc config :read-database db-config)))
 
-(defn default-node-ttl
-  "Assoc into `db-config` a :node-ttl when not already present. Default to node-ttl-days, if that's not there,
-   use 0 seconds"
-  [db-config]
-  (dissoc (if (:node-ttl db-config)
-            db-config
-            (-> db-config
-                (assoc :node-ttl (or (maybe-days (:node-ttl-days db-config))
-                                     (pl-time/parse-period "0s")))))
-          :node-ttl-days))
-
 (defn convert-write-db-config
   "Converts the `database` config using the write database config schema. Also defaults
    the node-ttl parameter."
   [global database]
-  (->> (default-node-ttl database)
+  (->> database
        (convert-db-config write-database-config-in write-database-config-out global)
        (pls/strip-unknown-keys write-database-config-out)))
 

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -98,17 +98,6 @@
       (let [{:keys [node-ttl]} (:database (configure-dbs { :database { :node-ttl "10d" }}))]
         (is (pl-time/period? node-ttl))
         (is (= (time/days 10) (time/days (pl-time/to-days node-ttl))))))
-    (testing "should support node-ttl-days for backward compatibility"
-      (let [{:keys [node-ttl] :as dbconfig} (:database (configure-dbs { :database { :node-ttl-days 10 }}))]
-        (is (pl-time/period? node-ttl))
-        (is (= 10 (pl-time/to-days node-ttl)))
-        (is (not (contains? dbconfig :node-ttl-days)))))
-    (testing "should prefer node-ttl over node-ttl-days"
-      (let [{:keys [node-ttl] :as dbconfig} (:database (configure-dbs { :database {:node-ttl "5d"
-                                                                                   :node-ttl-days 10 }}))]
-        (is (pl-time/period? node-ttl))
-        (is (= (time/days 5) (time/days (pl-time/to-days node-ttl))))
-        (is (not (contains? dbconfig :node-ttl-days)))))
     (testing "should default to zero (no expiration)"
       (let [{:keys [node-ttl] :as dbconfig} (:database (configure-dbs {}))]
         (is (pl-time/period? node-ttl))


### PR DESCRIPTION
Throw an IllegalArgumentException if the DB config contains a
:node-ttl-days option.

Remove all of the other code/tests affiliated with :node-ttl-days.
