### PR TITLE
NEEDS INFO: Allow tilde in resource name, like in puppet

### DIFF
--- a/src/puppetlabs/puppetdb/catalogs.clj
+++ b/src/puppetlabs/puppetdb/catalogs.clj
@@ -276,7 +276,7 @@
 ;; Functions to ensure that the catalog structure is coherent.
 
 (def ^:const tag-pattern
-  #"\A[a-z0-9_][a-z0-9_:\-.]*\Z")
+  #"\A[a-z0-9_~][a-z0-9_~:\-.]*\Z")
 
 (defn validate-resources
   "Ensure that all resource tags conform to the allowed tag pattern."


### PR DESCRIPTION
tilde character is allowed in the resource and tag names in puppet, but not in puppetdb.
This PR fixes this.
