### PR TITLE
(PDB-1064) Fixed a bug in extract with 2 element expressions

### DIFF
--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -90,13 +90,20 @@
   (when (after-v3? version)
     (let [basic         (:basic reports)
           report-hash   (:hash (store-example-report! basic (now)))
+          bar-report-hash (:hash (store-example-report! (assoc basic :certname "bar.local") (now)))
           basic (assoc basic :hash report-hash)]
 
       (testing "one projected column"
         (response-equal?
          (get-response endpoint ["extract" "hash"
                                  ["=" "certname" (:certname basic)]])
-         #{(select-keys basic [:hash])}))
+         #{{:hash report-hash}}))
+
+      (testing "one projected column with a not"
+        (response-equal?
+         (get-response endpoint ["extract" "hash"
+                                 ["not" ["=" "certname" (:certname basic)]]])
+         #{{:hash bar-report-hash}}))
 
       (testing "three projected columns"
         (response-equal?


### PR DESCRIPTION
Previously the query engine would fail if a top-level extract's
expression had only two elements (i.e. ["not" ["=" "certname"
"foo.com]]). This commit adds a guard to the extracts used for nested
queries to ensure it doesn't catch the two clause version of top-level
extract.
