### PR TITLE
(PDB-1034) Ezbake source based testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,5 +42,7 @@ group :test do
 end
 
 group :acceptance do
-  gem 'beaker', '~> 2.2'
+  #gem 'beaker', '~> 2.2'
+  # TODO: temporary while I'm testing this out
+  gem 'beaker', :git => 'https://github.com/kbarber/beaker.git', :branch => 'pdb-1034-ezbake-pr-testing'
 end

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -20,15 +20,13 @@ An example of how to run a package based build, with vagrant/virtualbox on Cento
     PUPPETDB_EXPECTED_RPM_VERSION="1.3.3.73-1" \
     rake beaker:acceptance
 
-Source based build, from a particular branch:
+Source based build:
 
-    PUPPETDB_REPO_PUPPETDB='git://github.com/puppetlabs/puppetdb#1.3.x'
     rake beaker:acceptance
 
 EC2 build from source on Debian 6:
 
     BEAKER_CONFIG="ec2-west-debian6-64mda-64a" \
-    PUPPETDB_REPO_PUPPETDB="git://github.com/puppetlabs/puppetdb#1.3.x" \
     rake beaker:acceptance
 
 EC2 build with packages on Debian 6:
@@ -115,10 +113,6 @@ in your hash; the environment variable names are the same but uppercased
   Specify the git repository and reference to use for installing Puppet/Facter/Hiera
   from source. This is primarily so we can test against alternate versions of
   Puppet, so if the Puppet repo is not specified we fall back to using packages.
-
-* `:puppetdb_repo_puppetdb` (`PUPPETDB_REPO_PUPPETDB`) :
-  Specify the git repository and reference for where we are to download the
-  PuppetDB source code.
 
 * `:puppetdb_git_ref` (`REF`) :
   Specify the specific git ref that the tests should be run against.  This should

--- a/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
+++ b/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
@@ -4,21 +4,7 @@ step "Install development build of PuppetDB on the PuppetDB server" do
 
     case test_config[:install_type]
     when :git
-      raise "No PUPPETDB_REPO_PUPPETDB set" unless test_config[:repo_puppetdb]
-
-      case os
-      when :redhat, :fedora
-        on database, "yum install -y git-core ruby rubygem-rake"
-      when :debian
-        on database, "apt-get install -y git-core ruby rake"
-      else
-        raise "OS #{os} not supported"
-      end
-
-      on database, "rm -rf #{GitReposDir}/puppetdb"
-      repo = extract_repo_info_from(test_config[:repo_puppetdb].to_s)
-      install_from_git database, GitReposDir, repo,
-        :refspec => '+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/*'
+      Log.notify("Install puppetdb from source")
 
       if (test_config[:database] == :postgres)
         install_postgres(database)

--- a/ext/jenkins/beaker-tests-source.sh
+++ b/ext/jenkins/beaker-tests-source.sh
@@ -32,6 +32,16 @@ mkdir vendor
 
 bundle install --path vendor/bundle --without test
 
+# Install a copy of leiningen
+if [ -d "leiningen" ];
+then
+  rm -rf leiningen
+fi
+mkdir leiningen
+
+wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -O leiningen/lein
+chmod +x leiningen/lein
+
 # Now run our tests
-PUPPETDB_REPO_PUPPETDB="${REPO_URL}#${sha1}" \
+PATH=$PATH:$(pwd)/leiningen \
 bundle exec rake test:beaker

--- a/ext/jenkins/beaker-tests.sh
+++ b/ext/jenkins/beaker-tests.sh
@@ -1,7 +1,7 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
 echo "**********************************************"
-echo "PARAMS FROM UPSTREAM:"
+echo "PARAMS:"
 echo ""
 echo "PUPPETDB_BRANCH: ${PUPPETDB_BRANCH}"
 echo "REF: ${REF}"


### PR DESCRIPTION
This change switched PuppetDB over to use the ezbake_utils helpers in ezbake
to install PuppetDB via source. This effectively means the old installation
methodology can be retired.

The beaker-tests-source.sh script is now modified to ensure that leiningen
is now installed (since its required by ezbake helpers in beaker).

Some minor code was removed that is no longer needed, but a major retirement
patch will be forthcoming to remove the greater amount of code no longer
required. Since it was deemed such a patch would make this patch hard to read.

Signed-off-by: Ken Barber <ken@bob.sh>