### PR TITLE
(PDB-775) Add database param to puppetdb manifest for package based installs

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -289,10 +289,11 @@ module PuppetDBExtensions
   def install_puppetdb(host, db, version=nil)
     puppetdb_manifest = <<-EOS
     class { 'puppetdb::server':
+      database         => '#{db}',
       puppetdb_version => '#{get_package_version(host, version)}',
     }
     EOS
-    if db == "postgres"
+    if db == :postgres
       manifest = append_postgres_manifest(host, puppetdb_manifest)
       manifest += "\nPostgresql::Server::Db['puppetdb'] -> Class['puppetdb::server']"
       apply_manifest_on(host, manifest)


### PR DESCRIPTION
This commit fixes an issue with package based acceptance tests whereby we
weren't applying the correct manifest for managing puppetdb on either
embedded or postgres puppetdb installs. The hsql issue was due to the fact
we weren't passing in `:embedded` to the module causing the module to try
and validate a postgres database, the postgres issue was due to the fact
that the db param to install_puppetdb is a keyword and not a string so we
were always applying the incorrect hsqldb manifest.
