### PR TITLE
(PDB-1076) Make environment garbage collection ignore null values

### DIFF
--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -746,11 +746,11 @@
   (time! (:gc-environments metrics)
          (sql/delete-rows :environments
            ["ID NOT IN
-              (SELECT environment_id FROM catalogs
-               UNION ALL
-               SELECT environment_id FROM reports
-               UNION ALL
-               SELECT environment_id FROM factsets)"])))
+              (SELECT environment_id FROM catalogs WHERE environment_id IS NOT NULL
+               UNION
+               SELECT environment_id FROM reports WHERE environment_id IS NOT NULL
+               UNION
+               SELECT environment_id FROM factsets WHERE environment_id IS NOT NULL)"])))
 
 (defn delete-unassociated-statuses!
   "Remove any statuses that aren't associated with a report"


### PR DESCRIPTION
If a factset, report or catalog is migrated from an earlier puppetdb
version or submitted with a earlier puppetdb-terminus version it has
NULL as environment_id. If any of them have a record with that PuppetDB
failed to garbage collect any environments at all as the subselect
returned a NULL value.

Switching from UNION ALL to just UNION speeds up the query dramatically
as the return value from the subselect is much smaller (doesn't contain
any duplicates).
