### PR TITLE
install i18n before activerecord to avoid dependency bug

### DIFF
--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -77,6 +77,7 @@ deb http://s3-us-west-2.amazonaws.com/puppetdb-jdk/jpkg/ pljdk main
         # we skip.
       else
         on master, "apt-get install -y rubygems ruby-dev libsqlite3-dev"
+        on master, "gem install i18n -v 0.6.9"
         on master, "gem install activerecord -v 3.2.17 --no-ri --no-rdoc -V --backtrace"
         on master, "gem install sqlite3 -v 1.3.9 --no-ri --no-rdoc -V --backtrace"
       end


### PR DESCRIPTION
Currently we're running into trouble installing activerecord with Ruby 1.8.7 because of the following

activerecord -> activesupport -> i18n (bumps to 0.7.0) -> Ruby 1.9.3

We think this is a bug in the activesupport dependencies:
Maybe, 
i18n (>= 0.6.9, ~> 0.6)
should be
i18n (>= 0.6.9, ~> 0.6.0)
