### PR TITLE
(PDB-353) Don't add new mbeans for metrics URLs.

### DIFF
--- a/test/puppetlabs/puppetdb/middleware_test.clj
+++ b/test/puppetlabs/puppetdb/middleware_test.clj
@@ -30,6 +30,19 @@
       ;; Should have separate meters for each status code
       (is (= (set (range 200 210)) (keyset (get-in @storage [:meters "/foo/bar/baz"]))))))
 
+  (testing "Should NOT create timers and meters for metrics URLs (PDB-353)"
+    (let [storage       (atom {})
+          normalize-uri identity
+          handler       (fn [req] (-> (rr/response nil)
+                                      (rr/status http/status-ok)))
+          app (wrap-with-metrics handler storage normalize-uri)]
+
+          (app {:uri "/v99/metrics/mbeans"})                    ;; the list of available metrics
+          (app {:uri "/some/user/prefix/v1/metrics/mbean/foo"}) ;; example of a given metric
+
+      ;; Should not have created timers or meters
+      (is (= #{} (keyset @storage)))))
+
   (testing "Should normalize according to supplied func"
     (let [storage       (atom {})
           ;; Normalize urls based on reversing the url


### PR DESCRIPTION
- Added a check to ensure that requests for metrics/mbeans information
  do not cause creation of additional mbeans to track the metrics URLs.
  We check specifically for the "available mbeans list" URL, and for any
  specific metric URL from that list.
- Added test code to verify that :timers and :meters are not created
  when metrics-related URLs are accessed.
