### PR TITLE
(maint) activesupport calls in the latest i18n, which drops support for ...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ gem 'facter'
 case RUBY_VERSION
 when '1.8.7'
   gem 'rake', '<= 10.1.1'
+  # activesupport calls in the latest i18n, which drops 1.8.7. This pins to
+  # a lower version
+  gem 'i18n', '~> 0.6.11'
 else
   gem 'rake'
 end

--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -76,6 +76,9 @@ step "Install rubygems and sqlite3 on master" do
       # we skip.
     else
       on master, "apt-get install -y rubygems ruby-dev libsqlite3-dev"
+      # this is to get around the activesupport dependency on Ruby 1.9.3 for
+      # Ubuntu 12.04. We can remove it when we drop support for 1.8.7.
+      on master, "gem install i18n -v 0.6.11"
       on master, "gem install activerecord -v 3.2.17 --no-ri --no-rdoc -V --backtrace"
       on master, "gem install sqlite3 -v 1.3.9 --no-ri --no-rdoc -V --backtrace"
     end


### PR DESCRIPTION
The latest i18n drops support for 1.8.7 and is pulled in by activesupport, which means acceptance tests are broken for ubuntu 12.04. This PR pins to a lower version with 1.8.7 support.
