### PR TITLE
(PDB-1071) Add pagination to service query method

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -327,7 +327,9 @@
 
 (defprotocol PuppetDBServer
   (shared-globals [this])
-  (query [this query-obj version query-expr query-row-callback-fn]))
+  (query [this query-obj version query-expr paging-options row-callback-fn]
+    "Call `row-callback-fn' for matching rows.  The `paging-options' should
+    be a map containing :order-by, :offset, and/or :limit."))
 
 (defservice puppetdb-service
   "Defines a trapperkeeper service for PuppetDB; this service is responsible
@@ -345,14 +347,14 @@
         (stop-puppetdb context))
   (shared-globals [this]
                   (:shared-globals (service-context this)))
-  (query [this query-obj version query-expr query-row-callback-fn]
+  (query [this query-obj version query-expr paging-options row-callback-fn]
          (qeng/stream-query-result
           query-obj
           version
           query-expr
-          nil
+          paging-options
           (get-in (service-context this) [:shared-globals :scf-read-db])
-          query-row-callback-fn)))
+          row-callback-fn)))
 
 (defn -main
   "Calls the trapperkeeper main argument to initialize tk.


### PR DESCRIPTION
In order to support pagination in the service query method, have it
accept a map instead of the raw query structure.  The map should contain
a :query referring to the original query, alongside (optional)
:order-by, :offset, and :limit members.