### PR TITLE
(maint) delete extraneous arguments to factsets endpoint

### DIFF
--- a/src/com/puppetlabs/puppetdb/http/factsets.clj
+++ b/src/com/puppetlabs/puppetdb/http/factsets.clj
@@ -53,16 +53,7 @@
   [query-app]
   (app
     []
-    (verify-accepts-json query-app)
-
-    [fact value &]
-    (comp query-app
-          (partial http-q/restrict-fact-query-to-name fact)
-          (partial http-q/restrict-fact-query-to-value value))
-
-    [fact &]
-    (comp query-app
-          (partial http-q/restrict-fact-query-to-name fact))))
+    (verify-accepts-json query-app)))
 
 (defn factset-app
   [version]


### PR DESCRIPTION
The factsets endpoint has some non-functioning url arguments copied from the facts
endpoint in error. This patch deletes them.
