### PR TITLE
(maint) Allow factset ordering on hash

### DIFF
--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -139,7 +139,8 @@
   (case entity
     :factsets
     (-> clause
-        (str/replace #"environment" "COALESCE(distinct_names.environment, '')"))
+        (str/replace #"environment" "COALESCE(distinct_names.environment, '')")
+        (str/replace #"hash" "COALESCE(distinct_names.hash, '')"))
     :reports
     (-> clause
         (str/replace #"environment" "COALESCE(distinct_names.environment, '')")
@@ -175,11 +176,19 @@
        (case entity
          :factsets
          (format "SELECT paged_results.* FROM (%s) paged_results
-                WHERE (certname,COALESCE(paged_results.environment,''),timestamp,
-                producer_timestamp) IN
-                (SELECT DISTINCT certname,COALESCE(distinct_names.environment,''),timestamp,
-                producer_timestamp FROM (%s)
-                distinct_names %s%s%s) %s"
+                 WHERE
+                 (certname,
+                 COALESCE(paged_results.environment, ''),
+                 COALESCE(paged_results.hash, ''),
+                 timestamp,
+                 producer_timestamp) IN
+                 (SELECT DISTINCT
+                 certname,
+                 COALESCE(distinct_names.environment,''),
+                 COALESCE(distinct_names.hash, ''),
+                 timestamp,
+                 producer_timestamp FROM (%s)
+                 distinct_names %s%s%s) %s"
                  sql sql inner-order-by limit-clause offset-clause order-by-clause)
 
          :reports

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -207,7 +207,8 @@
 (def factset-columns {"certname" "factsets"
                       "environment" "factsets"
                       "timestamp" "factsets"
-                      "producer-timestamp" "factsets"})
+                      "producer-timestamp" "factsets"
+                      "hash" "factsets"})
 
 ;; This map's keys are the queryable fields for resources, and the values are the
 ;;  corresponding table names where the fields reside

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -424,7 +424,8 @@
                          "producer_timestamp" :timestamp
                          "type" :string}
                :alias "factsets"
-               :queryable-fields ["certname" "environment" "timestamp" "producer-timestamp" "hash"]
+               :queryable-fields ["certname" "environment" "timestamp"
+                                  "producer-timestamp" "hash"]
                :entity :factsets
                :source-table "factsets"
                :subquery? false

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -1205,6 +1205,14 @@
                   actual (json/parse-string (slurp (:body (get-response endpoint nil ordering))))]
               (is (= actual expected))))))
 
+      (testing "order on hash"
+        (doseq [[order expected] [["ASC" (sort-by #(get % "hash") factset-results)]
+                                  ["DESC" (reverse (sort-by #(get % "hash") factset-results))]]]
+          (testing order
+            (let [ordering {:order-by (json/generate-string [{"field" "hash" "order" order}])}
+                  actual (json/parse-string (slurp (:body (get-response endpoint nil ordering))))]
+              (is (= actual expected))))))
+
       (testing "multiple fields"
         (doseq [[[env-order certname-order] expected-order] [[["DESC" "ASC"]  [2 0 1]]
                                                              [["DESC" "DESC"] [2 1 0]]


### PR DESCRIPTION
This corrects an oversight in adding the hash field to factsets that left
ordering results on hash impossible. I'm not a fan of the solution here, but it
follows our approach for environments and I can't think of a better way ATM.
The constraints are:

a) The factsets query must be "doubled up" in jdbc.clj so that paging options are applied
on an object basis instead of a by-row basis (a factset comprises multiple rows.)

b) Both environment and hash are nullable fields in factsets, so a COALESCE is
necessary to prevent a "WHERE null IN null" scenario.