### PR TITLE
Apply the TK hook config to the test instances too

### DIFF
--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -356,23 +356,26 @@
 
 (defn add-web-routing-config
   [config-data]
-  (let [prefix (get-in config-data [:global :url-prefix] "/")]
+  (let [prefix (normalize-url-prefix (get-in config-data [:global :url-prefix]
+                                             ""))]
     (assoc-in config-data [:web-router-service
                            :puppetlabs.puppetdb.cli.services/puppetdb-service] prefix)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
+(defn adjust-tk-config [config]
+  (-> config
+    warn-repl-retirement
+    default-ssl-protocols
+    add-web-routing-config))
+
 (defn hook-tk-parse-config-data
   "This is a robert.hooke compatible hook that is designed to intercept
    trapperkeeper configuration before it is used, so that we may munge &
    customize it."
   [f args]
-  (let [config (f args)]
-    (-> config
-        warn-repl-retirement
-        default-ssl-protocols
-        add-web-routing-config)))
+  (adjust-tk-config (f args)))
 
 (defn process-config!
   "Accepts a map containing all of the user-provided configuration values

--- a/test/puppetlabs/puppetdb/testutils/jetty.clj
+++ b/test/puppetlabs/puppetdb/testutils/jetty.clj
@@ -8,6 +8,7 @@
             [puppetlabs.puppetdb.cli.services :refer [puppetdb-service]]
             [puppetlabs.puppetdb.mq-listener :refer [message-listener-service]]
             [puppetlabs.puppetdb.command :refer [command-service]]
+            [puppetlabs.puppetdb.config :as conf]
             [clj-http.client :as client]))
 
 (def ^:dynamic *port* nil)
@@ -20,8 +21,7 @@
    :global {:vardir (temp-dir)}
    :jetty {:port 0}
    :database (fixt/create-db-map)
-   :command-processing {}
-   :web-router-service {:puppetlabs.puppetdb.cli.services/puppetdb-service "/"}})
+   :command-processing {}})
 
 (defn current-url
   "Uses the dynamically bound port to create a v4 URL to the
@@ -48,12 +48,13 @@
    If the port is assigned by Jetty, use *port* to get the currently running port."
   ([f] (puppetdb-instance (create-config) f))
   ([config f]
+   (let [config (conf/adjust-tk-config config)]
      (tkbs/with-app-with-config server
        [jetty9-service puppetdb-service message-listener-service command-service webrouting-service]
        config
        (binding [*port* (current-port server)
                  *server* server]
-         (f)))))
+         (f))))))
 
 (defmacro with-puppetdb-instance
   "Convenience macro to launch a puppetdb instance"


### PR DESCRIPTION
Previously the jetty testutils service instances' configs were only
adjusted by process-config!, but the actual server's config was also
adjusted by hook-tk-parse-config-data.  Change it so that
adjust-tk-config is applied in both cases.

Doing so exposes a bug -- a [global] url-prefix setting with a relative
path like "foo" will prevent the server from responding on /foo.  That's
because add-web-routing-config (via the tk hook) wasn't normalizing the
url-prefix before stashing it in in the web-router-service config.  To
fix that, normalize the url-prefix in add-web-routing-config.