### PR TITLE
(PDB-1070) Deprecate url-prefix in global

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -180,6 +180,8 @@ When this is set to true, debugging information will be written to `<vardir>/deb
 
 ### `url-prefix`
 
+> **Deprecated:** This setting will be removed in the future and url-prefixes should be configured using the `web-router-service`.
+
 This optional setting may be used to mount the PuppetDB web application at a URL other than "/".  This should not be necessary
 unless you intend to run additional web applications in the same server with your PuppetDB instance.  **NOTE:** if you change
 this setting, you must also set the corresponding setting in your Puppet Master's [puppetdb.conf][puppetdb.conf] file.

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -180,7 +180,7 @@ When this is set to true, debugging information will be written to `<vardir>/deb
 
 ### `url-prefix`
 
-> **Deprecated:** This setting will be removed in the future and url-prefixes should be configured using the `web-router-service`.
+> **Deprecated:** This setting will be removed in the future and url-prefixes should be configured using the [`web-router-service`](#:web-router-service).
 
 This optional setting may be used to mount the PuppetDB web application at a URL other than "/".  This should not be necessary
 unless you intend to run additional web applications in the same server with your PuppetDB instance.  **NOTE:** if you change
@@ -667,3 +667,17 @@ The port to use for the REPL.
 ### `host`
 
 Specifies the host or IP address for the repl service to listen on. By default this is `127.0.0.1` only, as this is an insecure channel this is the only recommended setting for production environments. Although this is generally not recommended for production, you can listen on all interfaces, you can specify `0.0.0.0` for example.
+
+`:web-router-service` Settings
+-----
+
+
+The `:web-router-service` section is used to configure the routes at which applications running with your PuppetDB instance are mounted. This configuration section must be done in a `.conf` file (this is the [Human-Optimized Config Object Notation](https://github.com/typesafehub/config/blob/master/HOCON.md) format; a flexible superset of JSON defined by the [typesafe config library](https://github.com/typesafehub/config)). For more information on configuring the `web-router-service` see the [trapperkeeper-webserver-jetty9 docs](https://github.com/puppetlabs/trapperkeeper-webserver-jetty9/blob/master/doc/webrouting-service.md).
+
+### `:puppetlabs.puppetdb.cli.services/puppetdb-service`
+
+This setting may be used to mount the PuppetDB web application at a URL other than "/".  This should not be necessary
+unless you intend to run additional web applications in the same server with your PuppetDB instance.  **NOTE:** if you change
+this setting, you must also set the corresponding setting in your Puppet Master's [puppetdb.conf][puppetdb.conf] file.
+
+

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -228,7 +228,7 @@
   (format "%s&wireFormat.maxFrameSize=%s&marshal=true" url (:max-frame-size config)))
 
 (defn start-puppetdb
-  [context config service add-ring-handler shutdown-on-error]
+  [context config service add-ring-handler get-route shutdown-on-error]
   {:pre [(map? context)
          (map? config)
          (ifn? add-ring-handler)
@@ -239,7 +239,7 @@
          :as config}                            (conf/process-config! config)
          product-name                               (:product-name global)
          update-server                              (:update-server global)
-         url-prefix                                 (:url-prefix global)
+         url-prefix                                 (get-route service)
          write-db                                   (pl-jdbc/pooled-datasource database)
          read-db                                    (pl-jdbc/pooled-datasource (assoc read-database :read-only? true))
          gc-interval                                (get database :gc-interval)
@@ -336,11 +336,11 @@
   that trapperkeeper will call on exit."
   PuppetDBServer
   [[:ConfigService get-config]
-   [:WebroutingService add-ring-handler]
+   [:WebroutingService add-ring-handler get-route]
    [:ShutdownService shutdown-on-error]]
 
   (start [this context]
-         (start-puppetdb context (get-config) this add-ring-handler shutdown-on-error))
+         (start-puppetdb context (get-config) this add-ring-handler get-route shutdown-on-error))
 
   (stop [this context]
         (stop-puppetdb context))

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -54,7 +54,7 @@
         (is (= 200 (:status response))))))
   (testing "should support mounting web app at alternate url prefix"
     (jutils/puppetdb-instance
-     (assoc-in (jutils/create-config) [:global :url-prefix] "puppetdb")
+     (assoc-in (jutils/create-config) [:web-router-service :puppetlabs.puppetdb.cli.services/puppetdb-service] "/puppetdb")
      (fn []
        (let [response (client/get (jutils/current-url "/v4/version") {:throw-exceptions false})]
          (is (= 404 (:status response))))

--- a/test/puppetlabs/puppetdb/testutils/jetty.clj
+++ b/test/puppetlabs/puppetdb/testutils/jetty.clj
@@ -17,11 +17,12 @@
   "Creates a default config, populated with a temporary vardir and
    a fresh hypersql instance"
   []
-  {:repl {}
+  {:nrepl {}
    :global {:vardir (temp-dir)}
    :jetty {:port 0}
    :database (fixt/create-db-map)
-   :command-processing {}})
+   :command-processing {}
+   :web-router-service {:puppetlabs.puppetdb.cli.services/puppetdb-service ""}})
 
 (defn current-url
   "Uses the dynamically bound port to create a v4 URL to the


### PR DESCRIPTION
This commit deprecates the use of the `url-prefix` config setting under
the `[global]` header, favoring the use of the webrouting service to
configure the url-prefix. This commit uses the WebroutingService
get-route function to retrieve the url-prefix from the config data,
using the hook in config.clj to add a default or copy the config from
global url-prefix to the web-routing config.