### PR TITLE
(PDB-1052) fix puppet 4 directory environment failures

### DIFF
--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -32,6 +32,15 @@ module Puppet::Util::Puppetdb
     defined?(Puppet::Parser::AST::HashOrArrayAccess)
   end
 
+  def self.create_environmentdir(environment)
+    if not puppet3compat?
+      envdir = File.join(Puppet[:environmentpath], environment)
+      if not Dir.exists?(envdir)
+        Dir.mkdir(envdir)
+      end
+    end
+  end
+
   # Given an instance of ruby's Time class, this method converts it to a String
   # that conforms to PuppetDB's wire format for representing a date/time.
   def self.to_wire_time(time)

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -11,6 +11,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
   before :each do
     Puppet::Util::Puppetdb.stubs(:server).returns 'localhost'
     Puppet::Util::Puppetdb.stubs(:port).returns 0
+    Puppet::Util::Puppetdb.create_environmentdir("my_environment")
   end
 
   describe "#save" do

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -17,8 +17,8 @@ describe Puppet::Node::Facts::Puppetdb do
   before :each do
     Puppet::Util::Puppetdb.config.stubs(:server_urls).returns [URI("https://localhost:8282")]
     Puppet::Node::Facts.indirection.stubs(:terminus).returns(subject)
-
     Puppet::Network::HttpPool.stubs(:http_instance).returns(http)
+    Puppet::Util::Puppetdb.create_environmentdir("my_environment")
   end
 
   describe "#save" do


### PR DESCRIPTION
In Puppet 4, directory environments are enabled by default and any environment
specified in a config must have a corresponding directory in the environmentpath.

This patch brings us into accordance so spec tests can pass on Puppet master.