### PR TITLE
(PDB-1052) fix spec tests on puppet master

### DIFF
--- a/puppet/spec/spec_helper.rb
+++ b/puppet/spec/spec_helper.rb
@@ -10,9 +10,17 @@ require 'puppetlabs_spec_helper/puppet_spec_helper'
 require 'tmpdir'
 require 'fileutils'
 require 'puppet'
+require 'puppet/util/puppetdb'
 require 'puppet/util/log'
-require 'puppet/util/puppetdb/command'
 
+def create_environmentdir(environment)
+  if not Puppet::Util::Puppetdb.puppet3compat?
+    envdir = File.join(Puppet[:environmentpath], environment)
+    if not Dir.exists?(envdir)
+      Dir.mkdir(envdir)
+    end
+  end
+end
 
 RSpec.configure do |config|
 

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -11,6 +11,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
   before :each do
     Puppet::Util::Puppetdb.stubs(:server).returns 'localhost'
     Puppet::Util::Puppetdb.stubs(:port).returns 0
+    create_environmentdir("my_environment")
   end
 
   describe "#save" do

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -15,6 +15,7 @@ describe Puppet::Node::Facts::Puppetdb do
     Puppet::Util::Puppetdb.stubs(:server).returns 'localhost'
     Puppet::Util::Puppetdb.stubs(:port).returns 0
     Puppet::Node::Facts.indirection.stubs(:terminus).returns(subject)
+    create_environmentdir("my_environment")
   end
 
   describe "#save" do


### PR DESCRIPTION
In Puppet 4 directory environments are enabled by default, which means that
environments referenced in a config file must have a corresponding directory
in the environment path or an error will be thrown. This patch creates a
my_environment directory for facts and catalogs to bring us into accordance.