### PR TITLE
(maint) Set Beaker AWS department to 'eso-dept'

### DIFF
--- a/ext/jenkins/beaker-tests-source.sh
+++ b/ext/jenkins/beaker-tests-source.sh
@@ -21,7 +21,7 @@ export BEAKER_COLOR=false
 export BEAKER_XML=true
 export PUPPETDB_USE_PROXIES=false
 export BEAKER_project=PuppetDB
-export BEAKER_department=Engineering
+export BEAKER_department=eso-dept
 
 # Remove old vendor directory to ensure we have a clean slate
 if [ -d "vendor" ];


### PR DESCRIPTION
This commit sets the BEAKER_department variable to 'eso-dept',
to improve AWS usage reporting.

After review and merge, please merge or cherry-pick up to 'master'.