### PR TITLE
(maint) Fix rake install process to use new ezbake uberjar file

### DIFF
--- a/tasks/tar.rake
+++ b/tasks/tar.rake
@@ -1,5 +1,5 @@
 # The tar task for creating a tarball of puppetdb
-JAR_FILE_V = "puppetdb-#{@version}-standalone.jar"
+JAR_FILE_V = "puppetdb-release.jar"
 
 # JAR_FILE the constant is defined in Rakefile
 #


### PR DESCRIPTION
Source based tests were failing since the uberjar name has been changed. This
patch ammends the rake install process to use the puppetdb-release.jar
filename instead as per the new project.clj change.

Signed-off-by: Ken Barber <ken@bob.sh>