### PR TITLE
(PDB-1024) Add support for hyphenated classnames

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -273,7 +273,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
                 # case problem here: http://projects.puppetlabs.com/issues/19474
                 # Once that problem is solved and older versions of Puppet that have
                 # the bug are no longer supported we can probably remove this code.
-                unless other_ref =~ /^[A-Z][a-z0-9_]*(::[A-Z][a-z0-9_]*)*\[.*\]/
+                unless other_ref =~ /^[A-Z][a-z0-9_-]*(::[A-Z][a-z0-9_-]*)*\[.*\]/
                   rel = edge_to_s(resource_hash_to_ref(resource_hash), other_ref, param)
                   raise Puppet::Error, "Invalid relationship: #{rel}, because " +
                     "#{other_ref} doesn't seem to be in the correct format. " +


### PR DESCRIPTION
This commit adds support for hyphenated classnames, supported by Puppet
2.7.x - 3.7.x.