### PR TITLE
(PDB-1068) Recognize prefix urls in import export

### DIFF
--- a/src/puppetlabs/puppetdb/cli/import.clj
+++ b/src/puppetlabs/puppetdb/cli/import.clj
@@ -11,9 +11,13 @@
             [puppetlabs.puppetdb.cheshire :as json]
             [clojure.java.io :as io]
             [slingshot.slingshot :refer [try+]]
-            [puppetlabs.puppetdb.utils :refer [export-root-dir]]
+            [puppetlabs.puppetdb.schema :refer [defn-validated]]
+            [puppetlabs.puppetdb.utils :as utils
+             :refer [base-url-schema export-root-dir]]
             [puppetlabs.kitchensink.core :refer [cli!]]
-            [puppetlabs.puppetdb.cli.export :refer [export-metadata-file-name]]))
+            [puppetlabs.puppetdb.cli.export :refer [export-metadata-file-name]]
+            [schema.core :as s]
+            [slingshot.slingshot :refer [try+ throw+]]))
 
 (def cli-description "Import PuppetDB catalog data from a backup file")
 
@@ -44,15 +48,13 @@
       (json/parse-string (archive/read-entry-content tar-reader) true))))
 
 
-(defn process-tar-entry
+(defn-validated process-tar-entry
   "Determine the type of an entry from the exported archive, and process it
   accordingly."
-  [^TarGzReader tar-reader ^TarArchiveEntry tar-entry host port metadata]
-  {:pre  [(instance? TarGzReader tar-reader)
-          (instance? TarArchiveEntry tar-entry)
-          (string? host)
-          (integer? port)
-          (map? metadata)]}
+  [^TarGzReader tar-reader :- TarGzReader
+   ^TarArchiveEntry tar-entry :- TarArchiveEntry
+   dest :- base-url-schema
+   metadata :- {s/Any s/Any}]
   (let [path    (.getName tar-entry)
         catalog-pattern (str "^" (.getPath (io/file export-root-dir "catalogs" ".*\\.json")) "$")
         report-pattern (str "^" (.getPath (io/file export-root-dir "reports" ".*\\.json")) "$")
@@ -64,24 +66,27 @@
       ;;   that polls puppetdb until the command queue is empty, then does a
       ;;   query to the /nodes endpoint and shows the set difference between
       ;;   the list of nodes that we submitted and the output of that query
-      (client/submit-catalog host port
+      (client/submit-catalog dest
                              (get-in metadata [:command-versions :replace-catalog])
                              (archive/read-entry-content tar-reader)))
     (when (re-find (re-pattern report-pattern) path)
       (println (format "Importing report from archive entry '%s'" path))
-      (client/submit-report host port
+      (client/submit-report dest
                             (get-in metadata [:command-versions :store-report])
                             (archive/read-entry-content tar-reader)))
     (when (re-find (re-pattern facts-pattern) path)
       (println (format "Importing facts from archive entry '%s'" path))
-      (client/submit-facts host port (get-in metadata [:command-versions :replace-facts])
+      (client/submit-facts dest
+                           (get-in metadata [:command-versions :replace-facts])
                            (archive/read-entry-content tar-reader)))))
 
 (defn- validate-cli!
   [args]
   (let [specs    [["-i" "--infile INFILE" "Path to backup file (required)"]
                   ["-H" "--host HOST" "Hostname of PuppetDB server" :default "localhost"]
-                  ["-p" "--port PORT" "Port to connect to PuppetDB server (HTTP protocol only)" :parse-fn #(Integer. %) :default 8080]]
+                  ["-p" "--port PORT" "Port to connect to PuppetDB server (HTTP protocol only)" :parse-fn #(Integer. %) :default 8080]
+                  ["" "--url-prefix PREFIX" "Server prefix (HTTP protocol only)"
+                   :default ""]]
         required [:infile]]
     (try+
      (cli! args specs required)
@@ -91,11 +96,17 @@
          :puppetlabs.kitchensink.core/cli-error (System/exit 1)
          :puppetlabs.kitchensink.core/cli-help  (System/exit 0))))))
 
-(defn -main
+(defn- main
   [& args]
-  (let [[{:keys [infile host port]} _] (validate-cli! args)
+  (let [[{:keys [infile host port url-prefix]} _] (validate-cli! args)
+        dest {:protocol "http" :host host :port port :prefix url-prefix}
+        _ (when-let [why (utils/describe-bad-base-url dest)]
+            (throw+ {:type ::invalid-url :utils/exit-status 1}
+                    (format "Invalid destination (%s)" why)))
         metadata                       (parse-metadata infile)]
     ;; TODO: do we need to deal with SSL or can we assume this only works over a plaintext port?
     (with-open [tar-reader (archive/tarball-reader infile)]
       (doseq [tar-entry (archive/all-entries tar-reader)]
-        (process-tar-entry tar-reader tar-entry host port metadata)))))
+        (process-tar-entry tar-reader tar-entry dest metadata)))))
+
+(def -main (utils/wrap-main main))

--- a/src/puppetlabs/puppetdb/client.clj
+++ b/src/puppetlabs/puppetdb/client.clj
@@ -6,78 +6,76 @@
             [clj-http.client :as http-client]
             [puppetlabs.puppetdb.command.constants :refer [command-names]]
             [puppetlabs.puppetdb.cheshire :as json]
-            [puppetlabs.kitchensink.core :as kitchensink]))
+            [puppetlabs.puppetdb.schema :refer [defn-validated]]
+            [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.kitchensink.core :as kitchensink]
+            [schema.core :as s]))
 
-(defn submit-command-via-http!
+(defn-validated submit-command-via-http!
   "Submits `payload` as a valid command of type `command` and
   `version` to the PuppetDB instance specified by `host` and
   `port`. The `payload` will be converted to JSON before
   submission. Alternately accepts a command-map object (such as those
   returned by `parse-command`). Returns the server response."
-  ([host port command version payload]
-     {:pre [(string? command)
-            (integer? version)]}
+  ([base-url
+    command :- s/Str
+    version :- s/Int
+    payload]
      (->> payload
           (command/assemble-command command version)
-          (submit-command-via-http! host port)))
-  ([host port command-map]
-     {:pre [(string? host)
-            (integer? port)
-            (map? command-map)]}
+          (submit-command-via-http! base-url)))
+  ([base-url :- utils/base-url-schema
+    command-map :- {s/Any s/Any}]
      (let [message (json/generate-string command-map)
            checksum (kitchensink/utf8-string->sha1 message)
-           url (format "http://%s:%s/v4/commands?checksum=%s" host port checksum)]
+           url (str (utils/base-url->str base-url)
+                    (format "/commands?checksum=%s" checksum))]
        (http-client/post url {:body               message
                               :throw-exceptions   false
                               :content-type       :json
                               :character-encoding "UTF-8"
                               :accept             :json}))))
 
-(defn submit-catalog
+(defn-validated submit-catalog
   "Send the given wire-format `catalog` (associated with `host`) to a
   command-processing endpoint located at `puppetdb-host`:`puppetdb-port`."
-  [puppetdb-host puppetdb-port command-version catalog-payload]
-  {:pre  [(string?  puppetdb-host)
-          (integer? puppetdb-port)
-          (integer? command-version)
-          (string?  catalog-payload)]}
+  [base-url :- utils/base-url-schema
+   command-version :- s/Int
+   catalog-payload :- s/Str]
   (let [result (submit-command-via-http!
-                puppetdb-host puppetdb-port
+                base-url
                 (command-names :replace-catalog) command-version
                 catalog-payload)]
     (when-not (= http/status-ok (:status result))
       (log/error result))))
 
-(defn submit-report
+(defn-validated submit-report
   "Send the given wire-format `report` (associated with `host`) to a
   command-processing endpoint located at `puppetdb-host`:`puppetdb-port`."
-  [puppetdb-host puppetdb-port command-version report-payload]
-  {:pre  [(string?  puppetdb-host)
-          (integer? puppetdb-port)
-          (integer? command-version)
-          (string?  report-payload)]}
+  [base-url :- utils/base-url-schema
+   command-version :- s/Int
+   report-payload :- s/Str]
   (let [payload (-> report-payload
                     json/parse-string
                     reports/sanitize-report)
         result  (submit-command-via-http!
-                 puppetdb-host puppetdb-port
+                 base-url
                  (command-names :store-report) command-version
                  payload)]
     (when-not (= http/status-ok (:status result))
       (log/error result))))
 
-(defn submit-facts
+(defn-validated submit-facts
   "Send the given wire-format `facts` (associated with `host`) to a
   command-processing endpoint located at `puppetdb-host`:`puppetdb-port`."
-  [puppetdb-host puppetdb-port facts-version fact-payload]
-  {:pre  [(string?  puppetdb-host)
-          (integer? puppetdb-port)
-          (string?  fact-payload)]}
+  [base-url :- utils/base-url-schema
+   facts-version :- s/Int
+   fact-payload :- s/Str]
   (let [payload (case facts-version
                   1 fact-payload
                   (json/parse-string fact-payload))
         result  (submit-command-via-http!
-                 puppetdb-host puppetdb-port
+                 base-url
                  (command-names :replace-facts)
                  facts-version
                  payload)]

--- a/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
+++ b/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
@@ -22,8 +22,9 @@
             [puppetlabs.puppetdb.utils :as utils]
             [clojure.tools.logging.impl :as li]
             [puppetlabs.puppetdb.client :as pdb-client]
-            [slingshot.slingshot :refer [throw+]]
-            [puppetlabs.puppetdb.testutils.jetty :as jutils]))
+            [slingshot.slingshot :refer [throw+ try+]]
+            [slingshot.test]
+            [puppetlabs.puppetdb.testutils.jetty :as jutils :refer [*base-url*]]))
 
 (use-fixtures :each fixt/with-test-logging-silenced)
 
@@ -37,8 +38,9 @@
 
 (defn submit-command
   "Submits a command to the running PuppetDB, launched by `puppetdb-instance`."
-  [cmd-kwd version payload]
-  (pdb-client/submit-command-via-http! "localhost" jutils/*port* (command-names cmd-kwd) version payload))
+  [base-url cmd-kwd version payload]
+  (pdb-client/submit-command-via-http! base-url
+                                       (command-names cmd-kwd) version payload))
 
 (defn block-until-results-fn
   "Executes `f`, if results are found, return them, otherwise
@@ -77,16 +79,17 @@
 (defn block-on-node
   "Waits for the queue to be empty, then blocks until the catalog, facts and reports are all
    found for `node-name`. Ensures that the commands have been stored before proceeding in a test."
-  [node-name]
+  [base-url node-name]
   (block-until-queue-empty)
-  (let [catalog-fut (block-until-results 100  (export/catalog-for-node "localhost" jutils/*port* node-name))
-        report-fut (block-until-results 100 (export/reports-for-node "localhost" jutils/*port* node-name))
-        facts-fut (block-until-results 100 (export/facts-for-node "localhost" jutils/*port* node-name))]
+  (let [catalog-fut (block-until-results 100 (export/catalog-for-node base-url node-name))
+        report-fut (block-until-results 100 (export/reports-for-node base-url node-name))
+        facts-fut (block-until-results 100 (export/facts-for-node base-url node-name))]
     @catalog-fut
     @report-fut
     @facts-fut))
 
-(deftest test-basic-roundtrip
+(defn- test-basic-roundtrip
+  [url-prefix]
   (let [facts {:name "foo.local"
                :environment "DEV"
                :values {:foo "the foo"
@@ -97,55 +100,79 @@
         export-out-file (testutils/temp-file "export-test" ".tar.gz")
         catalog (-> (get-in wire-catalogs [5 :empty])
                     (assoc :name "foo.local"))
-        report (:basic reports)]
+        report (:basic reports)
+        with-server #(jutils/puppetdb-instance
+                      (if (empty? url-prefix)
+                        (jutils/create-config)
+                        (assoc-in (jutils/create-config)
+                                  [:global :url-prefix] url-prefix))
+                      %)]
 
-    (jutils/with-puppetdb-instance
-      (is (empty? (export/get-nodes "localhost" jutils/*port*)))
-      (submit-command :replace-catalog 5 catalog)
-      (submit-command :store-report 3 (tur/munge-example-report-for-storage report))
-      (submit-command :replace-facts 3 facts)
+    (with-server
+      (fn []
+        (is (empty? (export/get-nodes *base-url*)))
+        (submit-command *base-url* :replace-catalog 5 catalog)
+        (submit-command *base-url* :store-report 3
+                        (tur/munge-example-report-for-storage report))
+        (submit-command *base-url* :replace-facts 3 facts)
 
-      (block-on-node (:name facts))
+        (block-on-node *base-url* (:name facts))
 
-      (is (= (map (partial tuc/munge-catalog-for-comparison :v5)
-                  (-> catalog
+        (is (= (map (partial tuc/munge-catalog-for-comparison :v5)
+                    (-> catalog
                       (dissoc :hash)
                       utils/vector-maybe))
-             (map (partial tuc/munge-catalog-for-comparison :v5)
-                  (-> (export/catalog-for-node "localhost" jutils/*port* (:name catalog))
+               (map (partial tuc/munge-catalog-for-comparison :v5)
+                    (-> (export/catalog-for-node *base-url* (:name catalog))
                       (json/parse-string true)
                       (dissoc :hash)
                       utils/vector-maybe))))
 
-      (is (= (tur/munge-report-for-comparison (tur/munge-example-report-for-storage report))
-             (tur/munge-report-for-comparison (-> (export/reports-for-node "localhost" jutils/*port* (:certname report))
-                                                  first
-                                                  tur/munge-example-report-for-storage))))
-      (is (= facts (export/facts-for-node "localhost" jutils/*port* "foo.local")))
+        (is (= (tur/munge-report-for-comparison
+                (tur/munge-example-report-for-storage report))
+               (tur/munge-report-for-comparison
+                (-> (export/reports-for-node *base-url* (:certname report))
+                  first
+                  tur/munge-example-report-for-storage))))
+        (is (= facts (export/facts-for-node *base-url* "foo.local")))
 
-      (export/-main "--outfile" export-out-file "--host" "localhost" "--port" jutils/*port*))
+        (apply #'export/main
+               "--outfile" export-out-file
+               "--host" (:host *base-url*) "--port" (:port *base-url*)
+               (when-not (empty? url-prefix) ["--url-prefix" url-prefix]))) )
 
-    (jutils/with-puppetdb-instance
+    (with-server
+      (fn []
+        (is (empty? (export/get-nodes *base-url*)))
+        (apply #'import/main
+               "--infile" export-out-file
+               "--host" (:host *base-url*) "--port" (:port *base-url*)
+               (when-not (empty? url-prefix) ["--url-prefix" url-prefix]))
 
-      (is (empty? (export/get-nodes "localhost" jutils/*port*)))
-        (import/-main "--infile" export-out-file "--host" "localhost" "--port" jutils/*port*)
+        (block-on-node *base-url* (:name facts))
 
-      (block-on-node (:name facts))
-
-      (is (= (map (partial tuc/munge-catalog-for-comparison :v5)
-                  (-> catalog
+        (is (= (map (partial tuc/munge-catalog-for-comparison :v5)
+                    (-> catalog
                       (dissoc :hash)
                       utils/vector-maybe))
-             (map (partial tuc/munge-catalog-for-comparison :v5)
-                  (-> (export/catalog-for-node "localhost" jutils/*port* (:name catalog))
+               (map (partial tuc/munge-catalog-for-comparison :v5)
+                    (-> (export/catalog-for-node *base-url* (:name catalog))
                       (json/parse-string true)
                       (dissoc :hash)
                       utils/vector-maybe))))
-      (is (= (tur/munge-report-for-comparison (tur/munge-example-report-for-storage report))
-             (tur/munge-report-for-comparison (-> (export/reports-for-node "localhost" jutils/*port* (:certname report))
-                                                  first
-                                                  tur/munge-example-report-for-storage))))
-      (is (= facts (export/facts-for-node "localhost" jutils/*port* "foo.local"))))))
+        (is (= (tur/munge-report-for-comparison
+                (tur/munge-example-report-for-storage report))
+               (tur/munge-report-for-comparison
+                (-> (export/reports-for-node *base-url* (:certname report))
+                  first
+                  tur/munge-example-report-for-storage))))
+        (is (= facts (export/facts-for-node *base-url* "foo.local")))))))
+
+(deftest basic-roundtrip
+  (test-basic-roundtrip nil))
+
+(deftest url-prefixed-roundtrip
+  (test-basic-roundtrip "foo"))
 
 (deftest test-max-frame-size
   (let [catalog (-> (get-in wire-catalogs [5 :empty])
@@ -153,7 +180,27 @@
     (jutils/puppetdb-instance
      (assoc-in (jutils/create-config) [:command-processing :max-frame-size] "1024")
      (fn []
-       (is (empty? (export/get-nodes "localhost" jutils/*port*)))
-       (submit-command :replace-catalog 5 catalog)
-       (is (thrown-with-msg? java.util.concurrent.ExecutionException #"Results not found"
-                             @(block-until-results 5 (json/parse-string (export/catalog-for-node "localhost" jutils/*port*  "foo.local")))))))))
+       (is (empty? (export/get-nodes *base-url*)))
+       (submit-command *base-url* :replace-catalog 5 catalog)
+       (is (thrown-with-msg?
+            java.util.concurrent.ExecutionException #"Results not found"
+            @(block-until-results 5
+                                  (json/parse-string
+                                   (export/catalog-for-node *base-url*
+                                                            "foo.local")))))))))
+
+(defn- check-invalid-url-handling [cmd expected-msg-re]
+  (let [ex (is (thrown+-with-msg? #(and (map? %) (:utils/exit-status %))
+                                  expected-msg-re
+                                  (cmd)))]
+    (is (not (zero? (:utils/exit-status ex))))))
+
+(deftest invalid-export-source-handling
+  (check-invalid-url-handling
+   #(#'export/main "--host" "local:host" "--outfile" "/dev/null" "--port" 10000)
+   #"^Invalid source .*"))
+
+(deftest invalid-import-destination-handling
+  (check-invalid-url-handling
+   #(#'import/main "--host" "local:host" "--infile" "/dev/null" "--port" 10000)
+   #"^Invalid destination .*"))

--- a/test/puppetlabs/puppetdb/utils_test.clj
+++ b/test/puppetlabs/puppetdb/utils_test.clj
@@ -68,3 +68,7 @@
         keys         (walk/keywordize-keys sample-data1)]
     (is (= sample-data1 (stringify-keys keys)))
     (is (= {"foo/bar" "data" "fuz/bash" "data2"} (stringify-keys sample-data2)))))
+
+(deftest describe-bad-base-url-behavior
+  (is (not (describe-bad-base-url {:protocol "http" :host "xy" :port 0})))
+  (is (string? (describe-bad-base-url {:protocol "http" :host "x:y" :port 0}))))


### PR DESCRIPTION
Note that there are 4 commits, which might or might not be easier to review individually, and I wondered about defaulting the base-url :protocol to "http".  Right now it has to be specified every time.

(This series is based on the PDB-1070 PR and so may need to be rebased once that goes in.)
