### PR TITLE
(maint) don't change dashed queryable fields to underscores before valid...

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -938,7 +938,7 @@
             ; For in-extract operator validation, please see annotate-with-context function
             [["extract" field & _]]
             (let [query-context (:query-context (meta node))
-                  queryable-fields (map #(str/replace % #"-" "_") (:queryable-fields query-context))
+                  queryable-fields (:queryable-fields query-context)
                   column-validation-message (validate-query-operation-fields
                                               field
                                               queryable-fields

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -107,7 +107,7 @@
 
       (testing "three projected columns"
         (response-equal?
-         (get-response endpoint ["extract" ["hash" "certname" "transaction_uuid"]
+         (get-response endpoint ["extract" ["hash" "certname" "transaction-uuid"]
                                  ["=" "certname" (:certname basic)]])
          #{(select-keys basic [:hash :certname :transaction-uuid])})))))
 


### PR DESCRIPTION
...ation

This removes a conversion to underscores before validation of top-level extract fields.
The prexisting conversion had broken querying on dashed fields.