### PR TITLE
Refactor lazy collapsing of DB results to use common code

### DIFF
--- a/src/puppetlabs/puppetdb/query/catalogs.clj
+++ b/src/puppetlabs/puppetdb/query/catalogs.clj
@@ -1,8 +1,8 @@
 (ns puppetlabs.puppetdb.query.catalogs
   "Catalog retrieval
 
-   Returns a catalog in the PuppetDB JSON wire format.  For more info, see
-   `documentation/api/wire_format/catalog_format.markdown`."
+  Returns a catalog in the PuppetDB JSON wire format.  For more info, see
+  `documentation/api/wire_format/catalog_format.markdown`."
   (:require [puppetlabs.puppetdb.schema :as pls]
             [puppetlabs.puppetdb.catalogs :as cats]
             [schema.core :as s]
@@ -67,9 +67,9 @@
                   :parameters (json/parse-strict-string parameters true)
                   :exported exported :file file}]
     (into acc
-            (-> resource
-                (kitchensink/dissoc-if-nil :line :file)
-                vector))))
+          (-> resource
+              (kitchensink/dissoc-if-nil :line :file)
+              vector))))
 
 (defn collapse-edges
   [acc row]
@@ -93,16 +93,13 @@
                    (into []))]
     (assoc (select-keys first-row [:name :version :environment :hash
                                    :transaction-uuid :producer-timestamp])
-           :edges edges :resources resources)))
+      :edges edges :resources resources)))
 
 (pls/defn-validated structured-data-seq
   "Produce a lazy seq of catalogs from a list of rows ordered by catalog hash"
   [version :- s/Keyword
    rows]
-  (when (seq rows)
-    (let [[catalog-rows more-rows] (split-with (create-catalog-pred rows) rows)]
-      (cons (collapse-catalog version catalog-rows)
-            (lazy-seq (structured-data-seq version more-rows))))))
+  (utils/collapse-seq create-catalog-pred #(collapse-catalog version %) rows))
 
 (defn query->sql
   "Converts a vector-structured `query` to a corresponding SQL query which will
@@ -117,7 +114,7 @@
                (jdbc/valid-jdbc-query? (:count-query %)))]}
    (paging/validate-order-by! catalog-columns paging-options)
    (qe/compile-user-query->sql
-     qe/catalog-query query paging-options)))
+    qe/catalog-query query paging-options)))
 
 (pls/defn-validated munge-result-rows
   "Reassemble rows from the database into the final expected format."

--- a/src/puppetlabs/puppetdb/query/factsets.clj
+++ b/src/puppetlabs/puppetdb/query/factsets.clj
@@ -7,7 +7,8 @@
             [puppetlabs.puppetdb.query.paging :as paging]
             [puppetlabs.puppetdb.query :as query]
             [puppetlabs.puppetdb.facts :as facts]
-            [puppetlabs.puppetdb.zip :as zip]))
+            [puppetlabs.puppetdb.zip :as zip]
+            [puppetlabs.puppetdb.utils :as utils]))
 
 ;; SCHEMA
 
@@ -73,12 +74,12 @@
 (defn recreate-fact-path
   "Produce the nested map corresponding to a path/value pair.
 
-   Operates by accepting an existing map `acc` and a map containing keys `path`
-   and `value`, it splits the path into its components and populates the data
-   structure with the `value` in the correct path.
+  Operates by accepting an existing map `acc` and a map containing keys `path`
+  and `value`, it splits the path into its components and populates the data
+  structure with the `value` in the correct path.
 
-   Returns the complete map structure after this operation is applied to
-   `acc`."
+  Returns the complete map structure after this operation is applied to
+  `acc`."
   [acc {:keys [path value]}]
   (let [split-path (facts/string-to-factpath path)]
     (assoc-in acc split-path value)))
@@ -96,10 +97,9 @@
   "Produce a lazy sequence of facts from a list of rows ordered by fact name"
   [version :- s/Keyword
    rows]
-  (when (seq rows)
-    (let [[certname-facts more-rows] (split-with (create-certname-pred rows) rows)]
-      (cons ((comp (partial collapse-factset version) convert-types) certname-facts)
-            (lazy-seq (structured-data-seq version more-rows))))))
+  (utils/collapse-seq create-certname-pred
+                      (comp #(collapse-factset version %) convert-types)
+                      rows))
 
 (pls/defn-validated munge-result-rows
   "Reassemble rows from the database into the final expected format."

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -90,8 +90,8 @@
 
 (defn stringify-keys
   "Recursively transforms all map keys from keywords to strings. This improves
-   on clojure.walk/stringify-keys by supporting the conversion of hyphenated
-   keywords to strings instead of trying to resolve them in a namespace first."
+  on clojure.walk/stringify-keys by supporting the conversion of hyphenated
+  keywords to strings instead of trying to resolve them in a namespace first."
   [m]
   (let [f (fn [[k v]] (if (keyword? k)
                         [(subs (str k) 1) v] [k v]))]
@@ -123,3 +123,14 @@
   "Vectorize an argument if it's not already vector"
   [v]
   (if (vector? v) v (vector v)))
+
+
+(defn collapse-seq
+  "Lazily consumes and collapses the seq `rows`. Uses `split-pred` to chunk the seq,
+  passes in each chunk to `collapse-fn`. Each result of `collapse-fn` is an item in
+  the return lazy-seq."
+  [split-pred collapse-fn rows]
+  (when (seq rows)
+    (let [[certname-facts more-rows] (split-with (split-pred rows) rows)]
+      (cons (collapse-fn certname-facts)
+            (lazy-seq (collapse-seq split-pred collapse-fn more-rows))))))


### PR DESCRIPTION
Reports, factsets and catalogs all have similar code, lazily collapsing n DB rows into a single JSON object. This commit refactors that logic to a single place.

I originally did this because I was repeating the logic again. Turned out I didn't need to collapse rows anymore, but the refactor still seemed good, so I'm pushing it up as a maint PR.