### PR TITLE
(PDB-885) Correct hostname for beaker fallback test instances

### DIFF
--- a/acceptance/config/ec2-west-debian7-64mda-fallback.cfg
+++ b/acceptance/config/ec2-west-debian7-64mda-fallback.cfg
@@ -12,7 +12,7 @@ HOSTS:
     snapshot: foss
     subnet_id: subnet-92dd65f7
     vpc_id: vpc-cc4aeda9
-  debian6-64-2:
+  debian7-64-2:
     roles:
       - database
     vmname: debian-7-amd64-west


### PR DESCRIPTION
This corrects a typo in the ec2 instance configuration designed to test the
terminus fallback scenario.

Signed-off-by: Ken Barber <ken@bob.sh>