### PR TITLE
(PDB-916) Only support puppet 3.7.3+ and 4.y.z releases

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -4,9 +4,9 @@ ezbake: {
     debian: { dependencies: ["pe-puppet (>= 4.0.0-1puppetlabs1)"] }
   }
   foss: {
-    redhat: { dependencies: ["puppet >= 3.7.3"],
+    redhat: { dependencies: ["puppet >= 3.7.3", "puppet < 5.0.0"],
               postinst: ["/usr/bin/puppetdb ssl-setup"] },
-    debian: { dependencies: ["puppet (>= 3.7.3-1puppetlabs1)"],
+    debian: { dependencies: ["puppet (>= 3.7.3-1puppetlabs1)", "puppet (<< 5.0.0-1puppetlabs1)"],
               postinst: ["/usr/bin/puppetdb ssl-setup"] }
   }
 }


### PR DESCRIPTION
Puppet 5.0.0 will likely include breaking changes as it is a major
version boundry. Putting this metadata in the package will prevent users
from accidentally having that broken setup.