### PR TITLE
(PDB-1109) Couldn't satisfy such that unit test failure

### DIFF
--- a/test/com/puppetlabs/puppetdb/test/zip.clj
+++ b/test/com/puppetlabs/puppetdb/test/zip.clj
@@ -18,8 +18,8 @@
             smaller-tree (gen/resize new-size (gen/sized (tree-generator coll-generators leaf-values)))]
         (gen/frequency
          (conj (mapv (fn [coll-generator]
-                       [3 (coll-generator smaller-tree)]) coll-generators)
-               [5 leaf-values]))))))
+                       [2 (coll-generator smaller-tree)]) coll-generators)
+               [1 leaf-values]))))))
 
 (def misc-leaves
   "Used for emulating typical tree contents with strings numbers and keywords"
@@ -86,7 +86,7 @@
 
 (cct/defspec post-order-collect
   50
-  (prop/for-all [w (gen/such-that coll? (gen/sized (tree-generator sequential-gen misc-leaves)))]
+  (prop/for-all [w (gen/such-that coll? (gen/sized (tree-generator sequential-gen misc-leaves)) 100)]
                 (= (:state (post-order-visit (tree-zipper w) [] [(extract-item number?)]))
                    (filter number? (flatten (seq w))))))
 


### PR DESCRIPTION
The couldn't satisfy such-that unit test failure can happen if the
test.check generator generates 10 possible "trees" that are not
collection, such as all leaves. This can cause false negative test
results. This commit increases the probability a tree with leaves will
be created and increases the number of attempts (from 10 to 100) that
such-that will make before giving up.