### PR TITLE
(PDB-1105) Remove experimental status of v4 api

### DIFF
--- a/documentation/api/index.markdown
+++ b/documentation/api/index.markdown
@@ -56,9 +56,7 @@ Version 3 of the query API added new endpoints, and introduces paging and sortin
 * [Server Time Endpoint](./query/v3/server-time.html)
 * [Version Endpoint](./query/v3/version.html)
 
-#### Version 4 (Experimental)
-
-Version 4 of the query API is currently experimental and may change without notice. For stability it is recommended to use the v3 query API.
+#### Version 4
 
 * [Nodes Endpoint](./query/v4/nodes.html)
 * [Environments Endpoint](./query/v4/environments.html)

--- a/documentation/api/query/v4/aggregate-event-counts.markdown
+++ b/documentation/api/query/v4/aggregate-event-counts.markdown
@@ -21,8 +21,6 @@ Once this information is stored in PuppetDB, it can be queried in various ways.
 * You can query **data about individual events** by making an HTTP request to the [`/events`][events] endpoint.
 * You can query **summaries of event data** by making an HTTP request to the [`/event-counts`][event-counts] or `aggregate-event-counts` endpoints.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, we recommend that you use the v3 API instead.
-
 ## `GET /v4/aggregate-event-counts`
 
 This will return aggregated count information about all of the resource events matching the given query.

--- a/documentation/api/query/v4/catalogs.markdown
+++ b/documentation/api/query/v4/catalogs.markdown
@@ -12,8 +12,6 @@ canonical: "/puppetdb/latest/api/query/v4/catalogs.html"
 You can query catalogs by making an HTTP request to the
 `/catalogs` endpoint.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, it is recommended that you use the v3 API instead.
-
 ## `GET /v4/catalogs`
 
 This will return a JSON array containing the most recent catalog for each node in your infrastructure.

--- a/documentation/api/query/v4/environments.markdown
+++ b/documentation/api/query/v4/environments.markdown
@@ -16,8 +16,6 @@ Environments are semi-isolated groups of nodes managed by Puppet. Nodes are assi
 
 When PuppetDB collects info about a node, it keeps track of the environment the node is assigned to. PuppetDB also keeps a list of environments it has seen. You can query this list by making an HTTP request to the `/environments` endpoint.
 
-> **Note:** The v4 API is experimental and may change without notice.
-
 ## `GET /v4/environments`
 
 This will return all environments known to PuppetDB.

--- a/documentation/api/query/v4/event-counts.markdown
+++ b/documentation/api/query/v4/event-counts.markdown
@@ -21,8 +21,6 @@ Once this information is stored in PuppetDB, it can be queried in various ways.
 * You can query **data about individual events** by making an HTTP request to the [`/events`][events] endpoint.
 * You can query **summaries of event data** by making an HTTP request to the `/event-counts` or [`aggregate-event-counts`](./aggregate-event-counts.html) endpoints.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, we recommend that you use the v3 API instead.
-
 ## `GET /v4/event-counts`
 
 This will return count information about all of the resource events matching the given query.

--- a/documentation/api/query/v4/events.markdown
+++ b/documentation/api/query/v4/events.markdown
@@ -24,8 +24,6 @@ Once this information is stored in PuppetDB, it can be queried in various ways.
 * You can query **data about individual events** by making an HTTP request to the `/events` endpoint.
 * You can query **summaries of event data** by making an HTTP request to the [`/event-counts`](./event-counts.html) or [`aggregate-event-counts`](./aggregate-event-counts.html) endpoints.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, it is recommended that you use the v3 API instead.
-
 ## `GET /v4/events`
 
 This will return all resource events matching the given query.  (Resource events

--- a/documentation/api/query/v4/fact-contents.markdown
+++ b/documentation/api/query/v4/fact-contents.markdown
@@ -28,8 +28,6 @@ Structured fact data is normally represented as a hash, which allows hashes, arr
 
 With the fact points endpoint it allows you to query data at a particular part of the tree using the `path` field, and then either analyze or filter on the `value` of that node.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, we recommend that you use the v3 API instead.
-
 ### `GET /v4/fact-contents`
 
 This will return all fact contents that match the given query.

--- a/documentation/api/query/v4/fact-names.markdown
+++ b/documentation/api/query/v4/fact-names.markdown
@@ -10,8 +10,6 @@ canonical: "/puppetdb/latest/api/query/v4/fact-names.html"
 
 The `/fact-names` endpoint can be used to retrieve all known fact names.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, it is recommended that you use the v3 API instead.
-
 
 ## `GET /fact-names`
 

--- a/documentation/api/query/v4/fact-paths.markdown
+++ b/documentation/api/query/v4/fact-paths.markdown
@@ -16,8 +16,6 @@ building autocompletion in GUIs or for other applications that require a
 basic top-level view of fact paths.  The fact-paths endpoint is not available
 for API versions 2 and 3.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, we recommend that you use the v3 API instead.
-
 ## `GET /fact-paths`
 
 This will return all fact paths matching the given query.

--- a/documentation/api/query/v4/facts.markdown
+++ b/documentation/api/query/v4/facts.markdown
@@ -12,8 +12,6 @@ You can query facts by making an HTTP request to the `/facts` endpoint.
 
 In Puppet's world, you only interact with facts from one node at a time, so any given fact consists of only a **fact name** and a **value.** But since PuppetDB interacts with a whole population of nodes, each PuppetDB fact also includes a **certname** and an **environment.**
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, we recommend that you use the v3 API instead.
-
 
 ## `GET /v4/facts`
 

--- a/documentation/api/query/v4/factsets.markdown
+++ b/documentation/api/query/v4/factsets.markdown
@@ -12,8 +12,6 @@ You can query factsets by making an HTTP request to the `/factsets` endpoint.
 
 A factset is the set of all facts for a single certname.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, we recommend that you use the v3 API instead.
-
 ### `GET /v4/factsets`
 
 This will return all factsets matching the given query.

--- a/documentation/api/query/v4/nodes.markdown
+++ b/documentation/api/query/v4/nodes.markdown
@@ -12,8 +12,6 @@ canonical: "/puppetdb/latest/api/query/v4/nodes.html"
 
 Nodes can be queried by making an HTTP request to the `/nodes` endpoint.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, it is recommended that you use the v3 API instead.
-
 
 ## `GET /v4/nodes`
 

--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -12,8 +12,6 @@ canonical: "/puppetdb/latest/api/query/v4/operators.html"
 
 PuppetDB's [query strings][query] can use several common operators.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, it is recommended that you use the v3 API instead.
-
 ## Binary Operators
 
 Each of these operators accepts two arguments: a **field,** and a

--- a/documentation/api/query/v4/paging.markdown
+++ b/documentation/api/query/v4/paging.markdown
@@ -11,8 +11,6 @@ canonical: "/puppetdb/latest/api/query/v4/paging.html"
 Most of PuppetDB's [query endpoints][api] support a general set of HTTP URL parameters that
 can be used for paging results.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, it is recommended that you use the v3 API instead.
-
 ## URL Parameters for Paging Results
 
 ### `order-by`

--- a/documentation/api/query/v4/query.markdown
+++ b/documentation/api/query/v4/query.markdown
@@ -19,8 +19,6 @@ PuppetDB's query API can retrieve data objects from PuppetDB for use in other ap
 
 The query API is implemented as HTTP URLs on the PuppetDB server. By default, it can only be accessed over the network via host-verified HTTPS; [see the jetty settings][jetty] if you need to access the API over unencrypted HTTP.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, it is recommended that you use the v3 API instead.
-
 ## Query Structure
 
 A query consists of:

--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -24,8 +24,6 @@ Once this information is stored in PuppetDB, it can be queried in various ways.
 * You can query **data about individual events** by making an HTTP request to the [`/events`][event] endpoint.
 * You can query **summaries of event data** by making an HTTP request to the [`/event-counts`](./event-counts.html) or [`aggregate-event-counts`](./aggregate-event-counts.html) endpoints.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, we recommend that you use the v3 API instead.
-
 ## `GET /v4/reports`
 
 ### URL Parameters

--- a/documentation/api/query/v4/resources.markdown
+++ b/documentation/api/query/v4/resources.markdown
@@ -11,8 +11,6 @@ canonical: "/puppetdb/latest/api/query/v4/resources.html"
 You can query resources by making an HTTP request to the
 `/resources` endpoint.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, it is recommended that you use the v3 API instead.
-
 
 ## `GET /v4/resources`
 

--- a/documentation/api/query/v4/server-time.markdown
+++ b/documentation/api/query/v4/server-time.markdown
@@ -9,8 +9,6 @@ canonical: "/puppetdb/latest/api/query/v4/server-time.html"
 
 The `/server-time` endpoint can be used to retrieve the server time from the PuppetDB server.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, it is recommended that you use the v3 API instead.
-
 
 ## `GET /v4/server-time`
 

--- a/documentation/api/query/v4/version.markdown
+++ b/documentation/api/query/v4/version.markdown
@@ -9,8 +9,6 @@ canonical: "/puppetdb/latest/api/query/v4/version.html"
 
 The `/version` endpoint can be used to retrieve version information from the PuppetDB server.
 
-> **Note:** The v4 API is experimental and may change without notice. For stability, it is recommended that you use the v3 API instead.
-
 
 ## `GET /v4/version`
 

--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -36,13 +36,6 @@
    "v2 query API is deprecated and will be removed in an upcoming release.  Please upgrade to v3."
    request))
 
-(defn experimental-v4-app
-  [request]
-  (experimental-warning
-   v4-app
-   "v4 query API is experimental and may change without warning. For stability use the v3 api."
-   request))
-
 (defn routes
   [url-prefix]
   (app
@@ -53,7 +46,7 @@
    {:any v3-app}
 
    ["v4" &]
-   {:any experimental-v4-app}
+   {:any v4-app}
 
    ["experimental" &]
    {:any experimental-app}


### PR DESCRIPTION
This commit removes the warning message when using the v4 endpoint of
the query api as well as the corresponding documentation changes needed
to express that v4 is the new 'stable' endpoint.

Merge with https://github.com/puppetlabs/puppet-docs/pull/426.