### PR TITLE
(PDB-693) Remove previously deprecated 'event-query-limit' setting

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -159,14 +159,6 @@ If you installed from packages, PuppetDB will use the logback.xml file in the `/
 
 You can edit the logging configuration file while PuppetDB is running, and it will automatically react to changes after a few seconds.
 
-### `event-query-limit`
-
-> **Deprecated:** With event streaming this setting is now ignored and will be removed in the future.
-
-The maximum number of legal results that a resource event query can return.  If you issue a query that would result in more results than this value, the query will simply return an error.  (This can be used to prevent accidental queries that would yield huge numbers of results from consuming undesirable amounts of resources on the server.)
-
-The default value is 20000.
-
 ### `update-server`
 
 The URL to query when checking for newer versions; defaults to `http://updates.puppetlabs.com/check-for-updates`.

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -317,14 +317,11 @@
 (defn configure-globals
   "Configures the global properties from the user defined config"
   [{:keys [global] :as config}]
-  (let [product-name (normalize-product-name (get global :product-name "puppetdb"))]
-    (when (:event-query-limit global)
-      (log/warn "The configuration item `event-query-limit` in the [global] section is deprecated and now ignored. It will be removed in the future."))
-    (update-in config [:global]
-               (fn [global-config]
-                 (-> global-config
-                     (assoc :product-name product-name)
-                     (utils/assoc-when :update-server "http://updates.puppetlabs.com/check-for-updates"))))))
+  (assoc config :global
+         (-> global
+             (utils/assoc-when :product-name "puppetdb")
+             (update-in [:product-name] normalize-product-name)
+             (utils/assoc-when :update-server "http://updates.puppetlabs.com/check-for-updates"))))
 
 (defn warn-if-sslv3
   "If the ssl-protocols config is present and contains sslv3, warn the user. Logging


### PR DESCRIPTION
Removed documentation for this setting, and code to check/warn about it's deprecation.