### PR TITLE
(PDB-477) Setup access-logging by default

### DIFF
--- a/resources/ext/config/conf.d/jetty.ini.erb
+++ b/resources/ext/config/conf.d/jetty.ini.erb
@@ -27,3 +27,7 @@ port = 8080
 
 # Certificate authority path
 # ssl-ca-cert = <ca_cert_path>
+
+# Access logging configuration path. To turn off access logging
+# comment out the line with `access-log-config=...`
+access-log-config = /etc<% if Pkg::Config.config[:build_pe] -%>/puppetlabs<% end -%>/puppetdb/request-logging.xml

--- a/resources/ext/config/logback.xml.erb
+++ b/resources/ext/config/logback.xml.erb
@@ -6,7 +6,7 @@
     </appender>
 
     <appender name="F1" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/var/log/puppetdb/puppetdb.log</file>
+        <file>/var/log/<% if Pkg::Config.config[:build_pe] -%>pe-<% end -%>puppetdb/puppetdb.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>/var/log/puppetdb/puppetdb-%d{yyyy-MM-dd}.log.gz</fileNamePattern>

--- a/resources/ext/config/request-logging.xml.erb
+++ b/resources/ext/config/request-logging.xml.erb
@@ -1,0 +1,15 @@
+<configuration debug="false">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>/var/log/<% if Pkg::Config.config[:build_pe] -%>pe-<% end -%>puppetdb/puppetdb-access.log</file>
+        <encoder>
+            <pattern>combined</pattern>
+            <!-- To have the same "combined" pattern with elapsedTime ('%D')
+                 appended use the following line:
+
+            <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D</pattern>
+
+            -->
+        </encoder>
+    </appender>
+    <appender-ref ref="FILE" />
+</configuration>


### PR DESCRIPTION
This commit add the necessary logback config and commented out param in
the jetty.ini to easily enable access-logging for PuppetDB.