### PR TITLE
WIP: (PDB-1034) Ezbake source based testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,5 @@ group :test do
 end
 
 group :acceptance do
-  #gem 'beaker', '~> 2.2'
-  # TODO: temporary while I'm testing this out
-  gem 'beaker', :git => 'https://github.com/kbarber/beaker.git', :branch => 'pdb-1034-ezbake-pr-testing'
+  gem 'beaker', '~> 2.2'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -42,5 +42,7 @@ group :test do
 end
 
 group :acceptance do
-  gem 'beaker', '~> 2.2'
+  #gem 'beaker', '~> 2.2'
+  # TODO: temporary while I'm testing this out
+  gem 'beaker', :git => 'https://github.com/kbarber/beaker.git', :branch => 'pdb-1034-ezbake-pr-testing'
 end

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -20,15 +20,13 @@ An example of how to run a package based build, with vagrant/virtualbox on Cento
     PUPPETDB_EXPECTED_RPM_VERSION="1.3.3.73-1" \
     rake beaker:acceptance
 
-Source based build, from a particular branch:
+Source based build:
 
-    PUPPETDB_REPO_PUPPETDB='git://github.com/puppetlabs/puppetdb#1.3.x'
     rake beaker:acceptance
 
 EC2 build from source on Debian 6:
 
     BEAKER_CONFIG="ec2-west-debian6-64mda-64a" \
-    PUPPETDB_REPO_PUPPETDB="git://github.com/puppetlabs/puppetdb#1.3.x" \
     rake beaker:acceptance
 
 EC2 build with packages on Debian 6:
@@ -115,10 +113,6 @@ in your hash; the environment variable names are the same but uppercased
   Specify the git repository and reference to use for installing Puppet/Facter/Hiera
   from source. This is primarily so we can test against alternate versions of
   Puppet, so if the Puppet repo is not specified we fall back to using packages.
-
-* `:puppetdb_repo_puppetdb` (`PUPPETDB_REPO_PUPPETDB`) :
-  Specify the git repository and reference for where we are to download the
-  PuppetDB source code.
 
 * `:puppetdb_git_ref` (`REF`) :
   Specify the specific git ref that the tests should be run against.  This should

--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -89,9 +89,6 @@ module PuppetDBExtensions
     puppetdb_repo_facter = get_option_value(options[:puppetdb_repo_facter],
       nil, "git repo for facter source installs", "PUPPETDB_REPO_FACTER", nil)
 
-    puppetdb_repo_puppetdb = get_option_value(options[:puppetdb_repo_puppetdb],
-      nil, "git repo for puppetdb source installs", "PUPPETDB_REPO_PUPPETDB", nil)
-
     puppetdb_git_ref = get_option_value(options[:puppetdb_git_ref],
       nil, "git revision of puppetdb to test against", "REF", nil)
 
@@ -114,7 +111,6 @@ module PuppetDBExtensions
       :repo_puppet => puppetdb_repo_puppet,
       :repo_hiera => puppetdb_repo_hiera,
       :repo_facter => puppetdb_repo_facter,
-      :repo_puppetdb => puppetdb_repo_puppetdb,
       :git_ref => puppetdb_git_ref,
     }
 
@@ -425,32 +421,7 @@ module PuppetDBExtensions
   # @return [void]
   # @api public
   def install_puppetdb_via_rake(host)
-    os = PuppetDBExtensions.config[:os_families][host.name]
-    case os
-      when :debian
-        preinst = "debian/puppetdb.preinst install"
-        postinst = "debian/puppetdb.postinst"
-      when :redhat, :fedora
-        preinst = "dev/redhat/redhat_dev_preinst install"
-        postinst = "dev/redhat/redhat_dev_postinst install"
-      else
-        raise ArgumentError, "Unsupported OS family: '#{os}'"
-    end
-
-    # We tag here so the build system knows what version to use, first
-    # we grab the version to use as tag from the project.clj,
-    # reformatting the output as necessary (since its in CLJ).
-    prepare_git_author(host)
-    result = on host, "#{LeinCommandPrefix} lein with-profile ci pprint :version | tail -n 1"
-    jar_version = result.stdout.chomp.gsub(/"/, '')
-    on host, "#{LeinCommandPrefix} git tag -f -a '#{jar_version}' -m 'temporary tag for source build to work'"
-
-    on host, "rm -rf /etc/puppetdb/ssl"
-    on host, "#{LeinCommandPrefix} rake package:bootstrap"
-    on host, "#{LeinCommandPrefix} rake template"
-    on host, "bash -x #{GitReposDir}/puppetdb/ext/files/#{preinst}"
-    on host, "#{LeinCommandPrefix} rake install"
-    on host, "bash -x #{GitReposDir}/puppetdb/ext/files/#{postinst}"
+    install_from_ezbake host
 
     step "Configure database.ini file" do
       manifest = "
@@ -466,7 +437,7 @@ module PuppetDBExtensions
   end
 
   def install_puppetdb_termini_via_rake(host, database)
-    on host, "#{LeinCommandPrefix} rake sourceterminus"
+    install_termini_from_ezbake host
 
     manifest = <<-EOS
       include puppetdb::master::routes
@@ -969,7 +940,7 @@ EOS
 
     tmp_repositories = []
 
-    repos = Hash[*test_config.select {|k, v| k =~ /^repo_/ and k != 'repo_puppetdb' }.flatten].values
+    repos = Hash[*test_config.select {|k, v| k =~ /^repo_/}.flatten].values
 
     repos.each do |uri|
       raise(ArgumentError, "#{uri} is not recognized.") unless(uri =~ git_uri)

--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -121,6 +121,7 @@ module PuppetDBExtensions
 
   class << self
     attr_reader :config
+    attr_reader :ezbake_config
   end
 
   def self.get_option_value(value, legal_values, description,
@@ -1042,6 +1043,226 @@ EOS
     # primary database must be numbered lowest
     databases[0]
   end
+
+  ##############################################################
+  # Ezbake helpers, this should be moved to core at some point #
+  ##############################################################
+
+  # Installs leiningen project with given name and version on remote host.
+  #
+  # @param [Host] host A single remote host on which to install the
+  #   specified leiningen project.
+  def install_from_ezbake host
+    ezbake_validate_support host
+    ezbake_tools_available?
+    install_ezbake_tarball_on_host host
+    ezbake_installsh host, "service"
+  end
+
+  # Installs termini with given name and version on remote host.
+  #
+  # @param [Host] host A single remote host on which to install the
+  #   specified leiningen project.
+  def install_termini_from_ezbake host
+    ezbake_validate_support host
+    ezbake_tools_available?
+    install_ezbake_tarball_on_host host
+    ezbake_installsh host, "termini"
+  end
+
+  # Test for support in one place
+  #
+  # @param [Host] host host to check for support
+  # @raise [RuntimeError] if OS is not supported
+  # @api private
+  def ezbake_validate_support host
+    variant, version, _, _ = host['platform'].to_array
+    unless variant =~ /^(fedora|el|centos|debian|ubuntu)$/
+      raise RuntimeError,
+            "No support for #{variant} within ezbake_utils ..."
+    end
+  end
+
+  # Build, copy & unpack tarball on remote host
+  #
+  # @param [Host] host installation destination
+  # @api private
+  def install_ezbake_tarball_on_host host
+    if not ezbake_config
+      ezbake_stage
+    end
+
+    # Skip installation if the remote directory exists
+    result = on host, "test -d #{ezbake_install_dir}", :acceptable_exit_codes => [0, 1]
+    return if result.exit_code == 0
+
+    ezbake_staging_dir = File.join('target', 'staging')
+    Dir.chdir(ezbake_staging_dir) do
+      ezbake_local_cmd 'rake package:tar'
+    end
+
+    local_tarball = ezbake_staging_dir + "/pkg/" + ezbake_install_name + ".tar.gz"
+    remote_tarball = ezbake_install_dir + ".tar.gz"
+    scp_to host, local_tarball, remote_tarball
+
+    # untar tarball on host
+    on host, "tar -xzf " + remote_tarball
+
+    # Check to ensure directory exists
+    on host, "test -d #{ezbake_install_dir}"
+  end
+
+  LOCAL_COMMANDS_REQUIRED = [
+    ['leiningen', 'lein --version', nil],
+    ['lein-pprint', 'lein with-profile ci pprint :version',
+      'Must have lein-pprint installed under the :ci profile.'],
+    ['java', 'java -version', nil],
+    ['git', 'git --version', nil],
+    ['rake', 'rake --version', nil],
+  ]
+
+  # Checks given host for the tools necessary to perform
+  # install_from_ezbake.
+  #
+  # @raise [RuntimeError] if tool is not found
+  # @api private
+  def ezbake_tools_available?
+    LOCAL_COMMANDS_REQUIRED.each do |software_name, command, additional_error_message|
+      if not system command
+        error_message = "Must have #{software_name} installed on development system.\n"
+        if additional_error_message
+          error_message += additional_error_message
+        end
+        raise RuntimeError, error_message
+      end
+    end
+  end
+
+  # Return the ezbake config.
+  #
+  # @return [Hash] configuration for ezbake
+  # @api private
+  def ezbake_config
+    ezbake_config
+  end
+
+  # Prepares a staging directory for the specified project.
+  #
+  # @api private
+  def ezbake_stage
+    # TODO: will need removal before merging, since we'll want to
+    # work against a shipped version of ezbake.
+    ezbake_dir = 'tmp/ezbake'
+    conditionally_clone "git@github.com:kbarber/ezbake.git",
+                        ezbake_dir, "pdb-1034-ezbake-pr-testing"
+
+    # Get the absolute path to the local repo
+    m2_repo = File.join(Dir.pwd, 'tmp', 'm2-local')
+
+    lein_prefix = 'lein update-in : assoc :local-repo "\"' +
+                  m2_repo + '\"" --'
+
+    # Install the PuppetDB jar into the local repository
+    ezbake_local_cmd "#{lein_prefix} install",
+                     :throw_on_failure => true
+
+    Dir.chdir(ezbake_dir) do
+      # TODO: here we compile a development version of the ezbake plugin,
+      # but for prod we'll need to work something else out
+      ezbake_local_cmd "#{lein_prefix} install",
+                        :throw_on_failure => true
+    end
+
+    ezbake_local_cmd "#{lein_prefix} with-profile ezbake ezbake stage",
+                     :throw_on_failure => true
+
+    staging_dir = File.join('target','staging')
+    Dir.chdir(staging_dir) do
+      ezbake_local_cmd 'rake package:bootstrap'
+
+      load 'ezbake.rb'
+      ezbake = EZBake::Config
+      ezbake[:package_version] = `echo -n $(rake pl:print_build_param[ref] | tail -n 1)`
+      PuppetDBExtensions.ezbake_config = ezbake
+    end
+  end
+
+  # Executes a local command using system, logging the prepared command
+  #
+  # @param [String] cmd command to execute
+  # @param [Hash] opts options
+  # @option opts [bool] :throw_on_failure If true, throws an
+  #   exception if the exit code is non-zero. Defaults to false.
+  # @return [bool] true if exit == 0 false if otherwise
+  # @raise [RuntimeError] if :throw_on_failure is true and
+  #   command fails
+  # @api private
+  def ezbake_local_cmd cmd, opts={}
+    opts = {
+      :throw_on_failure => false,
+    }.merge(opts)
+
+    logger.notify "localhost $ #{cmd}"
+    result = system cmd
+    if opts[:throw_on_failure] && result == false
+      raise RuntimeError, "Command failure #{cmd}"
+    end
+    result
+  end
+
+  # Retrieve the tarball installation name. This is the name of
+  # the tarball without the .tar.gz extension, and the name of the
+  # path where it will unpack to.
+  #
+  # @return [String] name of the tarball and directory
+  # @api private
+  def ezbake_install_name
+    ezbake = ezbake_config
+    project_package_version = ezbake[:package_version]
+    project_name = ezbake[:project]
+    "%s-%s" % [ project_name, project_package_version ]
+  end
+
+  # Returns the full path to the installed software on the remote host.
+  #
+  # This only returns the path, it doesn't work out if its installed or
+  # not.
+  #
+  # @return [String] path to the installation dir
+  # @api private
+  def ezbake_install_dir
+    "/root/#{ezbake_install_name}"
+  end
+
+  # A helper that wraps the execution of install.sh in the proper
+  # ezbake installation directory.
+  #
+  # @param [Host] host Host to run install.sh on
+  # @param [String] task Task to execute with install.sh
+  # @api private
+  def ezbake_installsh host, task=""
+    on host, "cd #{ezbake_install_dir}; bash install.sh #{task}"
+  end
+
+  # Only clone from given git URI if there is no existing git clone at the
+  # given local_path location.
+  #
+  # @param [String] upstream_uri git URI
+  # @param [String] local_path path to conditionally install to
+  # @param [String] branch to checkout
+  # @api private
+  def conditionally_clone upstream_uri, local_path, branch="origin/HEAD"
+    if ezbake_local_cmd "git --work-tree=#{local_path} --git-dir=#{local_path}/.git status"
+      ezbake_local_cmd "git --work-tree=#{local_path} --git-dir=#{local_path}/.git fetch origin"
+      ezbake_local_cmd "git --work-tree=#{local_path} --git-dir=#{local_path}/.git checkout #{branch}"
+    else
+      parent_dir = File.dirname(local_path)
+      FileUtils.mkdir_p(parent_dir)
+      ezbake_local_cmd "git clone #{upstream_uri} #{local_path}"
+      ezbake_local_cmd "git --work-tree=#{local_path} --git-dir=#{local_path}/.git checkout #{branch}"
+    end
+  end
+
 end
 
 # oh dear.

--- a/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
+++ b/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
@@ -4,21 +4,7 @@ step "Install development build of PuppetDB on the PuppetDB server" do
 
     case test_config[:install_type]
     when :git
-      raise "No PUPPETDB_REPO_PUPPETDB set" unless test_config[:repo_puppetdb]
-
-      case os
-      when :redhat, :fedora
-        on database, "yum install -y git-core ruby rubygem-rake"
-      when :debian
-        on database, "apt-get install -y git-core ruby rake"
-      else
-        raise "OS #{os} not supported"
-      end
-
-      on database, "rm -rf #{GitReposDir}/puppetdb"
-      repo = extract_repo_info_from(test_config[:repo_puppetdb].to_s)
-      install_from_git database, GitReposDir, repo,
-        :refspec => '+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/*'
+      Log.notify("Install puppetdb from source")
 
       if (test_config[:database] == :postgres)
         install_postgres(database)

--- a/ext/jenkins/beaker-tests-source.sh
+++ b/ext/jenkins/beaker-tests-source.sh
@@ -32,6 +32,16 @@ mkdir vendor
 
 bundle install --path vendor/bundle --without test
 
+# Install a copy of leiningen
+if [ -d "leiningen" ];
+then
+  rm -rf leiningen
+fi
+mkdir leiningen
+
+wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -O leiningen/lein
+chmod +x leiningen/lein
+
 # Now run our tests
-PUPPETDB_REPO_PUPPETDB="${REPO_URL}#${sha1}" \
+PATH=$PATH:$(pwd)/leiningen \
 bundle exec rake test:beaker

--- a/project.clj
+++ b/project.clj
@@ -120,7 +120,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "0.1.0"
+                      :plugins [[puppetlabs/lein-ezbake "0.1.1-SNAPSHOT"
                                  :exclusions [org.clojure/clojure]]]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}
 


### PR DESCRIPTION
This change switched PuppetDB over to use the ezbake_utils helpers in ezbake
to install PuppetDB via source. This effectively means the old installation
methodology can be retired.

The beaker-tests-source.sh script is now modified to ensure that leiningen
is now installed (since its required by ezbake helpers in beaker).

Some minor code was removed that is no longer needed, but a major retirement
patch will be forthcoming to remove the greater amount of code no longer
required. Since it was deemed such a patch would make this patch hard to read.

Signed-off-by: Ken Barber <ken@bob.sh>