### PR TITLE
(PDB-959) cluster resource events table on timestamp

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -891,6 +891,14 @@
     "ALTER TABLE factsets ADD hash VARCHAR(40)"
     "ALTER TABLE factsets ADD CONSTRAINT factsets_hash_key UNIQUE (hash)"))
 
+(defn cluster-resource-events
+  "CLUSTER resource_events table if using postgres"
+  []
+  (when (scf-utils/postgres?)
+    (sql/do-commands
+      "CLUSTER resource_events USING idx_resource_events_timestamp"
+      "ANALYZE")))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {1 initialize-store
@@ -920,7 +928,8 @@
    25 structured-facts
    26 structured-facts-deferrable-constraints
    27 switch-value-string-index-to-gin
-   28 insert-factset-hash-column})
+   28 insert-factset-hash-column
+   29 cluster-resource-events})
 
 (def desired-schema-version (apply max (keys migrations)))
 


### PR DESCRIPTION
This commit introduces a migration to CLUSTER the resource_events table on
idx_resource_events_timestamp. CS has found this necessary in a couple cases
for getting performant queries from the PE event inspector.