### PR TITLE
(PDB-1067) Warn user with unknown config items

### DIFF
--- a/src/puppetlabs/puppetdb/http/factsets.clj
+++ b/src/puppetlabs/puppetdb/http/factsets.clj
@@ -1,10 +1,8 @@
 (ns puppetlabs.puppetdb.http.factsets
   (:require [puppetlabs.puppetdb.http.query :as http-q]
             [puppetlabs.puppetdb.query.paging :as paging]
-            [puppetlabs.puppetdb.query.factsets :as fs]
             [puppetlabs.puppetdb.query-eng :refer [produce-streaming-body]]
             [puppetlabs.puppetdb.cheshire :as json]
-            [puppetlabs.puppetdb.query :as query]
             [net.cgrand.moustache :refer [app]]
             [puppetlabs.puppetdb.middleware :refer [verify-accepts-json validate-query-params
                                                     wrap-with-paging-options]]

--- a/src/puppetlabs/puppetdb/schema.clj
+++ b/src/puppetlabs/puppetdb/schema.clj
@@ -121,6 +121,11 @@
       (throw+ (su/error-val result))
       result)))
 
+(defn unknown-keys
+  "Returns all the keys in `data` not specified by `schema`"
+  [schema data]
+  (keys (apply dissoc data (map schema-key->data-key (keys schema)))))
+
 (defn strip-unknown-keys
   "Remove all keys from `data` not specified by `schema`"
   [schema data]

--- a/test/puppetlabs/puppetdb/schema_test.clj
+++ b/test/puppetlabs/puppetdb/schema_test.clj
@@ -45,6 +45,32 @@
        :foo :foo
        :foo (s/required-key :foo)))
 
+(deftest unknown-keys-test
+  (let [schema {(s/required-key :foo) Number
+                (s/optional-key :bar) Number
+                :baz String}]
+    (is (= '(:foo-1)
+           (unknown-keys
+            schema
+            {:foo 1
+             :foo-1 2
+             :bar 3
+             :baz 5})))
+    (is (= '(:foo-1)
+           (unknown-keys
+            schema
+            {:foo 1
+             :foo-1 2})))
+    (is (empty?
+          (unknown-keys
+            schema
+            {})))
+    (is (= '(:foo-1 :foo-2)
+           (unknown-keys
+            schema
+            {:foo-1 "foo"
+             :foo-2 "baz"})))))
+
 (deftest strip-unknown-keys-test
   (let [schema {(s/required-key :foo) Number
                 (s/optional-key :bar) Number


### PR DESCRIPTION
This commit changes the behavior of the config validation by warning
users in the log when there is an unused config item in the config file
instead of failing hard. This commit also refactors the items in
config.clj so that changes like this are a little easier in the future
by adding a `configure-section` function which removed the duplication
with `configure-puppetdb`, `configure-write-db`, etc.