### PR TITLE
(PDB-695) Configure module to test against v4 API

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -340,6 +340,7 @@ module PuppetDBExtensions
       enable_reports           => true,
       restart_puppet           => false,
       terminus_package         => '#{terminus_package}',
+      test_url                 => '/v4/version',
     }
     ini_setting {'server_urls':
       ensure => present,


### PR DESCRIPTION
Without this, we'll use the puppetdb module default, currently v3, when
testing with the packaged module.