### PR TITLE
(maint) fix puppetdb-env.erb so it generates valid bash

### DIFF
--- a/ext/templates/puppetdb-env.erb
+++ b/ext/templates/puppetdb-env.erb
@@ -10,9 +10,9 @@ elif [ `uname` == "OpenBSD" ] ; then
     USER="_puppetdb"
     INSTALL_DIR=<%= @install_dir %>
 else
-    JAVA_BIN=<%= @java_bin || "/usr/bin/java"  -%>
-    INSTALL_DIR="<%= @install_dir || "/usr/share/puppetdb" -%>"
-    JAVA_ARGS="<%= @java_args || @default_java_args -%>"
-    USER="<%= @name -%>"
-    CONFIG="<%= @config_dir -%>"
+    JAVA_BIN=<%= @java_bin || "/usr/bin/java"  %>
+    INSTALL_DIR="<%= @install_dir || "/usr/share/puppetdb" %>"
+    JAVA_ARGS="<%= @java_args || @default_java_args %>"
+    USER="<%= @name %>"
+    CONFIG="<%= @config_dir %>"
 fi


### PR DESCRIPTION
There is a bug affecting some OSes where this template will miss a necessary newline in the bash it generates.  An example is here:

https://gist.github.com/wkalt/fe8949ea40eb95c3aa9b

note that JAVA_BIN and INSTALL_DIR are on the same line