### PR TITLE
(patch) Turn off strict_validation for master::config

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -338,9 +338,9 @@ module PuppetDBExtensions
       puppetdb_startup_timeout => 120,
       manage_report_processor  => true,
       enable_reports           => true,
+      strict_validation        => false,
       restart_puppet           => false,
       terminus_package         => '#{terminus_package}',
-      test_url                 => '/v4/version',
     }
     ini_setting {'server_urls':
       ensure => present,


### PR DESCRIPTION
This commit addresses an issue where v3 of the http api was removed from
pdb but a bug in the pdb-module prevents us from validating a connection
from the master using the v4 of the api without a release of the module.
This *should* be turned back to the default (true) when this issue is
addressed.