### PR TITLE
(PDB-1026) Remove to_pson calls in terminus

### DIFF
--- a/documentation/connect_puppet_master.markdown
+++ b/documentation/connect_puppet_master.markdown
@@ -43,7 +43,7 @@ Currently, puppet masters need additional Ruby plugins in order to use PuppetDB.
 If your puppet master isn't running Puppet from a supported package, you will need to install the plugins manually:
 
 * [Download the PuppetDB source code][puppetdb_download], unzip it and navigate into the resulting directory in your terminal.
-* Run `sudo cp -R ext/master/lib/puppet /usr/lib/ruby/site_ruby/1.8/puppet`. Replace the second path with the path to your Puppet installation if you have installed it somewhere other than `/usr/lib/ruby/site_ruby`.
+* Run `sudo cp -R puppet/lib/puppet/* /usr/lib/ruby/site_ruby/1.8/puppet`. Replace the second path with the path to your Puppet installation if you have installed it somewhere other than `/usr/lib/ruby/site_ruby`.
 
 ## Step 2: Edit Config Files
 

--- a/puppet/lib/puppet/face/storeconfigs.rb
+++ b/puppet/lib/puppet/face/storeconfigs.rb
@@ -48,7 +48,7 @@ if Puppet::Util::Puppetdb.puppet3compat?
             filename = File.join(catalog_dir, "#{catalog[:name]}.json")
 
             File.open(filename, 'w') do |file|
-              file.puts catalog.to_pson
+              file.puts catalog.to_json
             end
           end
 
@@ -64,7 +64,7 @@ if Puppet::Util::Puppetdb.puppet3compat?
               }
             }
 
-            file.puts metadata.to_pson
+            file.puts metadata.to_json
           end
 
           tarfile = destination_file(timestamp)

--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -22,9 +22,14 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   def extract_extra_request_data(request)
     {
       :transaction_uuid => request.options[:transaction_uuid],
-      :environment => request.environment,
+      :environment => request.environment.to_s,
       :producer_timestamp => request.options[:producer_timestamp] || Time.now.iso8601(5),
     }
+  end
+
+  def hashify_tags(hash)
+    hash["resources"] = hash["resources"].map { |resource| resource["tags"] = resource["tags"].to_data_hash; resource }
+    hash
   end
 
   def munge_catalog(catalog, extra_request_data = {})
@@ -37,6 +42,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
       add_namevar_aliases(data, catalog)
       stringify_titles(data)
       stringify_version(data)
+      hashify_tags(data)
       sort_unordered_metaparams(data)
       munge_edges(data)
       synthesize_edges(data, catalog)

--- a/puppet/lib/puppet/util/puppetdb/command.rb
+++ b/puppet/lib/puppet/util/puppetdb/command.rb
@@ -28,7 +28,11 @@ class Puppet::Util::Puppetdb::Command
     @version = version
     @certname = certname
     profile("Format payload", [:puppetdb, :payload, :format]) do
-      @payload = self.class.format_payload(command, version, payload)
+      @payload = Puppet::Util::Puppetdb::CharEncoding.utf8_string({
+        :command => command,
+        :version => version,
+        :payload => payload,
+      }.to_json)
     end
   end
 
@@ -82,27 +86,13 @@ class Puppet::Util::Puppetdb::Command
     end
   end
 
-
-  # @!group Private class methods
-
-  # @api private
-  def self.format_payload(command, version, payload)
-    message = {
-      :command => command,
-      :version => version,
-      :payload => payload,
-    }.to_pson
-
-    Puppet::Util::Puppetdb::CharEncoding.utf8_string(message)
-  end
-
   # @!group Private instance methods
 
   # @api private
   def headers
     {
       "Accept" => "application/json",
-      "Content-Type" => "application/json",
+      "Content-Type" => "application/json; charset=utf-8",
     }
   end
 

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -43,7 +43,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         :command => Puppet::Util::Puppetdb::CommandNames::CommandReplaceCatalog,
         :version => 5,
         :payload => command_payload,
-      }.to_pson
+      }.to_json
 
       http.expects(:post).with do |uri, body, headers|
         expect(body).to eq(payload)

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -51,7 +51,7 @@ describe Puppet::Node::Facts::Puppetdb do
         :command => CommandReplaceFacts,
         :version => 3,
         :payload => f,
-      }.to_pson
+      }.to_json
 
       http.expects(:post).with do |uri, body, headers|
         expect(body).to eq(payload)


### PR DESCRIPTION
This commit removes all the to_pson calls in the terminus as well as
removing the associated char_encoding code that is dead code with the
switch to to_json.