### PR TITLE
(PDB-477) Untemplate the logback xml configs

### DIFF
--- a/resources/ext/config/logback.xml
+++ b/resources/ext/config/logback.xml
@@ -6,7 +6,7 @@
     </appender>
 
     <appender name="F1" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/var/log/<% if Pkg::Config.config[:build_pe] -%>pe-<% end -%>puppetdb/puppetdb.log</file>
+        <file>/var/log/puppetdb/puppetdb.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>/var/log/puppetdb/puppetdb-%d{yyyy-MM-dd}.log.gz</fileNamePattern>

--- a/resources/ext/config/request-logging.xml
+++ b/resources/ext/config/request-logging.xml
@@ -1,6 +1,6 @@
 <configuration debug="false">
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>/var/log/<% if Pkg::Config.config[:build_pe] -%>pe-<% end -%>puppetdb/puppetdb-access.log</file>
+        <file>/var/log/puppetdb/puppetdb-access.log</file>
         <encoder>
             <pattern>combined</pattern>
             <!-- To have the same "combined" pattern with elapsedTime ('%D')


### PR DESCRIPTION
This commit makes the logback xml configs for the pdb package static as
ezbake does not support templating anything not in the conf.d resource
directory yet.