### PR TITLE
(PDB-1198) Added support for submitting commands in-process

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -67,6 +67,7 @@
             [puppetlabs.puppetdb.scf.migrate :refer [migrate! indexes!]]
             [puppetlabs.puppetdb.version :refer [version update-info]]
             [puppetlabs.puppetdb.command.constants :refer [command-names]]
+            [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.query-eng :as qeng]))
 
 (def cli-description "Main PuppetDB daemon")
@@ -328,7 +329,8 @@
   (shared-globals [this])
   (query [this query-obj version query-expr paging-options row-callback-fn]
     "Call `row-callback-fn' for matching rows.  The `paging-options' should
-    be a map containing :order-by, :offset, and/or :limit."))
+    be a map containing :order-by, :offset, and/or :limit.")
+  (submit-command [this command version payload]))
 
 (defservice puppetdb-service
   "Defines a trapperkeeper service for PuppetDB; this service is responsible
@@ -353,13 +355,15 @@
           query-expr
           paging-options
           (get-in (service-context this) [:shared-globals :scf-read-db])
-          row-callback-fn)))
+          row-callback-fn))
+  (submit-command [this command version payload]
+                  (send-command! (command-names command) version payload)))
 
 (defn -main
   "Calls the trapperkeeper main argument to initialize tk.
 
-   For configuration customization, we intercept the call to parse-config-data
-   within TK."
+  For configuration customization, we intercept the call to parse-config-data
+  within TK."
   [& args]
   (rh/add-hook #'puppetlabs.trapperkeeper.config/parse-config-data #'conf/hook-tk-parse-config-data)
   (apply main args))

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -18,9 +18,7 @@
             [puppetlabs.puppetdb.time :refer [to-secs to-minutes to-hours to-days period?]]
             [puppetlabs.puppetdb.testutils.jetty :as jutils :refer [*base-url*]]
             [puppetlabs.trapperkeeper.app :refer [get-service]]
-            [puppetlabs.puppetdb.cli.import-export-roundtrip-test :refer [block-on-node
-                                                                          submit-command
-                                                                          block-until-results]]
+            [puppetlabs.puppetdb.cli.import-export-roundtrip-test :refer [block-until-results]]
             [clj-time.coerce :refer [to-string]]
             [clj-time.core :refer [now]]
             [puppetlabs.puppetdb.cli.export :as export :refer [facts-for-node]]))
@@ -87,58 +85,59 @@
 
 (deftest query-via-puppdbserver-service
   (jutils/with-puppetdb-instance
-    (submit-command *base-url*
-                    :replace-facts 3 {:name "foo.local"
-                                      :environment "DEV"
-                                      :values {:foo "the foo"
-                                               :bar "the bar"
-                                               :baz "the baz"}
-                                      :producer-timestamp (to-string (now))})
-    @(block-until-results 100 (facts-for-node *base-url* "foo.local"))
-    (check-service-query
-     :facts :v4 ["=" "certname" "foo.local"]
-     nil
-     (fn [result]
-       (is (= #{{:value "the baz",
-               :name "baz",
-                 :environment "DEV",
-                 :certname "foo.local"}
-                {:value "the bar",
-                 :name "bar",
-                 :environment "DEV",
-                 :certname "foo.local"}
-                {:value "the foo",
-                 :name "foo",
-                 :environment "DEV",
-                 :certname "foo.local"}}
-              (set result)))))))
+    (let [pdb-service (get-service jutils/*server* :PuppetDBServer)]
+      (submit-command pdb-service :replace-facts 3 {:name "foo.local"
+                                                    :environment "DEV"
+                                                    :values {:foo "the foo"
+                                                             :bar "the bar"
+                                                             :baz "the baz"}
+                                                    :producer-timestamp (to-string (now))})
+
+      @(block-until-results 100 (facts-for-node *base-url* "foo.local"))
+      (check-service-query
+       :facts :v4 ["=" "certname" "foo.local"]
+       nil
+       (fn [result]
+         (is (= #{{:value "the baz",
+                   :name "baz",
+                   :environment "DEV",
+                   :certname "foo.local"}
+                  {:value "the bar",
+                   :name "bar",
+                   :environment "DEV",
+                   :certname "foo.local"}
+                  {:value "the foo",
+                   :name "foo",
+                   :environment "DEV",
+                   :certname "foo.local"}}
+                (set result))))))))
 
 (deftest pagination-via-puppdbserver-service
   (jutils/with-puppetdb-instance
-    (submit-command *base-url*
-                    :replace-facts 3 {:name "foo.local"
-                                      :environment "DEV"
-                                      :values {:a "a" :b "b" :c "c"}
-                                      :producer-timestamp (to-string (now))})
-    @(block-until-results 100 (facts-for-node *base-url* "foo.local"))
-    (let [exp ["a" "b" "c"]
-          rexp (reverse exp)]
-      (doseq [order [:ascending :descending]
-              offset (range (dec (count exp)))
-              limit (range 1 (count exp))]
-        (let [expected (take limit
-                             (drop offset (if (= order :ascending) exp rexp)))]
-          (check-service-query
-           :facts :v4 ["=" "certname" "foo.local"]
-           {:order-by [[:name order]]
-            :offset offset
-            :limit limit}
-           (fn [result]
-             (is (= (map #(hash-map :name % :value %
-                                    :environment "DEV",
-                                    :certname "foo.local")
-                         expected)
-                    result)))))))))
+    (let [pdb-service (get-service jutils/*server* :PuppetDBServer)]
+      (submit-command pdb-service :replace-facts 3 {:name "foo.local"
+                                                    :environment "DEV"
+                                                    :values {:a "a" :b "b" :c "c"}
+                                                    :producer-timestamp (to-string (now))})
+      @(block-until-results 100 (facts-for-node *base-url* "foo.local"))
+      (let [exp ["a" "b" "c"]
+            rexp (reverse exp)]
+        (doseq [order [:ascending :descending]
+                offset (range (dec (count exp)))
+                limit (range 1 (count exp))]
+          (let [expected (take limit
+                               (drop offset (if (= order :ascending) exp rexp)))]
+            (check-service-query
+             :facts :v4 ["=" "certname" "foo.local"]
+             {:order-by [[:name order]]
+              :offset offset
+              :limit limit}
+             (fn [result]
+               (is (= (map #(hash-map :name % :value %
+                                      :environment "DEV",
+                                      :certname "foo.local")
+                           expected)
+                      result))))))))))
 
 (deftest api-retirements
   (jutils/with-puppetdb-instance
@@ -156,3 +155,32 @@
       (doseq [v [:v1 :v2 :v3]]
         (testing (format "%s requests are refused" (name v)))
         (is (retirement-response? v (ping v)))))))
+
+(deftest in-process-command-submission
+  (jutils/with-puppetdb-instance
+    (let [pdb-service (get-service jutils/*server* :PuppetDBServer)]
+      (submit-command pdb-service :replace-facts 3 {:name "foo.local"
+                                                    :environment "DEV"
+                                                    :values {:foo "the foo"
+                                                             :bar "the bar"
+                                                             :baz "the baz"}
+                                                    :producer-timestamp (to-string (now))})
+      @(block-until-results 100 (facts-for-node *base-url* "foo.local"))
+
+      (check-service-query
+       :facts :v4 ["=" "certname" "foo.local"]
+       nil
+       (fn [result]
+         (is (= #{{:value "the baz",
+                   :name "baz",
+                   :environment "DEV",
+                   :certname "foo.local"}
+                  {:value "the bar",
+                   :name "bar",
+                   :environment "DEV",
+                   :certname "foo.local"}
+                  {:value "the foo",
+                   :name "foo",
+                   :environment "DEV",
+                   :certname "foo.local"}}
+                (set result))))))))


### PR DESCRIPTION
Added another function to the PuppetDBServer TK service to allow
submission of commands in-process, similar to the way we allow querying
in-process. This allows other modules running in the same JVM instance
to submit commands directly to PuppetDB without having to use an HTTP call.