### PR TITLE
(PDB-1199) Remove timestamps from factset hash calculation

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1,23 +1,23 @@
 (ns puppetlabs.puppetdb.scf.storage
   "Catalog persistence
 
-   Catalogs are persisted in a relational database. Roughly speaking,
-   the schema looks like this:
+  Catalogs are persisted in a relational database. Roughly speaking,
+  the schema looks like this:
 
-   * resource_parameters are associated 0 to N catalog_resources (they are
-   deduped across catalogs). It's possible for a resource_param to exist in the
-   database, yet not be associated with a catalog. This is done as a
-   performance optimization.
+  * resource_parameters are associated 0 to N catalog_resources (they are
+  deduped across catalogs). It's possible for a resource_param to exist in the
+  database, yet not be associated with a catalog. This is done as a
+  performance optimization.
 
-   * edges are associated with a single catalog
+  * edges are associated with a single catalog
 
-   * catalogs are associated with a single certname
+  * catalogs are associated with a single certname
 
-   * facts are associated with a single certname
+  * facts are associated with a single certname
 
-   The standard set of operations on information in the database will
-   likely result in dangling resources and catalogs; to clean these
-   up, it's important to run `garbage-collect!`."
+  The standard set of operations on information in the database will
+  likely result in dangling resources and catalogs; to clean these
+  up, it's important to run `garbage-collect!`."
   (:require [puppetlabs.puppetdb.catalogs :as cat]
             [puppetlabs.puppetdb.reports :as report]
             [puppetlabs.puppetdb.facts :as facts]
@@ -74,9 +74,9 @@
 
 (def catalog-schema
   "This is a bit of a hack to make a more restrictive schema in the storage layer.
-   Moving the more restrictive resource/edge schemas into puppetdb.catalogs is TODO. Upstream
-   code needs to assume a map of resources (not a vector) and tests need to be update to adhere
-   to the new format."
+  Moving the more restrictive resource/edge schemas into puppetdb.catalogs is TODO. Upstream
+  code needs to assume a map of resources (not a vector) and tests need to be update to adhere
+  to the new format."
   (assoc (cat/catalog-wireformat :all)
     :resources resource-ref->resource-schema
     :edges #{edge-schema}))
@@ -543,7 +543,7 @@
 
 (defn strip-params
   "Remove params from the resource as it is stored (and hashed) separately
-   from the resource metadata"
+  from the resource metadata"
   [resource]
   (dissoc resource :parameters))
 
@@ -692,32 +692,32 @@
    similarity hash. `catalog-hash-debug-dir` is an optional path that
    indicates where catalog debugging information should be stored."
   ([catalog :- catalog-schema]
-     (add-catalog! catalog nil (now)))
+   (add-catalog! catalog nil (now)))
   ([{:keys [api_version resources edges name] :as catalog} :- catalog-schema
     catalog-hash-debug-dir :- (s/maybe s/Str)
     timestamp :- pls/Timestamp]
 
-     (let [refs-to-hashes (time! (:resource-hashes metrics)
-                                 (reduce-kv (fn [acc k v]
-                                              (assoc acc k (shash/resource-identity-hash v)))
-                                            {} resources))
-           hash           (time! (:catalog-hash metrics)
-                                 (shash/catalog-similarity-hash catalog))
-           {id :id
-            stored-hash :hash} (catalog-metadata name)]
+   (let [refs-to-hashes (time! (:resource-hashes metrics)
+                               (reduce-kv (fn [acc k v]
+                                            (assoc acc k (shash/resource-identity-hash v)))
+                                          {} resources))
+         hash           (time! (:catalog-hash metrics)
+                               (shash/catalog-similarity-hash catalog))
+         {id :id
+          stored-hash :hash} (catalog-metadata name)]
 
-       (sql/transaction
-        (cond
-         (nil? id)
-         (add-new-catalog hash catalog refs-to-hashes timestamp)
+     (sql/transaction
+      (cond
+       (nil? id)
+       (add-new-catalog hash catalog refs-to-hashes timestamp)
 
-         (= stored-hash hash)
-         (update-catalog-hash-match id hash catalog timestamp)
+       (= stored-hash hash)
+       (update-catalog-hash-match id hash catalog timestamp)
 
-         :else
-         (update-catalog-hash-miss id hash catalog refs-to-hashes catalog-hash-debug-dir timestamp)))
+       :else
+       (update-catalog-hash-miss id hash catalog refs-to-hashes catalog-hash-debug-dir timestamp)))
 
-       hash)))
+     hash)))
 
 (defn delete-catalog!
   "Remove the catalog identified by the following hash"
@@ -745,7 +745,7 @@
   []
   (time! (:gc-environments metrics)
          (sql/delete-rows :environments
-           ["ID NOT IN
+                          ["ID NOT IN
               (SELECT environment_id FROM catalogs WHERE environment_id IS NOT NULL
                UNION
                SELECT environment_id FROM reports WHERE environment_id IS NOT NULL
@@ -966,38 +966,38 @@
   "Given a certname and a map of fact names to values, store records for those
    facts associated with the certname."
   ([fact-data]
-     (add-facts! fact-data true))
+   (add-facts! fact-data true))
   ([{:keys [name values environment timestamp producer-timestamp] :as fact-data} :- facts-schema
     include-hash? :- s/Bool]
-     (let [factset {:certname name
-                    :timestamp (to-timestamp timestamp)
-                    :environment_id (ensure-environment environment)
-                    :producer_timestamp (to-timestamp producer-timestamp)}
-           fact-data-hash (shash/generic-identity-hash fact-data)]
-       (sql/insert-record :factsets
-                          (if include-hash?
-                            (assoc factset :hash fact-data-hash) factset))
-       (insert-facts!
-        (certname-to-factset-id name)
-        (set (new-fact-value-ids values))))))
+   (let [factset {:certname name
+                  :timestamp (to-timestamp timestamp)
+                  :environment_id (ensure-environment environment)
+                  :producer_timestamp (to-timestamp producer-timestamp)}
+         fact-data-hash (shash/generic-identity-hash (dissoc fact-data :producer-timestamp :timestamp))]
+     (sql/insert-record :factsets
+                        (if include-hash?
+                          (assoc factset :hash fact-data-hash) factset))
+     (insert-facts!
+      (certname-to-factset-id name)
+      (set (new-fact-value-ids values))))))
 
 (pls/defn-validated delete-facts!
   "Delete all the facts (1 arg) or just the fact-ids (2 args) for the given certname."
   ([certname :- String]
-     (let [factset-value-ids (query-to-vec ["select id, fact_value_id from factsets fs inner join facts f on fs.id = f.factset_id where fs.certname = ?" certname])
-           factset-id (:id (first factset-value-ids))]
-       (delete-facts! factset-id (set (map :fact_value_id factset-value-ids)))
-       (sql/delete-rows :factsets ["id=?" factset-id])))
+   (let [factset-value-ids (query-to-vec ["select id, fact_value_id from factsets fs inner join facts f on fs.id = f.factset_id where fs.certname = ?" certname])
+         factset-id (:id (first factset-value-ids))]
+     (delete-facts! factset-id (set (map :fact_value_id factset-value-ids)))
+     (sql/delete-rows :factsets ["id=?" factset-id])))
   ([factset :- s/Int
     fact-ids :- #{s/Int}]
-     (when (seq fact-ids)
-       (let [in-list (jdbc/in-clause fact-ids)]
-         (sql/transaction
+   (when (seq fact-ids)
+     (let [in-list (jdbc/in-clause fact-ids)]
+       (sql/transaction
 
-          (when (sutils/postgres?)
-            (sql/do-commands "SET CONSTRAINTS ALL DEFERRED")
+        (when (sutils/postgres?)
+          (sql/do-commands "SET CONSTRAINTS ALL DEFERRED")
 
-            (sql/do-prepared (format "DELETE FROM fact_paths fp
+          (sql/do-prepared (format "DELETE FROM fact_paths fp
                                       WHERE fp.id in ( SELECT fp.id
                                                        FROM fact_paths fp
                                                             inner join fact_values fv on fp.id = fv.path_id
@@ -1005,32 +1005,32 @@
                                                        WHERE fp.id in ( select fv.path_id from fact_values fv where fv.id %s )
                                                        GROUP BY fp.id
                                                        HAVING COUNT(fv.id) = 1)" in-list)
-                             fact-ids)
+                           fact-ids)
 
-            (sql/do-prepared (format "DELETE FROM fact_values WHERE id in (
+          (sql/do-prepared (format "DELETE FROM fact_values WHERE id in (
                                           SELECT fact_value_id FROM facts where factset_id = ? and fact_value_id %s
                                           EXCEPT
                                           SELECT fact_value_id FROM facts where factset_id <> ? and fact_value_id %s)" in-list in-list)
-                             (concat (cons factset fact-ids)
-                                     (cons factset fact-ids))))
+                           (concat (cons factset fact-ids)
+                                   (cons factset fact-ids))))
 
-          (sql/delete-rows :facts
-                           (into [(str "factset_id=? and fact_value_id "
-                                       in-list) factset]
-                                 fact-ids))
+        (sql/delete-rows :facts
+                         (into [(str "factset_id=? and fact_value_id "
+                                     in-list) factset]
+                               fact-ids))
 
-          ;; HSQLDB doesn't support delayed constraints. This query
-          ;; achieves the same goals as the DELETE FROM fact_values
-          ;; above, but does so in a less efficient manner. Having
-          ;; these two separated allows Postgres queries to execute
-          ;; faster, but still support HSQLDB
-          (when-not (sutils/postgres?)
-            (sql/do-prepared (format "DELETE FROM fact_values WHERE id in (
+        ;; HSQLDB doesn't support delayed constraints. This query
+        ;; achieves the same goals as the DELETE FROM fact_values
+        ;; above, but does so in a less efficient manner. Having
+        ;; these two separated allows Postgres queries to execute
+        ;; faster, but still support HSQLDB
+        (when-not (sutils/postgres?)
+          (sql/do-prepared (format "DELETE FROM fact_values WHERE id in (
                                         SELECT fv.id
                                         FROM fact_values fv left join facts f on fv.id = f.fact_value_id
                                         WHERE f.fact_value_id is NULL and fv.id %s )" in-list)
-                             fact-ids)
-            (sql/do-prepared (format "DELETE FROM fact_paths fp
+                           fact-ids)
+          (sql/do-prepared (format "DELETE FROM fact_paths fp
                                       WHERE fp.id in ( SELECT fp.id
                                                        FROM fact_paths fp left join fact_values fv on fp.id = fv.path_id
                                                        WHERE fv.path_id is NULL )"))))))))
@@ -1046,7 +1046,7 @@
         factset {:timestamp (to-timestamp timestamp)
                  :environment_id (ensure-environment environment)
                  :producer_timestamp (to-timestamp producer-timestamp)
-                 :hash (shash/generic-identity-hash fact-data)}]
+                 :hash (shash/generic-identity-hash (dissoc fact-data :producer-timestamp :timestamp))}]
     (sql/update-values :factsets ["id=?" factset-id] factset)
     (utils/diff-fn (zipmap new-facts (repeat nil))
                    (zipmap old-facts (repeat nil))
@@ -1099,8 +1099,8 @@
 
 (defn maybe-environment
   "This fn is most to help in testing, instead of persisting a value of
-   nil, just omit it from the row map. For tests that are running older versions
-   of migrations, this function prevents a failure"
+  nil, just omit it from the row map. For tests that are running older versions
+  of migrations, this function prevents a failure"
   [row-map]
   (if (nil? (:environment_id row-map))
     (dissoc row-map :environment_id)
@@ -1161,7 +1161,7 @@
 
 (defn db-unsupported?
   "Returns a string with an unsupported message if the DB is not supported,
-   nil otherwise."
+  nil otherwise."
   []
   (when (and (sutils/postgres?)
              (sutils/db-version-older-than? [9 3]))
@@ -1217,13 +1217,13 @@
   should be stored."
   ([catalog :- catalog-schema
     timestamp :- pls/Timestamp]
-     (replace-catalog! catalog timestamp nil))
+   (replace-catalog! catalog timestamp nil))
   ([{:keys [name] :as catalog} :- catalog-schema
     timestamp :- pls/Timestamp
     catalog-hash-debug-dir :- (s/maybe s/Str)]
-     (time! (:replace-catalog metrics)
-            (sql/transaction
-             (add-catalog! catalog catalog-hash-debug-dir timestamp)))))
+   (time! (:replace-catalog metrics)
+          (sql/transaction
+           (add-catalog! catalog catalog-hash-debug-dir timestamp)))))
 
 (pls/defn-validated replace-facts!
   "Updates the facts of an existing node, if the facts are newer than the current set of facts.
@@ -1246,8 +1246,8 @@
 
 (defn fail-on-unsupported
   "Log an error message to the log and console if the currently
-   configured database is unsupported, then call fail-fn  (probably to
-   exit)."
+  configured database is unsupported, then call fail-fn  (probably to
+  exit)."
   [fail-fn]
   (let [msg (db-unsupported?)]
     (when-let [attn-msg (and msg (utils/attention-msg msg))]
@@ -1257,6 +1257,6 @@
 
 (defn validate-database-version
   "Checks to ensure that the database is supported, fails if supported, logs
-   if deprecated"
+  if deprecated"
   [action-for-unsupported-fn]
   (fail-on-unsupported action-for-unsupported-fn))

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -206,7 +206,7 @@
    "/v4/facts" (omap/ordered-map
                 ;; Extract using invalid fields should throw an error
                 ["in" "certname" ["extract" "nothing" ["select-resources"
-                                                        ["=" "type" "Class"]]]]
+                                                       ["=" "type" "Class"]]]]
                 "Can't extract unknown 'resources' field 'nothing'. Acceptable fields are: [\"certname\",\"environment\",\"resource\",\"type\",\"title\",\"tag\",\"exported\",\"file\",\"line\",\"parameters\"]"
 
                 ["in" "certname" ["extract" ["nothing" "nothing2" "certname"] ["select-resources"
@@ -215,22 +215,22 @@
 
                 ;; In-query for invalid fields should throw an error
                 ["in" "nothing" ["extract" "certname" ["select-resources"
-                                                        ["=" "type" "Class"]]]]
+                                                       ["=" "type" "Class"]]]]
                 "Can't match on unknown 'facts' field 'nothing' for 'in'. Acceptable fields are: [\"name\",\"certname\",\"environment\",\"value\"]"
 
                 ["in" ["name" "nothing" "nothing2"] ["extract" "certname" ["select-resources"
-                                                                            ["=" "type" "Class"]]]]
+                                                                           ["=" "type" "Class"]]]]
                 "Can't match on unknown 'facts' fields: 'nothing', 'nothing2' for 'in'. Acceptable fields are: [\"name\",\"certname\",\"environment\",\"value\"]")))
 
 (def versioned-invalid-projections
   (omap/ordered-map
-    "/v4/facts" (omap/ordered-map
-                   ;; Top level extract using invalid fields should throw an error
-                   ["extract" "nothing" ["~" "certname" ".*"]]
-                   #"Can't extract unknown 'facts' field 'nothing'.*Acceptable fields are.*"
+   "/v4/facts" (omap/ordered-map
+                ;; Top level extract using invalid fields should throw an error
+                ["extract" "nothing" ["~" "certname" ".*"]]
+                #"Can't extract unknown 'facts' field 'nothing'.*Acceptable fields are.*"
 
-                   ["extract" ["certname" "nothing" "nothing2"] ["~" "certname" ".*"]]
-                   #"Can't extract unknown 'facts' fields: 'nothing', 'nothing2'.*Acceptable fields are.*")))
+                ["extract" ["certname" "nothing" "nothing2"] ["~" "certname" ".*"]]
+                #"Can't extract unknown 'facts' fields: 'nothing', 'nothing2'.*Acceptable fields are.*")))
 
 (deftestseq invalid-projections
   [[version endpoint] facts-endpoints]
@@ -401,13 +401,13 @@
 
 (defn test-app
   ([read-write-db]
-     (test-app read-write-db read-write-db))
+   (test-app read-write-db read-write-db))
   ([read-db write-db]
-     (server/build-app
-      :globals {:scf-read-db          read-db
-                :scf-write-db         write-db
-                :command-mq           *mq*
-                :product-name         "puppetdb"})))
+   (server/build-app
+    :globals {:scf-read-db          read-db
+              :scf-write-db         write-db
+              :command-mq           *mq*
+              :product-name         "puppetdb"})))
 
 (defn with-shutdown-after [dbs f]
   (f)
@@ -972,7 +972,7 @@
                                         "f" nil, "b" 3.14, "a" 1}},
          "environment" "DEV"
          "certname" "foo1"
-         "hash" "2148456e95cb3c513ebe80ffe10dd3c74991734b"}
+         "hash" "1ac62c7f4d290d8f064575b0ac5453a5a860d127"}
 
         {"facts" {"uptime_seconds" "6000"
                   "domain" "testing.com"
@@ -982,7 +982,7 @@
          "environment" "DEV"
          "certname" "foo2"
          "producer-timestamp" "2013-01-01T00:00:00.000Z"
-         "hash" "6c7a82560d100da6b40b55d652062cc603de5e58"}
+         "hash" "3e26b7428e60ad8f4c07cf2420a8b09b0da3e33e"}
 
         {"facts" {"domain" "testing.com"
                   "operatingsystem" "Darwin"
@@ -990,7 +990,7 @@
                                         "d" {"n" ""}, "" "g?", "c" ["a" "b" "c"]}},
          "environment" "PROD"
          "certname" "foo3"
-         "hash" "aa3b47b7337a04b34f395f02ede01ec2d2f577d9"}]))
+         "hash" "34a0dfb96739364467cab639a74802d6cf39a872"}]))
 
 (deftestseq factset-paging-results
   [[version endpoint] factsets-endpoints]
@@ -1106,7 +1106,7 @@
               "producer-timestamp" reference-time
               "environment" "DEV"
               "certname" "foo1"
-              "hash" "2148456e95cb3c513ebe80ffe10dd3c74991734b"}))
+              "hash" "1ac62c7f4d290d8f064575b0ac5453a5a860d127"}))
       (is (= (into [] (nth responses 1))
              [{"facts" {"my_structured_fact"
                         {"a" 1
@@ -1122,7 +1122,7 @@
                "producer-timestamp" reference-time
                "environment" "DEV"
                "certname" "foo1"
-               "hash" "2148456e95cb3c513ebe80ffe10dd3c74991734b"}
+               "hash" "1ac62c7f4d290d8f064575b0ac5453a5a860d127"}
 
               {"facts" {"my_structured_fact"
                         {"a" 1
@@ -1136,7 +1136,7 @@
                "producer-timestamp" (to-string (to-timestamp "2013-01-01"))
                "environment" "DEV"
                "certname" "foo2"
-               "hash" "6c7a82560d100da6b40b55d652062cc603de5e58"}]))
+               "hash" "3e26b7428e60ad8f4c07cf2420a8b09b0da3e33e"}]))
 
       (is (= (into [] (nth responses 2))
              [{"facts" {"my_structured_fact"
@@ -1151,7 +1151,7 @@
                "producer-timestamp" (to-string (to-timestamp "2013-01-01"))
                "environment" "DEV"
                "certname" "foo2"
-               "hash" "6c7a82560d100da6b40b55d652062cc603de5e58"}]))
+               "hash" "3e26b7428e60ad8f4c07cf2420a8b09b0da3e33e"}]))
       (is (= (into [] (nth responses 3))
              [{"facts" {"my_structured_fact"
                         {"a" 1
@@ -1165,10 +1165,10 @@
                "producer-timestamp" (to-string (to-timestamp "2013-01-01"))
                "environment" "DEV"
                "certname" "foo2"
-               "hash" "6c7a82560d100da6b40b55d652062cc603de5e58"}]))
+               "hash" "3e26b7428e60ad8f4c07cf2420a8b09b0da3e33e"}]))
       (is (= (into [] (nth responses 4))
              [{"certname" "foo1"
-               "hash" "2148456e95cb3c513ebe80ffe10dd3c74991734b"}])))))
+               "hash" "1ac62c7f4d290d8f064575b0ac5453a5a860d127"}])))))
 
 (defn structured-fact-results
   [version endpoint]

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -133,7 +133,7 @@
             (testing "should update existing keys"
               (is (some #{{:timestamp (to-timestamp reference-time)
                            :environment_id 1
-                           :hash "66c90476f974812b6532207f39d80d6010da1363"
+                           :hash "8f86953a82ce346712be249e851499721daf3c63"
                            :producer_timestamp (to-timestamp reference-time)}}
                         ;; Again we grab the pertinent non-id bits
                         (map (fn [itm] (last itm)) @updates)))
@@ -187,7 +187,24 @@
                            :producer-timestamp nil
                            :timestamp (now)})
           (is (= fact-map
-                 (factset-map "some_certname"))))))))
+                 (factset-map "some_certname")))))
+      (testing "stable hash when no facts change"
+        (let [fact-map (factset-map "some_certname")
+              {old-hash :hash} (first (query-to-vec "SELECT hash FROM factsets where certname=?" certname))]
+          (replace-facts! {:name certname
+                           :values fact-map
+                           :environment "DEV"
+                           :producer-timestamp (now)
+                           :timestamp (now)})
+          (let [{new-hash :hash} (first (query-to-vec "SELECT hash FROM factsets where certname=?" certname))]
+            (is (= old-hash new-hash)))
+          (replace-facts! {:name certname
+                           :values (assoc fact-map "another thing" "goes here")
+                           :environment "DEV"
+                           :producer-timestamp (now)
+                           :timestamp (now)})
+          (let [{new-hash :hash} (first (query-to-vec "SELECT hash FROM factsets where certname=?" certname))]
+            (is (not= old-hash new-hash))))))))
 
 (deftest fact-persistance-with-environment
   (testing "Persisted facts"


### PR DESCRIPTION
Submitting the same factset more than once causes the factset hash to
change even though it's payload is still the same. This patch removes
those fields from the hash calculation.