### PR TITLE
(PDB-908) Improve debugging info of in-process launched PDB

### DIFF
--- a/test/puppetlabs/puppetdb/testutils/jetty.clj
+++ b/test/puppetlabs/puppetdb/testutils/jetty.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.puppetdb.testutils.jetty
-  (:require [puppetlabs.puppetdb.testutils :refer [temp-dir]]
+  (:require [puppetlabs.puppetdb.testutils :refer [temp-dir temp-file]]
             [puppetlabs.puppetdb.fixtures :as fixt]
             [puppetlabs.trapperkeeper.app :as tka]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tkbs]
@@ -12,14 +12,35 @@
             [puppetlabs.puppetdb.utils :as utils]
             [clj-http.client :as client]
             [puppetlabs.puppetdb.config :as conf]
-            [clj-http.util :refer [url-encode]]))
+            [clj-http.util :refer [url-encode]]
+            [clj-http.client :as client]
+            [clojure.string :as str]
+            [fs.core :as fs]))
 
 ;; See utils.clj for more information about base-urls.
 (def ^:dynamic *base-url* nil) ; Will not have a :version.
 
+(defn log-config
+  "Returns a logback.xml string with the specified `log-file` and `log-level`."
+  [log-file log-level]
+  (str "<configuration>
+
+  <appender name=\"FILE\" class=\"ch.qos.logback.core.FileAppender\">
+    <file>" log-file "</file>
+    <append>true</append>
+    <encoder>
+      <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level=\"" log-level "\">
+    <appender-ref ref=\"FILE\" />
+  </root>
+</configuration>"))
+
 (defn create-config
   "Creates a default config, populated with a temporary vardir and
-   a fresh hypersql instance"
+  a fresh hypersql instance"
   []
   {:nrepl {}
    :global {:vardir (temp-dir)}
@@ -29,10 +50,19 @@
    :web-router-service {:puppetlabs.puppetdb.cli.services/puppetdb-service ""
                         :puppetlabs.puppetdb.metrics/metrics-service "/metrics"}})
 
+(defn assoc-logging-config
+  "Adds a dynamically created logback.xml with a test log. The
+  generated log file name is returned for printing to the console."
+  [config]
+  (let [logback-file (fs/absolute-path (temp-file "logback" ".xml"))
+        log-file (fs/absolute-path (temp-file "jett-test" ".log"))]
+    (spit logback-file (log-config log-file "ERROR"))
+    [log-file (assoc-in config [:global :logging-config] logback-file)]))
+
 (defn current-port
   "Given a trapperkeeper server, return the port of the running jetty instance.
-   Note there can be more than one port (i.e. SSL + non-SSL connector). This only
-   returns the first one."
+  Note there can be more than one port (i.e. SSL + non-SSL connector). This only
+  returns the first one."
   [server]
   (-> @(tka/app-context server)
       (get-in [:WebserverService :jetty9-servers :default :server])
@@ -44,22 +74,33 @@
 
 (defn puppetdb-instance
   "Stands up a puppetdb instance with `config`, tears down once `f` returns.
-   Adjusts *server* and *base-url* to refer to the instance."
+  `services` is a seq of additional services that should be started in addition
+  to the core PuppetDB services. Binds *server* and *base-url* to refer to
+  the instance."
   ([f] (puppetdb-instance (create-config) f))
-  ([config f]
-   (let [config (conf/adjust-tk-config config)
+  ([config f] (puppetdb-instance config [] f))
+  ([config services f]
+   (let [[log-file config] (-> config conf/adjust-tk-config assoc-logging-config)
          prefix (get-in config
                         [:web-router-service
                          :puppetlabs.puppetdb.cli.services/puppetdb-service])]
-     (tkbs/with-app-with-config server
-       [jetty9-service puppetdb-service message-listener-service command-service webrouting-service metrics-service]
-       config
-       (binding [*server* server
-                 *base-url* (merge {:protocol "http"
-                                    :host "localhost"
-                                    :port (current-port server)}
-                                   (when prefix {:prefix prefix}))]
-         (f))))))
+     (try
+       (tkbs/with-app-with-config server
+         (concat [jetty9-service puppetdb-service message-listener-service command-service webrouting-service metrics-service]
+                 services)
+         config
+         (binding [*server* server
+                   *base-url* (merge {:protocol "http"
+                                      :host "localhost"
+                                      :port (current-port server)}
+                                     (when prefix {:prefix prefix}))]
+           (f)))
+       (finally
+         (let [log-contents (slurp log-file)]
+           (when-not (str/blank? log-contents)
+             (utils/println-err "-------Begin PuppetDB Instance Log--------------------\n"
+                                log-contents
+                                "\n-------End PuppetDB Instance Log----------------------"))))))))
 
 (defmacro with-puppetdb-instance
   "Convenience macro to launch a puppetdb instance"


### PR DESCRIPTION
This patch dynamically creates a temp logback and temp log file that an
in-process launched PuppetDB instances uses. Previously when an error
occurred in that Jetty instance, it was difficult to determine the
problem. Sometimes errors were lost, others were difficult to sort
through since it wrote to the same System.err that the test thread was
running in. This patch writes all in-process PuppetDB log information to
an actually file, which is scraped and dumped into the test thread's
console, make it much easier to diagnose errors