### PR TITLE
(PDB-908) Add the ability to disable AMQ JMX and set a different queue destination name

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -76,7 +76,7 @@
 ;; PuppetDB components.
 
 (def mq-addr "vm://localhost?jms.prefetchPolicy.all=1&create=false")
-(def mq-endpoint "puppetlabs.puppetdb.commands")
+(def ^:dynamic mq-endpoint "puppetlabs.puppetdb.commands")
 (def send-command! (partial command/enqueue-command! mq-addr mq-endpoint))
 
 (defn auto-deactivate-nodes!

--- a/test/puppetlabs/puppetdb/mq_test.clj
+++ b/test/puppetlabs/puppetdb/mq_test.clj
@@ -5,7 +5,8 @@
             [puppetlabs.puppetdb.mq :refer :all]
             [puppetlabs.puppetdb.testutils :refer :all]
             [puppetlabs.puppetdb.fixtures :refer [with-test-logging-silenced]]
-            [clojure.test :refer :all]))
+            [clojure.test :refer :all]
+            [puppetlabs.puppetdb.testutils.jetty :as jutils]))
 
 (use-fixtures :each with-test-logging-silenced)
 
@@ -115,3 +116,10 @@
       (with-test-broker "test" conn
         (publish-json! conn "queue" "foo")
         (is (= ["\"foo\""] (map :body (bounded-drain-into-vec! conn "queue" 1))))))))
+
+(deftest test-jmx-enabled
+  (jutils/without-jmx
+   (jutils/with-puppetdb-instance
+     (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                           #"status 404"
+                           (jutils/current-queue-depth))))))


### PR DESCRIPTION
These shims are just for testing and specifically to allow in-process testing of more than one PuppetDB instance.