### PR TITLE
(PDB-1200) Added pinning to Puppet 3.7.3 on Fedora

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -863,7 +863,10 @@ EOS
       case os
       when :debian
         on host, "apt-get install -y puppet puppetmaster-common"
-      when :redhat, :fedora
+      # Puppet 3.7.4 is broken on fedora, pinning to 3.7.3 until it's fixed
+      when :fedora
+        on host, "yum install -y puppet-3.7.3"
+      when :redhat
         on host, "yum install -y puppet"
       else
         raise ArgumentError, "Unsupported OS '#{os}'"


### PR DESCRIPTION
Puppet 3.7.4 introduced a bug with Fedora (more info here
https://tickets.puppetlabs.com/browse/PUP-3927). This patch pins to
Puppet 3.7.3 only on Fedora, until a fix has been released.