### PR TITLE
(PDB-1202) Fix Travis OOM native thread error

### DIFF
--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -18,6 +18,7 @@ if [ $T_LANG == "ruby" ]; then
   bundle exec rspec spec/
 else
   if [ $T_LANG == "java" ]; then
+    ulimit -u 4096
     jdk_switcher use $T_VERSION
     java -version
     if [ $T_DB == "postgres" ]; then


### PR DESCRIPTION
Travis is frequently failing with the following message:
java.lang.OutOfMemoryError: unable to create new native thread, this
patch fixes that by bumping the ulimit before running the tests.