### PR TITLE
(maint) Use bundler retries for PR testing

### DIFF
--- a/ext/jenkins/beaker-tests-source.sh
+++ b/ext/jenkins/beaker-tests-source.sh
@@ -30,7 +30,7 @@ then
 fi
 mkdir vendor
 
-bundle install --path vendor/bundle --without test
+bundle install --path=vendor/bundle --without=test --retry=10
 
 # Now run our tests
 PUPPETDB_REPO_PUPPETDB="${REPO_URL}#${sha1}" \


### PR DESCRIPTION
To avoid transient errors with bundler, we can use the --retry argument to
retry attempts at downloading gemfiles & git repos during bundle install.

Signed-off-by: Ken Barber <ken@bob.sh>