### PR TITLE
(PDB-1034) Upgrade lein-ezbake to support :local-repo

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -120,7 +120,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "0.2.0"
+                      :plugins [[puppetlabs/lein-ezbake "0.2.1"
                                  :exclusions [org.clojure/clojure]]]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}
 


### PR DESCRIPTION
Previously lein-ezbake 0.2.0 wasn't working when we overrode local-repo
during beaker source based installation. The 0.2.1 revision passes the local-repo
through to the correct places so this works.

Signed-off-by: Ken Barber <ken@bob.sh>