### PR TITLE
Switch to using 3.2 version of activerecord

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :test do
   when '1.8.7'
     # No activerecord or sqlite for you
   else
-    gem 'activerecord', '2.3.14'
+    gem 'activerecord', '~> 3.2'
     gem 'sqlite3'
   end
 end


### PR DESCRIPTION
Without this, the upgrade to google-api-client 0.8 will have conflicts, since
this gem now pulls in activesupport >=3.2.

Signed-off-by: Ken Barber <ken@bob.sh>