### PR TITLE
(PDB-1003) Better message on whitelist failure

### DIFF
--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -52,15 +52,15 @@
 
   * `globals` - a map containing global state useful to request handlers.
 
-  * `authorized?` - a function that takes a request and returns a
-    truthy value if the request is authorized. If not supplied, we default
-    to authorizing all requests."
+  * `authorizer` - a function that takes a request and returns a
+    :authorized if the request is authorized, or a user-visible reason if not.
+    If not supplied, we default to authorizing all requests."
   [& options]
   (let [opts (apply hash-map options)]
     (-> (routes (get-in opts [:globals :url-prefix]))
         (wrap-resource "public")
         (wrap-params)
-        (wrap-with-authorization (opts :authorized? (constantly true)))
+        (wrap-with-authorization (opts :authorizer (constantly :authorized)))
         (wrap-with-certificate-cn)
         (wrap-with-default-body)
         (wrap-with-metrics (atom {}) http/leading-uris)

--- a/src/puppetlabs/puppetdb/metrics.clj
+++ b/src/puppetlabs/puppetdb/metrics.clj
@@ -10,11 +10,11 @@
    [:WebroutingService add-ring-handler get-route]]
 
   (start [this context]
-         (let [authorized? (if-let [wl (-> (get-config)
-                                           (get-in [:puppetdb :certificate-whitelist]))]
-                             (build-whitelist-authorizer wl)
-                             (constantly true))
-               app (server/build-app :authorized? authorized?)]
+         (let [authorizer (if-let [wl (-> (get-config)
+                                          (get-in [:puppetdb :certificate-whitelist]))]
+                            (build-whitelist-authorizer wl)
+                            (constantly :authorized))
+               app (server/build-app :authorizer authorizer)]
            (log/info "Starting metrics server")
            (add-ring-handler this (compojure/context (get-route this) [] app))
            context)))

--- a/src/puppetlabs/puppetdb/metrics/server.clj
+++ b/src/puppetlabs/puppetdb/metrics/server.clj
@@ -25,14 +25,14 @@
 
   `options` is a list of keys and values where keys can be the following:
 
-  * `authorized?` - a function that takes a request and returns a
-    truthy value if the request is authorized. If not supplied, we default
-    to authorizing all requests."
+  * `authorizer` - a function that takes a request and returns a
+    :authorized if the request is authorized, or a user-visible reason if not.
+    If not supplied, we default to authorizing all requests."
   [& options]
   (let [opts (apply hash-map options)]
     (-> (routes)
         (wrap-params)
-        (wrap-with-authorization (opts :authorized? (constantly true)))
+        (wrap-with-authorization (opts :authorizer (constantly :authorized)))
         (wrap-with-certificate-cn)
         (wrap-with-default-body)
         (wrap-with-debug-logging))))

--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -30,16 +30,18 @@
   supplied authorization function allows it. Otherwise an HTTP 403 is
   returned to the client.
 
-  `authorized?` is expected to take a single argument, the current
+  `authorizer` is expected to take a single argument, the current
   request. The request is allowed only if the return value of
-  `authorized?` is truthy."
-  [app authorized?]
+  `authorizor` is :authorized; otherwise, its value is taken to be a
+  message describing the reason that access is not allowed."
+  [app authorizer]
   (fn [req]
-    (if (authorized? req)
-      (app req)
-      (-> "You shall not pass!"
-          (rr/response)
-          (rr/status http/status-forbidden)))))
+    (let [auth-result (authorizer req)]
+     (if (= :authorized auth-result)
+       (app req)
+       (-> (str "Permission denied: " auth-result)
+           (rr/response)
+           (rr/status http/status-forbidden))))))
 
 (defn wrap-with-certificate-cn
   "Ring middleware that will annotate the request with an

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -33,9 +33,9 @@
       (.deleteOnExit wl)
       (spit wl "foobar")
       (let [f (build-whitelist-authorizer (fs/absolute-path wl))]
-        (is (true? (f {:ssl-client-cn "foobar"})))
+        (is (= :authorized (f {:ssl-client-cn "foobar"})))
         (with-log-output logz
-          (is (false? (f {:ssl-client-cn "badguy"})))
+          (is (string? (f {:ssl-client-cn "badguy"})))
           (is (= 1 (count (logs-matching #"^badguy rejected by certificate whitelist " @logz)))))))))
 
 (deftest url-prefix-test

--- a/test/puppetlabs/puppetdb/middleware_test.clj
+++ b/test/puppetlabs/puppetdb/middleware_test.clj
@@ -50,10 +50,13 @@
     ;; Setup an app that only lets through odd numbers
     (let [handler     (fn [req] (-> (rr/response nil)
                                     (rr/status http/status-ok)))
-          authorized? odd?
-          app         (wrap-with-authorization handler authorized?)]
+          message     "Only odd numbers are allowed!"
+          authorizer  #(if (odd? %) :authorized message)
+          app         (wrap-with-authorization handler authorizer)]
       ;; Even numbers should trigger an unauthorized response
       (is (= http/status-forbidden (:status (app 0))))
+      ;; The failure reason should be shown to the user
+      (is (.contains (:body (app 0)) message))
       ;; Odd numbers should get through fine
       (is (= http/status-ok (:status (app 1)))))))
 


### PR DESCRIPTION
Perhaps this is too ambitious? But simply changing the error message would mean middleware/wrap-with-authorization only really works for the whitelist, when an abstraction is already implemented via the `authorizer` parameter. 