### PR TITLE
(PDB-332) Add tags to catalog hash

### DIFF
--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -1,8 +1,30 @@
 ---
-title: "PuppetDB 2.2 » Release Notes"
+title: "PuppetDB 3.0 » Release Notes"
 layout: default
 canonical: "/puppetdb/latest/release_notes.html"
 ---
+
+3.0.0
+-----
+
+### Upgrading
+
+* You may notice some additional system load for the first 30 to 60
+  minutes after upgrading. This is expected, and is due to a change in
+  the way we check if a catalog is up-to-date.
+
+### Contributors
+
+Andrew Roetker, Erik Dalén, Ken Barber, Preben Ingvaldsen, Rob Braden,
+Rob Nelson, Roger Ignazio, Ryan Senior, Wyatt Alt, Jean Bond, and
+Russell Mull.
+
+### Changes
+
+#### Bug Fixes and Maintenance
+
+* If a new catalog is submitted whose only difference from the
+  previous catalog are tags, the change is now respected.
 
 2.2.2
 -----

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -68,7 +68,7 @@
   [resource]
   {:pre  [(map? resource)]
    :post [(map? %)]}
-  (select-keys resource [:type :title :parameters :exported :file :line]))
+  (select-keys resource [:type :title :parameters :exported :file :line :tags]))
 
 (defn resource-comparator
   "Compares two resources by the title and type.  Useful in calls to sort to

--- a/test-resources/puppetlabs/puppetdb/cli/export/big-catalog.json
+++ b/test-resources/puppetlabs/puppetdb/cli/export/big-catalog.json
@@ -10148,5 +10148,5 @@
     } ],
     "version" : "1330463446",
     "transaction_uuid" : "68b08e2a-eeb1-4322-b241-bfdf151d294b",
-    "hash": "591ba1fc87ef592bde41a7d827e95cbd802e8cc8"
+    "hash": "8a6d6cee6ecbf506de0e9cf32c00862ca9c5fddd"
 }

--- a/test/puppetlabs/puppetdb/scf/hash_test.clj
+++ b/test/puppetlabs/puppetdb/scf/hash_test.clj
@@ -83,7 +83,11 @@
 
       (testing "should return the same predictable string"
         (is (= (catalog-similarity-hash sample)
-               "40f42c42bcd81ae28ab306ab64498f0bd6674ce6")))))
+               "1be8cab0657f2d9d703fb48529d008cbe6955803")))
+
+      (testing "should change when tags change"
+        (is (not= (catalog-similarity-hash sample)
+                  (catalog-similarity-hash (update-in sample [:resources :foo :tags] conj "baz")))))))
 
   (testing "resource-event-identity-string"
     (let [sample {:resource_type  "Type"


### PR DESCRIPTION
If the user submits a new catalog with no changes other than tags, 
the catalog should still be stored. It previously was not, since the
tags were not part of the catalog hash computation. 

This does not update existing hashes stored in the db, so the next 
catalog update for each node will cause a db write.