### PR TITLE
Remove pinning against a git sha1 for beaker now ezbake helpers have been released

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,11 +42,7 @@ group :test do
 end
 
 group :acceptance do
-  #gem 'beaker', '~> 2.2'
-  # TODO: unpin when released:
-  #   https://github.com/puppetlabs/beaker/commit/34e5a2305b4beb0caf3bb58b6f308b59da160693
-  gem 'beaker', :git => 'git://github.com/puppetlabs/beaker.git',
-    :branch => '34e5a2305b4beb0caf3bb58b6f308b59da160693'
+  gem 'beaker', '~> 2.4'
   # This forces google-api-client to not download retirable 2.0.0 which lacks
   # ruby 1.9.x support.
   gem 'retriable', '~> 1.4'


### PR DESCRIPTION
We can now release our pinning against the sha1 in beaker master, now that the
ezbake code has been released as a gem.

Signed-off-by: Ken Barber <ken@bob.sh>