### PR TITLE
(PDB-1177) add noop flag to reports

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -1020,7 +1020,7 @@ EOS
     remote_path
   end
 
-  def run_agents_with_new_site_pp(host, manifest, env_vars = {})
+  def run_agents_with_new_site_pp(host, manifest, env_vars = {}, extra_cli_args = "")
 
     manifest_path = create_remote_site_pp(host, manifest)
     with_puppet_running_on host, {
@@ -1031,7 +1031,8 @@ EOS
         'manifest' => manifest_path
       }} do
       #only some of the opts work on puppet_agent, acceptable exit codes does not
-      agents.each{ |agent| on agent, puppet_agent("--test --server #{host}", { 'ENV' => env_vars }), :acceptable_exit_codes => [0,2] }
+      agents.each{ |agent| on agent, puppet_agent("--test --server #{host} #{extra_cli_args}",
+                                                  { 'ENV' => env_vars }), :acceptable_exit_codes => [0,2] }
 
     end
   end

--- a/documentation/api/commands.markdown
+++ b/documentation/api/commands.markdown
@@ -93,9 +93,10 @@ longer required.
 
 ### "store report", version 5
 
-As with version 4 or replace facts and version 6 of replace catalog, the
-version 5 store report command differs from version 4 only in that previously
-dash-separated fields are underscore-separated.
+The version 5 store report command differs from version four in the addition of
+a "noop" flag, which is a boolean indicating whether the report was produced by
+a puppet run with --noop, as well as in the conversion of dash-separated fields to
+underscored.
 
 The payload is expected to be a report, containing events that occurred on Puppet
 resources.  It is structured as a JSON object, conforming to the

--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -48,6 +48,8 @@ The below fields are allowed as filter criteria and are returned in all response
 
 * `status` (string): the status associated to report's node. Possible values for this field come from Puppet's report status, which can be found [here][statuses].
 
+* `noop` (boolean): a flag indicating whether the report was produced by a noop run.
+
 * `puppet_version` (string): the version of Puppet that generated the report.
 
 * `report_format` (number): the version number of the report format that Puppet used to generate the original report data.
@@ -77,6 +79,7 @@ is of the form:
       "end_time": <end of run timestamp>,
       "transaction_uuid": <string to identify puppet run>,
       "status": <status of node after report's associated puppet run>,
+      "noop": <boolean flag indicating noop run>,
       "environment": <report environment>,
       "configuration_version": <catalog identifier>,
       "certname": <node name>,
@@ -124,6 +127,7 @@ Query for all reports:
       "end_time" : "2014-12-24T00:00:49.705Z",
       "transaction_uuid" : "af4fb9ad-b267-4e0b-a295-53eba6b139b7",
       "status" : "changed",
+      "noop" : false,
       "environment" : "production",
       "configuration_version" : "1419379250",
       "certname" : "foo.com",

--- a/documentation/api/wire_format/report_format_v5.markdown
+++ b/documentation/api/wire_format/report_format_v5.markdown
@@ -21,7 +21,8 @@ otherwise noted, `null` is not allowed anywhere in the report.
         "end_time": <datetime>,
         "resource_events": [<resource_event>, <resource_event>, ...],
         "transaction_uuid": <string>,
-        "status": <string>
+        "status": <string>,
+        "noop": <boolean>
     }
 
 All keys are mandatory unless otherwise noted, though values that are lists may be empty lists.
@@ -49,6 +50,8 @@ the `datetime` format below.
 match a report with the catalog that was used for the run.  This field may be `null`.
 
 `"status"` is a string used to identify the status of the puppet run.
+
+`"noop"` is a flag that indicates whether the report was produced with a --noop run.
 
 ### Encoding
 

--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -37,6 +37,9 @@ Puppet::Reports.register_report(:puppetdb) do
         raise Puppet::Error, "Environment is nil, unable to submit report. This may be due a bug with Puppet. Ensure you are running the latest revision, see PUP-2508 for more details."
       end
 
+      resource_events = build_events_list
+      is_noop = resource_events.any? {|rs| rs["status"] == 'noop'} && resource_events.none? {|rs| rs["status"] == 'failed'}
+
       {
         "certname"                => host,
         "puppet_version"          => puppet_version,
@@ -44,10 +47,11 @@ Puppet::Reports.register_report(:puppetdb) do
         "configuration_version"   => configuration_version.to_s,
         "start_time"              => Puppet::Util::Puppetdb.to_wire_time(time),
         "end_time"                => Puppet::Util::Puppetdb.to_wire_time(time + run_duration),
-        "resource_events"         => build_events_list,
+        "resource_events"         => resource_events,
         "environment"             => environment,
         "transaction_uuid"        => transaction_uuid,
         "status"                  => status,
+        "noop"                    => is_noop,
       }
     end
   end

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -102,6 +102,7 @@ describe processor do
           result["report_format"].should == subject.report_format
           result["configuration_version"].should == subject.configuration_version.to_s
           result["resource_events"].should == []
+          result["noop"].should == false
         end
       end
 

--- a/src/puppetlabs/puppetdb/query/reports.clj
+++ b/src/puppetlabs/puppetdb/query/reports.clj
@@ -33,6 +33,7 @@
    :file (s/maybe String)
    :line (s/maybe s/Int)
    :containment_path (s/maybe [String])
+   :noop (s/maybe s/Bool)
    (s/optional-key :environment) (s/maybe String)})
 
 (def resource-event-schema
@@ -56,6 +57,7 @@
    :receive_time pls/Timestamp
    :start_time pls/Timestamp
    :end_time pls/Timestamp
+   :noop (s/maybe s/Bool)
    :report_format s/Int
    :configuration_version String
    :resource_events [resource-event-schema]
@@ -69,6 +71,7 @@
    :report_format
    :start_time
    :end_time
+   :noop
    :transaction_uuid
    :status
    :environment

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -181,6 +181,7 @@
                          "containment_path" :string
                          "event_status" :string
                          "file" :string
+                         "noop" :boolean
                          "resource_type" :string
                          "resource_title" :string
                          "start_time" :timestamp
@@ -195,7 +196,7 @@
                :queryable-fields ["certname" "environment" "puppet_version"
                                   "report_format" "configuration_version"
                                   "start_time" "end_time" "transaction_uuid"
-                                  "status" "hash" "receive_time"]
+                                  "status" "hash" "receive_time" "noop"]
                :alias "reports"
                :subquery? false
                :entity :reports
@@ -209,6 +210,7 @@
                        reports.end_time,
                        reports.receive_time,
                        reports.transaction_uuid,
+                       reports.noop,
                        environments.name as environment,
                        report_statuses.status as status,
                        re.report,

--- a/src/puppetlabs/puppetdb/reports.clj
+++ b/src/puppetlabs/puppetdb/reports.clj
@@ -14,6 +14,7 @@
    :start_time               :datetime
    :end_time                 :datetime
    :resource_events          :coll
+   :noop                     :boolean
    :transaction_uuid         {:optional? true
                               :type      :string}
    :environment              {:optional? true

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -890,6 +890,12 @@
     "ALTER TABLE factsets ADD hash VARCHAR(40)"
     "ALTER TABLE factsets ADD CONSTRAINT factsets_hash_key UNIQUE (hash)"))
 
+(defn insert-noop-column
+  "Insert a column in reports to be populated by boolean noop flag"
+  []
+  (sql/do-commands
+    "ALTER TABLE reports ADD noop boolean"))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {1 initialize-store
@@ -919,7 +925,8 @@
    25 structured-facts
    26 structured-facts-deferrable-constraints
    27 switch-value-string-index-to-gin
-   28 insert-factset-hash-column})
+   28 insert-factset-hash-column
+   29 insert-noop-column})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1110,7 +1110,7 @@
   scenarios."
   [{:keys [puppet_version certname report_format configuration_version
            start_time end_time resource_events transaction_uuid environment
-           status]
+           status noop]
     :as report}
    timestamp
    update-latest-report?]
@@ -1132,6 +1132,7 @@
             (sql/insert-record :reports
                                (maybe-environment
                                 {:hash                   report-hash
+                                 :noop                   noop
                                  :puppet_version         puppet_version
                                  :certname               certname
                                  :report_format          report_format

--- a/src/puppetlabs/puppetdb/validation.clj
+++ b/src/puppetlabs/puppetdb/validation.clj
@@ -60,6 +60,7 @@
                   :number   number?
                   :datetime kitchensink/datetime?
                   :coll     coll?
+                  :boolean   #(= (type %) java.lang.Boolean)
                   :jsonable #(satisfies? JSONable %)}
         type-errors (for [[field {:keys [optional? type]}] fields
                           :let [value (field obj)

--- a/test-resources/puppetlabs/puppetdb/cli/export/reports-query-rows.json
+++ b/test-resources/puppetlabs/puppetdb/cli/export/reports-query-rows.json
@@ -24,6 +24,7 @@
         "resource_type": "Notify",
         "start_time": "2014-12-24T00:00:49Z",
         "status": "changed",
+        "noop": false,
         "timestamp": "2014-12-24T00:00:50Z",
         "transaction_uuid": "af4fb9ad-b267-4e0b-a295-53eba6b139b7"
     },
@@ -52,6 +53,7 @@
         "resource_type": "File",
         "start_time": "2014-12-24T00:00:49Z",
         "status": "changed",
+        "noop": false,
         "timestamp": "2014-12-24T00:00:50Z",
         "transaction_uuid": "af4fb9ad-b267-4e0b-a295-53eba6b139b7"
     },
@@ -80,6 +82,7 @@
         "resource_type": "Notify",
         "start_time": "2014-12-24T00:01:11Z",
         "status": "changed",
+        "noop": false,
         "timestamp": "2014-12-24T00:01:12Z",
         "transaction_uuid": "f585ce01-0b5e-4ee3-b6d9-9d3ed6e42a05"
     }

--- a/test-resources/puppetlabs/puppetdb/cli/export/sample-report.json
+++ b/test-resources/puppetlabs/puppetdb/cli/export/sample-report.json
@@ -37,5 +37,6 @@
   "report_format": 4,
   "transaction_uuid": "68b08e2a-eeb1-4322-b241-bfdf151d294b",
   "environment": "DEV",
-  "status" : "unchanged"
+  "status" : "unchanged",
+  "noop" : false
 }

--- a/test/puppetlabs/puppetdb/examples/reports.clj
+++ b/test/puppetlabs/puppetdb/examples/reports.clj
@@ -11,6 +11,7 @@
     :end_time               "2011-01-01T12:10:00-03:00"
     :environment            "DEV"
     :status                 "unchanged"
+    :noop                   false
     :resource_events
     ;; NOTE: this is a bit wonky because resource events should *not* contain
     ;;  a certname or containment-class on input, but they will have one on output
@@ -74,6 +75,7 @@
     :end_time               "2013-08-28T19:10:00-03:00"
     :environment            "DEV"
     :status                 "unchanged"
+    :noop                   true
     :resource_events
     ;; NOTE: this is a bit wonky because resource events should *not* contain
     ;;  a certname on input, but they will have one on output.  To make it
@@ -134,6 +136,7 @@
     :end_time               "2011-01-03T12:10:00-03:00"
     :environment            "DEV"
     :status                 "unchanged"
+    :noop                   false
     :resource_events
     ;; NOTE: this is a bit wonky because resource events should *not* contain
     ;;  a certname or containment-class on input, but they will have one on output
@@ -194,6 +197,7 @@
     :end_time               "2011-01-03T12:10:00-03:00"
     :environment            "DEV"
     :status                 "unchanged"
+    :noop                   false
     :resource_events
     ;; NOTE: this is a bit wonky because resource events should *not* contain
     ;;  a certname or containment-class on input, but they will have one on output

--- a/test/puppetlabs/puppetdb/query/reports_test.clj
+++ b/test/puppetlabs/puppetdb/query/reports_test.clj
@@ -155,62 +155,64 @@
                   keywordize-keys))
 
 (def expected-result
-  [{:hash "89944d0dcac56d3ee641ca9b69c54b1c15ef01fe",
-    :puppet_version "3.7.3",
-    :receive_time "2014-12-24T00:00:50Z",
-    :report_format 4,
-    :start_time "2014-12-24T00:00:49Z",
-    :end_time "2014-12-24T00:00:49Z",
-    :transaction_uuid "af4fb9ad-b267-4e0b-a295-53eba6b139b7",
-    :status "changed",
-    :environment "production",
-    :configuration_version "1419379250",
-    :certname "foo.com",
-    :resource_events [{:new_value "Hi world",
-                       :property "message",
-                       :file "/home/wyatt/.puppet/manifests/site.pp",
-                       :old_value "absent",
-                       :line 3,
-                       :resource_type "Notify",
-                       :status "success",
-                       :resource_title "hi",
-                       :timestamp "2014-12-24T00:00:50Z",
-                       :containment_path ["Stage[main]" "Main" "Notify[hi]"],
+  [{:hash "89944d0dcac56d3ee641ca9b69c54b1c15ef01fe"
+    :puppet_version "3.7.3"
+    :receive_time "2014-12-24T00:00:50Z"
+    :report_format 4
+    :start_time "2014-12-24T00:00:49Z"
+    :end_time "2014-12-24T00:00:49Z"
+    :transaction_uuid "af4fb9ad-b267-4e0b-a295-53eba6b139b7"
+    :status "changed"
+    :noop false
+    :environment "production"
+    :configuration_version "1419379250"
+    :certname "foo.com"
+    :resource_events [{:new_value "Hi world"
+                       :property "message"
+                       :file "/home/wyatt/.puppet/manifests/site.pp"
+                       :old_value "absent"
+                       :line 3
+                       :resource_type "Notify"
+                       :status "success"
+                       :resource_title "hi"
+                       :timestamp "2014-12-24T00:00:50Z"
+                       :containment_path ["Stage[main]" "Main" "Notify[hi]"]
                        :message "defined 'message' as 'Hi world'"}
-                      {:new_value "file",
-                       :property "ensure",
-                       :file "/home/wyatt/.puppet/manifests/site.pp",
-                       :old_value "absent",
-                       :line 7,
-                       :resource_type "File",
-                       :status "success",
-                       :resource_title "/home/wyatt/Desktop/foo",
-                       :timestamp "2014-12-24T00:00:50Z",
+                      {:new_value "file"
+                       :property "ensure"
+                       :file "/home/wyatt/.puppet/manifests/site.pp"
+                       :old_value "absent"
+                       :line 7
+                       :resource_type "File"
+                       :status "success"
+                       :resource_title "/home/wyatt/Desktop/foo"
+                       :timestamp "2014-12-24T00:00:50Z"
                        :containment_path
-                       ["Stage[main]" "Main" "File[/home/wyatt/Desktop/foo]"],
+                       ["Stage[main]" "Main" "File[/home/wyatt/Desktop/foo]"]
                        :message
                        "defined content as '{md5}207995b58ba1956b97028ebb2f8caeba'"}]}
-   {:hash "afe03ad7377e3c44d0f1f2abcf0834778759afff",
-    :puppet_version "3.7.3",
-    :receive_time "2014-12-24T00:01:12Z",
-    :report_format 4,
-    :start_time "2014-12-24T00:01:11Z",
-    :end_time "2014-12-24T00:01:11Z",
-    :transaction_uuid "f585ce01-0b5e-4ee3-b6d9-9d3ed6e42a05",
-    :status "changed",
-    :environment "production",
-    :configuration_version "1419379250",
-    :certname "bar.com",
-    :resource_events [{:new_value "Hi world",
-                       :property "message",
-                       :file "/home/wyatt/.puppet/manifests/site.pp",
-                       :old_value "absent",
-                       :line 3,
-                       :resource_type "Notify",
-                       :status "success",
-                       :resource_title "hi",
-                       :timestamp "2014-12-24T00:01:12Z",
-                       :containment_path ["Stage[main]" "Main" "Notify[hi]"],
+   {:hash "afe03ad7377e3c44d0f1f2abcf0834778759afff"
+    :puppet_version "3.7.3"
+    :receive_time "2014-12-24T00:01:12Z"
+    :report_format 4
+    :start_time "2014-12-24T00:01:11Z"
+    :end_time "2014-12-24T00:01:11Z"
+    :transaction_uuid "f585ce01-0b5e-4ee3-b6d9-9d3ed6e42a05"
+    :status "changed"
+    :noop false
+    :environment "production"
+    :configuration_version "1419379250"
+    :certname "bar.com"
+    :resource_events [{:new_value "Hi world"
+                       :property "message"
+                       :file "/home/wyatt/.puppet/manifests/site.pp"
+                       :old_value "absent"
+                       :line 3
+                       :resource_type "Notify"
+                       :status "success"
+                       :resource_title "hi"
+                       :timestamp "2014-12-24T00:01:12Z"
+                       :containment_path ["Stage[main]" "Main" "Notify[hi]"]
                        :message "defined 'message' as 'Hi world'"}]}])
 
 (deftest structured-data-seq


### PR DESCRIPTION
This adds a "noop" field to the reports object, which is a boolean flag
indicating whether the run producing the report was a --noop.