### PR TITLE
(PDB-1132) events should not require a query

### DIFF
--- a/documentation/api/query/v4/events.markdown
+++ b/documentation/api/query/v4/events.markdown
@@ -31,7 +31,7 @@ are generated from Puppet reports.)
 
 ### URL Parameters
 
-* `query`: Required. A JSON array of query predicates, in prefix form (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`). See the sections below for the supported operators and fields. For general info about queries, see [the page on query structure.][query]
+* `query`: Optional. A JSON array of query predicates, in prefix form (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`). See the sections below for the supported operators and fields. For general info about queries, see [the page on query structure.][query] If `query` is omitted all events are returned.
 
 * `distinct_resources`: Optional. Boolean. (I.e. `distinct_resources=true`.) (EXPERIMENTAL: it is possible that the behavior
 of this parameter may change in future releases.) If specified, the result set will only return the most recent event for a given resource on a given node.

--- a/src/puppetlabs/puppetdb/http/events.clj
+++ b/src/puppetlabs/puppetdb/http/events.clj
@@ -64,9 +64,9 @@
   [version]
   (-> (routes version)
       middleware/verify-accepts-json
-      (middleware/validate-query-params {:required ["query"]
-                                         :optional (concat
-                                                    ["distinct_resources"
+      (middleware/validate-query-params {:optional (concat
+                                                    ["query"
+                                                     "distinct_resources"
                                                      "distinct_start_time"
                                                      "distinct_end_time"]
                                                     paging/query-params)})

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -7,6 +7,7 @@
             [flatland.ordered.map :as omap]
             [puppetlabs.puppetdb.examples :refer [catalogs]]
             [clj-time.core :refer [ago now secs]]
+            [clojure.set :as clj-set]
             [clj-time.coerce :refer [to-string to-long to-timestamp]]
             [puppetlabs.puppetdb.testutils :refer [response-equal?
                                                    assert-success!
@@ -267,6 +268,13 @@
     (testing "query by report end time"
       (let [expected  (http-expected-resource-events version basic3-events basic3)
             response  (get-response endpoint [">" "run_end_time" "2011-01-02T00:00:00-03:00"])]
+        (assert-success! response)
+        (response-equal? response expected munge-event-values)))
+
+    (testing "query without a query parameter"
+      (let [expected  (clj-set/union (http-expected-resource-events version basic3-events basic3)
+                                     (http-expected-resource-events version basic-events basic))
+            response  (get-response endpoint nil)]
         (assert-success! response)
         (response-equal? response expected munge-event-values)))
 


### PR DESCRIPTION
This makes the query parameter for /events optional, for consistency with our
other endpoints.