### PR TITLE
Bump to latest ezbake plugin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -120,7 +120,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "0.2.1"
+                      :plugins [[puppetlabs/lein-ezbake "0.2.2"
                                  :exclusions [org.clojure/clojure]]]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}
 


### PR DESCRIPTION
This bumps us to use ezbake 0.2.2, which at the very least solves logrotate
pathing mistakes in 0.2.1.

Signed-off-by: Ken Barber <ken@bob.sh>