### PR TITLE
(PDB-1241) Resource Event timestamps should be normalized before stored

### DIFF
--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -29,12 +29,15 @@
 
 (defn get-response
   ([endpoint query]
-     (get-response endpoint query {}))
+   (get-response endpoint query {}))
   ([endpoint query extra-query-params]
-     (let [resp (*app* (get-request endpoint query extra-query-params))]
-       (if (string? (:body resp))
-         resp
-         (update-in resp [:body] slurp)))))
+   (let [resp (*app* (get-request endpoint query extra-query-params))]
+     (update-in resp
+                [:body]
+                (fn [body]
+                  (if (string? body)
+                    body
+                    (slurp body)))))))
 
 (defn parse-result
   "Stringify (if needed) then parse the response"
@@ -153,8 +156,8 @@
                 [:status :line]]]]
         (let [response (get-response endpoint query)
               expected (->> (kitchensink/select-values basic-events-map matches)
-                         (map #(select-keys % ks))
-                         set)]
+                            (map #(select-keys % ks))
+                            set)]
           (response-equal? response expected))))
 
 
@@ -225,8 +228,8 @@
     (testing "should return only one event for a given resource"
       (let [expected  (http-expected-resource-events version basic3-events basic3)
             response  (get-response endpoint ["=" "certname" "foo.local"] {:distinct_resources true
-                                                                             :distinct_start_time 0
-                                                                             :distinct_end_time (now)})]
+                                                                           :distinct_start_time 0
+                                                                           :distinct_end_time (now)})]
         (assert-success! response)
         (response-equal? response expected munge-event-values)))
 
@@ -316,7 +319,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "227a8b2b960ab0183b2100923f05cee7c7f0d8d4"
+       :report "a32722b44f0852d9a16d326414c16a6941b9678f"
        :resource_title "hi"
        :property nil
        :file "bar"
@@ -341,7 +344,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "227a8b2b960ab0183b2100923f05cee7c7f0d8d4"
+       :report "a32722b44f0852d9a16d326414c16a6941b9678f"
        :resource_title "hi"
        :property nil
        :file "bar"
@@ -368,7 +371,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "227a8b2b960ab0183b2100923f05cee7c7f0d8d4"
+       :report "a32722b44f0852d9a16d326414c16a6941b9678f"
        :resource_title "hi"
        :property nil
        :file "bar"
@@ -437,13 +440,13 @@
 
 (def versioned-invalid-projections
   (omap/ordered-map
-    "/v4/events" (omap/ordered-map
-                   ;; Top level extract using invalid fields should throw an error
-                   ["extract" "nothing" ["~" "certname" ".*"]]
-                   #"Can't extract unknown 'events' field 'nothing'.*Acceptable fields are.*"
+   "/v4/events" (omap/ordered-map
+                 ;; Top level extract using invalid fields should throw an error
+                 ["extract" "nothing" ["~" "certname" ".*"]]
+                 #"Can't extract unknown 'events' field 'nothing'.*Acceptable fields are.*"
 
-                   ["extract" ["certname" "nothing" "nothing2"] ["~" "certname" ".*"]]
-                   #"Can't extract unknown 'events' fields: 'nothing', 'nothing2'.*Acceptable fields are.*")))
+                 ["extract" ["certname" "nothing" "nothing2"] ["~" "certname" ".*"]]
+                 #"Can't extract unknown 'events' fields: 'nothing', 'nothing2'.*Acceptable fields are.*")))
 
 (deftestseq invalid-projections
   [[version endpoint] endpoints]
@@ -456,12 +459,12 @@
 
 (def pg-versioned-invalid-regexps
   (omap/ordered-map
-    "/v4/events" (omap/ordered-map
-                  ["~" "certname" "*abc"]
-                  #".*invalid regular expression: quantifier operand invalid"
+   "/v4/events" (omap/ordered-map
+                 ["~" "certname" "*abc"]
+                 #".*invalid regular expression: quantifier operand invalid"
 
-                  ["~" "certname" "[]"]
-                  #".*invalid regular expression: brackets.*not balanced")))
+                 ["~" "certname" "[]"]
+                 #".*invalid regular expression: brackets.*not balanced")))
 
 (deftestseq ^{:hsqldb false} pg-invalid-regexps
   [[version endpoint] endpoints]

--- a/test/puppetlabs/puppetdb/testutils/reports.clj
+++ b/test/puppetlabs/puppetdb/testutils/reports.clj
@@ -52,16 +52,16 @@
 (defn store-example-report*!
   "Store an example report (from examples/report.clj) for use in tests.  Params:
 
-   - `validate-fn`: no-arg function called to validate the catalog
-   - `example-report`: the report (as a map)
-   - `timestamp`: the `received-time` for the report
-   - `update-latest-report?` (optional): if `false`, then the `latest_reports` table
-      will not be updated to reflect the new report.  Defaults to `true`.  This only
-      exists to allow testing of the schema migration code; you should almost never pass
-      a value for this."
+  - `validate-fn`: no-arg function called to validate the catalog
+  - `example-report`: the report (as a map)
+  - `timestamp`: the `received-time` for the report
+  - `update-latest-report?` (optional): if `false`, then the `latest_reports` table
+  will not be updated to reflect the new report.  Defaults to `true`.  This only
+  exists to allow testing of the schema migration code; you should almost never pass
+  a value for this."
   [validate-fn example-report timestamp update-latest-report?]
   (let [example-report  (munge-example-report-for-storage example-report)
-        report-hash     (shash/report-identity-hash example-report)]
+        report-hash     (shash/report-identity-hash (scf-store/normalize-report example-report))]
     (validate-fn)
     (scf-store/maybe-activate-node! (:certname example-report) timestamp)
     (scf-store/add-report!* example-report timestamp update-latest-report?)
@@ -70,9 +70,9 @@
 (defn store-example-report!
   "See store-example-reports*! calls that, passing in a version 3 validation function"
   ([example-report timestamp]
-     (store-example-report! example-report timestamp true))
+   (store-example-report! example-report timestamp true))
   ([example-report timestamp update-latest-report?]
-     (store-example-report*! #(report/validate! 5 (munge-example-report-for-storage example-report)) example-report timestamp update-latest-report?)))
+   (store-example-report*! #(report/validate! 5 (munge-example-report-for-storage example-report)) example-report timestamp update-latest-report?)))
 
 (defn expected-report
   [example-report]
@@ -108,9 +108,9 @@
 
 (defn reports-query-result
   ([version query]
-     (reports-query-result version query nil))
+   (reports-query-result version query nil))
   ([version query paging-options]
-     (:result (raw-reports-query-result version query paging-options))))
+   (:result (raw-reports-query-result version query paging-options))))
 
 (defn get-events-map
   [example-report]


### PR DESCRIPTION
There are many ways to represent an ISO 8601 timestamp in string
form. The end result is the posibility of having to two timestamps that
are the same, but represented different which causes the report to hash
differently. Although Puppet should be sending PuppetDB UTC dates, our
tests were using non-UTC dates, which would cause the dates to be stored
in another timezone, then converted to UTC on the way out of the
database which is really confusing.