### PR TITLE
Remove some unused legacy query code

### DIFF
--- a/test/puppetlabs/puppetdb/query/reports_test.clj
+++ b/test/puppetlabs/puppetdb/query/reports_test.clj
@@ -40,16 +40,6 @@
 
 ;; Begin tests
 
-(deftest test-compile-report-term
-  (testing "should successfully compile a valid equality query"
-    (is (= ((query/compile-reports-equality :v4) "certname" "foo.local")
-           {:where   "reports.certname = ?"
-            :params  ["foo.local"]})))
-  (testing "should fail with an invalid equality query"
-    (is (thrown-with-msg?
-         IllegalArgumentException #"is not a valid query term"
-         ((query/compile-reports-equality :v4) "foo" "foo")))))
-
 (deftest reports-retrieval
   (let [basic         (:basic reports)
         report-hash   (:hash (store-example-report! basic (now)))]


### PR DESCRIPTION
This removes some of the legacy query code since we've dropped v3.

This doesn't put much of a dent in the file query.clj, but it at least
removes the obvious unused functions. We still use this query engine in
some of our weird endpoints, so greater work will be required to remove
the lot.

For now this removes some of the dead code at least.

Signed-off-by: Ken Barber <ken@bob.sh>