### PR TITLE
(PDB-1218) Add id to reports table

### DIFF
--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -224,7 +224,7 @@
    "start_time"             ["reports" "run_start_time"]
    "end_time"               ["reports" "run_end_time"]
    "receive_time"           ["reports" "report_receive_time"]
-   "report"                 ["resource_events"]
+   "hash"                   ["reports" "report"]
    "status"                 ["resource_events"]
    "timestamp"              ["resource_events"]
    "resource_type"          ["resource_events"]
@@ -563,11 +563,15 @@
     (let [path (jdbc/dashes->underscores path)]
       (match [path]
              ["certname"]
-             {:where (format "reports.certname = ?")
+             {:where "reports.certname = ?"
+              :params [value]}
+
+             ["report"]
+             {:where "reports.hash = ?"
               :params [value]}
 
              ["latest_report?"]
-             {:where (format "resource_events.report %s (SELECT latest_reports.report FROM latest_reports)"
+             {:where (format "resource_events.report_id %s (SELECT latest_reports.report_id FROM latest_reports)"
                              (if value "IN" "NOT IN"))}
 
              ["environment"]
@@ -743,5 +747,5 @@
    If all you want is an unstreamed Seq, pass the function `doall` as `f` to
    convert the LazySeq to a Seq by full traversing it. This is useful for tests,
    that cannot analyze results easily in a streamed way."
-  ([version sql params f]
-   (jdbc/with-query-results-cursor sql params rs (f rs))))
+  [version sql params f]
+  (jdbc/with-query-results-cursor sql params rs (f rs)))

--- a/src/puppetlabs/puppetdb/query/events.clj
+++ b/src/puppetlabs/puppetdb/query/events.clj
@@ -24,7 +24,7 @@
   [(format
     "SELECT %s
          FROM resource_events
-         JOIN reports ON resource_events.report = reports.hash
+         JOIN reports ON resource_events.report_id = reports.id
          LEFT OUTER JOIN environments on reports.environment_id = environments.id
          WHERE %s"
     select-fields
@@ -47,7 +47,7 @@
   [(format
     "SELECT %s
          FROM resource_events
-         JOIN reports ON resource_events.report = reports.hash
+         JOIN reports ON resource_events.report_id = reports.id
          LEFT OUTER JOIN environments ON reports.environment_id = environments.id
          JOIN (SELECT reports.certname,
                       resource_events.resource_type,
@@ -55,7 +55,7 @@
                       resource_events.property,
                       MAX(resource_events.timestamp) AS timestamp
                   FROM resource_events
-                  JOIN reports ON resource_events.report = reports.hash
+                  JOIN reports ON resource_events.report_id = reports.id
                   WHERE resource_events.timestamp >= ?
                      AND resource_events.timestamp <= ?
                   GROUP BY certname, resource_type, resource_title, property) latest_events

--- a/src/puppetlabs/puppetdb/query/reports.clj
+++ b/src/puppetlabs/puppetdb/query/reports.clj
@@ -197,6 +197,8 @@
           (string? report-hash)]
    :post [(kitchensink/boolean? %)]}
   (= 1 (count (jdbc/query-to-vec
-               ["SELECT report FROM latest_reports
-                    WHERE certname = ? AND report = ?"
+               ["SELECT reports.hash as latest_report_hash
+                 FROM latest_reports
+                 INNER JOIN reports ON reports.id = latest_reports.report_id
+                 WHERE latest_reports.certname = ? AND reports.hash = ?"
                 node report-hash]))))

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -61,8 +61,8 @@
                             LEFT OUTER JOIN catalogs ON certnames.name = catalogs.certname
                             LEFT OUTER JOIN factsets as fs ON certnames.name = fs.certname
                             LEFT OUTER JOIN reports ON certnames.name = reports.certname
-                             AND reports.hash
-                               IN (SELECT report FROM latest_reports)
+                             AND reports.id
+                               IN (SELECT report_id FROM latest_reports)
                             LEFT OUTER JOIN environments AS catalog_environment ON catalog_environment.id = catalogs.environment_id
                             LEFT OUTER JOIN environments AS facts_environment ON facts_environment.id = fs.environment_id
                             LEFT OUTER JOIN environments AS reports_environment ON reports_environment.id = reports.environment_id"}))
@@ -202,6 +202,7 @@
                :entity :reports
                :source-table "reports"
                :source "select reports.hash,
+                       reports.hash as report,
                        reports.certname,
                        reports.puppet_version,
                        reports.report_format,
@@ -213,7 +214,7 @@
                        reports.noop,
                        environments.name as environment,
                        report_statuses.status as status,
-                       re.report,
+                       re.report_id,
                        re.status as event_status,
                        re.timestamp,
                        re.resource_type,
@@ -227,7 +228,7 @@
                        re.containment_path,
                        re.containing_class
                        FROM reports
-                       INNER JOIN resource_events re on reports.hash=re.report
+                       INNER JOIN resource_events re on reports.id=re.report_id
                        LEFT OUTER JOIN environments on reports.environment_id = environments.id
                        LEFT OUTER JOIN report_statuses on reports.status_id = report_statuses.id"}))
 
@@ -371,7 +372,7 @@
                        reports.start_time as run_start_time,
                        reports.end_time as run_end_time,
                        reports.receive_time as report_receive_time,
-                       report,
+                       reports.hash as report,
                        status,
                        timestamp,
                        resource_type,
@@ -386,7 +387,7 @@
                        containing_class,
                        environments.name as environment
                        FROM resource_events
-                       JOIN reports ON resource_events.report = reports.hash
+                       JOIN reports ON resource_events.report_id = reports.id
                        LEFT OUTER JOIN environments on reports.environment_id = environments.id"}))
 
 (def latest-report-query
@@ -397,8 +398,9 @@
                :subquery? false
                :source-table "latest_report"
                :supports-extract? true
-               :source "SELECT latest_reports.report as latest_report_hash
-                        FROM latest_reports"}))
+               :source "SELECT reports.hash as latest_report_hash
+                        FROM latest_reports
+                        INNER JOIN reports ON reports.id = latest_reports.report_id"}))
 
 (def environments-query
   "Basic environments query, more useful when used with subqueries"

--- a/test/puppetlabs/puppetdb/query/events_test.clj
+++ b/test/puppetlabs/puppetdb/query/events_test.clj
@@ -21,7 +21,7 @@
     (let [ops (query/resource-event-ops version)]
       (testing "should succesfully compile a valid equality query"
         (is (= (query/compile-term ops ["=" "report" "blah"])
-               {:where   "resource_events.report = ?"
+               {:where   "reports.hash = ?"
                 :params  ["blah"]})))
       (testing "should fail with an invalid equality query"
         (is (thrown-with-msg?

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -13,9 +13,16 @@
 
 (def db (test-db))
 
-(defn apply-migration-for-testing
+(defn apply-migration-for-testing!
   [i]
   (let [migration (migrations i)]
+    (migration)
+    (record-migration! i)))
+
+(defn fast-forward-to-migration!
+  [migration-number]
+  (doseq [[i migration] (sort migrations)
+          :while (<= i migration-number)]
     (migration)
     (record-migration! i)))
 
@@ -37,7 +44,7 @@
         (clear-db-for-testing!)
         (let [applied '(1 2 4)]
           (doseq [m applied]
-            (apply-migration-for-testing m))
+            (apply-migration-for-testing! m))
           (is (= (set (keys (pending-migrations)))
                  (difference (set (keys migrations))
                              (set applied))))))))
@@ -57,11 +64,11 @@
 
         (testing "should attempt a partial migration if there are migrations missing"
           (clear-db-for-testing!)
-          ;; We are using migration 13 here because it is isolated enough to be able
+          ;; We are using migration 28 here because it is isolated enough to be able
           ;; to execute on its own. This might need to be changed in the future.
-          (doseq [m (filter (fn [[i migration]] (not= i 13)) (pending-migrations))]
-            (apply-migration-for-testing (first m)))
-          (is (= (keys (pending-migrations)) '(13)))
+          (doseq [m (filter (fn [[i migration]] (not= i 28)) (pending-migrations))]
+            (apply-migration-for-testing! (first m)))
+          (is (= (keys (pending-migrations)) '(28)))
           (migrate!)
           (is (= (applied-migrations) expected-migrations))))))
 
@@ -77,10 +84,7 @@
     (sql/with-connection db
       (clear-db-for-testing!)
       ;; Migrate to prior to the cache table
-      (doseq [[i migration] (sort migrations)
-              :while (< i 14)]
-        (migration)
-        (record-migration! i))
+      (fast-forward-to-migration! 13)
 
       ;; Now add some resource parameters
       (sql/insert-records
@@ -97,8 +101,7 @@
        {:resource "7" :name "hash"    :value (db-serialize (sorted-map  "foo" 5 "bar" 10))})
 
       ;; Now add the parameter cache
-      (add-parameter-cache)
-      (record-migration! 14)
+      (apply-migration-for-testing! 14)
 
       ;; Now the cache table should have the json-ified version of
       ;; each resource as the value
@@ -116,62 +119,107 @@
               {:resource "7" :parameters {"hash" (sorted-map "foo" 5 "bar" 10)}}])))))
 
 (deftest migration-25
-  (testing "should contain same facts before and after migration")
-  (sql/with-connection db
-    (clear-db-for-testing!)
-    (doseq [[i migration] (sort migrations)
-            :while (< i 25)]
-      (migration)
-      (record-migration! i))
-    (let [current-time (to-timestamp (now))
-          yesterday (to-timestamp (-> 1 days ago))]
-      (sql/insert-records
-       :certnames
-       {:name "testing1" :deactivated nil}
-       {:name "testing2" :deactivated nil}
-       {:name "testing3" :deactivated current-time}
-       {:name "testing4" :deactivated nil}
-       {:name "testing5" :deactivated current-time})
-      (sql/insert-records
-       :environments
-       {:id 1 :name "test_env_1"}
-       {:id 2 :name "test_env_2"}
-       {:id 3 :name "test_env_3"}
-       {:id 4 :name "test_env_4"}
-       {:id 5 :name "test_env_5"})
-      (sql/insert-records
-       :certname_facts_metadata
-       {:certname "testing1" :timestamp current-time :environment_id 1}
-       {:certname "testing2" :timestamp current-time :environment_id 2}
-       ;; deactivated node with facts
-       {:certname "testing3" :timestamp current-time :environment_id 3}
-       ;; active node with no facts
-       {:certname "testing4" :timestamp yesterday :environment_id 4}
-       ;; deactivated node with no facts
-       {:certname "testing5" :timestamp yesterday :environment_id 5})
-      (sql/insert-records
-       :certname_facts
-       {:certname "testing1" :name "foo"  :value  "1"}
-       {:certname "testing2" :name "bar"  :value "true"}
-       {:certname "testing3" :name "baz"  :value "false"})
+  (testing "should contain same facts before and after migration"
+    (sql/with-connection db
+      (clear-db-for-testing!)
+      (fast-forward-to-migration! 24)
+      (let [current-time (to-timestamp (now))
+            yesterday (to-timestamp (-> 1 days ago))]
+        (sql/insert-records
+          :certnames
+          {:name "testing1" :deactivated nil}
+          {:name "testing2" :deactivated nil}
+          {:name "testing3" :deactivated current-time}
+          {:name "testing4" :deactivated nil}
+          {:name "testing5" :deactivated current-time})
+        (sql/insert-records
+          :environments
+          {:id 1 :name "test_env_1"}
+          {:id 2 :name "test_env_2"}
+          {:id 3 :name "test_env_3"}
+          {:id 4 :name "test_env_4"}
+          {:id 5 :name "test_env_5"})
+        (sql/insert-records
+          :certname_facts_metadata
+          {:certname "testing1" :timestamp current-time :environment_id 1}
+          {:certname "testing2" :timestamp current-time :environment_id 2}
+          ;; deactivated node with facts
+          {:certname "testing3" :timestamp current-time :environment_id 3}
+          ;; active node with no facts
+          {:certname "testing4" :timestamp yesterday :environment_id 4}
+          ;; deactivated node with no facts
+          {:certname "testing5" :timestamp yesterday :environment_id 5})
+        (sql/insert-records
+          :certname_facts
+          {:certname "testing1" :name "foo"  :value  "1"}
+          {:certname "testing2" :name "bar"  :value "true"}
+          {:certname "testing3" :name "baz"  :value "false"})
 
-      (structured-facts)
-      (record-migration! 25)
+        (apply-migration-for-testing! 25)
 
-      (let [response
-            (query-to-vec
-             "SELECT path, e.id AS environment_id, e.name AS environment,
-              timestamp, value_string
-               FROM
-               environments e INNER JOIN factsets fs on e.id=fs.environment_id
-                              INNER JOIN facts f on f.factset_id=fs.id
-                              INNER JOIN fact_values fv on f.fact_value_id=fv.id
-                              INNER JOIN fact_paths fp on fp.id=fv.path_id")]
-        ;; every node should with facts should be represented
-        (is (= response
-               [{:path "foo" :environment_id 1 :environment "test_env_1"
-                 :timestamp (to-timestamp current-time) :value_string "1"}
-                {:path "bar" :environment_id 2 :environment "test_env_2"
-                 :timestamp (to-timestamp current-time) :value_string "true"}
-                {:path "baz" :environment_id 3 :environment "test_env_3"
-                 :timestamp (to-timestamp current-time) :value_string "false"}]))))))
+        (let [response
+              (query-to-vec
+                "SELECT path, e.id AS environment_id, e.name AS environment,
+                 timestamp, value_string
+                 FROM
+                 environments e INNER JOIN factsets fs on e.id=fs.environment_id
+                 INNER JOIN facts f on f.factset_id=fs.id
+                 INNER JOIN fact_values fv on f.fact_value_id=fv.id
+                 INNER JOIN fact_paths fp on fp.id=fv.path_id")]
+          ;; every node should with facts should be represented
+          (is (= response
+                 [{:path "foo" :environment_id 1 :environment "test_env_1"
+                   :timestamp (to-timestamp current-time) :value_string "1"}
+                  {:path "bar" :environment_id 2 :environment "test_env_2"
+                   :timestamp (to-timestamp current-time) :value_string "true"}
+                  {:path "baz" :environment_id 3 :environment "test_env_3"
+                   :timestamp (to-timestamp current-time) :value_string "false"}])))))))
+
+(deftest migration-29
+  (testing "should contain same reports before and after migration"
+    (sql/with-connection db
+      (clear-db-for-testing!)
+      (fast-forward-to-migration! 28)
+
+      (let [current-time (to-timestamp (now))]
+        (sql/insert-records
+          :report_statuses
+          {:status "testing1" :id 1})
+        (sql/insert-records
+          :environments
+          {:id 1 :name "testing1"})
+        (sql/insert-records
+          :certnames
+          {:name "testing1" :deactivated nil})
+
+        (sql/insert-records
+          :reports
+          {:hash                   "thisisacoolhash"
+           :configuration_version  "thisisacoolconfigversion"
+           :certname               "testing1"
+           :puppet_version         "0.0.0"
+           :report_format          1
+           :start_time             current-time
+           :end_time               current-time
+           :receive_time           current-time
+           :environment_id         1
+           :status_id              1})
+
+        (sql/insert-records
+          :latest_reports
+          {:report                 "thisisacoolhash"
+           :certname               "testing1"})
+
+        (apply-migration-for-testing! 29)
+
+        (let [response
+              (query-to-vec
+                "SELECT r.hash, r.certname, e.name AS environment, rs.status
+                 FROM
+                 latest_reports lr INNER JOIN reports r on lr.report_id=r.id AND lr.certname=r.certname
+                 INNER JOIN environments e on r.environment_id=e.id
+                 INNER JOIN report_statuses rs on r.status_id=rs.id")]
+          ;; every node should with facts should be represented
+          (is (= response
+                 [{:hash "thisisacoolhash" :environment "testing1"
+                   :certname "testing1" :status "testing1"}])))))))


### PR DESCRIPTION
This commit adds a migration which changes our database schema to use an
integer primary key for reports. This commit merges this migration with
the noop column migration since they are going out in the same release.