### PR TITLE
(PDB-1243) Accept null noop field in reports

### DIFF
--- a/src/puppetlabs/puppetdb/reports.clj
+++ b/src/puppetlabs/puppetdb/reports.clj
@@ -14,7 +14,8 @@
    :start_time               :datetime
    :end_time                 :datetime
    :resource_events          :coll
-   :noop                     :boolean
+   :noop                     {:optional? true
+                              :type :boolean}
    :transaction_uuid         {:optional? true
                               :type      :string}
    :environment              {:optional? true

--- a/test/puppetlabs/puppetdb/reports_test.clj
+++ b/test/puppetlabs/puppetdb/reports_test.clj
@@ -5,12 +5,16 @@
             [puppetlabs.puppetdb.testutils.reports
              :refer [munge-example-report-for-storage]]))
 
-(let [report (munge-example-report-for-storage (:basic reports))]
+(let [report (munge-example-report-for-storage (:basic reports))
+      report-missing-noop (dissoc report :noop)]
 
   (deftest test-validate!
 
-    (testing "should accept a valid v2 report"
+    (testing "should accept a valid v5 report"
       (is (= report (validate! 5 report))))
+
+    (testing "should accept a v5 report which has a missing noop field"
+      (is (= report-missing-noop (validate! 5 report-missing-noop))))
 
     (testing "should fail when a report is missing a key"
       (is (thrown-with-msg?


### PR DESCRIPTION
This commit changes the defmodel for report to have the noop field be
optional as it is in the database which will allow users to use the
store-report! command on old exported data.