### PR TITLE
(PDB-1252) Remove clamq; use ActiveMQ directly

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  [clj-stacktrace "0.2.6"]
                  [metrics-clojure "0.7.0" :exclusions [org.clojure/clojure org.slf4j/slf4j-api]]
                  [clj-time "0.5.1"]
-                 [org.clojure/java.jmx "0.2.0"]
+                 [org.clojure/java.jmx "0.3.1"]
                  ;; Filesystem utilities
                  [fs "1.1.2"]
                  ;; Version information
@@ -55,10 +55,14 @@
                  [org.postgresql/postgresql "9.2-1003-jdbc4"]
                  [clojureql "1.0.3"]
                  ;; MQ connectivity
-                 [clamq/clamq-activemq "0.4" :exclusions [org.slf4j/slf4j-api]]
-                 [org.apache.activemq/activemq-core "5.7.0" :exclusions [org.slf4j/slf4j-api org.fusesource.fuse-extra/fusemq-leveldb]]
+                 [org.apache.activemq/activemq-core "5.7.0"
+                  :exclusions [org.slf4j/slf4j-api
+                               org.fusesource.fuse-extra/fusemq-leveldb]]
+                 [org.apache.activemq/activemq-pool "5.7.0"
+                  :exclusions [org.slf4j/slf4j-api]]
+
                  ;; bridge to allow some spring/activemq stuff to log over slf4j
-                 [org.slf4j/jcl-over-slf4j "1.7.6"]
+                 [org.slf4j/jcl-over-slf4j "1.7.10"]
                  ;; WebAPI support libraries.
                  [net.cgrand/moustache "1.1.0" :exclusions [ring/ring-core org.clojure/clojure]]
                  [compojure "1.1.6"]

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -43,7 +43,7 @@
      database, compacting it and performing regular cleanup so we can
      maintain acceptable performance."
   (:require [puppetlabs.puppetdb.scf.storage :as scf-store]
-            [puppetlabs.puppetdb.command :as command]
+            [puppetlabs.puppetdb.command :refer [enqueue-command!]]
             [puppetlabs.puppetdb.command.dlo :as dlo]
             [puppetlabs.puppetdb.query.population :as pop]
             [puppetlabs.puppetdb.jdbc :as pl-jdbc]
@@ -66,7 +66,8 @@
             [puppetlabs.puppetdb.version :refer [version update-info]]
             [puppetlabs.puppetdb.command.constants :refer [command-names]]
             [puppetlabs.puppetdb.cheshire :as json]
-            [puppetlabs.puppetdb.query-eng :as qeng]))
+            [puppetlabs.puppetdb.query-eng :as qeng])
+  (:import [javax.jms ExceptionListener]))
 
 (def cli-description "Main PuppetDB daemon")
 
@@ -78,15 +79,10 @@
 (def mq-addr "vm://localhost?jms.prefetchPolicy.all=1&create=false")
 (def mq-endpoint "puppetlabs.puppetdb.commands")
 
-(defn send-command!
-  "Send the command using the default MQ address and endpoint"
-  [command version payload]
-  (command/enqueue-command! mq-addr mq-endpoint command version payload))
-
 (defn auto-deactivate-nodes!
   "Deactivate nodes which haven't had any activity (catalog/fact submission)
   for more than `node-ttl`."
-  [node-ttl db]
+  [node-ttl db mq-connection]
   {:pre [(map? db)
          (period? node-ttl)]}
   (try
@@ -95,7 +91,9 @@
              (format-period node-ttl))
      (with-transacted-connection db
        (doseq [node (scf-store/stale-nodes (ago node-ttl))]
-         (send-command! (command-names :deactivate-node) 2 node))))
+         (enqueue-command! mq-connection
+                           mq-endpoint
+                           (command-names :deactivate-node) 2 node))))
     (catch Exception e
       (log/error e "Error while deactivating stale nodes"))))
 
@@ -151,16 +149,6 @@
     (catch Exception e
       (log/error e "Error during garbage collection"))))
 
-(defn perform-db-maintenance!
-  "Runs the full set of database maintenance tasks in `fns` on `db` in order.
-  Has no error-handling of its own, so all `fns` must handle their own errors.
-  The purpose of this function is primarily to serialize these tasks, to avoid
-  concurrent long-running database tasks."
-  [db & fns]
-  {:pre [(map? db)]}
-  (doseq [f fns]
-    (f db)))
-
 (defn check-for-updates
   "This will fetch the latest version number of PuppetDB and log if the system
   is out of date."
@@ -204,19 +192,19 @@
                        "listed in PuppetDB's certificate-whitelist file?")
                   ssl-client-cn))))))
 
-(defn shutdown-mq-broker
+(defn shutdown-mq
   "Explicitly shut down the queue `broker`"
-  [{:keys [broker]}]
+  [{:keys [broker mq-factory mq-connection]}]
   (when broker
-    (log/info "Shutting down message broker.")
-    ;; Stop the mq the old-fashioned way
+    (log/info "Shutting down the messsage queues.")
+    (.close mq-connection)
+    (.close mq-factory)
     (mq/stop-broker! broker)))
 
 (defn stop-puppetdb
-  "Callback to execute any necessary cleanup during a normal shutdown."
   [context]
   (log/info "Shutdown request received; puppetdb exiting.")
-  (shutdown-mq-broker context)
+  (shutdown-mq context)
   context)
 
 (defn error-shutdown!
@@ -226,8 +214,7 @@
   (when-let [updater (context :updater)]
     (log/info "Shutting down updater thread.")
     (future-cancel updater))
-
-  (shutdown-mq-broker context))
+  (shutdown-mq context))
 
 (defn add-max-framesize
   "Add a maxFrameSize to broker url for activemq."
@@ -264,8 +251,6 @@
         globals {:scf-read-db read-db
                  :scf-write-db write-db
                  :authorizer authorizer
-                 :command-mq {:connection-string mq-connection-str
-                              :endpoint mq-endpoint}
                  :update-server update-server
                  :product-name product-name
                  :url-prefix url-prefix
@@ -302,6 +287,20 @@
                       "PuppetDB troubleshooting guide.")
                      (throw e)))
           context (assoc context :broker broker)
+          mq-factory (mq/activemq-connection-factory
+                      (add-max-framesize max-frame-size mq-addr))
+          mq-connection (doto (.createConnection mq-factory)
+                          (.setExceptionListener
+                           (reify ExceptionListener
+                             (onException [this ex]
+                               (log/error
+                                ex "service queue connection error"))))
+                          .start)
+          context (assoc context
+                         :mq-factory mq-factory
+                         :mq-connection mq-connection)
+          globals (assoc globals :command-mq {:connection mq-connection
+                                              :endpoint mq-endpoint})
           updater (when-not disable-update-checking
                     (future (shutdown-on-error
                              (service-id service)
@@ -320,7 +319,8 @@
             gc-interval-millis (to-millis gc-interval)
             gc-task #(interspaced gc-interval-millis % job-pool)
             db-maintenance-tasks [(when (pos? (to-secs node-ttl))
-                                    (partial auto-deactivate-nodes! node-ttl))
+                                    #(auto-deactivate-nodes!
+                                      node-ttl % mq-connection))
                                   (when (pos? (to-secs node-purge-ttl))
                                     (partial purge-nodes! node-purge-ttl))
                                   (when (pos? (to-secs report-ttl))
@@ -329,8 +329,10 @@
                                   ;; anything referencing an env or resource
                                   ;; param is purged first
                                   garbage-collect!]]
-
-        (gc-task #(apply perform-db-maintenance! write-db (remove nil? db-maintenance-tasks)))
+        ;; Run database maintenance tasks seqentially to avoid
+        ;; competition. Each task must handle its own errors.
+        (gc-task #(doseq [maintain (remove nil? db-maintenance-tasks)]
+                    (maintain write-db)))
         (gc-task #(compress-dlo! dlo-compression-threshold discard-dir)))
 
       (assoc context :shared-globals globals))))
@@ -368,7 +370,9 @@
           (get-in (service-context this) [:shared-globals :url-prefix])
           row-callback-fn))
   (submit-command [this command version payload]
-                  (send-command! (command-names command) version payload)))
+                  (enqueue-command! (:mq-connection (service-context this))
+                                    mq-endpoint
+                                    (command-names command) version payload)))
 
 (defn -main
   "Calls the trapperkeeper main argument to initialize tk.

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -4,10 +4,10 @@
             [puppetlabs.puppetdb.middleware :as mid]))
 
 (defn enqueue-command
-  "Enqueue the comman in the request parameters, return a UUID"
+  "Enqueues the command in request and returns a UUID"
   [{:keys [body-string globals] :as request}]
   (let [uuid (command/enqueue-raw-command!
-              (get-in globals [:command-mq :connection-string])
+              (get-in globals [:command-mq :connection])
               (get-in globals [:command-mq :endpoint])
               body-string)]
     (http/json-response {:uuid uuid})))

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -74,7 +74,8 @@
   `(let [log-output#     (atom [])
          publish#        (call-counter)
          discard-dir#    (fs/temp-dir)
-         handle-message# (mql/produce-message-handler publish# discard-dir# #(process-command! % ~opts-map))
+         handle-message# (mql/create-message-handler
+                          publish# discard-dir# #(process-command! % ~opts-map))
          msg#            {:headers {:id "foo-id-1"
                                     :received (tfmt/unparse (tfmt/formatters :date-time) (now))}
                           :body (json/generate-string ~command)}]

--- a/test/puppetlabs/puppetdb/fixtures.clj
+++ b/test/puppetlabs/puppetdb/fixtures.clj
@@ -15,7 +15,6 @@
 
 (def ^:dynamic *db* nil)
 (def ^:dynamic *mq* nil)
-(def ^:dynamic *conn* nil)
 (def ^:dynamic *app* nil)
 
 (defn init-db [db read-only?]
@@ -49,13 +48,12 @@
     (f)))
 
 (defn with-test-mq
-  "A fixture to start an MQ broker, making the broker information available as
-  `*mq*` and the connection as `*conn*`."
+  "Calls f after starting an embedded MQ broker that will be available
+  for the duration of the call via *mq*."
   [f]
-  (with-test-broker "test" conn
-    (binding [*mq*   {:connection-string "vm://test"
-                      :endpoint          "puppetlabs.puppetdb.commands"}
-              *conn* conn]
+  (with-test-broker "test" connection
+    (binding [*mq* {:connection connection
+                    :endpoint "puppetlabs.puppetdb.commands"}]
       (f))))
 
 (defn with-http-app

--- a/test/puppetlabs/puppetdb/http/command_test.clj
+++ b/test/puppetlabs/puppetdb/http/command_test.clj
@@ -80,8 +80,11 @@
     (fixt/*app* (request good-payload good-checksum))
     (fixt/*app* (request bad-payload bad-checksum))
 
-    (let [[good-msg bad-msg] (mq/bounded-drain-into-vec! fixt/*conn* "puppetlabs.puppetdb.commands" 2)
-          good-command       (json/parse-string (:body good-msg) true)]
+    (let [[good-msg bad-msg] (mq/bounded-drain-into-vec!
+                              (:connection fixt/*mq*)
+                              "puppetlabs.puppetdb.commands"
+                              2)
+          good-command (json/parse-string (:body good-msg) true)]
       (testing "should be timestamped when parseable"
         (let [timestamp (get-in good-msg [:headers :received])]
           (time/parse (time/formatters :date-time) timestamp)))


### PR DESCRIPTION
(PDB-1252) Remove clamq; use ActiveMQ directly
    
Remove clamq entirely, and instead, just call ActiveMQ and javax.jms
directly.
