### PR TITLE
(maint) Add =-after? macro for import/export testing

### DIFF
--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -187,6 +187,12 @@
        (is (= expected actual)
            (str response)))))
 
+(defmacro =-after?
+  "Checks equality of `args` after
+   the `func` has been applied to them"
+  [func & args]
+  `(= ~@(map #(list func %) args)))
+
 (defn assert-success!
   "Given a Ring response, verify that the status
   code is 200 OK.  If not, print the body and fail."


### PR DESCRIPTION
This commit adds an =-after? macro for use in puppetdb tests which takes
some transform function as its first arg and applies that function to
all subsequent args.