### PR TITLE
(PDB-1254) move latest report to certnames table

### DIFF
--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -28,8 +28,11 @@ TODO
 
 * The reports endpoint now implements the latest_report? query, which filters the
 response to only include reports that are from the latest puppet run for each
-node.
-([PDB-1244](https://tickets.puppetlabs.com/browse/PDB-1244))
+node.  ([PDB-1244](https://tickets.puppetlabs.com/browse/PDB-1244))
+
+* We have dropped the latest_reports table in favor of storing a reference to
+  the latest report of each certname in the certnames table.
+  ([PDB-1254](https://tickets.puppetlabs.com/browse/PDB-1254))
 
 #### Bug Fixes and Maintenance
 

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -571,7 +571,7 @@
               :params [value]}
 
              ["latest_report?"]
-             {:where (format "resource_events.report_id %s (SELECT latest_reports.report_id FROM latest_reports)"
+             {:where (format "resource_events.report_id %s (SELECT certnames.latest_report FROM certnames)"
                              (if value "IN" "NOT IN"))}
 
              ["environment"]

--- a/src/puppetlabs/puppetdb/query/reports.clj
+++ b/src/puppetlabs/puppetdb/query/reports.clj
@@ -198,7 +198,7 @@
    :post [(kitchensink/boolean? %)]}
   (= 1 (count (jdbc/query-to-vec
                ["SELECT reports.hash as latest_report_hash
-                 FROM latest_reports
-                 INNER JOIN reports ON reports.id = latest_reports.report_id
-                 WHERE latest_reports.certname = ? AND reports.hash = ?"
+                 FROM certnames
+                 INNER JOIN reports ON reports.id = certnames.latest_report_id
+                 WHERE certnames.certname = ? AND reports.hash = ?"
                 node report-hash]))))

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -62,7 +62,7 @@
                             LEFT OUTER JOIN factsets as fs ON certnames.certname = fs.certname
                             LEFT OUTER JOIN reports ON certnames.certname = reports.certname
                              AND reports.id
-                               IN (SELECT report_id FROM latest_reports)
+                               IN (SELECT latest_report_id FROM certnames)
                             LEFT OUTER JOIN environments AS catalog_environment ON catalog_environment.id = catalogs.environment_id
                             LEFT OUTER JOIN environments AS facts_environment ON facts_environment.id = fs.environment_id
                             LEFT OUTER JOIN environments AS reports_environment ON reports_environment.id = reports.environment_id"}))
@@ -394,11 +394,11 @@
                :queryable-fields ["latest_report_hash"]
                :alias "latest_report"
                :subquery? false
-               :source-table "latest_report"
+               :source-table "certnames"
                :supports-extract? true
                :source "SELECT reports.hash as latest_report_hash
-                        FROM latest_reports
-                        INNER JOIN reports ON reports.id = latest_reports.report_id"}))
+                        FROM certnames
+                        INNER JOIN reports ON reports.id = certnames.latest_report_id"}))
 
 (def environments-query
   "Basic environments query, more useful when used with subqueries"

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -890,7 +890,7 @@
     "ALTER TABLE factsets ADD hash VARCHAR(40)"
     "ALTER TABLE factsets ADD CONSTRAINT factsets_hash_key UNIQUE (hash)"))
 
-(defn migrate-to-report-id-and-noop-column
+(defn migrate-to-report-id-and-noop-column-and-drop-latest-reports
   "Migrate to report id and
    insert a column in reports to be populated by boolean noop flag"
   []
@@ -927,10 +927,10 @@
                       ["containment_path" (scf-utils/sql-array-type-string "TEXT")]
                       ["containing_class" "varchar(255)"])
 
-    (sql/create-table :latest_reports_transform
-                      ["certname"  "text NOT NULL"]
-                      ["report_id" "bigint NOT NULL"])
-
+    (sql/create-table :certnames_transform
+                      ["name"  "text NOT NULL"]
+                      ["latest_report_id" "bigint"]
+                      ["deactivated" "timestamp with time zone"])
 
     (sql/do-commands
      "INSERT INTO reports_transform (
@@ -958,19 +958,26 @@
           INNER JOIN reports_transform rt on re.report = rt.hash")
 
     (sql/do-commands
-     "INSERT INTO latest_reports_transform(certname, report_id)
-        SELECT lr.certname, rt.id
-          FROM latest_reports AS lr
-          INNER JOIN reports_transform rt on lr.report = rt.hash")
+
+      "INSERT INTO certnames_transform(name,latest_report_id,deactivated)
+       SELECT c.name, rt.id as latest_report_id, c.deactivated FROM
+       certnames c left outer join latest_reports lr on c.name=lr.certname
+       inner join reports_transform rt on lr.report=rt.hash"
+
+      "ALTER TABLE edges DROP CONSTRAINT edges_certname_fkey"
+      "ALTER TABLE catalogs DROP CONSTRAINT catalogs_certname_fkey"
+      "ALTER TABLE factsets DROP CONSTRAINT factsets_certname_fk"
+
+      "DROP TABLE latest_reports"
+      "DROP TABLE certnames CASCADE"
+      "ALTER TABLE certnames_transform RENAME TO certnames")
 
     (sql/do-commands
      "DROP TABLE resource_events"
-     "DROP TABLE latest_reports"
      "DROP TABLE reports")
 
     (sql/do-commands
      "ALTER TABLE resource_events_transform RENAME to resource_events"
-     "ALTER TABLE latest_reports_transform RENAME to latest_reports"
      "ALTER TABLE reports_transform RENAME to reports")
 
     (sql/do-commands
@@ -980,15 +987,8 @@
      "CREATE INDEX idx_reports_environment_id ON reports(environment_id)"
      "CREATE INDEX idx_reports_status_id ON reports(status_id)"
      "CREATE INDEX idx_reports_transaction_uuid ON reports(transaction_uuid)"
-     "ALTER TABLE reports ADD CONSTRAINT reports_certname_fkey FOREIGN KEY (certname) REFERENCES certnames(name) ON DELETE CASCADE"
      "ALTER TABLE reports ADD CONSTRAINT reports_env_fkey FOREIGN KEY (environment_id) REFERENCES environments(id) ON DELETE CASCADE"
      "ALTER TABLE reports ADD CONSTRAINT reports_status_fkey FOREIGN KEY (status_id) REFERENCES report_statuses(id) ON DELETE CASCADE")
-
-    (sql/do-commands
-     "ALTER TABLE latest_reports ADD CONSTRAINT latest_reports_pkey PRIMARY KEY (certname)"
-     "CREATE INDEX idx_latest_reports_report_id ON latest_reports(report_id)"
-     "ALTER TABLE latest_reports ADD CONSTRAINT latest_reports_certname_fkey FOREIGN KEY (certname) REFERENCES certnames(name) ON DELETE CASCADE"
-     "ALTER TABLE latest_reports ADD CONSTRAINT latest_reports_report_id_fkey FOREIGN KEY (report_id) REFERENCES reports(id) ON DELETE CASCADE")
 
     (sql/do-commands
      "ALTER TABLE resource_events ADD CONSTRAINT resource_events_unique UNIQUE (report_id, resource_type, resource_title, property)"
@@ -999,7 +999,19 @@
      "CREATE INDEX idx_resource_events_resource_title ON resource_events(resource_title)"
      "CREATE INDEX idx_resource_events_status ON resource_events(status)"
      "CREATE INDEX idx_resource_events_timestamp ON resource_events(timestamp)"
-     "ALTER TABLE resource_events ADD CONSTRAINT resource_events_report_id_fkey FOREIGN KEY (report_id) REFERENCES reports(id) ON DELETE CASCADE"))
+     "ALTER TABLE resource_events ADD CONSTRAINT resource_events_report_id_fkey FOREIGN KEY (report_id) REFERENCES reports(id) ON DELETE CASCADE")
+
+    (sql/do-commands
+      "ALTER TABLE certnames ADD CONSTRAINT certnames_pkey PRIMARY KEY (name)"
+      "CREATE INDEX idx_certnames_latest_report_id ON certnames(latest_report_id)"
+      "ALTER TABLE edges ADD CONSTRAINT edges_certname_fkey FOREIGN KEY (certname) REFERENCES certnames(name) ON UPDATE NO ACTION ON DELETE CASCADE"
+      "ALTER TABLE catalogs ADD CONSTRAINT catalogs_certname_fkey FOREIGN KEY (certname) REFERENCES certnames(name) ON UPDATE NO ACTION ON DELETE CASCADE"
+      "ALTER TABLE factsets ADD CONSTRAINT factsets_certname_fk FOREIGN KEY (certname) REFERENCES certnames(name) ON UPDATE CASCADE ON DELETE CASCADE"
+      "ALTER TABLE reports ADD CONSTRAINT reports_certname_fkey FOREIGN KEY (certname) REFERENCES certnames(name) ON DELETE CASCADE")
+
+    (when (scf-utils/postgres?)
+      (sql/do-commands
+        "ALTER TABLE certnames ADD CONSTRAINT certnames_reports_id_fkey FOREIGN KEY (latest_report_id) REFERENCES reports(id) ON DELETE SET NULL")))
 
 (defn change-name-to-certname
   "Rename the 'name' column of certnames to 'certname'."
@@ -1039,7 +1051,7 @@
    26 structured-facts-deferrable-constraints
    27 switch-value-string-index-to-gin
    28 insert-factset-hash-column
-   29 migrate-to-report-id-and-noop-column
+   29 migrate-to-report-id-and-noop-column-and-drop-latest-reports
    30 change-name-to-certname})
 
 (def desired-schema-version (apply max (keys migrations)))


### PR DESCRIPTION
Prior to this commit we were storing two columns of certnames, one in latest_reports
and one in certnames. This moves the report_id column of latest_reports to a new
latest_report column in certnames, then dropso the latest_reports table to eliminate
the redundancy.