### PR TITLE
(PDB-908) Remove dyanmic from mq-endpoint, test function refactors

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -76,8 +76,12 @@
 ;; PuppetDB components.
 
 (def mq-addr "vm://localhost?jms.prefetchPolicy.all=1&create=false")
-(def ^:dynamic mq-endpoint "puppetlabs.puppetdb.commands")
-(def send-command! (partial command/enqueue-command! mq-addr mq-endpoint))
+(def mq-endpoint "puppetlabs.puppetdb.commands")
+
+(defn send-command!
+  "Send the command using the default MQ address and endpoint"
+  [command version payload]
+  (command/enqueue-command! mq-addr mq-endpoint command version payload))
 
 (defn auto-deactivate-nodes!
   "Deactivate nodes which haven't had any activity (catalog/fact submission)
@@ -302,8 +306,8 @@
                     (assoc context :updater updater)
                     context)
           _       (let [authorizer (if-let [wl (:certificate-whitelist puppetdb)]
-                                          (build-whitelist-authorizer wl)
-                                          (constantly :authorized))
+                                     (build-whitelist-authorizer wl)
+                                     (constantly :authorized))
                         app (server/build-app :globals globals :authorizer authorizer)]
                     (log/info "Starting query server")
                     (add-ring-handler service (compojure/context url-prefix [] app)))

--- a/src/puppetlabs/puppetdb/query/factsets.clj
+++ b/src/puppetlabs/puppetdb/query/factsets.clj
@@ -43,14 +43,6 @@
 
 ;; FUNCS
 
-(defn create-certname-pred
-  "Create a function to compare the certnames in a list of
-  rows with that of the first row."
-  [rows]
-  (let [certname (:certname (first rows))]
-    (fn [row]
-      (= certname (:certname row)))))
-
 (pls/defn-validated convert-types :- [converted-row-schema]
   [rows :- [row-schema]]
   (map (partial facts/convert-row-type [:type :value_integer :value_float]) rows))
@@ -97,7 +89,7 @@
   "Produce a lazy sequence of facts from a list of rows ordered by fact name"
   [version :- s/Keyword
    rows]
-  (utils/collapse-seq create-certname-pred
+  (utils/collapse-seq utils/create-certname-pred
                       (comp #(collapse-factset version %) convert-types)
                       rows))
 

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -192,3 +192,11 @@
       (binding [*out* *err*] (flush))
       (flush)
       (System/exit status))))
+
+(defn create-certname-pred
+  "Create a function to compare the certnames in a list of
+  rows with that of the first row."
+  [rows]
+  (let [certname (:certname (first rows))]
+    (fn [row]
+      (= certname (:certname row)))))

--- a/test/puppetlabs/puppetdb/testutils/jetty.clj
+++ b/test/puppetlabs/puppetdb/testutils/jetty.clj
@@ -5,6 +5,7 @@
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tkbs]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :refer [webrouting-service]]
+            [puppetlabs.puppetdb.client :as pdb-client]
             [puppetlabs.puppetdb.cli.services :refer [puppetdb-service mq-endpoint]]
             [puppetlabs.puppetdb.metrics :refer [metrics-service]]
             [puppetlabs.puppetdb.mq-listener :refer [message-listener-service]]
@@ -263,8 +264,7 @@
                                                      (.setUseJmx broker# false))]
      (do ~@body)))
 
-(defmacro with-command-endpoint
-  "Invoke `body` with a different command endpoint (destination) name"
-  [new-endpoint-name & body]
-  `(binding [puppetlabs.puppetdb.cli.services/mq-endpoint ~new-endpoint-name]
-     (do ~@body)))
+(defn sync-command-post [base-url cmd version payload]
+  (until-consumed
+   (fn []
+     (pdb-client/submit-command-via-http! base-url cmd version payload))))


### PR DESCRIPTION
Making mq-endpoint ended up not being useful in running multiple
PuppetDB command queues, this commit removes it. This also moves a
couple of now shared functions to a more reusable place.