### PR TITLE
(maint) Switch us to use c4.large instances for acceptance

### DIFF
--- a/acceptance/config/ec2-west-debian6-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-debian6-64mda-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: debian6-amd64-west
     platform: debian-6-amd64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7
@@ -17,7 +17,7 @@ HOSTS:
       - agent
     vmname: debian6-amd64-west
     platform: debian-6-amd64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7

--- a/acceptance/config/ec2-west-debian7-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-debian7-64mda-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: debian-7-amd64-west
     platform: debian-7-amd64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7
@@ -17,7 +17,7 @@ HOSTS:
       - agent
     vmname: debian-7-amd64-west
     platform: debian-7-amd64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7

--- a/acceptance/config/ec2-west-el5-64mda-el5-64a.cfg
+++ b/acceptance/config/ec2-west-el5-64mda-el5-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: el-5-x86_64-west
     platform: el-5-x86_64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7
@@ -17,7 +17,7 @@ HOSTS:
       - agent
     vmname: el-5-x86_64-west
     platform: el-5-x86_64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7

--- a/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: el-6-x86_64-west
     platform: el-6-x86_64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7
@@ -17,7 +17,7 @@ HOSTS:
       - agent
     vmname: el-5-x86_64-west
     platform: el-5-x86_64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7
@@ -27,7 +27,7 @@ HOSTS:
       - agent
     vmname: ubuntu-12.04-amd64-west
     platform: ubuntu-12.04-amd64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7

--- a/acceptance/config/ec2-west-el6-64mda-el6-64a.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-el6-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: el-6-x86_64-west
     platform: el-6-x86_64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7
@@ -17,7 +17,7 @@ HOSTS:
       - agent
     vmname: el-6-x86_64-west
     platform: el-6-x86_64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7

--- a/acceptance/config/ec2-west-el6-64mda.cfg
+++ b/acceptance/config/ec2-west-el6-64mda.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - database
     vmname: el-6-x86_64-west
     platform: el-6-x86_64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7

--- a/acceptance/config/ec2-west-el7-64mda-el7-64a.cfg
+++ b/acceptance/config/ec2-west-el7-64mda-el7-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: el-7-x86_64-west
     platform: el-7-x86_64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7
@@ -17,7 +17,7 @@ HOSTS:
       - agent
     vmname: el-7-x86_64-west
     platform: el-7-x86_64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7

--- a/acceptance/config/ec2-west-f20-64mda-f20-64a.cfg
+++ b/acceptance/config/ec2-west-f20-64mda-f20-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - database
     vmname: fedora-20-x86_64-west
     platform: fedora-20-x86_64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7
@@ -17,7 +17,7 @@ HOSTS:
       - agent
     vmname: fedora-20-x86_64-west
     platform: fedora-20-x86_64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7

--- a/acceptance/config/ec2-west-ubuntu1004-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1004-64mda-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: ubuntu-10.04-amd64-west
     platform: ubuntu-10.04-amd64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7
@@ -17,7 +17,7 @@ HOSTS:
       - agent
     vmname: ubuntu-10.04-amd64-west
     platform: ubuntu-10.04-amd64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7

--- a/acceptance/config/ec2-west-ubuntu1204-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1204-64mda-64a.cfg
@@ -7,7 +7,7 @@ HOSTS:
       - agent
     vmname: ubuntu-12.04-amd64-west
     platform: ubuntu-12.04-amd64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7
@@ -17,7 +17,7 @@ HOSTS:
       - agent
     vmname: ubuntu-12.04-amd64-west
     platform: ubuntu-12.04-amd64
-    amisize: c3.large
+    amisize: c4.large
     hypervisor: ec2
     snapshot: foss
     subnet_id: subnet-92dd65f7


### PR DESCRIPTION
The c3.large instances are starting to hit capacity in Oregon, this switches
us to c4.large which are ever-so-slightly faster, but lack the SSD disks (we
don't use these anyway).

Signed-off-by: Ken Barber <ken@bob.sh>