### PR TITLE
(maint) Switch to different subnet-id for different availability zone

### DIFF
--- a/acceptance/config/ec2-west-debian6-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-debian6-64mda-64a.cfg
@@ -10,7 +10,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
   debian6-64-2:
     roles:
@@ -20,7 +20,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none

--- a/acceptance/config/ec2-west-debian7-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-debian7-64mda-64a.cfg
@@ -10,7 +10,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
   debian7-64-2:
     roles:
@@ -20,7 +20,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none

--- a/acceptance/config/ec2-west-el5-64mda-el5-64a.cfg
+++ b/acceptance/config/ec2-west-el5-64mda-el5-64a.cfg
@@ -10,7 +10,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
   el5-64-2:
     roles:
@@ -20,7 +20,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none

--- a/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
@@ -10,7 +10,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
   el5-64-1:
     roles:
@@ -20,7 +20,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
   ubuntu-12.04-64-1:
     roles:
@@ -30,7 +30,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none

--- a/acceptance/config/ec2-west-el6-64mda-el6-64a.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-el6-64a.cfg
@@ -10,7 +10,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
   el6-64-2:
     roles:
@@ -20,7 +20,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none

--- a/acceptance/config/ec2-west-el6-64mda.cfg
+++ b/acceptance/config/ec2-west-el6-64mda.cfg
@@ -10,7 +10,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
 
 CONFIG:

--- a/acceptance/config/ec2-west-el7-64mda-el7-64a.cfg
+++ b/acceptance/config/ec2-west-el7-64mda-el7-64a.cfg
@@ -10,7 +10,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
   el7-64-2:
     roles:
@@ -20,7 +20,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none

--- a/acceptance/config/ec2-west-f20-64mda-f20-64a.cfg
+++ b/acceptance/config/ec2-west-f20-64mda-f20-64a.cfg
@@ -10,7 +10,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
   fedora-20-2:
     roles:
@@ -20,7 +20,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
 
 CONFIG:

--- a/acceptance/config/ec2-west-ubuntu1004-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1004-64mda-64a.cfg
@@ -10,7 +10,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
   ubuntu-1004-64-2:
     roles:
@@ -20,7 +20,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none

--- a/acceptance/config/ec2-west-ubuntu1204-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1204-64mda-64a.cfg
@@ -10,7 +10,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
   ubuntu-1204-64-2:
     roles:
@@ -20,7 +20,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-92dd65f7
+    subnet_id: subnet-4a74d73d
     vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none


### PR DESCRIPTION
This switches us to availability zone us-west-2a to work on c3.large
capacity issues in us-west-2b.

Signed-off-by: Ken Barber <ken@bob.sh>