### PR TITLE
(PDB-1247) Upgrade TK, move certificate-whitelist

### DIFF
--- a/acceptance/tests/security/cert_whitelist_legacy.rb
+++ b/acceptance/tests/security/cert_whitelist_legacy.rb
@@ -1,4 +1,4 @@
-test_name "certificate whitelisting" do
+test_name "certificate whitelisting using legacy location in [jetty]" do
 
   confd = "#{puppetdb_confdir(database)}/conf.d"
   dbname = database.node_name
@@ -7,10 +7,10 @@ test_name "certificate whitelisting" do
   ssldir = stdout.chomp
 
   step "reconfigure PuppetDB to use certificate whitelist" do
-    on database, "cp #{confd}/config.ini #{confd}/config.ini.bak"
-    on database, "grep -v ^certificate-whitelist #{confd}/config.ini > #{confd}/config.ini.tmp"
-    on database, "mv -f #{confd}/config.ini.tmp #{confd}/config.ini"
-    modify_config_setting(database, "config.ini", "puppetdb",
+    on database, "cp #{confd}/jetty.ini #{confd}/jetty.ini.bak"
+    on database, "grep -v ^certificate-whitelist #{confd}/jetty.ini > #{confd}/jetty.ini.tmp"
+    on database, "mv -f #{confd}/jetty.ini.tmp #{confd}/jetty.ini"
+    modify_config_setting(database, "jetty.ini", "jetty",
                           "certificate-whitelist", "#{confd}/whitelist")
   end
 
@@ -20,7 +20,7 @@ test_name "certificate whitelisting" do
     create_remote_file database, "#{confd}/whitelist", whitelist
     on database, "chmod 644 #{confd}/whitelist"
     restart_puppetdb database
-    on database, "curl --tlsv1 -sL -w '%{http_code}\\n' " +
+    on database, "curl -sL -w '%{http_code}\\n' " +
                  "--cacert #{ssldir}/certs/ca.pem " +
                  "--cert #{ssldir}/certs/#{dbname}.pem " +
                  "--key #{ssldir}/private_keys/#{dbname}.pem "+
@@ -38,9 +38,9 @@ test_name "certificate whitelisting" do
     curl_against_whitelist.call "", 403
   end
 
-  step "restore original config.ini" do
-    on database, "mv #{confd}/config.ini.bak #{confd}/config.ini"
-    on database, "chmod 644 #{confd}/config.ini"
+  step "restore original jetty.ini" do
+    on database, "mv #{confd}/jetty.ini.bak #{confd}/jetty.ini"
+    on database, "chmod 644 #{confd}/jetty.ini"
     on database, "rm #{confd}/whitelist"
     restart_puppetdb database
   end

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -180,6 +180,19 @@ This optional setting may be used to mount the PuppetDB web application at a URL
 unless you intend to run additional web applications in the same server with your PuppetDB instance.  **NOTE:** if you change
 this setting, you must also set the corresponding setting in your Puppet Master's [puppetdb.conf][puppetdb.conf] file.
 
+
+`[puppetdb]` Settings
+-----
+
+The `[puppetdb]` section is used to configure PuppetDB application specific behavior.
+
+### `certificate-whitelist`
+
+Optional. This describes the path to a file that contains a list of certificate names, one per line.  Incoming HTTPS requests will have their certificates validated against this list of names and only those with an _exact_ matching entry will be allowed through. (For a puppet master, this compares against the value of the `certname` setting, rather than the `dns_alt_names` setting.)
+
+If not supplied, PuppetDB uses standard HTTPS without any additional authorization. All HTTPS clients must still supply valid, verifiable SSL client certificates.
+
+
 `[database]` Settings
 -----
 
@@ -529,11 +542,6 @@ This describes the path to a Java keystore file containing the CA certificate(s)
 
 This sets the passphrase to use for unlocking the truststore file.
 
-### `certificate-whitelist`
-
-Optional. This describes the path to a file that contains a list of certificate names, one per line.  Incoming HTTPS requests will have their certificates validated against this list of names and only those with an _exact_ matching entry will be allowed through. (For a puppet master, this compares against the value of the `certname` setting, rather than the `dns_alt_names` setting.)
-
-If not supplied, PuppetDB uses standard HTTPS without any additional authorization. All HTTPS clients must still supply valid, verifiable SSL client certificates.
 
 ### `cipher-suites`
 

--- a/project.clj
+++ b/project.clj
@@ -15,9 +15,9 @@
            (s/trim out)
            "0.0-dev-build"))))))
 
-(def tk-version "0.3.4")
-(def tk-jetty9-version "0.3.3")
-(def ks-version "0.5.3")
+(def tk-version "0.5.1")
+(def tk-jetty9-version "0.7.5")
+(def ks-version "0.7.2")
 
 (defproject puppetdb (version-string)
   :description "Puppet-integrated catalog and fact storage"
@@ -59,7 +59,7 @@
                  [clamq/clamq-activemq "0.4" :exclusions [org.slf4j/slf4j-api]]
                  [org.apache.activemq/activemq-core "5.6.0" :exclusions [org.slf4j/slf4j-api org.fusesource.fuse-extra/fusemq-leveldb]]
                  ;; bridge to allow some spring/activemq stuff to log over slf4j
-                 [org.slf4j/jcl-over-slf4j "1.7.5"]
+                 [org.slf4j/jcl-over-slf4j "1.7.6"]
                  ;; WebAPI support libraries.
                  [net.cgrand/moustache "1.1.0" :exclusions [ring/ring-core org.clojure/clojure]]
                  [compojure "1.1.6"]
@@ -69,7 +69,7 @@
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]
-                 [prismatic/schema "0.2.1"]
+                 [prismatic/schema "0.2.2"]
                  [org.clojure/tools.macro "0.1.5"]
                  [com.novemberain/pantomime "2.1.0"]
                  [fast-zip-visit "1.0.2"]

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -57,7 +57,9 @@
             [com.puppetlabs.puppetdb.config :as conf]
             [com.puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.kitchensink.core :as kitchensink]
+            [robert.hooke :as rh]
             [puppetlabs.trapperkeeper.core :refer [defservice main]]
+            [puppetlabs.trapperkeeper.services :refer [service-id]]
             [compojure.core :as compojure]
             [clojure.java.io :refer [file]]
             [clj-time.core :refer [ago]]
@@ -257,7 +259,7 @@
          (ifn? shutdown-on-error)]
    :post [(map? %)
           (every? (partial contains? %) [:broker :command-procs :updater])]}
-  (let [{:keys [jetty database read-database global command-processing]
+  (let [{:keys [jetty database read-database global command-processing puppetdb]
          :as config}                            (conf/process-config! config)
         product-name                               (:product-name global)
         update-server                              (:update-server global)
@@ -322,7 +324,7 @@
           context (assoc context :command-procs command-procs)
           updater (future (maybe-check-for-updates product-name update-server read-db))
           context (assoc context :updater updater)
-          _       (let [authorized? (if-let [wl (jetty :certificate-whitelist)]
+          _       (let [authorized? (if-let [wl (puppetdb :certificate-whitelist)]
                                       (build-whitelist-authorizer wl)
                                       (constantly true))
                         app (server/build-app :globals globals :authorized? authorized?)]
@@ -369,6 +371,10 @@
         (stop-puppetdb context)))
 
 (defn -main
+  "Calls the trapperkeeper main argument to initialize tk.
+
+   For configuration customization, we intercept the call to parse-config-data
+   within TK."
   [& args]
   (rh/add-hook #'puppetlabs.trapperkeeper.config/parse-config-data #'conf/hook-tk-parse-config-data)
   (apply main args))

--- a/src/com/puppetlabs/puppetdb/config.clj
+++ b/src/com/puppetlabs/puppetdb/config.clj
@@ -7,7 +7,6 @@
   (:import [java.security KeyStore]
            [org.joda.time Minutes Days Period])
   (:require [clojure.tools.logging :as log]
-            [puppetlabs.kitchensink.ssl :as ssl]
             [puppetlabs.kitchensink.core :as kitchensink]
             [com.puppetlabs.time :as pl-time]
             [clj-time.core :as time]
@@ -115,6 +114,10 @@
    (s/optional-key :store-usage) s/Int
    (s/optional-key :temp-usage) s/Int})
 
+(def puppetdb-config-in
+  "Schema for validating the [puppetdb] block"
+  {(s/optional-key :certificate-whitelist) s/Str})
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Database config
 
@@ -208,13 +211,20 @@
     (s/validate command-processing-out converted-config)
     (assoc config :command-processing converted-config)))
 
+(defn configure-puppetdb
+  "Validates the [puppetdb] section of the config"
+  [{:keys [puppetdb] :as config :or {puppetdb {}}}]
+  (s/validate puppetdb-config-in puppetdb)
+  (assoc config :puppetdb puppetdb))
+
 (defn convert-config
   "Given a `config` map (created from the user defined config), validate, default and convert it
    to the internal Clojure format that PuppetDB expects"
   [config]
   (-> config
       configure-dbs
-      configure-command-params))
+      configure-command-params
+      configure-puppetdb))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Global Config
@@ -340,6 +350,22 @@
     (warn-if-sslv3 config-data)
     (assoc-in config-data [:jetty :ssl-protocols] "TLSv1, TLSv1.1, TLSv1.2")))
 
+(defn fix-tk-config
+  "Fix configuration before passing it to trapperkeeper.
+
+   In particular:
+   * Move certificate-whitelist from [jetty] to [global]"
+  [config-data]
+  (if-let [cw (get-in config-data [:jetty :certificate-whitelist])]
+    (do
+      ;; Log to stderr, logging is not yet initialized (and may never be).
+      (binding [*out* *err*]
+          (println "Option `certificate-whitelist` in [jetty] is now deprecated, the option must now be placed in [puppetdb]"))
+      (-> config-data
+          (kitchensink/dissoc-in [:jetty :certificate-whitelist])
+          (assoc-in [:puppetdb :certificate-whitelist] cw)))
+    config-data))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
@@ -349,7 +375,9 @@
    customize it."
   [f args]
   (let [config (f args)]
-    (default-ssl-protocols config)))
+    (->> config
+         default-ssl-protocols
+         fix-tk-config)))
 
 (defn process-config!
   "Accepts a map containing all of the user-provided configuration values

--- a/src/com/puppetlabs/puppetdb/http/metrics.clj
+++ b/src/com/puppetlabs/puppetdb/http/metrics.clj
@@ -19,6 +19,9 @@
               (map? v)
               [k (filter-mbean v)]
 
+              (instance? java.util.HashMap v)
+              [k (filter-mbean (into {} v))]
+
               ;; Cheshire can serialize to JSON anything that
               ;; implements the JSONable protocol
               (satisfies? JSONable v)

--- a/test/com/puppetlabs/puppetdb/testutils/jetty.clj
+++ b/test/com/puppetlabs/puppetdb/testutils/jetty.clj
@@ -32,7 +32,7 @@
    returns the first one."
   [server]
   (-> @(tka/app-context server)
-      (get-in [:WebserverService :jetty9-server :server])
+      (get-in [:WebserverService :jetty9-servers :default :server])
       .getConnectors
       first
       .getLocalPort))


### PR DESCRIPTION
This is a cherry-pick of commit ea8f696, whose commit message is as 
follows:

This patch upgrades trapperkeeper, and the jetty component to the latest
revision. All lines of this patch are attributable to getting this to
work.

The major change was the change to certificate-whitelist, which is
not supported in trapperkeeper-webserver-jetty9 so we had to intercept
the configuration item, deprecate it and move it to a new [puppetdb] section
so we could do this work ourselves.

We avoid using [global] in this instance, since we have identified
a potential to clash if we want to bundle PDB with other clojure applications,
this is a general problem anyway - but our first move to try and reduce
this potential.