### PR TITLE
(PDB-1247) Upgrade TK to get max-threads support

### DIFF
--- a/acceptance/tests/security/cert_whitelist_legacy.rb
+++ b/acceptance/tests/security/cert_whitelist_legacy.rb
@@ -1,4 +1,4 @@
-test_name "certificate whitelisting" do
+test_name "certificate whitelisting using legacy location in [jetty]" do
 
   confd = "#{puppetdb_confdir(database)}/conf.d"
   dbname = database.node_name
@@ -7,10 +7,10 @@ test_name "certificate whitelisting" do
   ssldir = stdout.chomp
 
   step "reconfigure PuppetDB to use certificate whitelist" do
-    on database, "cp #{confd}/config.ini #{confd}/config.ini.bak"
-    on database, "grep -v ^certificate-whitelist #{confd}/config.ini > #{confd}/config.ini.tmp"
-    on database, "mv -f #{confd}/config.ini.tmp #{confd}/config.ini"
-    modify_config_setting(database, "config.ini", "puppetdb",
+    on database, "cp #{confd}/jetty.ini #{confd}/jetty.ini.bak"
+    on database, "grep -v ^certificate-whitelist #{confd}/jetty.ini > #{confd}/jetty.ini.tmp"
+    on database, "mv -f #{confd}/jetty.ini.tmp #{confd}/jetty.ini"
+    modify_config_setting(database, "jetty.ini", "jetty",
                           "certificate-whitelist", "#{confd}/whitelist")
   end
 
@@ -20,7 +20,7 @@ test_name "certificate whitelisting" do
     create_remote_file database, "#{confd}/whitelist", whitelist
     on database, "chmod 644 #{confd}/whitelist"
     restart_puppetdb database
-    on database, "curl --tlsv1 -sL -w '%{http_code}\\n' " +
+    on database, "curl -sL -w '%{http_code}\\n' " +
                  "--cacert #{ssldir}/certs/ca.pem " +
                  "--cert #{ssldir}/certs/#{dbname}.pem " +
                  "--key #{ssldir}/private_keys/#{dbname}.pem "+
@@ -38,9 +38,9 @@ test_name "certificate whitelisting" do
     curl_against_whitelist.call "", 403
   end
 
-  step "restore original config.ini" do
-    on database, "mv #{confd}/config.ini.bak #{confd}/config.ini"
-    on database, "chmod 644 #{confd}/config.ini"
+  step "restore original jetty.ini" do
+    on database, "mv #{confd}/jetty.ini.bak #{confd}/jetty.ini"
+    on database, "chmod 644 #{confd}/jetty.ini"
     on database, "rm #{confd}/whitelist"
     restart_puppetdb database
   end

--- a/acceptance/tests/security/cert_whitelist_legacy.rb
+++ b/acceptance/tests/security/cert_whitelist_legacy.rb
@@ -20,7 +20,7 @@ test_name "certificate whitelisting using legacy location in [jetty]" do
     create_remote_file database, "#{confd}/whitelist", whitelist
     on database, "chmod 644 #{confd}/whitelist"
     restart_puppetdb database
-    on database, "curl -sL -w '%{http_code}\\n' " +
+    on database, "curl --tlsv1 -sL -w '%{http_code}\\n' " +
                  "--cacert #{ssldir}/certs/ca.pem " +
                  "--cert #{ssldir}/certs/#{dbname}.pem " +
                  "--key #{ssldir}/private_keys/#{dbname}.pem "+

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -184,7 +184,7 @@ this setting, you must also set the corresponding setting in your Puppet Master'
 `[puppetdb]` Settings
 -----
 
-The `[puppetdb]` section is used to configure PuppetDB application specific behavior.
+The `[puppetdb]` section is used to configure PuppetDB application-specific behavior.
 
 ### `certificate-whitelist`
 

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -180,6 +180,19 @@ This optional setting may be used to mount the PuppetDB web application at a URL
 unless you intend to run additional web applications in the same server with your PuppetDB instance.  **NOTE:** if you change
 this setting, you must also set the corresponding setting in your Puppet Master's [puppetdb.conf][puppetdb.conf] file.
 
+
+`[puppetdb]` Settings
+-----
+
+The `[puppetdb]` section is used to configure PuppetDB application specific behavior.
+
+### `certificate-whitelist`
+
+Optional. This describes the path to a file that contains a list of certificate names, one per line.  Incoming HTTPS requests will have their certificates validated against this list of names and only those with an _exact_ matching entry will be allowed through. (For a puppet master, this compares against the value of the `certname` setting, rather than the `dns_alt_names` setting.)
+
+If not supplied, PuppetDB uses standard HTTPS without any additional authorization. All HTTPS clients must still supply valid, verifiable SSL client certificates.
+
+
 `[database]` Settings
 -----
 
@@ -529,11 +542,6 @@ This describes the path to a Java keystore file containing the CA certificate(s)
 
 This sets the passphrase to use for unlocking the truststore file.
 
-### `certificate-whitelist`
-
-Optional. This describes the path to a file that contains a list of certificate names, one per line.  Incoming HTTPS requests will have their certificates validated against this list of names and only those with an _exact_ matching entry will be allowed through. (For a puppet master, this compares against the value of the `certname` setting, rather than the `dns_alt_names` setting.)
-
-If not supplied, PuppetDB uses standard HTTPS without any additional authorization. All HTTPS clients must still supply valid, verifiable SSL client certificates.
 
 ### `cipher-suites`
 

--- a/project.clj
+++ b/project.clj
@@ -15,9 +15,9 @@
            (s/trim out)
            "0.0-dev-build"))))))
 
-(def tk-version "0.3.4")
-(def tk-jetty9-version "0.3.3")
-(def ks-version "0.5.3")
+(def tk-version "0.5.1")
+(def tk-jetty9-version "0.7.5")
+(def ks-version "0.7.2")
 
 (defproject puppetdb (version-string)
   :description "Puppet-integrated catalog and fact storage"
@@ -59,7 +59,7 @@
                  [clamq/clamq-activemq "0.4" :exclusions [org.slf4j/slf4j-api]]
                  [org.apache.activemq/activemq-core "5.6.0" :exclusions [org.slf4j/slf4j-api org.fusesource.fuse-extra/fusemq-leveldb]]
                  ;; bridge to allow some spring/activemq stuff to log over slf4j
-                 [org.slf4j/jcl-over-slf4j "1.7.5"]
+                 [org.slf4j/jcl-over-slf4j "1.7.6"]
                  ;; WebAPI support libraries.
                  [net.cgrand/moustache "1.1.0" :exclusions [ring/ring-core org.clojure/clojure]]
                  [compojure "1.1.6"]
@@ -69,7 +69,7 @@
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]
-                 [prismatic/schema "0.2.1"]
+                 [prismatic/schema "0.2.2"]
                  [org.clojure/tools.macro "0.1.5"]
                  [com.novemberain/pantomime "2.1.0"]
                  [fast-zip-visit "1.0.2"]

--- a/project.clj
+++ b/project.clj
@@ -15,9 +15,9 @@
            (s/trim out)
            "0.0-dev-build"))))))
 
-(def tk-version "0.5.1")
-(def tk-jetty9-version "0.7.5")
-(def ks-version "0.7.2")
+(def tk-version "1.1.0")
+(def tk-jetty9-version "1.2.0")
+(def ks-version "1.0.0")
 
 (defproject puppetdb (version-string)
   :description "Puppet-integrated catalog and fact storage"
@@ -63,7 +63,7 @@
                  ;; WebAPI support libraries.
                  [net.cgrand/moustache "1.1.0" :exclusions [ring/ring-core org.clojure/clojure]]
                  [compojure "1.1.6"]
-                 [clj-http "0.5.3"]
+                 [clj-http "0.9.2"]
                  [ring/ring-core "1.2.1" :exclusions [javax.servlet/servlet-api]]
                  [org.apache.commons/commons-compress "1.8"]
                  [puppetlabs/kitchensink ~ks-version]

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -58,6 +58,7 @@
             [com.puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.trapperkeeper.core :refer [defservice main]]
+            [puppetlabs.trapperkeeper.services :refer [service-id]]
             [compojure.core :as compojure]
             [clojure.java.io :refer [file]]
             [clj-time.core :refer [ago]]
@@ -257,7 +258,7 @@
          (ifn? shutdown-on-error)]
    :post [(map? %)
           (every? (partial contains? %) [:broker :command-procs :updater])]}
-  (let [{:keys [jetty database read-database global command-processing]
+  (let [{:keys [jetty database read-database global command-processing puppetdb]
          :as config}                            (conf/process-config! config)
         product-name                               (:product-name global)
         update-server                              (:update-server global)
@@ -322,7 +323,7 @@
           context (assoc context :command-procs command-procs)
           updater (future (maybe-check-for-updates product-name update-server read-db))
           context (assoc context :updater updater)
-          _       (let [authorized? (if-let [wl (jetty :certificate-whitelist)]
+          _       (let [authorized? (if-let [wl (puppetdb :certificate-whitelist)]
                                       (build-whitelist-authorizer wl)
                                       (constantly true))
                         app (server/build-app :globals globals :authorized? authorized?)]
@@ -369,6 +370,10 @@
         (stop-puppetdb context)))
 
 (defn -main
+  "Calls the trapperkeeper main argument to initialize tk.
+
+   For configuration customization, we intercept the call to parse-config-data
+   within TK."
   [& args]
   (rh/add-hook #'puppetlabs.trapperkeeper.config/parse-config-data #'conf/hook-tk-parse-config-data)
   (apply main args))

--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -369,11 +369,6 @@
   (stop [this context]
         (stop-puppetdb context)))
 
-(defn -main
-  "Calls the trapperkeeper main argument to initialize tk.
-
-   For configuration customization, we intercept the call to parse-config-data
-   within TK."
-  [& args]
+(defn -main [& args]
   (rh/add-hook #'puppetlabs.trapperkeeper.config/parse-config-data #'conf/hook-tk-parse-config-data)
   (apply main args))

--- a/src/com/puppetlabs/puppetdb/http/metrics.clj
+++ b/src/com/puppetlabs/puppetdb/http/metrics.clj
@@ -19,6 +19,9 @@
               (map? v)
               [k (filter-mbean v)]
 
+              (instance? java.util.HashMap v)
+              [k (filter-mbean (into {} v))]
+
               ;; Cheshire can serialize to JSON anything that
               ;; implements the JSONable protocol
               (satisfies? JSONable v)

--- a/test/com/puppetlabs/puppetdb/test/config.clj
+++ b/test/com/puppetlabs/puppetdb/test/config.clj
@@ -207,27 +207,3 @@
     (is (thrown-with-msg? IllegalArgumentException #"product-name puppet is illegal"
           (normalize-product-name "puppet")))))
 
-(deftest sslv3-warn-test
-  (testing "output to log"
-    (tu-log/with-log-output log-output
-      (let [bad-config {:jetty {:ssl-protocols "SSLv3, TLSv1, TLSv1.1, TLSv1.2"}}]
-        (is (= bad-config
-               (default-ssl-protocols bad-config)))
-        (is (.contains (last (first @log-output)) "contains SSLv3")))))
-
-  (testing "output to standard out"
-    (let [bad-config {:jetty {:ssl-protocols "SSLv3, TLSv1, TLSv1.1, TLSv1.2"}}
-          out-str (with-out-str
-                    (binding [*err* *out*]
-                      (default-ssl-protocols bad-config)))]
-      (is (.contains out-str "contains SSLv3"))))
-
-  (testing "defaulted-config"
-    (tu-log/with-log-output log-output
-      (is (= {:jetty {:ssl-protocols "TLSv1, TLSv1.1, TLSv1.2"}}
-             (default-ssl-protocols {})))
-      (is (empty? @log-output))
-      (is (str/blank?
-             (with-out-str
-               (binding [*err* *out*]
-                 (default-ssl-protocols {}))))))))

--- a/test/com/puppetlabs/puppetdb/testutils/jetty.clj
+++ b/test/com/puppetlabs/puppetdb/testutils/jetty.clj
@@ -32,7 +32,7 @@
    returns the first one."
   [server]
   (-> @(tka/app-context server)
-      (get-in [:WebserverService :jetty9-server :server])
+      (get-in [:WebserverService :jetty9-servers :default :server])
       .getConnectors
       first
       .getLocalPort))


### PR DESCRIPTION
This includes cherry-picks of ea8f696:

    This patch upgrades trapperkeeper, and the jetty component to the latest
    revision. All lines of this patch are attributable to getting this to
    work.

    The major change was the change to certificate-whitelist, which is
    not supported in trapperkeeper-webserver-jetty9 so we had to intercept
    the configuration item, deprecate it and move it to a new [puppetdb] section
    so we could do this work ourselves.

    We avoid using [global] in this instance, since we have identified
    a potential to clash if we want to bundle PDB with other clojure applications,
    this is a general problem anyway - but our first move to try and reduce
    this potential.

and 1476b28:

    Correct the ssl-protocols rewrite for the master branch

    Right now tk-webserver-jetty9 0.7.5 requires a list to be passed to it for
    the setting `ssl-protocols` but our rewrite still provides a comma separated
    string.

    While this is a bug in-and-of-itself, its causing our tests to fail. This
    patch gets us back to passing. We'll look at the configuration issue as a
    part of the fixes going into TK that might resolve this.