### PR TITLE
(re-4060)(packaging) Update puppet 4 paths to match the change from agent/ to puppet/

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -134,7 +134,7 @@ case @osfamily
 end
 
 # The Puppet 4 load path
-@p4libdir = "/opt/puppetlabs/agent/lib/ruby/vendor_ruby"
+@p4libdir = "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby"
 
 @heap_dump_path = "#{@log_dir}/puppetdb-oom.hprof"
 @default_java_args = "-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=#{@heap_dump_path} -Djava.security.egd=file:/dev/urandom"

--- a/ext/redhat/puppetdb.spec.erb
+++ b/ext/redhat/puppetdb.spec.erb
@@ -26,7 +26,7 @@
 %else
 %global puppet_libdir     %(ruby -rrbconfig -e "puts RbConfig::CONFIG['sitelibdir']")
 %endif
-%global puppet_4_libdir   /opt/puppetlabs/agent/lib/ruby/vendor_ruby
+%global puppet_4_libdir   /opt/puppetlabs/puppet/lib/ruby/vendor_ruby
 <% end -%>
 
 # Fedora 17 and later and EL > 7 use systemd


### PR DESCRIPTION
Update the terminus installation path for puppet 4 to match the paths specified
at https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md,
changing agent/ to puppet/