### PR TITLE
(PDB-1259) Faster conversion of strings to timestamps

### DIFF
--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -61,7 +61,6 @@
             [puppetlabs.puppetdb.reports :as report]
             [puppetlabs.puppetdb.mq :as mq]
             [puppetlabs.kitchensink.core :as kitchensink]
-            [clj-time.coerce :refer [to-timestamp]]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.puppetdb.utils :as utils]
@@ -69,7 +68,8 @@
             [cheshire.custom :refer [JSONable]]
             [puppetlabs.puppetdb.command.constants :refer [command-names]]
             [puppetlabs.trapperkeeper.services :refer [defservice]]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [puppetlabs.puppetdb.time :refer [to-timestamp]]))
 
 ;; ## Command parsing
 

--- a/src/puppetlabs/puppetdb/http/events.clj
+++ b/src/puppetlabs/puppetdb/http/events.clj
@@ -3,10 +3,10 @@
   (:require [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.query.paging :as paging]
             [puppetlabs.puppetdb.query-eng :refer [produce-streaming-body]]
-            [clj-time.coerce :refer [to-timestamp]]
             [puppetlabs.puppetdb.middleware :as middleware]
             [net.cgrand.moustache :refer [app]]
-            [puppetlabs.puppetdb.http :as http]))
+            [puppetlabs.puppetdb.http :as http]
+            [puppetlabs.puppetdb.time :refer [to-timestamp]]))
 
 (defn validate-distinct-options!
   "Validate the HTTP query params related to a `distinct_resources` query.  Return a

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -63,7 +63,7 @@
   (:require [clojure.string :as str]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.jdbc :as jdbc]
-            [clj-time.coerce :refer [to-timestamp]]
+            [puppetlabs.puppetdb.time :refer [to-timestamp]]
             [puppetlabs.kitchensink.core :refer [parse-number keyset valset order-by-expr?]]
             [puppetlabs.puppetdb.scf.storage-utils :refer [db-serialize sql-as-numeric sql-array-query-string sql-regexp-match sql-regexp-array-match]]
             [puppetlabs.puppetdb.jdbc :refer [valid-jdbc-query? limited-query-to-vec query-to-vec paged-sql count-sql get-result-count]]
@@ -529,7 +529,7 @@
 (defn compile-resource-event-inequality
   "Compile a timestamp inequality for a resource event query (> < >= <=).
   The `value` for comparison must be coercible to a timestamp via
-  `clj-time.coerce/to-timestamp` (e.g., an ISO-8601 compatible date-time string)."
+  `puppetlabs.puppetdb.time/to-timestamp` (e.g., an ISO-8601 compatible date-time string)."
   [& [op path value :as args]]
   {:post [(map? %)
           (string? (:where %))]}
@@ -715,16 +715,16 @@
   (fn [op]
     (let [op (str/lower-case op)]
       (cond
-        (= op "=") (compile-resource-event-equality version)
-        (= op "and") (partial compile-and (resource-event-ops version))
-        (= op "or") (partial compile-or (resource-event-ops version))
-        (= op "not") (partial compile-not version (resource-event-ops version))
-        (#{">" "<" ">=" "<="} op) (partial compile-resource-event-inequality op)
-        (= op "~") (compile-resource-event-regexp version)
-        (= op "extract") (partial compile-extract version (resource-event-ops version))
-        (= op "in") (partial compile-in :event version (resource-event-ops version))
-        (= op "select_resources") (partial resource-query->sql (resource-operators version))
-        (= op "select_facts") (partial fact-query->sql (fact-operators version))))))
+       (= op "=") (compile-resource-event-equality version)
+       (= op "and") (partial compile-and (resource-event-ops version))
+       (= op "or") (partial compile-or (resource-event-ops version))
+       (= op "not") (partial compile-not version (resource-event-ops version))
+       (#{">" "<" ">=" "<="} op) (partial compile-resource-event-inequality op)
+       (= op "~") (compile-resource-event-regexp version)
+       (= op "extract") (partial compile-extract version (resource-event-ops version))
+       (= op "in") (partial compile-in :event version (resource-event-ops version))
+       (= op "select_resources") (partial resource-query->sql (resource-operators version))
+       (= op "select_facts") (partial fact-query->sql (fact-operators version))))))
 
 (defn event-count-ops
   "Maps resource event count operators to the functions implementing them.

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -10,7 +10,7 @@
             [schema.core :as s]
             [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.puppetdb.cheshire :as json]
-            [clj-time.coerce :refer [to-timestamp]]
+            [puppetlabs.puppetdb.time :refer [to-timestamp]]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.puppetdb.query.paging :as paging]))
 

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -54,7 +54,7 @@
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.scf.storage-utils :as scf-utils]
             [clojure.set :refer :all]
-            [clj-time.coerce :refer [to-timestamp]]
+            [puppetlabs.puppetdb.time :refer [to-timestamp]]
             [clj-time.core :refer [now]]
             [puppetlabs.puppetdb.jdbc :as jdbc]))
 


### PR DESCRIPTION
Previously we were using clj-time.format/to-timestamps's default
ordering of date formatters to attempt to parse the incoming
string. This just used the values in the formatters map in whatever
order they are stored. These formats are used in the order they come out
of the hash-map until one successfully parses the time. This means we
could potentially have 10+ failures to parse a date before a successful
parse, and we do this each time in each report/catalog/factset etc.

This commit switches to use an ordered list of formatters, using the
most likely parsers to work (i.e. ISO8601), then falls through to the
existing behavior.