### PR TITLE
Fix "Overview" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Troubleshooting
 The PuppetDB API
 -----
 
-* [Overview](./documentation/api/query/index.markdown)
+* [Overview](./documentation/api/index.markdown)
 * [Curl Tips](./documentation/api/query/curl.markdown)
 * [Commands](./documentation/api/commands.markdown)
 * Querying


### PR DESCRIPTION
The "Overview" link is broken. I guess it should point to index.markdown in the "documentation/api" instead of "documentation/api/query"