### PR TITLE
(PDB-1277) Fix puppetdb-ssl-setup/postinsts for AIO

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -134,7 +134,9 @@ case @osfamily
 end
 
 # The Puppet 4 load path
-@p4libdir = "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby"
+@labsdir = '/opt/puppetlabs'
+@labsbindir = "#{@labsdir}/bin"
+@p4libdir = "#{@labsdir}/puppet/lib/ruby/vendor_ruby"
 
 @heap_dump_path = "#{@log_dir}/puppetdb-oom.hprof"
 @default_java_args = "-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=#{@heap_dump_path} -Djava.security.egd=file:/dev/urandom"

--- a/ext/templates/deb/postinst.erb
+++ b/ext/templates/deb/postinst.erb
@@ -1,10 +1,6 @@
 #!/bin/bash
 
-<% if @pe -%>
-export PATH=/opt/puppet/bin:$PATH
-<% end -%>
-
-# Setup the SSL stuff
+# Set up the SSL stuff
 
 <%= @sbin_dir -%>/puppetdb ssl-setup
 

--- a/ext/templates/dev/redhat/redhat_dev_postinst.erb
+++ b/ext/templates/dev/redhat/redhat_dev_postinst.erb
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-<% if @pe -%>
-export PATH=/opt/puppet/bin:$PATH
-<% end -%>
-
 # Setup the SSL stuff
 <%= @sbin_dir -%>/puppetdb ssl-setup
 

--- a/ext/templates/puppetdb-ssl-setup.erb
+++ b/ext/templates/puppetdb-ssl-setup.erb
@@ -222,7 +222,7 @@ then
   done
 else
   # This should be run on the host with PuppetDB
-  PATH=/opt/puppet/bin:$PATH
+  PATH="<%= @labsbindir -%>:/opt/puppet/bin:$PATH"
   agent_confdir=`puppet agent --configprint confdir`
   agent_vardir=`puppet agent --configprint vardir`
 
@@ -392,7 +392,7 @@ else
   echo "Error: Unable to find PuppetDB Jetty configuration at ${jettyfile} so unable to provide automatic configuration for that file."
   echo
   echo "   Confirm the file exists in the path specified before running the"
-  echo "   tool again. The file should have been created automatically when" 
+  echo "   tool again. The file should have been created automatically when"
   echo "   the package was installed."
 fi
 

--- a/tasks/template.rake
+++ b/tasks/template.rake
@@ -16,7 +16,8 @@ task :template => [ :clean ] do
     "ext/templates/puppetdb.erb"            => "ext/files/puppetdb",
     "ext/templates/puppetdb-legacy.erb"     => "ext/files/puppetdb-legacy",
     "ext/templates/init_debian.erb"         => "ext/files/#{@name}.debian.init",
-    "ext/templates/puppetdb-env.erb"        => "ext/files/puppetdb.env"
+    "ext/templates/puppetdb-env.erb"        => "ext/files/puppetdb.env",
+    "ext/templates/puppetdb-ssl-setup.erb"  => "ext/files/puppetdb-ssl-setup"
   }
 
   deb_templates = {
@@ -56,7 +57,6 @@ task :template => [ :clean ] do
   chmod 0700, "ext/files/puppetdb-import"
   chmod 0700, "ext/files/puppetdb-export"
   chmod 0700, "ext/files/puppetdb-anonymize"
-  cp_p "ext/templates/puppetdb-ssl-setup", "ext/files"
   chmod 0700, "ext/files/puppetdb-ssl-setup"
   chmod 0700, "ext/files/puppetdb"
   chmod 0700, "ext/files/puppetdb-legacy"


### PR DESCRIPTION
Convert puppetdb-ssl-setup to puppetdb-ssl-setup.erb, and prepend the
AIO path to PATH.

Remove extraneous PATH settings from the Debian and Red Hat postinsts
since puppetlabs-ssl-setup sets the PATH internally, and nothing else in
the postinsts is relevant.
