### PR TITLE
(maint) fix -F/-C/-R options for benchmark tool

### DIFF
--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -346,7 +346,7 @@
     (let [options (-> (ks/cli! args supported-cli-options required-cli-options)
                       first
                       (validate-options #(System/exit 1)))]
-      (if (empty? (select-keys [:facts :reports :catalogs] options))
+      (if (empty? (select-keys options [:facts :reports :catalogs]))
         (default-options options)
         options))
 


### PR DESCRIPTION
This fixes an argument ordering error that caused the -F, -C, and -R flags to have the same
effect as the default case.