### PR TITLE
(maint) Remove facter requirement from rpm specfile

### DIFF
--- a/ext/redhat/puppetdb.spec.erb
+++ b/ext/redhat/puppetdb.spec.erb
@@ -97,7 +97,6 @@ BuildRequires: puppet >= %{puppetminversion}
 BuildRequires: rubygem-rake
 BuildRequires: ruby
 Requires:      puppet >= %{puppetminversion}
-Requires:      facter >= %{facterminversion}
 <% end -%>
 BuildArch:     noarch
 %if 0%{?suse_version}


### PR DESCRIPTION
Nothing in puppetdb's runtime requires facter itself. Facter is a
transitive dependency of puppet, but does not need to be called out by
itself in the specfile. Puppet is required for the ssl setup.