### PR TITLE
(PDB-1179) Remove PE references from PDB packaging

### DIFF
--- a/resources/ext/config/conf.d/config.ini
+++ b/resources/ext/config/conf.d/config.ini
@@ -3,20 +3,10 @@
 
 [global]
 # Store mq/db data in a custom directory
-<% if Pkg::Config.config[:build_pe] -%>
-vardir = /opt/puppet/share/puppetdb
-<% else -%>
 vardir = /var/lib/puppetdb
-<% end -%>
 
 # Use an external logback config file
-<% if Pkg::Config.config[:build_pe] -%>
-logging-config = /etc/puppetlabs/puppetdb/logback.xml
-<% else -%>
 logging-config = /etc/puppetdb/logback.xml
-
-product-name = pe-puppetdb
-<% end -%>
 
 [command-processing]
 # How many command-processing threads to use, defaults to (CPUs / 2)

--- a/resources/ext/config/conf.d/database.ini
+++ b/resources/ext/config/conf.d/database.ini
@@ -1,14 +1,4 @@
 [database]
-<% if Pkg::Config.config[:build_pe] -%>
-# PostgreSQL: org.postgresql.Driver
-classname = org.postgresql.Driver
-
-# PostgreSQL: postgresql
-subprotocol = postgresql
-
-# PostgreSQL: //host:port/databaseName
-subname = //localhost:5432/puppetdb
-<% else -%>
 # For the embedded DB: org.hsqldb.jdbcDriver
 # For PostgreSQL: org.postgresql.Driver
 # Defaults to embedded DB
@@ -23,7 +13,6 @@ subprotocol = hsqldb
 # For PostgreSQL: //host:port/databaseName
 # Defaults to embedded DB located in <vardir>/db
 subname = file:/var/lib/puppetdb/db/db;hsqldb.tx=mvcc;sql.syntax_pgs=true
-<% end -%>
 
 # Connect as a specific user
 # username = foobar

--- a/resources/ext/config/conf.d/jetty.ini
+++ b/resources/ext/config/conf.d/jetty.ini
@@ -30,4 +30,4 @@ port = 8080
 
 # Access logging configuration path. To turn off access logging
 # comment out the line with `access-log-config=...`
-access-log-config = /etc<% if Pkg::Config.config[:build_pe] -%>/puppetlabs<% end -%>/puppetdb/request-logging.xml
+access-log-config = /etc/puppetdb/request-logging.xml

--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -1,8 +1,5 @@
 ezbake: {
-  pe: {
-    redhat: { dependencies: ["pe-puppet >= 4.0.0"] },
-    debian: { dependencies: ["pe-puppet (>= 4.0.0-1puppetlabs1)"] }
-  }
+  pe: {}
   foss: {
     redhat: { dependencies: ["puppet >= 3.7.3", "puppet < 5.0.0"],
               postinst: ["/usr/bin/puppetdb ssl-setup"] },


### PR DESCRIPTION
This commit removes the PE references from the pdb ezbake packaging
configs as we are going to build the pe package of puppetdb out of the
pe-puppet-extensions/puppet-sync repo.