### PR TITLE
(PDB-1179) Simplify start-puppetdb and webapp building

### DIFF
--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -48,21 +48,19 @@
 (defn build-app
   "Generate a Ring application that handles PuppetDB requests
 
-  `options` is a list of keys and values where keys can be the following:
-
-  * `globals` - a map containing global state useful to request handlers.
+  `globals` is a map containing global state useful
+   to request handlers which may contain the following:
 
   * `authorizer` - a function that takes a request and returns a
     :authorized if the request is authorized, or a user-visible reason if not.
     If not supplied, we default to authorizing all requests."
-  [& options]
-  (let [opts (apply hash-map options)]
-    (-> (routes (get-in opts [:globals :url-prefix]))
-        (wrap-resource "public")
-        (wrap-params)
-        (wrap-with-authorization (opts :authorizer (constantly :authorized)))
-        (wrap-with-certificate-cn)
-        (wrap-with-default-body)
-        (wrap-with-metrics (atom {}) http/leading-uris)
-        (wrap-with-globals (opts :globals))
-        (wrap-with-debug-logging))))
+  [{:keys [authorizer url-prefix] :as globals}]
+  (-> (routes url-prefix)
+      (wrap-resource "public")
+      wrap-params
+      (wrap-with-authorization authorizer)
+      wrap-with-certificate-cn
+      wrap-with-default-body
+      (wrap-with-metrics (atom {}) http/leading-uris)
+      (wrap-with-globals globals)
+      wrap-with-debug-logging))

--- a/src/puppetlabs/puppetdb/metrics.clj
+++ b/src/puppetlabs/puppetdb/metrics.clj
@@ -1,20 +1,16 @@
 (ns puppetlabs.puppetdb.metrics
   (:require [clojure.tools.logging :as log]
             [puppetlabs.puppetdb.metrics.server :as server]
-            [puppetlabs.trapperkeeper.core :refer [defservice main]]
-            [compojure.core :as compojure]
-            [puppetlabs.puppetdb.cli.services :refer [build-whitelist-authorizer]]))
+            [puppetlabs.trapperkeeper.core :refer [defservice]]
+            [compojure.core :as compojure]))
 
 (defservice metrics-service
-  [[:ConfigService get-config]
+  [[:PuppetDBServer shared-globals]
    [:WebroutingService add-ring-handler get-route]]
 
   (start [this context]
-         (let [authorizer (if-let [wl (-> (get-config)
-                                          (get-in [:puppetdb :certificate-whitelist]))]
-                            (build-whitelist-authorizer wl)
-                            (constantly :authorized))
-               app (server/build-app :authorizer authorizer)]
+         (let [app (->> (server/build-app (shared-globals))
+                        (compojure/context (get-route this) []))]
            (log/info "Starting metrics server")
-           (add-ring-handler this (compojure/context (get-route this) [] app))
+           (add-ring-handler this app)
            context)))

--- a/src/puppetlabs/puppetdb/metrics/server.clj
+++ b/src/puppetlabs/puppetdb/metrics/server.clj
@@ -23,16 +23,15 @@
 (defn build-app
   "Generate a Ring application that handles metrics requests
 
-  `options` is a list of keys and values where keys can be the following:
+   Takes an `options` map which may contain the following keys:
 
   * `authorizer` - a function that takes a request and returns a
     :authorized if the request is authorized, or a user-visible reason if not.
     If not supplied, we default to authorizing all requests."
-  [& options]
-  (let [opts (apply hash-map options)]
-    (-> (routes)
-        (wrap-params)
-        (wrap-with-authorization (opts :authorizer (constantly :authorized)))
-        (wrap-with-certificate-cn)
-        (wrap-with-default-body)
-        (wrap-with-debug-logging))))
+  [{:keys [authorizer]}]
+  (-> (routes)
+      wrap-params
+      (wrap-with-authorization authorizer)
+      wrap-with-certificate-cn
+      wrap-with-default-body
+      wrap-with-debug-logging))

--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -35,13 +35,16 @@
   `authorizor` is :authorized; otherwise, its value is taken to be a
   message describing the reason that access is not allowed."
   [app authorizer]
-  (fn [req]
-    (let [auth-result (authorizer req)]
-     (if (= :authorized auth-result)
-       (app req)
-       (-> (str "Permission denied: " auth-result)
-           (rr/response)
-           (rr/status http/status-forbidden))))))
+  (let [authorizer (if-not (nil? authorizer)
+                     authorizer
+                     (constantly :authorized))]
+    (fn [req]
+      (let [auth-result (authorizer req)]
+        (if (= :authorized auth-result)
+          (app req)
+          (-> (str "Permission denied: " auth-result)
+              (rr/response)
+              (rr/status http/status-forbidden)))))))
 
 (defn wrap-with-certificate-cn
   "Ring middleware that will annotate the request with an

--- a/test/puppetlabs/puppetdb/fixtures.clj
+++ b/test/puppetlabs/puppetdb/fixtures.clj
@@ -67,13 +67,13 @@
      (with-http-app {} f))
   ([globals-overrides f]
      (binding [*app* (server/build-app
-                      :globals (merge
-                                {:scf-read-db          *db*
-                                 :scf-write-db         *db*
-                                 :command-mq           *mq*
-                                 :product-name         "puppetdb"
-                                 :url-prefix           ""}
-                                globals-overrides))]
+                       (merge
+                         {:scf-read-db          *db*
+                          :scf-write-db         *db*
+                          :command-mq           *mq*
+                          :product-name         "puppetdb"
+                          :url-prefix           ""}
+                         globals-overrides))]
        (f))))
 
 (defn defaulted-write-db-config

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -419,10 +419,10 @@
    (test-app read-write-db read-write-db))
   ([read-db write-db]
    (server/build-app
-    :globals {:scf-read-db          read-db
-              :scf-write-db         write-db
-              :command-mq           *mq*
-              :product-name         "puppetdb"})))
+     {:scf-read-db          read-db
+      :scf-write-db         write-db
+      :command-mq           *mq*
+      :product-name         "puppetdb"})))
 
 (defn with-shutdown-after [dbs f]
   (f)

--- a/test/puppetlabs/puppetdb/metrics/core_test.clj
+++ b/test/puppetlabs/puppetdb/metrics/core_test.clj
@@ -36,7 +36,7 @@
 (deftestseq metrics-set-handler
   [version api-versions]
 
-  (let [app (server/build-app)
+  (let [app (server/build-app {})
         mbeans-endpoint (str version "/mbeans")]
     (testing "Remote metrics endpoint"
       (testing "should return a http/status-not-found for an unknown metric"


### PR DESCRIPTION
This commit cleans up the syntax of the starting of puppetdb and the
building of puppetdb webapplications with an authorizer. As new
webservers are added into the puppetdb project it is desirable to have
clean, standardized examples of build-app functions and configuration
manipulation. This commit also adds the authorizer, built from the
certificate-whitelist config, to the shared-globals of the
PuppetDBServer so that other apps need not build the authorizer from
scratch again.