### PR TITLE
(PDB-1305) Update install from source docs for AIO

### DIFF
--- a/documentation/connect_puppet_master.markdown
+++ b/documentation/connect_puppet_master.markdown
@@ -43,7 +43,7 @@ Currently, puppet masters need additional Ruby plugins in order to use PuppetDB.
 If your puppet master isn't running Puppet from a supported package, you will need to install the plugins manually:
 
 * [Download the PuppetDB source code][puppetdb_download], unzip it and navigate into the resulting directory in your terminal.
-* Run `sudo cp -R ext/master/lib/puppet /usr/lib/ruby/site_ruby/1.8/puppet`. Replace the second path with the path to your Puppet installation if you have installed it somewhere other than `/usr/lib/ruby/site_ruby`. If you are using the Puppet all-in-one agent, replace the second path with the path to the Puppet supplied ruby at `/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet`.
+* Run `sudo cp -R ext/master/lib/puppet /usr/lib/ruby/site_ruby/1.8/puppet`. Replace the second path with the path to your Puppet installation if you have installed it somewhere other than `/usr/lib/ruby/site_ruby`. If you are using Puppet 4 or greater, replace the second path with the path to the ruby supplied by Puppet at `/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet`.
 
 ## Step 2: Edit Config Files
 

--- a/documentation/connect_puppet_master.markdown
+++ b/documentation/connect_puppet_master.markdown
@@ -43,7 +43,7 @@ Currently, puppet masters need additional Ruby plugins in order to use PuppetDB.
 If your puppet master isn't running Puppet from a supported package, you will need to install the plugins manually:
 
 * [Download the PuppetDB source code][puppetdb_download], unzip it and navigate into the resulting directory in your terminal.
-* Run `sudo cp -R ext/master/lib/puppet /usr/lib/ruby/site_ruby/1.8/puppet`. Replace the second path with the path to your Puppet installation if you have installed it somewhere other than `/usr/lib/ruby/site_ruby`.
+* Run `sudo cp -R ext/master/lib/puppet /usr/lib/ruby/site_ruby/1.8/puppet`. Replace the second path with the path to your Puppet installation if you have installed it somewhere other than `/usr/lib/ruby/site_ruby`. If you are using the Puppet all-in-one agent, replace the second path with the path to the Puppet supplied ruby at `/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet`.
 
 ## Step 2: Edit Config Files
 
@@ -106,6 +106,7 @@ very basic querying.  For more information, see:
 More information about Puppet report processors in general can be found
 [here][report_processors].
 
+
 ### 3. Edit routes.yaml
 
 The [routes.yaml][routes_yaml] file will probably not exist yet. The path to this Puppet configuration file can be found with the command `puppet master --configprint route_file`.
@@ -117,6 +118,13 @@ Create it if necessary, and add the following:
       facts:
         terminus: puppetdb
         cache: yaml
+
+### Ensure proper ownership of the config files
+
+The files created above need to be owned by the `puppet` user. Ensure that
+this ownership is applied by running the following command.
+
+    $ sudo chown -R puppet:puppet `sudo puppet config print confdir`
 
 ## Step 3: Set Security Policy
 

--- a/documentation/install_from_source.markdown
+++ b/documentation/install_from_source.markdown
@@ -48,13 +48,30 @@ Install Leiningen:
 
 Run the following commands:
 
+> **Note:**
+>
+> If you are using the Puppet all-in-one agent, the `rake` command below should
+> be replaced by the `rake` version supplied by the all-in-one agent at
+> `/opt/puppetlabs/puppet/bin/rake`
+
     $ mkdir -p ~/git && cd ~/git
     $ git clone git://github.com/puppetlabs/puppetdb
     $ cd puppetdb
     $ rake package:bootstrap
     $ sudo LEIN_ROOT=true rake install
 
-This will install PuppetDB, put a `puppetdb` init script in `/etc/init.d` and create a default configuration directory in `/etc/puppetdb`.
+This will install PuppetDB, putting a `puppetdb` init script in `/etc/init.d` on
+[sysvinit](http://en.wikipedia.org/wiki/Init#SysV-style) based systems or in
+`/etc/sysconfig` on [systemd](http://en.wikipedia.org/wiki/Systemd) based systems.
+This also creates a default configuration directory in `/etc/puppetdb`.
+
+The puppetdb service is set to run as the puppetdb user. You will need to add
+this user to your system.
+
+Create a `puppetdb` user and group:
+
+    $ sudo groupadd puppetdb
+    $ sudo useradd puppetdb -g puppetdb
 
 Step 2, Option B: Run Directly from Source
 -----
@@ -156,13 +173,17 @@ If this is a production deployment, you should confirm and configure your databa
 You can change PuppetDB's database at any time, but note that changing the database does not migrate PuppetDB's data, so the new database will be empty. However, as this data is automatically generated many times a day, PuppetDB should recover in a relatively short period of time.
 
 
+Set `puppetdb` ownership on puppetdb system files:
+
+    $ sudo chown -R puppetdb:puppetdb /etc/puppetdb
+    $ sudo chown -R puppetdb:puppetdb /var/lib/puppetdb
 
 Step 6: Start the PuppetDB Service
 -----
 
 If you _installed_ PuppetDB from source, you can start PuppetDB by running the following:
 
-    $ sudo /etc/init.d/puppetdb start
+    $ sudo service puppetdb start
 
 And if Puppet is installed, you can permanently enable PuppetDB by running:
 

--- a/documentation/install_from_source.markdown
+++ b/documentation/install_from_source.markdown
@@ -50,8 +50,8 @@ Run the following commands:
 
 > **Note:**
 >
-> If you are using the Puppet all-in-one agent, the `rake` command below should
-> be replaced by the `rake` version supplied by the all-in-one agent at
+> If you are using Puppet 4 or greater, the `rake` command below should
+> be replaced by the `rake` version supplied by Puppet at
 > `/opt/puppetlabs/puppet/bin/rake`
 
     $ mkdir -p ~/git && cd ~/git


### PR DESCRIPTION
This commit updates the install from source documentation to reflect
steps needed when using the Puppet all-in-one agent.

It also updates the system calls to by init style agnostic.

Specific changes:

* If AIO is used the rake command should be the puppet supplied rake.
* The puppetdb user and group need to be created, since the service runs as
this user by default.
* System files need to be owned by the puppetdb user.
*  If AIO is used, the terminus code should be copied to the puppet vendored
ruby location.
* Change sysvinit system calls to be init system agnostic. Indicate where the
 init files go for both sysvinit and systemd