### PR TITLE
(docs) Add docs sidebar nav (TOC) file to PuppetDB repo, as _puppetdb_na...

### DIFF
--- a/documentation/_puppetdb_nav.html
+++ b/documentation/_puppetdb_nav.html
@@ -1,0 +1,95 @@
+{% capture puppetdb_version %}master{% endcapture %}
+
+<h2 id="puppetdb">PuppetDB NEXT</h2>
+
+<p class="versionnote">This documentation is for an unreleased version of PuppetDB! If you are running PuppetDB from source on the master branch, this is the documentation for you; otherwise, please see the documentation for the <a href="/puppetdb/latest/">latest official release</a>.</p>
+
+<ul>
+  <li><strong>General Information</strong>
+    <ul>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/index.html">Overview & Requirements</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/puppetdb-faq.html">Frequently Asked Questions</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/release_notes.html">Release Notes</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/versioning_policy.html">Versioning Policy</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/known_issues.html">Known Issues</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/community_add_ons.html">Community Add-ons</a></li>
+    </ul>
+  </li>
+  <li><strong>Installation</strong>
+    <ul>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/migrate.html">Migrating Existing Data</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/install_via_module.html">Installing via Puppet Module</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/install_from_packages.html">Installing From Packages</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/install_from_source.html">Installing from Source</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/upgrade.html">Upgrading PuppetDB</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/connect_puppet_master.html">Connecting Puppet Masters</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/connect_puppet_apply.html">Connecting Standalone Puppet</a></li>
+    </ul>
+  </li>
+  <li><strong>Configuration</strong>
+    <ul>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/configure.html">Configuring PuppetDB</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/puppetdb_connection.html">puppetdb.conf: Configuring a Puppet/PuppetDB Connection</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/postgres_ssl.html">Setting Up SSL for PostgreSQL</a></li>
+    </ul>
+  <li><strong>Usage/Admin</strong>
+    <ul>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/using.html">Using PuppetDB</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/maintain_and_tune.html">Maintaining and Tuning</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/migrate.html">Migrating Data</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/anonymization.html">Anonymizing Data</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/scaling_recommendations.html">Scaling Recommendations</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/repl.html">Debugging with Remote REPL</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/load_testing_tool.html">Load Testing</a></li>
+    </ul>
+  </li>
+  <li><strong>Troubleshooting</strong>
+    <ul>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/trouble_kahadb_corruption.html">KahaDB Corruption</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/trouble_low_catalog_duplication.html">Low Catalog Duplication</a></li>
+    </ul>
+  </li>
+  <li><strong>API</strong>
+    <ul>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/index.html">Overview</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/tutorial.html">Query Tutorial</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/curl.html">Curl Tips</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/commands.html">Command API</a></li>
+    </ul>
+  </li>
+  <li><strong>Query API Version 4</strong>
+    <ul>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/upgrading-from-v3.html">Upgrading from Version 3</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/query.html">Query Structure</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/operators.html">Available Operators</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/paging.html">Query Paging</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/nodes.html">Nodes Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/environments.html">Environments Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/factsets.html">Factsets Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/facts.html">Facts Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/fact-names.html">Fact-Names Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/fact-paths.html">Fact-Paths Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/fact-contents.html">Fact-Contents Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/catalogs.html">Catalogs Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/resources.html">Resources Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/reports.html">Reports Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/events.html">Events Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/event-counts.html">Event Counts Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/aggregate-event-counts.html">Aggregate Event Counts Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/server-time.html">Server Time Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/version.html">Version Endpoint</a></li>
+    </ul>
+  </li>
+  <li><strong>Metrics API Version 1</strong>
+    <ul>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/metrics/v1/index.html">Metrics Endpoint</a></li>
+    </ul>
+  </li>
+  <li><strong>Wire Formats</strong>
+    <ul>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/catalog_format_v6.html">Catalog Wire Format - v6</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/facts_format_v4.html">Facts Wire Format - v4</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/wire_format/report_format_v5.html">Report Wire Format - v5</a></li>
+    </ul>
+  </li>
+</ul>


### PR DESCRIPTION
...v.html

This is similar to commit 7739f6d5baceba94356712926c8572ec3a9c5d00 on stable,
but it pulls in the source/_includes/puppetdb_master.html file from puppet-docs,
rather than the 2.3 version of the nav.

New process:

- When you create or remove docs pages, please edit this TOC file to match.
- When you branch to make a new PuppetDB version, please edit the version number
  in the TOC.
- We'll still need to wire up new PuppetDB versions in the puppet-docs repo,
  but we won't need to host the TOC file in our repo; we can use it in place.