### PR TITLE
(PDB-1264) Ensure producer_timestamp has a value

### DIFF
--- a/acceptance/tests/inventory/basic_fact_retrieval.rb
+++ b/acceptance/tests/inventory/basic_fact_retrieval.rb
@@ -40,10 +40,13 @@ test_name "structured and trusted facts should be available through facts termin
     end
 
     step "create a custom structured fact" do
+      time = Time.now.iso8601
       payload = <<-EOM
       -H "Accept: application/json" -H "Content-Type: application/json" \
       -d '{"command":"replace facts","version":4, \
       "payload":{"environment":"DEV","certname":"#{master}", \
+      "timestamp": "#{time}", \
+      "producer_timestamp": "#{time}", \
       "values":{"my_structured_fact":#{JSON.generate(structured_data)}}}}' http://localhost:8080/v4/commands
       EOM
       on database, %Q|curl -X POST #{payload}|

--- a/documentation/api/wire_format/catalog_format_v6.markdown
+++ b/documentation/api/wire_format/catalog_format_v6.markdown
@@ -79,8 +79,7 @@ This field may be `null`.
 #### `producer_timestamp`
 
 Datetime.  The time of catalog submission from the master to PuppetDB.  This
-field is currently populated by the master.  This field may be `null`.
-Versions prior to version 5 will populate this with a `null` value.
+field is currently populated by the master.
 
 ### Data Type: `<string>`
 

--- a/puppet/spec/unit/face/storeconfigs_spec.rb
+++ b/puppet/spec/unit/face/storeconfigs_spec.rb
@@ -107,7 +107,7 @@ if Puppet::Util::Puppetdb.puppet3compat?
 
           catalog = JSON.load(results['catalogs/foo.json'])
 
-          catalog.keys.should =~ ['metadata', 'environment', 'certname', 'version', 'edges', 'resources']
+          catalog.keys.should =~ ['metadata', 'environment', 'certname', 'version', 'edges', 'resources', 'timestamp', 'producer_timestamp']
 
           catalog['metadata'].should == {'api_version' => 1}
 

--- a/resources/puppetlabs/puppetdb/benchmark/samples/facts/pg2.vm.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/facts/pg2.vm.json
@@ -1,5 +1,6 @@
 {
   "certname" : "pg2.vm",
+  "producer_timestamp" : "2015-03-02T21:51:45.395Z",
   "values" : {
     "mtu_eth0" : "1500",
     "path" : "/usr/lib64/qt-3.3/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/facts/puppetdb1.vm.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/facts/puppetdb1.vm.json
@@ -1,5 +1,6 @@
 {
   "certname" : "puppetdb1.vm",
+  "producer_timestamp" : "2015-03-02T21:51:45.395Z",
   "values" : {
     "mtu_eth0" : "1500",
     "path" : "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",

--- a/src/puppetlabs/puppetdb/catalogs.clj
+++ b/src/puppetlabs/puppetdb/catalogs.clj
@@ -92,7 +92,8 @@
             [schema.core :as s]
             [puppetlabs.puppetdb.schema :as pls]
             [puppetlabs.puppetdb.utils :as utils]
-            [clojure.core.match :refer [match]]))
+            [clojure.core.match :refer [match]]
+            [puppetlabs.puppetdb.time :refer [to-timestamp]]))
 
 (def ^:const catalog-version
   "Constant representing the version number of the PuppetDB
@@ -114,7 +115,8 @@
    :version s/Str
    :environment (s/maybe s/Str)
    :transaction_uuid (s/maybe s/Str)
-   :producer_timestamp (s/maybe pls/Timestamp)
+   :producer_timestamp pls/Timestamp
+
 
    ;; This is a crutch. We use sets for easier searching and avoid
    ;; reliance on ordering. We should pick one of the below (probably
@@ -149,7 +151,6 @@
   (utils/assoc-when catalog
                     :transaction_uuid nil
                     :environment nil
-                    :producer_timestamp nil
                     :api_version 1))
 
 (pls/defn-validated canonical-catalog

--- a/src/puppetlabs/puppetdb/facts.clj
+++ b/src/puppetlabs/puppetdb/facts.clj
@@ -30,7 +30,7 @@
    :values fact-set
    :timestamp pls/Timestamp
    :environment (s/maybe s/Str)
-   :producer_timestamp (s/either (s/maybe s/Str) pls/Timestamp)})
+   :producer_timestamp (s/either s/Str pls/Timestamp)})
 
 (def valuemap-schema
   {:value_hash s/Str

--- a/src/puppetlabs/puppetdb/query/catalogs.clj
+++ b/src/puppetlabs/puppetdb/query/catalogs.clj
@@ -32,7 +32,7 @@
    :transaction_uuid (s/maybe String)
    :environment (s/maybe String)
    :certname String
-   :producer_timestamp (s/maybe pls/Timestamp)
+   :producer_timestamp pls/Timestamp
    :resource (s/maybe String)
    :type (s/maybe String)
    :title (s/maybe String)

--- a/src/puppetlabs/puppetdb/query/factsets.clj
+++ b/src/puppetlabs/puppetdb/query/factsets.clj
@@ -20,7 +20,7 @@
    :hash (s/maybe s/Str)
    :value_float (s/maybe s/Num)
    :value_integer (s/maybe s/Int)
-   :producer_timestamp (s/maybe pls/Timestamp)
+   :producer_timestamp pls/Timestamp
    :type (s/maybe String)
    :timestamp pls/Timestamp})
 
@@ -30,14 +30,14 @@
    :path String
    :hash (s/maybe s/Str)
    :value s/Any
-   :producer_timestamp (s/maybe pls/Timestamp)
+   :producer_timestamp pls/Timestamp
    :timestamp pls/Timestamp})
 
 (def factset-schema
   {:certname String
    :environment (s/maybe s/Str)
    :timestamp pls/Timestamp
-   :producer_timestamp (s/maybe pls/Timestamp)
+   :producer_timestamp pls/Timestamp
    :hash (s/maybe s/Str)
    :facts {s/Str s/Any}})
 

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -727,7 +727,7 @@
              :values facts
              :timestamp timestamp
              :environment environment
-             :producer_timestamp nil}))))))
+             :producer_timestamp timestamp}))))))
 
 (defn structured-facts []
   ;; -----------
@@ -1125,6 +1125,18 @@
    "ALTER TABLE fact_paths DROP COLUMN value_type_id"
    "ALTER TABLE fact_values DROP COLUMN path_id"))
 
+(defn fill-in-null-producer-timestamp
+  "The producer_timestamp column can sometimes contain null values,
+  especially when updating from older versions. New use cases require
+  a value in that position, so we'll use the value from the
+  'timestamp' column if it's not there. "
+  []
+  (sql/do-commands
+   "UPDATE catalogs SET producer_timestamp=timestamp WHERE producer_timestamp IS NULL"
+   "UPDATE factsets SET producer_timestamp=timestamp WHERE producer_timestamp IS NULL"
+   "ALTER TABLE catalogs ALTER COLUMN producer_timestamp SET NOT NULL"
+   "ALTER TABLE factsets ALTER COLUMN producer_timestamp SET NOT NULL"))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {1 initialize-store
@@ -1158,7 +1170,8 @@
    29 insert-factset-hash-column
    30 migrate-to-report-id-and-noop-column-and-drop-latest-reports
    31 change-name-to-certname
-   32 insert-report-metrics-and-logs})
+   32 insert-report-metrics-and-logs
+   33 fill-in-null-producer-timestamp})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -360,12 +360,14 @@
   {:pre  [(coll? resource-hashes)
           (every? string? resource-hashes)]
    :post [(set? %)]}
-  (let [qmarks     (str/join "," (repeat (count resource-hashes) "?"))
-        query      (format "SELECT DISTINCT resource FROM resource_params_cache WHERE resource IN (%s)" qmarks)
-        sql-params (vec (cons query resource-hashes))]
-    (sql/with-query-results result-set
-      sql-params
-      (set (map :resource result-set)))))
+  (if (seq resource-hashes)
+    (let [qmarks     (str/join "," (repeat (count resource-hashes) "?"))
+          query      (format "SELECT DISTINCT resource FROM resource_params_cache WHERE resource IN (%s)" qmarks)
+          sql-params (vec (cons query resource-hashes))]
+      (sql/with-query-results result-set
+        sql-params
+        (set (map :resource result-set))))
+    #{}))
 
 ;;The schema definition of this function should be
 ;;resource-ref->resource-schema, but there are a lot of tests that

--- a/test/puppetlabs/puppetdb/examples.clj
+++ b/test/puppetlabs/puppetdb/examples.clj
@@ -7,7 +7,7 @@
     :version          "1330463884"
     :transaction_uuid nil
     :environment      nil
-    :producer_timestamp nil
+    :producer_timestamp "2014-07-10T22:33:54.781Z"
     :edges            #{{:source       {:type "Stage" :title "main"}
                          :target       {:type "Class" :title "Settings"}
                          :relationship :contains}
@@ -36,7 +36,7 @@
     :transaction_uuid "68b08e2a-eeb1-4322-b241-bfdf151d294b"
     :environment      "DEV"
     :version          "123456789"
-    :producer_timestamp nil
+    :producer_timestamp "2014-07-10T22:33:54.781Z"
     :edges            #{{:source       {:type "Class" :title "foobar"}
                          :target       {:type "File" :title "/etc/foobar"}
                          :relationship :contains}

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -401,7 +401,7 @@
                            :values {"ipaddress" "1.1.1.1"}
                            :timestamp (now)
                            :environment nil
-                           :producer_timestamp nil}))
+                           :producer_timestamp (now)}))
 
   (doseq [[query results] (get versioned-subqueries endpoint)]
     (testing (str "query: " query " should match expected output")

--- a/test/puppetlabs/puppetdb/http/explore_test.clj
+++ b/test/puppetlabs/puppetdb/http/explore_test.clj
@@ -57,17 +57,17 @@
                            :values facts1
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/add-facts! {:certname "host2"
                            :values facts2
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/add-facts! {:certname "host3"
                            :values facts3
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/deactivate-node! "host3")
 
     (let [version :v4

--- a/test/puppetlabs/puppetdb/http/fact_names_test.clj
+++ b/test/puppetlabs/puppetdb/http/fact_names_test.clj
@@ -48,18 +48,18 @@
                              :values facts2
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp nil})
+                             :producer_timestamp (now)})
       (scf-store/add-facts! {:certname "foo3"
                              :values facts3
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp nil})
+                             :producer_timestamp (now)})
       (scf-store/deactivate-node! "foo1")
       (scf-store/add-facts! {:certname "foo1"
                              :values  facts1
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp nil}))
+                             :producer_timestamp (now)}))
 
     (testing "should retrieve all fact names, order alphabetically, including deactivated nodes"
       (let [request (get-request endpoint)
@@ -112,18 +112,18 @@
                              :values facts2
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp nil})
+                             :producer_timestamp (now)})
       (scf-store/add-facts! {:certname "foo3"
                              :values facts3
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp nil})
+                             :producer_timestamp (now)})
       (scf-store/deactivate-node! "foo1")
       (scf-store/add-facts! {:certname "foo1"
                              :values  facts1
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp nil}))
+                             :producer_timestamp (now)}))
 
     (testing "query should return appropriate results"
       (let [request (get-request

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -463,22 +463,22 @@
                              :values facts1
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp nil})
+                             :producer_timestamp (now)})
       (scf-store/add-facts! {:certname  "foo2"
                              :values facts2
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp nil})
+                             :producer_timestamp (now)})
       (scf-store/add-facts! {:certname "foo3"
                              :values facts3
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp nil})
+                             :producer_timestamp (now)})
       (scf-store/add-facts! {:certname "foo4"
                              :values facts4
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp nil})
+                             :producer_timestamp (now)})
       (scf-store/deactivate-node! "foo4"))
 
     (testing "query without param should not fail"
@@ -519,17 +519,17 @@
                          :values {"ipaddress" "192.168.1.100" "operatingsystem" "Debian" "osfamily" "Debian" "uptime_seconds" 11000}
                          :timestamp (now)
                          :environment "DEV"
-                         :producer_timestamp nil})
+                         :producer_timestamp (now)})
   (scf-store/add-facts! {:certname "bar"
                          :values {"ipaddress" "192.168.1.101" "operatingsystem" "Ubuntu" "osfamily" "Debian" "uptime_seconds" 12}
                          :timestamp (now)
                          :environment "DEV"
-                         :producer_timestamp nil})
+                         :producer_timestamp (now)})
   (scf-store/add-facts! {:certname "baz"
                          :values {"ipaddress" "192.168.1.102" "operatingsystem" "CentOS" "osfamily" "RedHat" "uptime_seconds" 50000}
                          :timestamp (now)
                          :environment "DEV"
-                         :producer_timestamp nil})
+                         :producer_timestamp (now)})
 
   (let [catalog (:empty catalogs)
         apache-resource {:type "Class" :title "Apache"}
@@ -576,7 +576,7 @@
                                    :values facts1
                                    :timestamp (now)
                                    :environment "DEV"
-                                   :producer_timestamp nil}))
+                                   :producer_timestamp (now)}))
 
           (testing "queries only use the read database"
             (let [request (get-request endpoint (json/parse-string nil))
@@ -629,12 +629,12 @@
                              :values facts1
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp nil})
+                             :producer_timestamp (now)})
       (scf-store/add-facts! {:certname "foo2"
                              :values facts2
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp nil}))
+                             :producer_timestamp (now)}))
 
     (testing "should support fact paging"
       (doseq [[label counts?] [["without" false]
@@ -702,31 +702,31 @@
                            :values {"hostname" "c-host"}
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/add-certname! "a.local")
     (scf-store/add-facts! {:certname "a.local"
                            :values {"hostname" "a-host"}
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/add-certname! "d.local")
     (scf-store/add-facts! {:certname "d.local"
                            :values {"uptime_days" "2"}
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/add-certname! "b.local")
     (scf-store/add-facts! {:certname "b.local"
                            :values {"uptime_days" "4"}
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/add-certname! "e.local")
     (scf-store/add-facts! {:certname "e.local"
                            :values {"my_structured_fact" (:value f5)}
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
 
     (testing "include total results count"
       (let [actual (:count (raw-query-endpoint endpoint nil {:include_total true}))]
@@ -810,31 +810,31 @@
                            :values {"my_structured_fact" (:value f3)}
                            :timestamp (now)
                            :environment "C"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/add-certname! "a.local")
     (scf-store/add-facts! {:certname "a.local"
                            :values {"hostname" "a-host"}
                            :timestamp (now)
                            :environment "A"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/add-certname! "b.local")
     (scf-store/add-facts! {:certname "b.local"
                            :values {"uptime_days" "4"}
                            :timestamp (now)
                            :environment "B"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/add-certname! "b2.local")
     (scf-store/add-facts! {:certname "b2.local"
                            :values {"max" "4"}
                            :timestamp (now)
                            :environment "B"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/add-certname! "d.local")
     (scf-store/add-facts! {:certname "d.local"
                            :values {"min" "-4"}
                            :timestamp (now)
                            :environment "D"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
 
     (testing "ordering by environment should work"
       (doseq [[[env-order name-order] expected] [[["DESC" "ASC"]  [f5 f3 f4 f2 f1]]
@@ -886,22 +886,22 @@
                                :values facts1
                                :timestamp (now)
                                :environment "DEV"
-                               :producer_timestamp nil})
+                               :producer_timestamp (now)})
         (scf-store/add-facts! {:certname "foo2"
                                :values facts2
                                :timestamp (now)
                                :environment "DEV"
-                               :producer_timestamp nil})
+                               :producer_timestamp (now)})
         (scf-store/add-facts! {:certname "foo3"
                                :values facts3
                                :timestamp (now)
                                :environment "PROD"
-                               :producer_timestamp nil})
+                               :producer_timestamp (now)})
         (scf-store/add-facts! {:certname "foo4"
                                :values facts4
                                :timestamp (now)
                                :environment "PROD"
-                               :producer_timestamp nil}))
+                               :producer_timestamp (now)}))
 
       (doseq [query '[[= environment PROD]
                       [not [= environment DEV]]
@@ -1293,22 +1293,22 @@
                              :values facts1
                              :timestamp reference-time
                              :environment "DEV"
-                             :producer_timestamp nil})
+                             :producer_timestamp reference-time})
       (scf-store/add-facts! {:certname  "foo2"
                              :values facts2
                              :timestamp (to-timestamp "2013-01-01")
                              :environment "DEV"
-                             :producer_timestamp nil})
+                             :producer_timestamp reference-time})
       (scf-store/add-facts! {:certname "foo3"
                              :values facts3
                              :timestamp reference-time
                              :environment "PROD"
-                             :producer_timestamp nil})
+                             :producer_timestamp reference-time})
       (scf-store/add-facts! {:certname "foo4"
                              :values facts4
                              :timestamp reference-time
                              :environment "PROD"
-                             :producer_timestamp nil})
+                             :producer_timestamp reference-time})
       (scf-store/deactivate-node! "foo4"))
 
     (testing "query without param should not fail"

--- a/test/puppetlabs/puppetdb/query/fact_names_test.clj
+++ b/test/puppetlabs/puppetdb/query/fact_names_test.clj
@@ -23,7 +23,7 @@
                            :values (into {} (map (fn [x] [x "unused"]) [f2 f4 f1 f3]))
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
 
     (testing "include total results count"
       (let [actual (:count (facts/fact-names {:count? true}))]

--- a/test/puppetlabs/puppetdb/query/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/query/nodes_test.clj
@@ -62,27 +62,27 @@
                            :values {"kernel" "Linux"}
                            :timestamp timestamp
                            :environment "production"
-                           :producer_timestamp nil})
+                           :producer_timestamp timestamp})
     (scf-store/add-facts! {:certname "node_b"
                            :values {"kernel" "Linux"}
                            :timestamp timestamp
                            :environment "production"
-                           :producer_timestamp nil})
+                           :producer_timestamp timestamp})
     (scf-store/add-facts! {:certname "node_c"
                            :values {"kernel" "Darwin"}
                            :timestamp timestamp
                            :environment "production"
-                           :producer_timestamp nil})
+                           :producer_timestamp timestamp})
     (scf-store/add-facts! {:certname "node_d"
                            :values {"uptime_seconds" "10000"}
                            :timestamp timestamp
                            :environment "production"
-                           :producer_timestamp nil})
+                           :producer_timestamp timestamp})
     (scf-store/add-facts! {:certname "node_e"
                            :values {"uptime_seconds" "10000"}
                            :timestamp timestamp
                            :environment "production"
-                           :producer_timestamp nil})
+                           :producer_timestamp timestamp})
 
     (testing "basic combination testing"
       (let [test-cases {["=" ["fact" "kernel"] "Linux"]
@@ -109,9 +109,19 @@
                                              [3 "node_c" 3 1]
                                              [4 "node_d" 2 3]
                                              [5 "node_e" 5 2]]]
-      (sql/insert-record :certnames {:certname node})
-      (sql/insert-record :factsets {:certname node :timestamp (to-timestamp (-> facts-age days ago))})
-      (sql/insert-record :catalogs {:id id :hash node :api_version 0 :catalog_version 0 :certname node :timestamp (to-timestamp (minus right-now (-> catalog-age days)))})))
+      (let [factset-timestamp (to-timestamp (-> facts-age days ago))
+            catalog-timestamp (to-timestamp (minus right-now (-> catalog-age days)))]
+        (sql/insert-record :certnames {:certname node})
+        (sql/insert-record :factsets {:certname node
+                                      :timestamp factset-timestamp
+                                      :producer_timestamp factset-timestamp})
+        (sql/insert-record :catalogs {:id id
+                                      :hash node
+                                      :api_version 0
+                                      :catalog_version 0
+                                      :certname node
+                                      :timestamp catalog-timestamp
+                                      :producer_timestamp catalog-timestamp}))))
 
   (let [version [:v4]]
 

--- a/test/puppetlabs/puppetdb/query/population_test.clj
+++ b/test/puppetlabs/puppetdb/query/population_test.clj
@@ -4,7 +4,9 @@
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.scf.storage :refer [deactivate-node!]]
             [puppetlabs.puppetdb.scf.storage-utils :refer [to-jdbc-varchar-array]]
-            [puppetlabs.puppetdb.fixtures :refer :all]))
+            [puppetlabs.puppetdb.fixtures :refer :all]
+            [clj-time.coerce :refer [to-timestamp]]
+            [clj-time.core :refer [now]]))
 
 (use-fixtures :each with-test-db)
 
@@ -23,8 +25,8 @@
 
       (sql/insert-records
        :catalogs
-       {:id 1 :hash "c1" :api_version 1 :catalog_version "1" :certname "h1"}
-       {:id 2 :hash "c2" :api_version 1 :catalog_version "1" :certname "h2"})
+       {:id 1 :hash "c1" :api_version 1 :catalog_version "1" :certname "h1" :producer_timestamp (to-timestamp (now))}
+       {:id 2 :hash "c2" :api_version 1 :catalog_version "1" :certname "h2" :producer_timestamp (to-timestamp (now))})
 
       (sql/insert-records
        :resource_params_cache
@@ -76,8 +78,8 @@
 
       (sql/insert-records
        :catalogs
-       {:id 1 :hash "c1" :api_version 1 :catalog_version "1" :certname "h1"}
-       {:id 2 :hash "c2" :api_version 1 :catalog_version "1" :certname "h2"})
+       {:id 1 :hash "c1" :api_version 1 :catalog_version "1" :certname "h1" :producer_timestamp (to-timestamp (now))}
+       {:id 2 :hash "c2" :api_version 1 :catalog_version "1" :certname "h2" :producer_timestamp (to-timestamp (now))})
 
       (sql/insert-records
        :resource_params_cache

--- a/test/puppetlabs/puppetdb/query/resources_test.clj
+++ b/test/puppetlabs/puppetdb/query/resources_test.clj
@@ -4,7 +4,9 @@
             [puppetlabs.puppetdb.scf.storage :refer [ensure-environment]]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.fixtures :refer :all]
-            [puppetlabs.puppetdb.scf.storage-utils :refer [db-serialize to-jdbc-varchar-array]]))
+            [puppetlabs.puppetdb.scf.storage-utils :refer [db-serialize to-jdbc-varchar-array]]
+            [clj-time.coerce :refer [to-timestamp]]
+            [clj-time.core :refer [now]]))
 
 (use-fixtures :each with-test-db)
 
@@ -51,8 +53,8 @@
    {:certname "subset.local"})
   (sql/insert-records
    :catalogs
-   {:id 1 :hash "foo" :api_version 1 :catalog_version "12" :certname "example.local" :environment_id (ensure-environment "DEV")}
-   {:id 2 :hash "bar" :api_version 1 :catalog_version "14" :certname "subset.local" :environment_id nil})
+   {:id 1 :hash "foo" :api_version 1 :catalog_version "12" :certname "example.local" :environment_id (ensure-environment "DEV") :producer_timestamp (to-timestamp (now))}
+   {:id 2 :hash "bar" :api_version 1 :catalog_version "14" :certname "subset.local" :environment_id nil :producer_timestamp (to-timestamp (now))})
 
   (sql/insert-records :catalog_resources
                       {:catalog_id 1 :resource "1" :type "File" :title "/etc/passwd" :exported true :tags (to-jdbc-varchar-array []) :file "a" :line 1}
@@ -280,7 +282,7 @@
   (sql/insert-records :certnames
                       {:certname "foo.local"})
   (sql/insert-records :catalogs
-                      {:id 1 :hash "foo" :api_version 1 :catalog_version "12" :certname "foo.local" :environment_id (ensure-environment "DEV")})
+                      {:id 1 :hash "foo" :api_version 1 :catalog_version "12" :certname "foo.local" :environment_id (ensure-environment "DEV") :producer_timestamp (to-timestamp (now))})
   (sql/insert-records :catalog_resources
                       {:catalog_id 1 :resource "1" :type "File" :title "alpha"   :exported true  :tags (to-jdbc-varchar-array []) :file "a" :line 1}
                       {:catalog_id 1 :resource "2" :type "File" :title "beta"    :exported true  :tags (to-jdbc-varchar-array []) :file "a" :line 4}

--- a/test/puppetlabs/puppetdb/testutils/nodes.clj
+++ b/test/puppetlabs/puppetdb/testutils/nodes.clj
@@ -43,22 +43,22 @@
                            :values {"ipaddress" "192.168.1.100" "hostname" "web1" "operatingsystem" "Debian" "uptime_seconds" 10000}
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/add-facts! {:certname web2
                            :values {"ipaddress" "192.168.1.101" "hostname" "web2" "operatingsystem" "Debian" "uptime_seconds" 13000}
                            :timestamp (plus (now) (secs 1))
                            :environment "DEV"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/add-facts! {:certname puppet
                            :values {"ipaddress" "192.168.1.110" "hostname" "puppet" "operatingsystem" "RedHat" "uptime_seconds" 15000}
                            :timestamp (plus (now) (secs 2))
                            :environment "DEV"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/add-facts! {:certname db
                            :values {"ipaddress" "192.168.1.111" "hostname" "db" "operatingsystem" "Debian"}
                            :timestamp (plus (now) (secs 3))
                            :environment "DEV"
-                           :producer_timestamp nil})
+                           :producer_timestamp (now)})
     (scf-store/replace-catalog! (assoc web1-catalog :certname web1) (now))
     (scf-store/replace-catalog! (assoc puppet-catalog :certname puppet) (plus (now) (secs 1)))
     (scf-store/replace-catalog! (assoc db-catalog :certname db) (plus (now) (secs 2)))

--- a/test/puppetlabs/puppetdb/testutils/resources.clj
+++ b/test/puppetlabs/puppetdb/testutils/resources.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.puppetdb.testutils.resources
   (:require [clojure.java.jdbc :as sql]
             [clj-time.core :refer [now]]
+            [clj-time.coerce :refer [to-timestamp]]
             [puppetlabs.puppetdb.fixtures :refer :all]
             [puppetlabs.puppetdb.jdbc :refer [with-transacted-connection]]
             [puppetlabs.puppetdb.scf.storage :refer [add-facts! ensure-environment]]
@@ -29,23 +30,35 @@
         {:certname "two.local"})
        (sql/insert-records
         :catalogs
-        {:id 1 :hash "foo" :api_version 1 :catalog_version "12" :certname "one.local" :environment_id (when environment? (ensure-environment "DEV"))}
-        {:id 2 :hash "bar" :api_version 1 :catalog_version "14" :certname "two.local" :environment_id (when environment? (ensure-environment "PROD"))})
+        {:id 1
+         :hash "foo"
+         :api_version 1
+         :catalog_version "12"
+         :certname "one.local"
+         :producer_timestamp (to-timestamp (now))
+         :environment_id (when environment? (ensure-environment "DEV"))}
+        {:id 2
+         :hash "bar"
+         :api_version 1
+         :catalog_version "14"
+         :certname "two.local"
+         :producer_timestamp (to-timestamp (now))
+         :environment_id (when environment? (ensure-environment "PROD"))})
        (add-facts! {:certname "one.local"
                     :values {"operatingsystem" "Debian"
                              "kernel" "Linux"
                              "uptime_seconds" 50000}
-                    :timestamp (now)
+                    :timestamp (to-timestamp (to-timestamp (now)))
                     :environment "DEV"
-                    :producer_timestamp nil})
+                    :producer_timestamp (to-timestamp (now))})
        (add-facts! {:certname "two.local"
                     :values {"operatingsystem" "Ubuntu"
                              "kernel" "Linux"
                              "uptime_seconds" 10000
                              "message" "hello"}
-                    :timestamp (now)
+                    :timestamp (to-timestamp (now))
                     :environment "DEV"
-                    :producer_timestamp nil})
+                    :producer_timestamp (to-timestamp (now))})
        (sql/insert-records :catalog_resources
                            {:catalog_id 1 :resource "1" :type "File" :title "/etc/passwd" :exported false :tags (to-jdbc-varchar-array ["one" "two"])}
                            {:catalog_id 1 :resource "2" :type "Notify" :title "hello" :exported false :tags (to-jdbc-varchar-array [])}


### PR DESCRIPTION
Other features would like to rely on the value of producer_timestamp. 
Newer versions of puppet populate this field, but it may be null
in upgrade scenarios. In that case, we can use the receive time 
('timestamp') with no ill effects.