### PR TITLE
(PDB-1286) backport resource timestamp normalization to stable

### DIFF
--- a/src/com/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/com/puppetlabs/puppetdb/scf/hash.clj
@@ -132,16 +132,16 @@
   [{:keys [resource-type resource-title property timestamp status old-value
            new-value message file line] :as resource-event}]
   (generic-identity-string
-    { :resource-type resource-type
-      :resource-title resource-title
-      :property property
-      :timestamp timestamp
-      :status status
-      :old-value old-value
-      :new-value new-value
-      :message message
-      :file file
-      :line line}))
+    {:resource_type resource-type
+     :resource_title resource-title
+     :property property
+     :timestamp timestamp
+     :status status
+     :old_value old-value
+     :new_value new-value
+     :message message
+     :file file
+     :line line}))
 
 (defn report-identity-hash
   "Compute a hash for a report's content
@@ -154,11 +154,11 @@
            start-time end-time resource-events transaction-uuid] :as report}]
   (generic-identity-hash
     {:certname certname
-     :puppet-version puppet-version
-     :report-format report-format
-     :configuration-version configuration-version
-     :start-time start-time
-     :end-time end-time
-     :resource-events (sort (map resource-event-identity-string resource-events))
-     :transaction-uuid transaction-uuid}))
+     :puppet_version puppet-version
+     :report_format report-format
+     :configuration_version configuration-version
+     :start_time start-time
+     :end_time end-time
+     :resource_events (sort (map resource-event-identity-string resource-events))
+     :transaction_uuid transaction-uuid}))
 

--- a/src/com/puppetlabs/puppetdb/utils.clj
+++ b/src/com/puppetlabs/puppetdb/utils.clj
@@ -111,3 +111,11 @@
   ks in map m."
   [m ks f]
     (reduce #(update-in %1 [%2] f) m ks))
+
+(defn update-when
+  "Works like update, but only if ks is found in the map(s)"
+  [m ks f & args]
+  (let [val (get-in m ks ::not-found)]
+    (if (= val ::not-found)
+      m
+      (assoc-in m ks (apply f val args)))))

--- a/test/com/puppetlabs/puppetdb/test/http/events.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/events.clj
@@ -285,7 +285,7 @@
         :new-value nil
         :containing-class "Foo"
         :report-receive-time "2014-04-16T12:44:40.978Z"
-        :report "e52935c051785ec6f3eeb67877aed320c90c2a88"
+        :report "93d449ce6907e55e463c5ff67b9019d9bdef8ae8"
         :resource-title "hi"
         :property nil
         :file "bar"
@@ -310,7 +310,7 @@
         :new-value nil
         :containing-class "Foo"
         :report-receive-time "2014-04-16T12:44:40.978Z"
-        :report "e52935c051785ec6f3eeb67877aed320c90c2a88"
+        :report "93d449ce6907e55e463c5ff67b9019d9bdef8ae8"
         :resource-title "hi"
         :property nil
         :file "bar"
@@ -337,7 +337,7 @@
         :new-value nil
         :containing-class "Foo"
         :report-receive-time "2014-04-16T12:44:40.978Z"
-        :report "e52935c051785ec6f3eeb67877aed320c90c2a88"
+        :report "93d449ce6907e55e463c5ff67b9019d9bdef8ae8"
         :resource-title "hi"
         :property nil
         :file "bar"

--- a/test/com/puppetlabs/puppetdb/test/scf/hash.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/hash.clj
@@ -101,7 +101,7 @@
 
       (testing "should return the same predictable string"
         (is (= (resource-event-identity-string sample)
-               "{\"file\":null,\"line\":null,\"message\":\"Name changed from baz to foo\",\"new-value\":\"foo\",\"old-value\":\"baz\",\"property\":\"name\",\"resource-title\":\"foo\",\"resource-type\":\"Type\",\"status\":\"skipped\",\"timestamp\":\"foo\"}")))))
+               "{\"file\":null,\"line\":null,\"message\":\"Name changed from baz to foo\",\"new_value\":\"foo\",\"old_value\":\"baz\",\"property\":\"name\",\"resource_title\":\"foo\",\"resource_type\":\"Type\",\"status\":\"skipped\",\"timestamp\":\"foo\"}")))))
 
   (testing "catalog-resource-identity-format"
     (let [sample {:type "Type"
@@ -145,7 +145,7 @@
 
       (testing "should return sorted predictable string output"
         (is (= (report-identity-hash sample)
-               "3504b79ff27eb17f4b83bf597d3944bb91cbb1ab")))
+               "7fddeb9eb1f4469acb9ea6c5d1bea15f8654326b")))
 
       (testing "should return the same value twice"
         (is (= (report-identity-hash sample)

--- a/test/com/puppetlabs/puppetdb/testutils/reports.clj
+++ b/test/com/puppetlabs/puppetdb/testutils/reports.clj
@@ -71,7 +71,7 @@
       a value for this."
   [validate-fn example-report timestamp update-latest-report?]
   (let [example-report  (munge-example-report-for-storage example-report)
-        report-hash     (shash/report-identity-hash example-report)]
+        report-hash     (shash/report-identity-hash (scf-store/normalize-report example-report))]
     (validate-fn)
     (scf-store/maybe-activate-node! (:certname example-report) timestamp)
     (scf-store/add-report!* example-report timestamp update-latest-report?)


### PR DESCRIPTION
In master, we've changed our report hashing so that timestamps are converted to
a consistent representation before being hashed.

This backports that change to stable so that users will receive the update in 2.3.1,
and by the time they make it to 3.0 their reports should already be right.

Additional handling will be required in master for various edge cases.