### PR TITLE
(PDB-1290) fix inner join in migration 29

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -962,7 +962,7 @@
       "INSERT INTO certnames_transform(name,latest_report_id,deactivated)
        SELECT c.name, rt.id as latest_report_id, c.deactivated FROM
        certnames c left outer join latest_reports lr on c.name=lr.certname
-       inner join reports_transform rt on lr.report=rt.hash"
+       left outer join reports_transform rt on lr.report=rt.hash"
 
       "ALTER TABLE edges DROP CONSTRAINT edges_certname_fkey"
       "ALTER TABLE catalogs DROP CONSTRAINT catalogs_certname_fkey"


### PR DESCRIPTION
This fixes an issue with migrations from stable->master if facts exist in the
database without reports. Migration 29 was using an inner join
where a left outer join was required, which was causing the new certnames
table to leave behind everything without an associated report.

To reproduce the original problem,
git checkout stable
* start puppet, puppetdb
git checkout 1aafe0637f59bebf39ae61a1125907f5655b1e59
lein run benchmark -c postgres.ini -F acceptance/benchmark/facts -n 5 -N 20 -r 10
* stop puppetdb, puppet
git checkout master
* restart puppet, puppetdb
<migration fails>