### PR TITLE
(PDB-1182) Factor out default puppetdb middleware

### DIFF
--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -7,11 +7,9 @@
             [puppetlabs.puppetdb.http :as http]
             [puppetlabs.puppetdb.http.v4 :refer [v4-app]]
             [puppetlabs.puppetdb.middleware :refer
-             [wrap-with-debug-logging wrap-with-authorization wrap-with-certificate-cn
-              wrap-with-globals wrap-with-metrics wrap-with-default-body]]
+             [wrap-with-puppetdb-middleware wrap-with-globals wrap-with-metrics]]
             [net.cgrand.moustache :refer [app]]
             [ring.middleware.resource :refer [wrap-resource]]
-            [ring.middleware.params :refer [wrap-params]]
             [ring.util.response :refer [redirect header]]))
 
 (defn deprecated-app
@@ -54,11 +52,7 @@
     If not supplied, we default to authorizing all requests."
   [{:keys [authorizer url-prefix] :as globals}]
   (-> (routes url-prefix)
+      (wrap-with-puppetdb-middleware authorizer)
       (wrap-resource "public")
-      wrap-params
-      (wrap-with-authorization authorizer)
-      wrap-with-certificate-cn
-      wrap-with-default-body
       (wrap-with-metrics (atom {}) http/leading-uris)
-      (wrap-with-globals globals)
-      wrap-with-debug-logging))
+      (wrap-with-globals globals)))

--- a/src/puppetlabs/puppetdb/metrics/server.clj
+++ b/src/puppetlabs/puppetdb/metrics/server.clj
@@ -1,10 +1,7 @@
 (ns puppetlabs.puppetdb.metrics.server
   (:require [puppetlabs.puppetdb.metrics.core :as metrics]
             [net.cgrand.moustache :refer [app]]
-            [puppetlabs.puppetdb.middleware :refer
-             [wrap-with-debug-logging wrap-with-authorization
-              wrap-with-certificate-cn wrap-with-default-body]]
-            [ring.middleware.params :refer [wrap-params]]))
+            [puppetlabs.puppetdb.middleware :refer [wrap-with-puppetdb-middleware]]))
 
 (def v1-app
   (app
@@ -14,8 +11,7 @@
     [& names]
     {:get (app (metrics/mbean names))}))
 
-(defn routes
-  []
+(def routes
   (app
    ["v1" "mbeans" &]
    {:any v1-app}))
@@ -29,9 +25,5 @@
     :authorized if the request is authorized, or a user-visible reason if not.
     If not supplied, we default to authorizing all requests."
   [{:keys [authorizer]}]
-  (-> (routes)
-      wrap-params
-      (wrap-with-authorization authorizer)
-      wrap-with-certificate-cn
-      wrap-with-default-body
-      wrap-with-debug-logging))
+  (-> routes
+      (wrap-with-puppetdb-middleware authorizer)))

--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -7,6 +7,7 @@
             [ring.util.request :as request]
             [clojure.string :as s]
             [clojure.tools.logging :as log]
+            [ring.middleware.params :refer [wrap-params]]
             [puppetlabs.puppetdb.query.paging :as paging]
             [clojure.set :as set]
             [pantomime.media :as media]
@@ -282,3 +283,13 @@
         (if-let [payload (params "payload")]
           (app (assoc req :body-string payload))
           (http/error-response (str "Missing required parameter 'payload'")))))))
+
+(defn wrap-with-puppetdb-middleware
+  "Default middleware for puppetdb webservers."
+  [app authorizer]
+  (-> app
+      wrap-params
+      (wrap-with-authorization authorizer)
+      wrap-with-certificate-cn
+      wrap-with-default-body
+      wrap-with-debug-logging))


### PR DESCRIPTION
This commit factors out the wrapping of the default puppetdb middleware
to a `wrap-with-puppetdb-middleware` that is to be used to for all the
puppetdb webservers.