### PR TITLE
(maint) Clean up BoneCP resources when finished

### DIFF
--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -422,7 +422,8 @@
   (f)
   (doseq [db dbs]
     (sql/with-connection db
-      (sql/do-commands "SHUTDOWN"))))
+      (sql/do-commands "SHUTDOWN"))
+    (.close (:datasource db))))
 
 (deftestseq fact-queries
   [[version endpoint] facts-endpoints]


### PR DESCRIPTION
Close the BoneCPDataSource when finished, freeing its threads (among
possibly other things).  Doing so substantially decreases the active
thread count at for the end of "lein test", which can be demonstrated by
adding this to the top of a test file before a run:

  (defmethod report :begin-test-var [m]
    (binding [*out* *err*]
      (prn (:var m) :active-threads (Thread/activeCount))))

These changes should also affect normal invocations of "services -c ...".

 src/puppetlabs/puppetdb/cli/services.clj     | 28 ++++++++++++++--------------
 test/puppetlabs/puppetdb/http/facts_test.clj |  3 ++-
 2 files changed, 16 insertions(+), 15 deletions(-)
