### PR TITLE
(PDB-1300) Update acceptance suite for Puppet 4.0

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -874,6 +874,7 @@ EOS
         on host, "yum install -y puppet-3.7.3"
       when :redhat
         if options[:type] == 'aio' then
+          on host, "yum install -y java-1.7.0-openjdk"
           on host, "yum install -y puppet-agent"
           on host, "yum install -y puppetserver"
         else

--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -763,10 +763,11 @@ EOS
   #
   # @api private
   def restore_puppet_conf host
-    on host, "if [ -f #{host['puppetpath']}/puppet.conf.bak ]; then " +
-               "cat #{host['puppetpath']}/puppet.conf.bak > " +
-               "#{host['puppetpath']}/puppet.conf; " +
-               "rm -rf #{host['puppetpath']}/puppet.conf.bak; " +
+    confdir = host.puppet['confdir']
+    on host, "if [ -f #{confdir}/puppet.conf.bak ]; then " +
+               "cat #{confdir}/puppet.conf.bak > " +
+               "#{confdir}/puppet.conf; " +
+               "rm -rf #{confdir}/puppet.conf.bak; " +
              "fi"
   end
 
@@ -976,9 +977,10 @@ EOS
 
   def install_puppet_conf
     hosts.each do |host|
-      puppetconf = File.join(host['puppetpath'], 'puppet.conf')
+      confdir = host.puppet['confdir']
+      puppetconf = File.join(confdir, 'puppet.conf')
 
-      on host, "mkdir -p #{host['puppetpath']}"
+      on host, "mkdir -p #{confdir}"
 
       conf = IniFile.new
       conf['agent'] = {

--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -994,6 +994,11 @@ EOS
       conf['master'] = {
         'pidfile' => pidfile,
       }
+      if options[:type] == 'aio' then
+        hostname = fact_on(host, "hostname")
+        fqdn = fact_on(host, "fqdn")
+        conf['master']['dns_alt_names']="puppet,#{hostname},#{fqdn},#{host.hostname}"
+      end
       create_remote_file host, puppetconf, conf.to_s
     end
   end

--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -986,8 +986,13 @@ EOS
       conf['agent'] = {
         'server' => master,
       }
+      if options[:is_puppetserver] then
+        pidfile = '/var/run/puppetlabs/puppetserver/puppetserver.pid'
+      else
+        pidfile = master.puppet('master')['pidfile']
+      end
       conf['master'] = {
-        'pidfile' => '/var/run/puppet/master.pid',
+        'pidfile' => pidfile,
       }
       create_remote_file host, puppetconf, conf.to_s
     end

--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -862,12 +862,22 @@ EOS
 
       case os
       when :debian
-        on host, "apt-get install -y puppet puppetmaster-common"
+        if options[:type] == 'aio' then
+          on host, "apt-get install -y puppet-agent"
+          on host, "apt-get install -y puppetserver"
+        else
+          on host, "apt-get install -y puppet puppetmaster-common"
+        end
       # Puppet 3.7.4 is broken on fedora, pinning to 3.7.3 until it's fixed
       when :fedora
         on host, "yum install -y puppet-3.7.3"
       when :redhat
-        on host, "yum install -y puppet"
+        if options[:type] == 'aio' then
+          on host, "yum install -y puppet-agent"
+          on host, "yum install -y puppetserver"
+        else
+          on host, "yum install -y puppet"
+        end
       else
         raise ArgumentError, "Unsupported OS '#{os}'"
       end

--- a/acceptance/options/puppetserver_embedded_db.rb
+++ b/acceptance/options/puppetserver_embedded_db.rb
@@ -1,0 +1,12 @@
+# We are eval'd in the scope of the acceptance framework's option-parsing
+#  code, so we can't use __FILE__ to find our location.  We have access to
+#  a variable 'options_file_path', though.
+require File.expand_path(File.join(File.dirname(options_file_path), 'common.rb'))
+
+common_options_hash.merge({
+  :puppetdb_database      => 'embedded',
+  :is_puppetserver        => 'true',
+  :'use-service'          => 'true',
+  :'puppetserver-confdir' => '/etc/puppetlabs/puppetserver/conf.d',
+  :puppetservice          => 'puppetserver',
+})

--- a/acceptance/setup/pre_suite/15_setup_repos.rb
+++ b/acceptance/setup/pre_suite/15_setup_repos.rb
@@ -1,29 +1,42 @@
 def initialize_repo_on_host(host, os)
   case os
   when :debian
-    on host, "wget http://apt.puppetlabs.com/puppetlabs-release-$(lsb_release -sc).deb"
-    on host, "dpkg -i puppetlabs-release-$(lsb_release -sc).deb"
-    on host, "apt-get update"
+    if options[:type] == 'aio' then
+      on host, "curl -O http://apt.puppetlabs.com/puppetlabs-release-pc1-$(lsb_release -sc).deb"
+      on host, "dpkg -i puppetlabs-release-pc1-$(lsb_release -sc).deb"
+    else
+      on host, "curl -O http://apt.puppetlabs.com/puppetlabs-release-$(lsb_release -sc).deb"
+      on host, "dpkg -i puppetlabs-release-$(lsb_release -sc).deb"
+    end
+      on host, "apt-get update"
   when :redhat
-    create_remote_file host, '/etc/yum.repos.d/puppetlabs-dependencies.repo', <<-REPO.gsub(' '*8, '')
+    if options[:type] == 'aio' then
+      /^(el|centos)-(\d+)-(.+)$/.match(host.platform)
+      variant = ($1 == 'centos') ? 'el' : $1
+      version = $2
+
+      on host, "curl -O http://yum.puppetlabs.com/puppetlabs-release-pc1-#{variant}-#{version}.noarch.rpm"
+      on host, "rpm -i puppetlabs-release-pc1-#{variant}-#{version}.noarch.rpm"
+    else
+      create_remote_file host, '/etc/yum.repos.d/puppetlabs-dependencies.repo', <<-REPO.gsub(' '*8, '')
 [puppetlabs-dependencies]
 name=Puppet Labs Dependencies - $basearch
 baseurl=http://yum.puppetlabs.com/el/$releasever/dependencies/$basearch
 gpgkey=http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
 enabled=1
 gpgcheck=1
-    REPO
+      REPO
 
-    create_remote_file host, '/etc/yum.repos.d/puppetlabs-products.repo', <<-REPO.gsub(' '*8, '')
+      create_remote_file host, '/etc/yum.repos.d/puppetlabs-products.repo', <<-REPO.gsub(' '*8, '')
 [puppetlabs-products]
 name=Puppet Labs Products - $basearch
 baseurl=http://yum.puppetlabs.com/el/$releasever/products/$basearch
 gpgkey=http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
 enabled=1
 gpgcheck=1
-    REPO
+      REPO
 
-    create_remote_file host, '/etc/yum.repos.d/epel.repo', <<-REPO
+      create_remote_file host, '/etc/yum.repos.d/epel.repo', <<-REPO
 [epel]
 name=Extra Packages for Enterprise Linux $releasever - $basearch
 baseurl=http://download.fedoraproject.org/pub/epel/$releasever/$basearch
@@ -31,7 +44,8 @@ mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch
 failovermethod=priority
 enabled=1
 gpgcheck=0
-    REPO
+      REPO
+    end
   when :fedora
     create_remote_file host, '/etc/yum.repos.d/puppetlabs-dependencies.repo', <<-REPO.gsub(' '*8, '')
 [puppetlabs-dependencies]

--- a/acceptance/setup/pre_suite/20_install_puppet.rb
+++ b/acceptance/setup/pre_suite/20_install_puppet.rb
@@ -12,7 +12,7 @@ test_name "Install Puppet" do
   master_facts = facts(master.name)
 
   if options[:type] == 'aio' then
-    on master, "service puppetserver start"
+    bounce_service( master, master['puppetservice'], 10 )
   else
     with_puppet_running_on(
       master,

--- a/acceptance/setup/pre_suite/20_install_puppet.rb
+++ b/acceptance/setup/pre_suite/20_install_puppet.rb
@@ -11,13 +11,17 @@ test_name "Install Puppet" do
 
   master_facts = facts(master.name)
 
-  with_puppet_running_on(
-    master,
-    :master => {:dns_alt_names => "puppet,#{master_facts['hostname']},#{master_facts['fqdn']}",
-                :trace => 'true'}) do
-    # PID file exists?
-    step "PID file created?" do
-      on master, "[ -f #{pidfile} ]"
+  if options[:type] == 'aio' then
+    on master, "service puppetserver start"
+  else
+    with_puppet_running_on(
+      master,
+      :master => {:dns_alt_names => "puppet,#{master_facts['hostname']},#{master_facts['fqdn']}",
+                  :trace => 'true'}) do
+      # PID file exists?
+      step "PID file created?" do
+        on master, "[ -f #{pidfile} ]"
+      end
     end
   end
 end

--- a/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
+++ b/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
@@ -52,4 +52,9 @@ step "Install development build of PuppetDB on the PuppetDB server" do
     end
 
   end
+
+  hosts.each do |host|
+    on host, "iptables -F INPUT -t filter"
+    on host, "iptables -F FORWARD -t filter"
+  end
 end

--- a/acceptance/tests/import_export/import_export_facts_only.rb
+++ b/acceptance/tests/import_export/import_export_facts_only.rb
@@ -12,10 +12,10 @@ test_name "export and import tools" do
       'master' => {
         'storeconfigs' => 'false',
         'autosign' => 'true',
-        'manifest' => manifest_path,
         'trusted_node_data' => 'true'
       },
       'main' => {
+        'environmentpath' => manifest_path,
         'stringify_facts' => 'false'
       }} do
       #only some of the opts work on puppet_agent, acceptable exit codes does not

--- a/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
+++ b/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
@@ -2,6 +2,8 @@ test_name "storeconfigs export and import" do
 
   confine :except, :platform => 'ubuntu-10.04-amd64'
 
+  skip_test "storeconfigs not supported in puppet >= 4.0" unless version_is_less(facts(master.name)['puppetversion'], '4.0.0')
+
   skip_test "Skipping test for PE because sqlite3 isn't available" if master.is_pe?
 
   db_path = master.tmpfile('storeconfigs.sqlite3')

--- a/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
+++ b/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
@@ -16,9 +16,8 @@ test_name "storeconfigs export and import" do
     }
     MANIFEST
 
-    create_remote_file master, manifest_path, manifest
-    on master, "chmod ugo+r #{manifest_path}"
-    #on master, "mkdir -p #{db_path}"
+    manifest_path = create_remote_site_pp(master, manifest)
+
     on master, "chown puppet:puppet #{db_path}"
     on master, "chmod -R 777 #{db_path}"
   end
@@ -31,9 +30,12 @@ test_name "storeconfigs export and import" do
         'dblocation' => db_path,
         'storeconfigs_backend' => 'active_record',
         'debug' => 'true',
-        'manifest' => manifest_path,
         'autosign' => 'true'
-      }} do
+      },
+      'main' => {
+        'environmentpath' => manifest_path,
+      }
+    } do
       hosts.each do |host|
         run_agent_on host, "--test --server #{master}", :acceptable_exit_codes => [0,2]
       end

--- a/acceptance/tests/reports/event_query_with_read_db.rb
+++ b/acceptance/tests/reports/event_query_with_read_db.rb
@@ -56,15 +56,8 @@ notify { "hi":
 MANIFEST
 
 
-  tmpdir = master.tmpdir('report_storage')
+  manifest_path = create_remote_site_pp(master, manifest)
 
-  manifest_file = File.join(tmpdir, 'site.pp')
-
-  create_remote_file(master, manifest_file, manifest)
-
-  File.open('/tmp/manifest-out.txt', 'w') {|f| f.write(manifest) }
-  
-  on master, "chmod -R +rX #{tmpdir}"
 
   # NOTE: this implementation assumes that the test coordinator machine and
   # all of the SUTs are using NTP, and that their system date/times are roughly
@@ -80,8 +73,11 @@ MANIFEST
       'storeconfigs' => 'true',
       'storeconfigs_backend' => 'puppetdb',
       'autosign' => 'true',
-      'manifest' => manifest_file
-    }} do
+    },
+    'main' => {
+      'environmentpath' => manifest_path,
+    }
+  } do
 
       step "Run agents once to submit reports" do
         run_agent_on agents, "--test --server #{master}", :acceptable_exit_codes => [0,2]

--- a/acceptance/tests/storeconfigs/basic_collection.rb
+++ b/acceptance/tests/storeconfigs/basic_collection.rb
@@ -16,19 +16,15 @@ node "#{name}" {
 
   manifest << "\nNotify <<| |>>"
 
-  tmpdir = master.tmpdir('storeconfigs')
-
-  manifest_file = File.join(tmpdir, 'site.pp')
-
-  create_remote_file(master, manifest_file, manifest)
-
-  on master, "chmod -R +rX #{tmpdir}"
-
+  manifest_path = create_remote_site_pp(master, manifest)
   with_puppet_running_on master, {
     'master' => {
       'autosign' => 'true',
-      'manifest' => manifest_file
-    }} do
+    },
+    'main' => {
+      'environmentpath' => manifest_path
+    }
+  } do
 
     step "Run agent once to populate database" do
       run_agent_on hosts, "--test --server #{master}", :acceptable_exit_codes => [0,2]

--- a/acceptance/tests/storeconfigs/collections_with_queries.rb
+++ b/acceptance/tests/storeconfigs/collections_with_queries.rb
@@ -13,25 +13,25 @@ test_name "collections with queries" do
 node "#{exporter}" {
   @@file { "#{dir}/file-a":
     ensure  => present,
-    mode    => 0777,
+    mode    => "0777",
     content => "foo"
   }
 
   @@file { "#{dir}/file-b":
     ensure  => present,
-    mode    => 0755,
+    mode    => "0755",
     content => "bar"
   }
 
   @@file { "#{dir}/file-c":
     ensure  => present,
-    mode    => 0744,
+    mode    => "0744",
     content => "foo",
   }
 
   @@file { "#{dir}/file-d":
     ensure  => present,
-    mode    => 0744,
+    mode    => "0744",
     content => "bar"
   }
 }
@@ -46,23 +46,23 @@ node #{collectors.map {|collector| "\"#{collector}\""}.join(', ')} {
 }
 
 class equal_query {
-  File <<| mode == 0744 |>>
+  File <<| mode == "0744" |>>
 }
 
 class not_equal_query {
-  File <<| mode != 0755 |>>
+  File <<| mode != "0755" |>>
 }
 
 class or_query {
-  File <<| mode == 0755 or content == "bar" |>>
+  File <<| mode == "0755" or content == "bar" |>>
 }
 
 class and_query {
-  File <<| mode == 0744 and content == "foo" |>>
+  File <<| mode == "0744" and content == "foo" |>>
 }
 
 class nested_query {
-  File <<| (mode == 0777 or mode == 0755) and content == "bar" |>>
+  File <<| (mode == "0777" or mode == "0755") and content == "bar" |>>
 }
 MANIFEST
 

--- a/acceptance/tests/storeconfigs/collections_with_queries.rb
+++ b/acceptance/tests/storeconfigs/collections_with_queries.rb
@@ -66,19 +66,17 @@ class nested_query {
 }
 MANIFEST
 
-  tmpdir = master.tmpdir('storeconfigs')
 
-  manifest_file = File.join(tmpdir, 'site.pp')
-
-  create_remote_file(master, manifest_file, manifest)
-
-  on master, "chmod -R +rX #{tmpdir}"
+  manifest_path = create_remote_site_pp(master, manifest)
 
   with_puppet_running_on master, {
     'master' => {
       'autosign' => 'true',
-      'manifest' => manifest_file
-    }} do
+    },
+    'main' => {
+      'environmentpath' => manifest_path,
+    }
+  } do
 
     step "Run exporter to populate the database" do
       run_agent_on exporter, "--test --server #{master}", :acceptable_exit_codes => [0,2]

--- a/acceptance/tests/storeconfigs/deactivated_nodes.rb
+++ b/acceptance/tests/storeconfigs/deactivated_nodes.rb
@@ -13,7 +13,7 @@ test_name "queries against deactivated nodes" do
 node "#{exporter}" {
   @@file { "#{dir}/from_exporter":
     ensure => present,
-    mode => 0777,
+    mode => "0777",
   }
 }
 

--- a/acceptance/tests/storeconfigs/deactivated_nodes.rb
+++ b/acceptance/tests/storeconfigs/deactivated_nodes.rb
@@ -41,19 +41,16 @@ class reactivated {
 }
 MANIFEST
 
-  tmpdir = master.tmpdir('storeconfigs')
-
-  manifest_file = File.join(tmpdir, 'site.pp')
-
-  create_remote_file(master, manifest_file, manifest)
-
-  on master, "chmod -R +rX #{tmpdir}"
+  manifest_path = create_remote_site_pp(master, manifest)
 
   with_puppet_running_on master, {
     'master' => {
       'autosign' => 'true',
-      'manifest' => manifest_file
-    }} do
+    },
+    'main' => {
+      'environmentpath' => manifest_path,
+    }
+  } do
 
     step "Run exporter to populate the database" do
       run_agent_on exporter, "--test --server #{master}", :acceptable_exit_codes => [0,2]

--- a/acceptance/tests/storeconfigs/deactivated_nodes.rb
+++ b/acceptance/tests/storeconfigs/deactivated_nodes.rb
@@ -81,11 +81,13 @@ MANIFEST
 
     step "deactivate the exporter node" do
       # Deactivate the node and wait until it's been processed
-      on database, "puppet node deactivate '#{exporter.node_name}'"
+      # FYI `puppet node deactivate` and `puppet node status` rely on the the
+      # pdb terminus, so they can only be run on the master
+      on master, "puppet node deactivate '#{exporter.node_name}'"
       sleep_until_queue_empty database
 
       # Check that it's actually deactivated
-      on database, "puppet node status '#{exporter.node_name}'" do
+      on master, "puppet node status '#{exporter.node_name}'" do
         assert_match(/Deactivated at/, result.output, "#{exporter.node_name} was not properly deactivated")
       end
     end
@@ -100,7 +102,7 @@ MANIFEST
       # Wait until the catalog has been processed
       sleep_until_queue_empty database
 
-      on database, "puppet node status '#{exporter.node_name}'" do
+      on master, "puppet node status '#{exporter.node_name}'" do
         assert_match(/Currently active/, result.output, "#{exporter.node_name} was not properly reactivated")
       end
     end

--- a/acceptance/tests/storeconfigs/dup_collected_resources.rb
+++ b/acceptance/tests/storeconfigs/dup_collected_resources.rb
@@ -20,19 +20,15 @@ node #{collectors.map {|collector| "\"#{collector}\""}.join(', ')} {
 }
 MANIFEST
 
-  tmpdir = master.tmpdir('puppetdb-storeconfigs')
-
-  manifest_file = File.join(tmpdir, 'site.pp')
-
-  create_remote_file(master, manifest_file, manifest)
-
-  on master, "chmod -R +rX #{tmpdir}"
-
+  manifest_path = create_remote_site_pp(master, manifest)
   with_puppet_running_on master, {
     'master' => {
       'autosign' => 'true',
-      'manifest' => manifest_file
-    }} do
+    },
+    'main' => {
+      'environmentpath' => manifest_path,
+    }
+  } do
 
     step "Run exporters to populate the database" do
       run_agent_on exporter1, "--test --server #{master}", :acceptable_exit_codes => [0,2]

--- a/acceptance/tests/storeconfigs/file_with_binary_template.rb
+++ b/acceptance/tests/storeconfigs/file_with_binary_template.rb
@@ -15,7 +15,7 @@ test_name "submit a catalog that contains a file built from a binary template" d
 file { "/tmp/myfile":
   owner => "root",
   group => "root",
-  mode => 755,
+  mode => "755",
 
   content => template("foomodule/mytemplate.erb"),
   tag => "binary_file"

--- a/acceptance/tests/storeconfigs/file_with_binary_template.rb
+++ b/acceptance/tests/storeconfigs/file_with_binary_template.rb
@@ -22,28 +22,24 @@ file { "/tmp/myfile":
 }
   EOF
 
-  tmpdir = master.tmpdir('storeconfigs')
-  moduledir = master.tmpdir('storeconfigs-moduledir')
+  manifest_path = create_remote_site_pp(master, manifest)
 
+  moduledir = File.join(manifest_path,'production','modules','foomodule')
   test_module = File.join(test_config[:acceptance_data_dir], "storeconfigs", "file_with_binary_template", "modules", "foomodule")
 
   scp_to(master, test_module, moduledir)
 
-  manifest_file = File.join(tmpdir, 'site.pp')
-  create_remote_file(master, manifest_file, manifest)
-
-  on master, "chmod -R +rX #{tmpdir}"
-  on master, "chmod -R +rX #{moduledir}"
-
-  result = on master, "puppet master --configprint modulepath"
-  resmod = "#{result.stdout.strip}:#{moduledir}"
+  on master, "chmod -R +rX #{manifest_path}"
+  on master, "chown -R #{master.puppet['user']}:#{master.puppet['user']} #{manifest_path}"
 
   with_puppet_running_on(master,
     'master' => {
       'autosign' => 'true',
-      'manifest' => manifest_file,
-      'modulepath' => resmod
+    },
+    'main' => {
+      'environmentpath' => manifest_path,
     }) do
+
     step "Run agent to submit catalog" do
       run_agent_on hosts, "--test --server #{master}", :acceptable_exit_codes => (0..4)
     end

--- a/acceptance/tests/storeconfigs/non_parameter_queries.rb
+++ b/acceptance/tests/storeconfigs/non_parameter_queries.rb
@@ -64,18 +64,13 @@ class tag_uppercase_query {
 }
 MANIFEST
 
-  tmpdir = master.tmpdir('storeconfigs')
-
-  manifest_file = File.join(tmpdir, 'site.pp')
-
-  create_remote_file(master, manifest_file, manifest)
-
-  on master, "chmod -R +rX #{tmpdir}"
-
+  manifest_path = create_remote_site_pp(master, manifest)
   with_puppet_running_on master, {
     'master' => {
       'autosign' => 'true',
-      'manifest' => manifest_file
+    },
+    'main' => {
+      'environmentpath' => manifest_path,
     }} do
 
     step "Run exporter to populate the database" do


### PR DESCRIPTION
This pull request updates the PuppetDB acceptance test suite to be able to run against Puppet 4.0 using the `puppet-agent` and `puppetserver` packages. Specifically, this pull request focuses on enabling the testing of this platform on RHEL 7 using the embedded database.

* Pin to beaker 7d0cccf
* Add options file for puppetserver and embedded database
* Add nightly repos for puppet-agent and puppetserver on RHEL 7
* Modify use of global `manifest` value to use a constructed `environmentpath` instead
* Quote all uses of file mode values
* Update use of beaker `puppetpath` value to use `host.puppet` method instead
