### PR TITLE
(PDB-1362) Drop values constraint earlier in fact paths migration

### DIFF
--- a/src/com/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/com/puppetlabs/puppetdb/scf/migrate.clj
@@ -889,7 +889,6 @@
   value) to (id path value)."
   []
   (sql/do-commands
-   ;; Build complete facts table as of migration 28.
 
    "CREATE TABLE facts_unique_transform
       (factset_id bigint NOT NULL,
@@ -914,6 +913,7 @@
 
    ;; Remove all the orphaned duplicates (all but the row in each set
    ;; with min-id).
+   "ALTER TABLE fact_values DROP CONSTRAINT fact_values_path_id_fk"
    "DELETE FROM fact_paths t1
       WHERE t1.id <> (SELECT MIN(t2.id) FROM fact_paths t2
                         WHERE t1.path = t2.path)"
@@ -972,7 +972,6 @@
    "ALTER TABLE fact_paths DROP CONSTRAINT fact_paths_value_type_id"
    "DROP INDEX fact_paths_value_type_id"
    "ALTER TABLE fact_values DROP CONSTRAINT fact_values_path_id_value_key"
-   "ALTER TABLE fact_values DROP CONSTRAINT fact_values_path_id_fk"
 
    "ALTER TABLE fact_paths DROP COLUMN value_type_id"
    "ALTER TABLE fact_values DROP COLUMN path_id"))

--- a/test/com/puppetlabs/puppetdb/test/scf/migrate.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/migrate.clj
@@ -185,7 +185,7 @@
                  :timestamp (to-timestamp current-time) :value_string "false"}]))))))
 
 
-(deftest migration-29
+(deftest migration-28
   (sql/with-connection db
     (clear-db-for-testing!)
     (doseq [[i migration] (sort migrations)
@@ -221,6 +221,25 @@
       (store/add-certname! "probe-values")
       (legacy/add-facts-27! (facts-now "probe-values" {"foo-1" "bar"
                                                        "foo-2" "bar"}))
+
+      ;; Add two facts with the same :path, but different values.
+      (let [[p1 p2] (map :id (sql/insert-records
+                              :fact_paths
+                              {:value_type_id 0
+                               :path "orphan" :name "orphan" :depth 0}
+                              {:value_type_id 1
+                               :path "orphan" :name "orphan" :depth 0}))]
+        (sql/insert-records
+         :fact_values
+         {:path_id p1
+          :value_type_id 0
+          :value_hash (hash/generic-identity-hash "1")
+          :value_string "1"}
+         {:path_id p2
+          :value_type_id 1
+          :value_hash (hash/generic-identity-hash 1)
+          :value_integer 1}))
+
       (testing "different paths produce different values"
         (is (= 2
                (count (query-to-vec


### PR DESCRIPTION
(PDB-1362) Drop values constraint earlier in fact paths migration

```
 src/com/puppetlabs/puppetdb/scf/migrate.clj       |  2 +-
 test/com/puppetlabs/puppetdb/test/scf/migrate.clj | 22 +++++++++++++++++++++-
 2 files changed, 22 insertions(+), 2 deletions(-)
```