### PR TITLE
(PDB-1412) Update rspec dependency from 2.x to 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,9 +26,8 @@ else
 end
 
 group :test do
-  # Pinning to work-around an incompatiblity with 2.14 in puppetlabs_spec_helper
-  gem 'rspec', '2.13.0'
-  gem 'puppetlabs_spec_helper', '0.4.1', :require => false
+  gem 'rspec', '~> 3.1'
+  gem 'puppetlabs_spec_helper', :require => false
 
   case puppet_branch
   when "latest"

--- a/puppet/spec/spec_helper.rb
+++ b/puppet/spec/spec_helper.rb
@@ -35,4 +35,8 @@ RSpec.configure do |config|
 
   end
 
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+
 end

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -84,7 +84,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
 
       it "should add nil transaction uuid if none was given" do
         result = subject.add_transaction_uuid(catalog_data_hash, nil)
-        result.has_key?('transaction-uuid').should be_true
+        result.has_key?('transaction-uuid').should be_truthy
         result['transaction-uuid'].should be_nil
       end
     end

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -96,7 +96,7 @@ describe processor do
           result = subject.send(:report_to_hash)
           # the server will populate the report id, so we validate that the
           # client doesn't include one
-          result.has_key?("report").should be_false
+          result.has_key?("report").should be_falsey
           result["certname"].should == subject.host
           result["puppet-version"].should == subject.puppet_version
           result["report-format"].should == subject.report_format

--- a/puppet/spec/unit/util/puppetdb/config_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/config_spec.rb
@@ -2,12 +2,6 @@ require 'spec_helper'
 require 'puppet/util/puppetdb/config'
 require 'puppet/util/puppetdb/command_names'
 
-# Create a local copy of these constants so that we don't have to refer to them
-# by their full namespaced name
-CommandReplaceCatalog   = Puppet::Util::Puppetdb::CommandNames::CommandReplaceCatalog
-CommandReplaceFacts     = Puppet::Util::Puppetdb::CommandNames::CommandReplaceFacts
-CommandStoreReport      = Puppet::Util::Puppetdb::CommandNames::CommandStoreReport
-
 describe Puppet::Util::Puppetdb::Config do
   describe "#load" do
     let(:confdir) do
@@ -69,7 +63,7 @@ CONF
         config.server.should == 'main_server'
         config.port.should == 1234
         config.ignore_blacklisted_events?.should == false
-        config.soft_write_failure.should be_true
+        config.soft_write_failure.should be_truthy
         config.url_prefix.should == "/puppetdb"
       end
 
@@ -80,7 +74,7 @@ CONF
         config.server.should == 'puppetdb'
         config.port.should == 8081
         config.ignore_blacklisted_events?.should == true
-        config.soft_write_failure.should be_false
+        config.soft_write_failure.should be_falsey
         config.url_prefix.should == ""
       end
 


### PR DESCRIPTION
This commit updates the rspec dependency and updates the terminus spec
code to remove the associated updates new failures, deprecations and
warnings. This commit enables the `:should` syntax explicitly in the
`spec_helper.rb` to remove a deprecation warning that was introduced in
rspec 3.x.

Relates to https://tickets.puppetlabs.com/browse/BKR-100.