### PR TITLE
(PDB-1390) Fix dash to underscore issue with aggregate event counts

### DIFF
--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -538,9 +538,9 @@
                                                                                                                  args))))))
 
   (let [timestamp-fields {"timestamp"           "resource_events.timestamp"
-                          "run-start-time"      "reports.start_time"
-                          "run-end-time"        "reports.end_time"
-                          "report-receive-time" "reports.receive_time"}]
+                          "run_start_time"      "reports.start_time"
+                          "run_end_time"        "reports.end_time"
+                          "report_receive_time" "reports.receive_time"}]
     (match [path]
            [(field :guard (kitchensink/keyset timestamp-fields))]
            (if-let [timestamp (to-timestamp value)]


### PR DESCRIPTION
This specifically breaks when distinct_resources is true when using
report_receive_time, run_start_time or run_end_time. This code path
doesn't go through the query engine and we just missed these extra query
fields.