### PR TITLE
(PDB-1428) Suppress version-check INFO logging

### DIFF
--- a/src/com/puppetlabs/puppetdb/version.clj
+++ b/src/com/puppetlabs/puppetdb/version.clj
@@ -57,6 +57,7 @@
         query-string           (ring-codec/form-encode version-data)
         url                    (format "%s?product=puppetdb&%s" update-server query-string)
         {:keys [status body]}  (client/get url {:throw-exceptions false
+                                                :retry-handler    (constantly false)
                                                 :accept           :json})]
     (when (= status 200)
       (json/parse-string body true))))

--- a/test/com/puppetlabs/puppetdb/test/http/version.clj
+++ b/test/com/puppetlabs/puppetdb/test/http/version.clj
@@ -2,6 +2,7 @@
   (:import (java.util.concurrent TimeUnit))
   (:require [com.puppetlabs.cheshire :as json]
             [clojure.test :refer :all]
+            [puppetlabs.trapperkeeper.testutils.logging :refer [with-log-output]]
             [com.puppetlabs.puppetdb.http.version :refer :all]
             [com.puppetlabs.puppetdb.fixtures :as fixt]
             [com.puppetlabs.puppetdb.testutils :refer [get-request deftestseq]]
@@ -62,3 +63,13 @@
              false "newer"
              "99.0.0" "version"
              nil "link")))))
+
+(deftestseq test-latest-version
+  [[version endpoint] endpoints]
+
+  (testing "shouldn't log HTTP errors hitting update server at INFO"
+    (with-log-output logz
+      (let [response (app-with-update-server {:update-server "http://known.invalid.domain"}
+                                             (get-request (str endpoint "/latest")))
+            log-levels-emitted (set (map second @logz))]
+        (is (nil? (log-levels-emitted :info)))))))


### PR DESCRIPTION
The version-check function uses clj-http, which uses Apache HttpClient
for all the heavy lifting. Recent versions of HttpClient log connection
problems to INFO when using the library's built-in retry facilities.
This is suboptimal, as what's supposed to be a silent background process
(one where it's okay if it fails) to something that may freak out users
with scary looking error messages that are actually harmless.

If you disable automatic retries on the request, HttpClient throws an
exception; this matches the behavior of older versions. Since retries
aren't really required for version-checking, this patch disables them
and thus returns control of logging back to us.