### PR TITLE
(maint) Bump to latest trapperkeeper/jetty9/kitchensink

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,9 +15,9 @@
            (s/trim out)
            "0.0-dev-build"))))))
 
-(def tk-version "1.1.0")
-(def tk-jetty9-version "1.3.0")
-(def ks-version "1.0.0")
+(def tk-version "1.1.1")
+(def tk-jetty9-version "1.3.1")
+(def ks-version "1.1.0")
 
 (defproject puppetdb (version-string)
   :description "Puppet-integrated catalog and fact storage"
@@ -70,7 +70,6 @@
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]
                  [prismatic/schema "0.4.0"]
-                 [prismatic/plumbing "0.4.2"]
                  [org.clojure/tools.macro "0.1.5"]
                  [com.novemberain/pantomime "2.1.0"]
                  [fast-zip-visit "1.0.2"]


### PR DESCRIPTION
This bumps us to the latest revision of TK/jetty9 for the purposes of bumping
the schema dependency. I've also upgraded to the latest kitchensink just for
maint purposes mainly.

Signed-off-by: Ken Barber <ken@bob.sh>