### PR TITLE
(maint) Move late-project? from queries to columns

### DIFF
--- a/src/puppetlabs/puppetdb/facts.clj
+++ b/src/puppetlabs/puppetdb/facts.clj
@@ -259,6 +259,6 @@
                      "json" json/parse-string
                      ("string" "null") identity
                      identity)]
-    (reduce #(dissoc %1 %2)
-            (utils/update-when row [:value] conversion)
-            dissociated-fields)))
+    (apply dissoc
+           (utils/update-when row [:value] conversion)
+           dissociated-fields)))

--- a/src/puppetlabs/puppetdb/query/fact_contents.clj
+++ b/src/puppetlabs/puppetdb/query/fact_contents.clj
@@ -2,6 +2,7 @@
   (:require [puppetlabs.puppetdb.facts :as f]
             [puppetlabs.puppetdb.query-eng.engine :as qe]
             [puppetlabs.puppetdb.schema :as pls]
+            [puppetlabs.puppetdb.utils :as utils]
             [schema.core :as s]))
 
 (def row-schema
@@ -24,11 +25,10 @@
 (pls/defn-validated munge-result-row :- converted-row-schema
   "Coerce the value of a row to the proper type, and convert the path back to
    an array structure."
-  [row :- row-schema]
+  [{:keys [value_integer value_float type] :as row} :- row-schema]
   (-> row
-      (update-in [:value] #(or (:value_integer row) (:value_float row)
-                               (f/unstringify-value (:type row) %)))
-      (update-in [:path] f/string-to-factpath)
+      (utils/update-when [:value] #(or value_integer value_float (f/unstringify-value type %)))
+      (utils/update-when [:path] f/string-to-factpath)
       (dissoc :type :value_integer :value_float)))
 
 (pls/defn-validated munge-result-rows

--- a/src/puppetlabs/puppetdb/query/facts.clj
+++ b/src/puppetlabs/puppetdb/query/facts.clj
@@ -4,6 +4,7 @@
             [puppetlabs.puppetdb.facts :as facts]
             [puppetlabs.puppetdb.query :as query]
             [puppetlabs.puppetdb.query.paging :as paging]
+            [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.query-eng.engine :as qe]
             [puppetlabs.puppetdb.schema :as pls]
             [schema.core :as s]))
@@ -51,7 +52,7 @@
 (defn munge-path-result-rows
   [_ _ _ _]
   (fn [rows]
-     (map #(update-in % [:path] facts/string-to-factpath) rows)))
+     (map #(utils/update-when % [:path] facts/string-to-factpath) rows)))
 
 ;; QUERY
 


### PR DESCRIPTION
This commit moves the late-project? field from the query-recs to
specific columns in the query-recs so that the specific fields that
queries can't do without are called out specifcally. The field is also
renamed to must-have? to align the name with the purpose.