### PR TITLE
(PDB-1263) Use beaker EC2 subnet rotation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,11 +58,7 @@ group :acceptance do
     gem 'beaker', *location_for(beaker_version)
   else
     # use the pinned version
-
-    # We're pinning to a a prerelease version of beaker that fixes errors when
-    # running with an OS X host. We only need to do this until a new version is
-    # released with the fix included.
-    gem 'beaker', :git => 'git://github.com/puppetlabs/beaker.git', :ref => '3e2e1e6d3e0234612c3a6af7dbfac06c797676f4'
+    gem 'beaker', '~>2.11'
   end
   # This forces google-api-client to not download retirable 2.0.0 which lacks
   # ruby 1.9.x support.

--- a/acceptance/config/ec2-west-debian7-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-debian7-64mda-64a.cfg
@@ -10,8 +10,6 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
   debian7-64-2:
     roles:
       - agent
@@ -20,8 +18,11 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443
+  vpc_id: vpc-cc4aeda9
+  subnet_ids:
+    - subnet-4a74d73d
+    - subnet-6169e404
+    - subnet-5870b101

--- a/acceptance/config/ec2-west-debian7-64mda-fallback.cfg
+++ b/acceptance/config/ec2-west-debian7-64mda-fallback.cfg
@@ -10,8 +10,6 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
   debian7-64-2:
     roles:
       - database
@@ -20,8 +18,11 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443
+  vpc_id: vpc-cc4aeda9
+  subnet_ids:
+    - subnet-4a74d73d
+    - subnet-6169e404
+    - subnet-5870b101

--- a/acceptance/config/ec2-west-dev.cfg
+++ b/acceptance/config/ec2-west-dev.cfg
@@ -10,11 +10,10 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4e768a39
-    vpc_id: vpc-3ea7605b
     # ip: 54.186.214.143
 CONFIG:
   nfs_server: none
   consoleport: 443
-
-
+  vpc_id: vpc-3ea7605b
+  subnet_ids:
+    - subnet-4e768a39

--- a/acceptance/config/ec2-west-el5-64mda-el5-64a.cfg
+++ b/acceptance/config/ec2-west-el5-64mda-el5-64a.cfg
@@ -10,8 +10,6 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
   el5-64-2:
     roles:
       - agent
@@ -20,8 +18,11 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443
+  vpc_id: vpc-cc4aeda9
+  subnet_ids:
+    - subnet-4a74d73d
+    - subnet-6169e404
+    - subnet-5870b101

--- a/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
@@ -10,8 +10,6 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
   el5-64-1:
     roles:
       - agent
@@ -20,8 +18,6 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
   ubuntu-12.04-64-1:
     roles:
       - agent
@@ -30,8 +26,11 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443
+  vpc_id: vpc-cc4aeda9
+  subnet_ids:
+    - subnet-4a74d73d
+    - subnet-6169e404
+    - subnet-5870b101

--- a/acceptance/config/ec2-west-el6-64mda-el6-64a.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-el6-64a.cfg
@@ -10,8 +10,6 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
   el6-64-2:
     roles:
       - agent
@@ -20,8 +18,11 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443
+  vpc_id: vpc-cc4aeda9
+  subnet_ids:
+    - subnet-4a74d73d
+    - subnet-6169e404
+    - subnet-5870b101

--- a/acceptance/config/ec2-west-el6-64mda-perf.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-perf.cfg
@@ -14,3 +14,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
+  vpc_id: vpc-cc4aeda9
+  subnet_ids:
+    - subnet-4a74d73d
+    - subnet-6169e404
+    - subnet-5870b101

--- a/acceptance/config/ec2-west-el6-64mda.cfg
+++ b/acceptance/config/ec2-west-el6-64mda.cfg
@@ -10,9 +10,12 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
 
 CONFIG:
   nfs_server: none
   consoleport: 443
+  vpc_id: vpc-cc4aeda9
+  subnet_ids:
+    - subnet-4a74d73d
+    - subnet-6169e404
+    - subnet-5870b101

--- a/acceptance/config/ec2-west-el7-64mda-el7-64a.cfg
+++ b/acceptance/config/ec2-west-el7-64mda-el7-64a.cfg
@@ -10,8 +10,6 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
   el7-64-2:
     roles:
       - agent
@@ -20,8 +18,11 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443
+  vpc_id: vpc-cc4aeda9
+  subnet_ids:
+    - subnet-4a74d73d
+    - subnet-6169e404
+    - subnet-5870b101

--- a/acceptance/config/ec2-west-f20-64mda-f20-64a.cfg
+++ b/acceptance/config/ec2-west-f20-64mda-f20-64a.cfg
@@ -10,8 +10,6 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
   fedora-20-2:
     roles:
       - agent
@@ -20,9 +18,12 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
 
 CONFIG:
   nfs_server: none
   consoleport: 443
+  vpc_id: vpc-cc4aeda9
+  subnet_ids:
+    - subnet-4a74d73d
+    - subnet-6169e404
+    - subnet-5870b101

--- a/acceptance/config/ec2-west-ubuntu1204-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1204-64mda-64a.cfg
@@ -10,8 +10,6 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
   ubuntu-1204-64-2:
     roles:
       - agent
@@ -20,8 +18,11 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-    subnet_id: subnet-4a74d73d
-    vpc_id: vpc-cc4aeda9
 CONFIG:
   nfs_server: none
   consoleport: 443
+  vpc_id: vpc-cc4aeda9
+  subnet_ids:
+    - subnet-4a74d73d
+    - subnet-6169e404
+    - subnet-5870b101


### PR DESCRIPTION
Use the beaker version at the current tip of
rbrw:tmp/rotate-ec2-subnets, and change all of the acceptance/config
files to use CONFIG level vpc_id and subnet_ids settings.

(Don't merge this.)