### PR TITLE
(PDB-1431) Remove PE packages from el-7 AMI

### DIFF
--- a/config/image_templates/ec2.yaml
+++ b/config/image_templates/ec2.yaml
@@ -1,8 +1,8 @@
 AMI:
   el-7-x86_64-west:
     :image:
-      :pe: ami-bd420e8d
-      :foss: ami-bd420e8d
+      :pe: ami-d5c2e8e5
+      :foss: ami-d5c2e8e5
     :region: us-west-2
 
   el-6-x86_64-west:


### PR DESCRIPTION
Switch to a hand-modified el-7 image -- the only change was to purge the
pe-* packages that had been left behind by a bug in the puppetdb-packer
scripts.