### PR TITLE
(PDB-1187) Provide endpoints for a specific report's logs and metrics

### DIFF
--- a/acceptance/tests/reports/report_storage.rb
+++ b/acceptance/tests/reports/report_storage.rb
@@ -55,8 +55,14 @@ test_name "basic validation of puppet report submission" do
     result = on database, %Q|curl -G http://localhost:8080/v4/reports --data 'query=["=",%20"certname",%20"#{agent.node_name}"]' --data 'order_by=[{"field":"receive_time","order":"desc"}]'|
     reports = JSON.parse(result.stdout)
     report = reports[0]
-    metrics = report["metrics"]["data"]
-    logs = report["logs"]["data"]
+    metrics_endpoint = report["metrics"]["href"]
+    logs_endpoint = report["logs"]["href"]
+
+    result = on database, %Q|curl -G http://localhost:8080#{metrics_endpoint}|
+    metrics = JSON.parse(result.stdout)
+
+    result = on database, %Q|curl -G http://localhost:8080#{logs_endpoint}|
+    logs = JSON.parse(result.stdout)
 
     step "ensure that noop is false for #{agent}" do
       assert_equal(false, report["noop"], "noop does not match!")

--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -150,7 +150,7 @@ In the resource_event schema above, `containment_path`, `new_value`, `old_value`
 **Note on querying resource events, metrics, and logs**
 
 The `reports` endpoint does not support querying on the value of `resource_events`, `logs`,
-or `metrics`. In the case of `resource_events` the same information can be accessed by querying the `events` endpoint for events with field `report` equal to a given report's `hash`.
+or `metrics`. For `resource_events` the same information can be accessed by querying the `events` endpoint for events with field `report` equal to a given report's `hash`.
 Making metrics and logs queryable may be the target of future work.
 
 ### Examples
@@ -325,6 +325,16 @@ Query for all reports:
 This will return all events for a particular report, designated by its unique hash.
 
 This is a shortcut to the [`/events`][events] endpoint. It behaves the same as a call to [`/events`][events] with a query string of `["=", "report", "<HASH>"]`.
+
+## `GET /v4/reports/<HASH>/metrics`
+
+This will return all metrics for a particular report, designated by its unique hash.
+This endpoint does not currently support querying or paging.
+
+## `GET /v4/reports/<HASH>/logs`
+
+This will return all logs for a particular report, designated by its unique hash.
+This endpoint does not currently support querying or paging.
 
 ### URL Parameters / Query Operators / Query Fields / Response Format
 

--- a/documentation/api/query/v4/upgrading-from-v3.markdown
+++ b/documentation/api/query/v4/upgrading-from-v3.markdown
@@ -83,6 +83,10 @@ Each change below is marked with the corresponding release version.
 
 * (3.0) `/v4/reports/<hash>/events` This convenience endpoint allows you to show events for a particular report by its hash. See the [/v4/reports documentation](./reports.html)
 
+* (3.0) `/v4/reports/<hash>/metrics` This endpoint allows you to show metrics for a particular report by its hash. See the [/v4/reports documentation](./reports.html)
+
+* (3.0) `/v4/reports/<hash>/logs` This endpoint allows you to show logs for a particular report by its hash. See the [/v4/reports documentation](./reports.html)
+
 * (3.0) `/v4/catalogs/<node>/[resources|edges]` Both of these endpoints provide convenience for drilling into resources & edges data specific to a particular catalog. See [/v4/catalogs documentation](./catalogs)
 
 #### Features affecting all endpoints

--- a/src/puppetlabs/puppetdb/cli/export.clj
+++ b/src/puppetlabs/puppetdb/cli/export.clj
@@ -164,8 +164,7 @@
 (pls/defn-validated reports-expansion :- {s/Keyword s/Any}
   [record :- {s/Keyword s/Any}
    base-url :- utils/base-url-schema]
-  (-> record
-      (update-in [:resource_events] complete-unexpanded base-url)))
+  (kitchensink/mapvals #(complete-unexpanded % base-url) [:resource_events :metrics :logs] record))
 
 (pls/defn-validated reports-for-node-query :- (s/maybe (s/pred seq? 'seq?))
   "Given a node name, retrieves the reports for the node."
@@ -179,10 +178,7 @@
                            (url-encode (format "[\"=\",\"certname\",\"%s\"]"
                                                node)))
                       {:accept :json}))]
-      (map
-       reports-expansion
-       body
-       (repeat base-url)))))
+      (map #(reports-expansion % base-url) body))))
 
 (pls/defn-validated reports-for-node :- (s/maybe (s/pred seq? 'seq?))
   "Given a node name, retrieves the reports for the node and converts it

--- a/src/puppetlabs/puppetdb/http/reports.clj
+++ b/src/puppetlabs/puppetdb/http/reports.clj
@@ -4,30 +4,54 @@
             [net.cgrand.moustache :refer [app]]
             [puppetlabs.puppetdb.http.query :as http-q]
             [puppetlabs.puppetdb.http.events :as e]
-            [puppetlabs.puppetdb.middleware :refer [verify-accepts-json validate-query-params
+            [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.middleware :refer [verify-accepts-json
+                                                    validate-query-params
+                                                    validate-no-query-params
                                                     wrap-with-paging-options]]))
 
-(defn query-app
+(defn report-responder
+  "Respond with reports."
   [version]
   (app
-    [hash "events" &]
-    (comp (e/events-app version)
-          (partial http-q/restrict-query-to-report hash))
+   []
+   {:get
+    (fn [{:keys [params globals paging-options]}]
+      (let [{db :scf-read-db url-prefix :url-prefix} globals
+            {:strs [query]} params]
+        (produce-streaming-body :reports version query paging-options db url-prefix)))}))
 
-    []
-    {:get  (fn [{:keys [params globals paging-options] :as request}]
-             (produce-streaming-body
-               :reports
-               version
-               (params "query")
-               paging-options
-               (:scf-read-db globals)
-               (:url-prefix globals)))}))
+(defn report-data-responder
+  "Respond with either metrics or logs for a given report hash.
+  `entity` should be either :metrics or :logs."
+  [version entity hash]
+  (app
+   []
+   {:get
+    (fn [{:keys [globals]}]
+      (let [{db :scf-read-db url-prefix :url-prefix} globals
+            query (json/generate-string ["=" "hash" hash])]
+        (produce-streaming-body entity version query {} db url-prefix)))}))
 
 (defn reports-app
   [version]
-  (-> (query-app version)
-      (validate-query-params
-        {:optional (cons "query" paging/query-params)})
-      wrap-with-paging-options
-      verify-accepts-json))
+  (app
+   [hash "events" &]
+   (comp (e/events-app version)
+         (partial http-q/restrict-query-to-report hash))
+
+   [hash "metrics" &]
+   (-> (report-data-responder version :report-metrics hash)
+       validate-no-query-params
+       verify-accepts-json)
+
+   [hash "logs" &]
+   (-> (report-data-responder version :report-logs hash)
+       validate-no-query-params
+       verify-accepts-json)
+
+   [&]
+   (-> (report-responder version)
+       (validate-query-params {:optional (cons "query" paging/query-params)})
+       wrap-with-paging-options
+       verify-accepts-json)))

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -27,6 +27,12 @@
    (string? (first q))
    (every? (complement coll?) (rest q))))
 
+(def valid-results-query-schema
+  "Schema type for compiled query-eng queries"
+  (s/pred
+   #(and (map? %)
+         (valid-jdbc-query? (:results-query %)))))
+
 ;; ## String operations
 
 (defn dashes->underscores

--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -97,11 +97,11 @@
       (app (assoc req :paging-options
                   (-> params
                       (select-keys ["limit" "offset" "order_by" "include_total"])
-                      (keywordize-keys)
-                      (paging/parse-limit)
-                      (paging/parse-offset)
-                      (paging/parse-count)
-                      (paging/parse-order-by))))
+                      keywordize-keys
+                      paging/parse-limit
+                      paging/parse-offset
+                      paging/parse-count
+                      paging/parse-order-by)))
       (catch IllegalArgumentException e
         (http/error-response e)))))
 

--- a/src/puppetlabs/puppetdb/query/report_data.clj
+++ b/src/puppetlabs/puppetdb/query/report_data.clj
@@ -1,0 +1,31 @@
+(ns puppetlabs.puppetdb.query.report-data
+  (:require [puppetlabs.puppetdb.jdbc :as jdbc]
+            [puppetlabs.puppetdb.query-eng.engine :as qe]
+            [puppetlabs.puppetdb.scf.storage-utils :as sutils]
+            [puppetlabs.puppetdb.schema :as pls]
+            [schema.core :as s]))
+
+(pls/defn-validated munge-result-rows
+  "Intended to be used for parsing the results
+  from either the report :metrics or :logs queries."
+  [data :- s/Keyword]
+  (fn [rows]
+    (if-let [maybe-json (-> rows first data)]
+      (sutils/parse-db-json maybe-json)
+      [])))
+
+(pls/defn-validated logs-query->sql :- jdbc/valid-results-query-schema
+  "Converts a vector-structured `query` to a corresponding SQL query which will
+  return nodes matching the `query`."
+  [_
+   query :- (s/maybe [s/Any])
+   & _]
+  (qe/compile-user-query->sql qe/report-logs-query query {}))
+
+(pls/defn-validated metrics-query->sql :- jdbc/valid-results-query-schema
+  "Converts a vector-structured `query` to a corresponding SQL query which will
+  return nodes matching the `query`."
+  [_
+   query :- (s/maybe [s/Any])
+   & _]
+  (qe/compile-user-query->sql qe/report-metrics-query query {}))

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -16,6 +16,7 @@
             [puppetlabs.puppetdb.query.fact-contents :as fact-contents]
             [puppetlabs.puppetdb.query.nodes :as nodes]
             [puppetlabs.puppetdb.query.reports :as reports]
+            [puppetlabs.puppetdb.query.report-data :as report-data]
             [puppetlabs.puppetdb.query.resources :as resources]))
 
 (defn ignore-engine-params
@@ -24,8 +25,7 @@
    currently adhere to that contract, so this function will wrap the
    given function `f` and ignore those arguments"
   [f]
-  (fn [_ _ _ _]
-    f))
+  (constantly f))
 
 (defn stream-query-result
   "Given a query, and database connection, return a Ring response with the query
@@ -44,6 +44,8 @@
           :nodes [nodes/query->sql nodes/munge-result-rows]
           :environments [environments/query->sql (ignore-engine-params identity)]
           :reports [reports/query->sql reports/munge-result-rows]
+          :report-metrics [report-data/metrics-query->sql (ignore-engine-params (report-data/munge-result-rows :metrics))]
+          :report-logs [report-data/logs-query->sql (ignore-engine-params (report-data/munge-result-rows :logs))]
           :factsets [factsets/query->sql factsets/munge-result-rows]
           :resources [resources/query->sql resources/munge-result-rows]
           :edges [edges/query->sql edges/munge-result-rows]

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -254,6 +254,42 @@
                :subquery? false
                :late-project? true}))
 
+(defn report-logs-query
+  "Query intended to be used by the `/reports/<hash>/logs` endpoint
+  used for digging into the logs for a specific report."
+  []
+  (map->Query {:projections {"logs" {:type :json
+                                     :queryable? false
+                                     :field :reports.logs}
+                             "hash" {:type :string
+                                     :queryable? true
+                                     :query-only? true
+                                     :field (hsql-hash-as-str :reports.hash)}}
+               :selection {:from [:reports]}
+
+               :alias "logs"
+               :subquery? false
+               :entity :reports
+               :source-table "reports"}))
+
+(defn report-metrics-query
+  "Query intended to be used by the `/reports/<hash>/metrics` endpoint
+  used for digging into the metrics for a specific report."
+  []
+  (map->Query {:projections {"metrics" {:type :json
+                                        :queryable? false
+                                        :field :reports.metrics}
+                             "hash" {:type :string
+                                     :queryable? true
+                                     :query-only? true
+                                     :field (hsql-hash-as-str :reports.hash)}}
+               :selection {:from [:reports]}
+
+               :alias "metrics"
+               :subquery? false
+               :entity :reports
+               :source-table "reports"}))
+
 (defn reports-query
   "Query for the reports entity"
   []
@@ -280,10 +316,12 @@
                                                 :field :reports.end_time}
                              "metrics"        {:type :json
                                                 :queryable? false
-                                                :field :reports.metrics}
+                                                :field :reports.metrics
+                                                :expandable? true}
                              "logs"            {:type :json
                                                 :queryable? false
-                                                :field :reports.logs}
+                                                :field :reports.logs
+                                                :expandable? true}
                              "receive_time"    {:type :timestamp
                                                 :queryable? true
                                                 :field :reports.receive_time}
@@ -1166,15 +1204,15 @@
   [node state]
   (cm/match [node]
             [[(:or "=" "~" ">" "<" "<=" ">=") field _]]
-            (let [query-context (:query-context (meta node))
+            (let [{:keys [alias] :as query-context} (:query-context (meta node))
                   qfields (queryable-fields query-context)]
-              (when (and (not (vec? field))
-                         (not (contains? (set qfields) field)))
+              (when-not (or (vec? field) (contains? (set qfields) field))
                 {:node node
-                 :state (conj state (format "'%s' is not a queryable object for %s, known queryable objects are %s"
-                                            field
-                                            (:alias query-context)
-                                            (json/generate-string qfields)))}))
+                 :state (conj state
+                              (format "'%s' is not a queryable object for %s, %s" field alias 
+                                      (if (empty? qfields)
+                                        (format "%s has no queryable objects" alias)
+                                        (format "known queryable objects are %s" (json/generate-string qfields)))))}))
 
             ; This validation is only for top-level extract operator
             ; For in-extract operator validation, please see annotate-with-context function

--- a/test/puppetlabs/puppetdb/query/reports_test.clj
+++ b/test/puppetlabs/puppetdb/query/reports_test.clj
@@ -22,7 +22,7 @@
   [report]
   (if (sutils/postgres?)
     report
-    (dissoc report :resource_events)))
+    (dissoc report :resource_events :metrics :logs)))
 
 (defn normalize-time
   "Normalize start_time end_time, by coercing it, it forces the timezone to


### PR DESCRIPTION
This commit provides two new endpoints for each report, namely
`/v4/reports/<hash>/logs` and `/v4/reports/<hash>/metrics`.