### PR TITLE
(PDB-1391) Add another error message when handling distinct_resources

### DIFF
--- a/src/puppetlabs/puppetdb/http/aggregate_event_counts.clj
+++ b/src/puppetlabs/puppetdb/http/aggregate_event_counts.clj
@@ -11,9 +11,10 @@
    [""]
    {:get (fn [{:keys [params globals]}]
            (let [{:strs [query summarize_by counts_filter count_by] :as query-params} params
-                 counts_filter (if counts_filter (json/parse-string counts_filter true))
                  distinct-options (events-http/validate-distinct-options! query-params)
-                 query-options (merge {:counts_filter counts_filter :count_by count_by} distinct-options)]
+                 query-options (-> {:counts_filter (when counts_filter (json/parse-string counts_filter true))
+                                    :count_by count_by}
+                                   (merge distinct-options))]
              (produce-streaming-body
               :aggregate-event-counts
               version

--- a/src/puppetlabs/puppetdb/http/events.clj
+++ b/src/puppetlabs/puppetdb/http/events.clj
@@ -6,40 +6,41 @@
             [puppetlabs.puppetdb.middleware :as middleware]
             [net.cgrand.moustache :refer [app]]
             [puppetlabs.puppetdb.http :as http]
+            [puppetlabs.puppetdb.schema :as pls :refer [defn-validated]]
+            [schema.core :as s]
             [puppetlabs.puppetdb.time :refer [to-timestamp]]))
 
-(defn validate-distinct-options!
+(defn-validated validate-distinct-options! :- {:distinct_resources? s/Bool
+                                               :distinct_start_time (s/maybe pls/Timestamp)
+                                               :distinct_end_time (s/maybe pls/Timestamp)}
   "Validate the HTTP query params related to a `distinct_resources` query.  Return a
   map containing the validated `distinct_resources` options, parsed to the correct
   data types.  Throws `IllegalArgumentException` if any arguments are missing
   or invalid."
-  [params]
-  {:pre [(map? params)]
-   :post [(map? %)
-          (every? (partial contains? %) #{:distinct_resources? :distinct_start_time :distinct_end_time})
-          (kitchensink/boolean? (:distinct_resources? %))
-          ((some-fn (partial instance? Timestamp) nil?) (:distinct_start_time %))
-          ((some-fn (partial instance? Timestamp) nil?) (:distinct_end_time %))]}
-  (let [distinct-params ["distinct_resources" "distinct_start_time" "distinct_end_time"]]
-    (cond
-     (not-any? #(contains? params %) distinct-params)
+  [params :- {s/Any s/Any}]
+  (let [distinct-params-names #{"distinct_resources" "distinct_start_time" "distinct_end_time"}
+        {:strs [distinct_start_time distinct_end_time] :as distinct-params}
+        (select-keys params distinct-params-names)]
+    (condp = (kitchensink/keyset distinct-params)
+     #{}
      {:distinct_resources? false
       :distinct_start_time nil
       :distinct_end_time   nil}
 
-     (every? #(contains? params %) distinct-params)
-     (let [start (to-timestamp (params "distinct_start_time"))
-           end   (to-timestamp (params "distinct_end_time"))]
+     distinct-params-names
+     (let [start (to-timestamp distinct_start_time)
+           end   (to-timestamp distinct_end_time)]
        (when (some nil? [start end])
          (throw (IllegalArgumentException.
                  (str "query parameters 'distinct_start_time' and 'distinct_end_time' must be valid datetime strings: "
-                      (params "distinct_start_time") " "
-                      (params "distinct_end_time")))))
-       {:distinct_resources? (http/parse-boolean-query-param params "distinct_resources")
+                      distinct_start_time " " distinct_end_time))))
+       {:distinct_resources? (http/parse-boolean-query-param distinct-params "distinct_resources")
         :distinct_start_time start
         :distinct_end_time   end})
 
-     :else
+     #{"distinct_start_time" "distinct_end_time"}
+     (throw (IllegalArgumentException.
+             "'distinct_resources' query parameter must accompany parameters 'distinct_start_time' and 'distinct_end_time'"))
      (throw (IllegalArgumentException.
              "'distinct_resources' query parameter requires accompanying parameters 'distinct_start_time' and 'distinct_end_time'")))))
 

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -223,6 +223,14 @@
         (is (= (:status response) http/status-bad-request))
         (is (re-find
              #"'distinct_resources' query parameter requires accompanying parameters 'distinct_start_time' and 'distinct_end_time'"
+             body)))
+      
+      (let [response  (get-response endpoint ["=" "certname" "foo.local"] {:distinct_start_time 0
+                                                                           :distinct_end_time 0})
+            body      (get response :body "null")]
+        (is (= (:status response) http/status-bad-request))
+        (is (re-find
+             #"'distinct_resources' query parameter must accompany parameters 'distinct_start_time' and 'distinct_end_time'"
              body))))
 
     (testing "should return only one event for a given resource"


### PR DESCRIPTION
This commit cleans up some of the syntax of the distinct_resources param
handling as well as adding another error message to make the param
handling a little more consistent.