### PR TITLE
(maint) Speed up storage.clj `<hash> in (?,?,?...)` queries

### DIFF
--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -86,8 +86,8 @@
       sql-query-and-params
       (let [limited-result-set (limit-result-set! limit result-set)]
         (-> limited-result-set
-            (convert-result-arrays)
-            (vec))))))
+            convert-result-arrays
+            vec)))))
 
 (defn query-to-vec
   "Take an SQL query and parameters, and return the result of the


### PR DESCRIPTION
This commit addresses an issue where the above query for both
`resources` and `facts` was very slow on Postgres because we were
trimming the bytea hash to a string which was causing Postgres to do a
table scan. This commit fixes this issue by changing the parameters in
the `(?,?...)` to be munged bytea hashes so we don't do a table scan.