### PR TITLE
(maint) Bump to clojure 1.7.0-beta2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0-beta2"]
                  [cheshire "5.4.0"]
                  [org.clojure/core.match "0.2.0-rc5"]
                  [org.clojure/math.combinatorics "0.0.4"]

--- a/test/puppetlabs/puppetdb/query/events_test.clj
+++ b/test/puppetlabs/puppetdb/query/events_test.clj
@@ -7,7 +7,7 @@
             [puppetlabs.puppetdb.testutils.reports :refer [store-example-report! get-events-map]]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.testutils.events :refer :all]
-            [puppetlabs.puppetdb.testutils :refer [deftestseq]]
+            [puppetlabs.puppetdb.testutils :refer [deftestseq select-values']]
             [clj-time.coerce :refer [to-string to-timestamp to-long]]
             [clj-time.core :refer [now ago days]]))
 
@@ -446,8 +446,7 @@
   (let [basic4        (store-example-report! (:basic4 reports) (now))
         events        (get-in reports [:basic4 :resource_events])
         event-count   (count events)
-        select-values #(reverse (kitchensink/select-values
-                                  (get-events-map (:basic4 reports)) %))]
+        select-values #(select-values' (get-events-map (:basic4 reports)) %)]
     (let [version :v4]
       (testing "include total results count"
         (let [actual (:count (raw-resource-events-query-result

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -371,3 +371,25 @@
 (defn strip-hash
   [xs]
   (map #(dissoc % :hash) xs))
+
+(defn select-keys'
+  "Similar to clojure.core/select-keys, adds selected keys an empty
+  instance of `map`, whereas clojure.core/select-keys will use an
+  arraymap (and promote to hash-map). Passing in an ordered or sorted
+  version of `map` will preserve order."
+  [map keyseq]
+  (loop [ret (empty map)
+         keys (seq keyseq)]
+    (if keys
+      (let [entry (. clojure.lang.RT (find map (first keys)))]
+        (recur
+         (if entry
+           (conj ret entry)
+           ret)
+         (next keys)))
+      (with-meta ret (meta map)))))
+
+(def select-values'
+  "Like kitchensink.core/select-values but will preserve the order of the map
+  if an orderd/sorted map is passed in"
+  (comp vals select-keys'))

--- a/test/puppetlabs/puppetdb/testutils/reports.clj
+++ b/test/puppetlabs/puppetdb/testutils/reports.clj
@@ -5,7 +5,8 @@
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.query.reports :as query]
             [clj-time.coerce :as time-coerce]
-            [puppetlabs.puppetdb.testutils.events :refer [munge-example-event-for-storage]]))
+            [puppetlabs.puppetdb.testutils.events :refer [munge-example-event-for-storage]]
+            [flatland.ordered.map :as omap]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Utility functions for massaging results and example data into formats that
@@ -123,6 +124,6 @@
 
 (defn get-events-map
   [example-report]
-  (into {}
+  (into (omap/ordered-map)
         (for [ev (:resource_events example-report)]
           [(:test_id ev) ev])))


### PR DESCRIPTION
Found some failures in the events_test that was relying on the order of
entries in a map that has changed in 1.7.0. Created a version of
clojure.core/select-values that will preserve the order of selected keys
and switched to an ordered-map to fix the issue.