### PR TITLE
(maint) Upgrade clj-time ring-core and compojure deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  [vimclojure/server "2.3.6" :exclusions [org.clojure/clojure]]
                  [clj-stacktrace "0.2.6"]
                  [metrics-clojure "0.7.0" :exclusions [org.clojure/clojure org.slf4j/slf4j-api]]
-                 [clj-time "0.5.1"]
+                 [clj-time "0.9.0"]
                  [org.clojure/java.jmx "0.3.1"]
                  ;; Filesystem utilities
                  [fs "1.1.2"]
@@ -65,9 +65,9 @@
                  [org.slf4j/jcl-over-slf4j "1.7.10"]
                  ;; WebAPI support libraries.
                  [net.cgrand/moustache "1.1.0" :exclusions [ring/ring-core org.clojure/clojure]]
-                 [compojure "1.1.6"]
+                 [compojure "1.3.3"]
                  [clj-http "1.0.1"]
-                 [ring/ring-core "1.2.1" :exclusions [javax.servlet/servlet-api]]
+                 [ring/ring-core "1.3.2" :exclusions [javax.servlet/servlet-api]]
                  [org.apache.commons/commons-compress "1.8"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -60,7 +60,7 @@
             [clojure.java.io :refer [file]]
             [clj-time.core :refer [ago]]
             [overtone.at-at :refer [mk-pool interspaced]]
-            [puppetlabs.puppetdb.time :refer [to-secs to-millis parse-period format-period period?]]
+            [puppetlabs.puppetdb.time :refer [to-seconds to-millis parse-period format-period period?]]
             [puppetlabs.puppetdb.jdbc :refer [with-transacted-connection]]
             [puppetlabs.puppetdb.scf.migrate :refer [migrate! indexes!]]
             [puppetlabs.puppetdb.version :refer [version update-info]]
@@ -321,12 +321,12 @@
       (let [job-pool (mk-pool)
             gc-interval-millis (to-millis gc-interval)
             gc-task #(interspaced gc-interval-millis % job-pool)
-            db-maintenance-tasks [(when (pos? (to-secs node-ttl))
+            db-maintenance-tasks [(when (pos? (to-seconds node-ttl))
                                     #(auto-deactivate-nodes!
                                       node-ttl % mq-connection))
-                                  (when (pos? (to-secs node-purge-ttl))
+                                  (when (pos? (to-seconds node-purge-ttl))
                                     (partial purge-nodes! node-purge-ttl))
-                                  (when (pos? (to-secs report-ttl))
+                                  (when (pos? (to-seconds report-ttl))
                                     (partial sweep-reports! report-ttl))
                                   ;; Order is important here to ensure
                                   ;; anything referencing an env or resource

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -328,7 +328,7 @@
   (let [;; Load the database driver class explicitly, to avoid jar load ordering
         ;; issues.
         _ (Class/forName classname)
-        log-slow-statements-duration (pl-time/to-secs log-slow-statements)
+        log-slow-statements-duration (pl-time/to-seconds log-slow-statements)
         config          (doto (new BoneCPConfig)
                           (.setDefaultAutoCommit false)
                           (.setLazyInit true)

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -36,7 +36,7 @@
             [schema.core :as s]
             [puppetlabs.puppetdb.schema :as pls :refer [defn-validated]]
             [puppetlabs.puppetdb.utils :as utils]
-            [clj-time.core :refer [ago secs now before?]]
+            [clj-time.core :refer [now]]
             [metrics.counters :refer [counter inc! value]]
             [metrics.gauges :refer [gauge]]
             [metrics.histograms :refer [histogram update!]]

--- a/src/puppetlabs/puppetdb/schema.clj
+++ b/src/puppetlabs/puppetdb/schema.clj
@@ -115,7 +115,7 @@
    {org.joda.time.Minutes (comp time/minutes coerce-to-int)
     org.joda.time.Period (comp pl-time/parse-period str)
     org.joda.time.Days (comp time/days coerce-to-int)
-    org.joda.time.Seconds (comp time/secs coerce-to-int)
+    org.joda.time.Seconds (comp time/seconds coerce-to-int)
     Boolean (comp #(Boolean/valueOf %) str)}))
 
 (defn convert-to-schema

--- a/src/puppetlabs/puppetdb/time.clj
+++ b/src/puppetlabs/puppetdb/time.clj
@@ -131,7 +131,7 @@
 (defn format-period
   "Convert a `Period` object into a human-readable String; e.g.:
 
-      `(format-period (clj-time.core/secs 120))`
+      `(format-period (clj-time.core/seconds 120))`
 
   returns '2 minutes'.  The `Period` will only be normalized to
   the largest round unit; e.g., a `Period` of 121 seconds will
@@ -197,7 +197,7 @@
   "Given an instance of `Period`, return an integer representing the number of minutes"
   (partial to-unit #(.getStandardMinutes %)))
 
-(def to-secs
+(def to-seconds
   "Given an instance of `Period`, return an integer representing the number of seconds"
   (partial to-unit #(.getStandardSeconds %)))
 

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -7,7 +7,6 @@
             [puppetlabs.puppetdb.cli.services :refer :all]
             [puppetlabs.puppetdb.utils :as utils]
             [clojure.test :refer :all]
-            [clj-time.core :refer [days hours minutes secs]]
             [puppetlabs.puppetdb.testutils.services :as svc-utils :refer [*base-url*]]
             [puppetlabs.trapperkeeper.app :refer [get-service]]
             [puppetlabs.puppetdb.cli.import-export-roundtrip-test :refer [block-until-results]]

--- a/test/puppetlabs/puppetdb/command/dlo_test.clj
+++ b/test/puppetlabs/puppetdb/command/dlo_test.clj
@@ -2,7 +2,7 @@
   (:require [fs.core :as fs]
             [puppetlabs.kitchensink.core :as kitchensink]
             [clojure.test :refer :all]
-            [clj-time.core :refer [years days secs ago now]]
+            [clj-time.core :refer [years days seconds ago now]]
             [puppetlabs.puppetdb.command.dlo :refer :all]))
 
 (deftest dlo-compression-introspection
@@ -95,7 +95,7 @@
 (deftest dlo-compression
   (let [dlo (fs/temp-dir)
         threshold (days 7)
-        short-threshold (secs 0)
+        short-threshold (seconds 0)
         stale-timestamp (.getMillis (ago (days 8)))]
     (testing "should work with no subdirectories"
       (compress! "non-existent-dir" (days 7))

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -117,7 +117,7 @@
       (testing "should default to zero (no expiration)"
         (let [{:keys [node-ttl] :as dbconfig} (:database (configure-dbs {}))]
           (is (pl-time/period? node-ttl))
-          (is (= 0 (pl-time/to-secs node-ttl))))))
+          (is (= 0 (pl-time/to-seconds node-ttl))))))
     (testing "report-ttl"
       (testing "should parse report-ttl and produce report-ttl"
         (let [{:keys [report-ttl]} (:database (configure-dbs { :database { :report-ttl "10d" }}))]

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -6,7 +6,7 @@
             [puppetlabs.puppetdb.testutils.events :refer [http-expected-resource-events]]
             [flatland.ordered.map :as omap]
             [puppetlabs.puppetdb.examples :refer [catalogs]]
-            [clj-time.core :refer [ago now secs]]
+            [clj-time.core :refer [ago now seconds]]
             [clojure.set :as clj-set]
             [clj-time.coerce :refer [to-string to-long to-timestamp]]
             [puppetlabs.puppetdb.testutils :refer [response-equal?
@@ -290,7 +290,7 @@
 (deftestseq query-by-report-receive-timestamp
   [[version endpoint] endpoints]
 
-  (let [test-start-time (ago (secs 1))
+  (let [test-start-time (ago (seconds 1))
 
         basic           (store-example-report! (:basic reports) (now))
         basic-events    (get-in reports [:basic :resource_events])]

--- a/test/puppetlabs/puppetdb/http/server_time_test.clj
+++ b/test/puppetlabs/puppetdb/http/server_time_test.clj
@@ -4,7 +4,7 @@
             [puppetlabs.puppetdb.fixtures :as fixt]
             [puppetlabs.puppetdb.testutils :refer [get-request deftestseq
                                                    assert-success!]]
-            [clj-time.core :refer [ago secs interval in-secs]]
+            [clj-time.core :refer [ago seconds interval in-seconds]]
             [clj-time.coerce :refer [from-string]]))
 
 (def endpoints [[:v4 "/v4/server-time"]])
@@ -14,7 +14,7 @@
 (deftestseq server-time-response
   [[version endpoint] endpoints]
 
-  (let [test-time (ago (secs 1))
+  (let [test-time (ago (seconds 1))
         response  (fixt/*app* (get-request endpoint))]
     (assert-success! response)
     (let [server-time (-> response
@@ -22,6 +22,6 @@
                           (json/parse-string true)
                           :server_time
                           from-string)]
-      (is (> (in-secs (interval test-time server-time)) 0))
-      (is (> 5 (in-secs (interval test-time server-time)))))))
+      (is (> (in-seconds (interval test-time server-time)) 0))
+      (is (> 5 (in-seconds (interval test-time server-time)))))))
 

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -9,7 +9,7 @@
             [clojure.java.jdbc :as sql]
             [puppetlabs.puppetdb.scf.migrate :refer :all]
             [clj-time.coerce :refer [to-timestamp]]
-            [clj-time.core :refer [now ago days secs]]
+            [clj-time.core :refer [now ago days]]
             [clojure.test :refer :all]
             [clojure.set :refer :all]
             [puppetlabs.puppetdb.jdbc :refer [query-to-vec with-transacted-connection]]

--- a/test/puppetlabs/puppetdb/schema_test.clj
+++ b/test/puppetlabs/puppetdb/schema_test.clj
@@ -166,8 +166,8 @@
     (time/minutes 10) Minutes String "10"
     (time/minutes 10) Minutes Number 10
 
-    (time/secs 10) Seconds String "10"
-    (time/secs 10) Seconds Number 10
+    (time/seconds 10) Seconds String "10"
+    (time/seconds 10) Seconds Number 10
 
     (time/days 10) Days String "10"
     (time/days 10) Days Number 10
@@ -193,7 +193,7 @@
 
           result {:foo (time/days 10)
                   :bar (time/minutes 20)
-                  :baz (time/secs 30)}]
+                  :baz (time/seconds 30)}]
       (is (= result
              (convert-to-schema schema {:foo 10
                                         :bar 20

--- a/test/puppetlabs/puppetdb/testutils/nodes.clj
+++ b/test/puppetlabs/puppetdb/testutils/nodes.clj
@@ -4,7 +4,7 @@
             [puppetlabs.puppetdb.examples :refer :all]
             [puppetlabs.puppetdb.zip :as zip]
             [puppetlabs.puppetdb.testutils.reports :as tur]
-            [clj-time.core :refer [now plus secs]]))
+            [clj-time.core :refer [now plus seconds]]))
 
 (defn change-certname
   "Changes [:certname certname] anywhere in `data` to `new-certname`"
@@ -46,25 +46,25 @@
                            :producer_timestamp (now)})
     (scf-store/add-facts! {:certname web2
                            :values {"ipaddress" "192.168.1.101" "hostname" "web2" "operatingsystem" "Debian" "uptime_seconds" 13000}
-                           :timestamp (plus (now) (secs 1))
+                           :timestamp (plus (now) (seconds 1))
                            :environment "DEV"
                            :producer_timestamp (now)})
     (scf-store/add-facts! {:certname puppet
                            :values {"ipaddress" "192.168.1.110" "hostname" "puppet" "operatingsystem" "RedHat" "uptime_seconds" 15000}
-                           :timestamp (plus (now) (secs 2))
+                           :timestamp (plus (now) (seconds 2))
                            :environment "DEV"
                            :producer_timestamp (now)})
     (scf-store/add-facts! {:certname db
                            :values {"ipaddress" "192.168.1.111" "hostname" "db" "operatingsystem" "Debian"}
-                           :timestamp (plus (now) (secs 3))
+                           :timestamp (plus (now) (seconds 3))
                            :environment "DEV"
                            :producer_timestamp (now)})
     (scf-store/replace-catalog! (assoc web1-catalog :certname web1) (now))
-    (scf-store/replace-catalog! (assoc puppet-catalog :certname puppet) (plus (now) (secs 1)))
-    (scf-store/replace-catalog! (assoc db-catalog :certname db) (plus (now) (secs 2)))
+    (scf-store/replace-catalog! (assoc puppet-catalog :certname puppet) (plus (now) (seconds 1)))
+    (scf-store/replace-catalog! (assoc db-catalog :certname db) (plus (now) (seconds 2)))
     (scf-store/add-report! (basic-report-for-node web1) (now))
-    (scf-store/add-report! (basic-report-for-node puppet) (plus (now) (secs 2)))
-    (scf-store/add-report! (basic-report-for-node db) (plus (now) (secs 3)))
+    (scf-store/add-report! (basic-report-for-node puppet) (plus (now) (seconds 2)))
+    (scf-store/add-report! (basic-report-for-node db) (plus (now) (seconds 3)))
     {:web1    web1
      :web2    web2
      :db      db

--- a/test/puppetlabs/puppetdb/time_test.clj
+++ b/test/puppetlabs/puppetdb/time_test.clj
@@ -1,20 +1,20 @@
 (ns puppetlabs.puppetdb.time-test
   (:require [clojure.test :refer :all]
-            [clj-time.core :refer [days hours secs minutes]]
+            [clj-time.core :refer [days hours seconds minutes]]
             [puppetlabs.puppetdb.time :refer :all]))
 
 (deftest test-periods-equal?
   (testing "should return true for a single period"
-    (is (periods-equal? (secs 10))))
+    (is (periods-equal? (seconds 10))))
   (testing "should return true for periods that are equal"
     (is (periods-equal? (days 2) (hours 48)))
     (is (periods-equal? (hours 3) (minutes 180)))
-    (is (periods-equal? (days 1) (hours 24) (minutes (* 60 24)) (secs (* 60 60 24)))))
+    (is (periods-equal? (days 1) (hours 24) (minutes (* 60 24)) (seconds (* 60 60 24)))))
   (testing "should return false for periods that are not equal"
     (is (not (periods-equal? (days 2) (hours 2))))
     (is (not (periods-equal? (hours 1) (minutes 59))))
-    (is (not (periods-equal? (hours 1) (minutes 60) (secs 10))))
-    (is (not (periods-equal? (hours 1) (days 1) (minutes 60) (secs (* 60 60 24)))))))
+    (is (not (periods-equal? (hours 1) (minutes 60) (seconds 10))))
+    (is (not (periods-equal? (hours 1) (days 1) (minutes 60) (seconds (* 60 60 24)))))))
 
 (deftest test-parse-period
   (testing "should successfully parse a value in days"
@@ -24,9 +24,9 @@
   (testing "should successfully parse a value in minutes"
     (is (periods-equal? (parse-period "120m") (hours 2))))
   (testing "should successfully parse a value in seconds"
-    (is (periods-equal? (parse-period "14s") (secs 14))))
+    (is (periods-equal? (parse-period "14s") (seconds 14))))
   (testing "should successfully parse a value in milliseconds"
-    (is (periods-equal? (parse-period "4000ms") (secs 4))))
+    (is (periods-equal? (parse-period "4000ms") (seconds 4))))
   (testing "should throw an exception if the string is not valid"
     (is (thrown-with-msg? IllegalArgumentException #"Invalid format: \"foo\""
                           (parse-period "foo")))
@@ -41,12 +41,12 @@
   (testing "should normalize when possible, and return a human-readable string"
     (is (= "2 hours" (format-period (minutes 120)))))
   (testing "should use singular versions of time units when appropriate"
-    (is (= "1 minute" (format-period (secs 60)))))
+    (is (= "1 minute" (format-period (seconds 60)))))
   (testing "should not use weeks when normalizing"
     (is (= "30 days" (format-period (days 30)))))
   (testing "should only normalize to the largest whole unit"
-    (is (= "121 seconds" (format-period (secs 121))))
-    (is (= "2 minutes" (format-period (secs 120))))
+    (is (= "121 seconds" (format-period (seconds 121))))
+    (is (= "2 minutes" (format-period (seconds 120))))
     (is (= "26 hours" (format-period (hours 26))))
     (is (= "1 day" (format-period (hours 24))))))
 
@@ -58,19 +58,19 @@
 (deftest test-to-hours
   (testing "should convert periods in various units to hours"
     (is (= 1 (to-hours (minutes 60))))
-    (is (= 2 (to-hours (secs (* 60 60 2)))))))
+    (is (= 2 (to-hours (seconds (* 60 60 2)))))))
 
 (deftest test-to-minutes
   (testing "should convert periods in various units to minutes"
     (is (= 60 (to-minutes (hours 1))))
     (is (= (* 60 24) (to-minutes (days 1))))))
 
-(deftest test-to-secs
+(deftest test-to-seconds
   (testing "should convert periods in various units to seconds"
-    (is (= 60 (to-secs (minutes 1))))
-    (is (= (* 60 60) (to-secs (hours 1))))))
+    (is (= 60 (to-seconds (minutes 1))))
+    (is (= (* 60 60) (to-seconds (hours 1))))))
 
 (deftest test-to-millis
   (testing "should convert periods in various units to millis"
-    (is (= 1000 (to-millis (secs 1))))
+    (is (= 1000 (to-millis (seconds 1))))
     (is (= (* 1000 60) (to-millis (minutes 1))))))


### PR DESCRIPTION
This commit upgrades the clj-time, ring-core, and compojure deps. In
clj-time "0.6.0" instances of secs were deprecated in favor of seconds.
This patch also updates references of secs in puppetdb to be seconds.