### PR TITLE
(PDB-1447) remove late project

### DIFF
--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -353,23 +353,13 @@
   (let [{:keys [where params]} (compile-term ops query)
         sql (format "SELECT %s FROM (
                       SELECT fs.certname,
-                             fp.path as path,
                              fp.name as name,
-                             fp.depth as depth,
-                             fv.value_integer as value_integer,
-                             fv.value_float as value_float,
-                             COALESCE(fv.value_string,
-                                      fv.value_json,
-                                      cast(fv.value_integer as text),
-                                      cast(fv.value_float as text),
-                                      cast(fv.value_boolean as text)) as value,
-                             vt.type as type,
+                             fv.value,
                              env.name as environment
                       FROM factsets fs
                         INNER JOIN facts as f on fs.id = f.factset_id
                         INNER JOIN fact_values as fv on f.fact_value_id = fv.id
                         INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
-                        INNER JOIN value_types as vt on vt.id=fv.value_type_id
                         LEFT OUTER JOIN environments as env on fs.environment_id = env.id
                       WHERE depth = 0) AS facts
                     WHERE %s" (column-map->sql fact-columns) where)]

--- a/src/puppetlabs/puppetdb/query/catalogs.clj
+++ b/src/puppetlabs/puppetdb/query/catalogs.clj
@@ -72,14 +72,10 @@
 (pls/defn-validated munge-result-rows
   "Reassemble rows from the database into the final expected format."
   [version :- s/Keyword
-   projected-fields :- [s/Keyword]
-   _
    url-prefix :- s/Str]
   (let [base-url (str url-prefix "/" (name version))]
     (fn [rows]
-      (map (comp (qe/basic-project projected-fields)
-                 (row->catalog base-url))
-           rows))))
+      (map (row->catalog base-url) rows))))
 
 ;; QUERY
 
@@ -118,12 +114,11 @@
    :post [(map? %)
           (sequential? (:result %))]}
   (let [{[sql & params] :results-query
-         count-query    :count-query
-         projections    :projections} query-sql
+         count-query    :count-query} query-sql
          result {:result (query/streamed-query-result
                           version sql params
                           (comp doall
-                                (munge-result-rows version projections {} url-prefix)))}]
+                                (munge-result-rows version url-prefix)))}]
     (if count-query
       (assoc result :count (jdbc/get-result-count count-query))
       result)))

--- a/src/puppetlabs/puppetdb/query/edges.clj
+++ b/src/puppetlabs/puppetdb/query/edges.clj
@@ -23,14 +23,9 @@
 
 (pls/defn-validated munge-result-rows
   "Reassemble rows from the database into the final expected format."
-  [_
-   projected-fields :- [s/Keyword]
-   _
-   _]
+  [_ _]
   (fn [rows]
-    (map (comp (qe/basic-project projected-fields)
-               #(s/validate edge-schema %))
-         rows)))
+    (map #(s/validate edge-schema %) rows)))
 
 ;; QUERY
 
@@ -62,11 +57,10 @@
   [version query-sql url-prefix]
   {:pre [[(map? query-sql)]]}
   (let [{[sql & params] :results-query
-         count-query    :count-query
-         projections    :projections} query-sql
+         count-query    :count-query} query-sql
          result {:result (query/streamed-query-result
                           version sql params
-                          (comp doall (munge-result-rows version projections {} url-prefix)))}]
+                          (comp doall (munge-result-rows version url-prefix)))}]
     (if count-query
       (assoc result :count (jdbc/get-result-count count-query))
       result)))

--- a/src/puppetlabs/puppetdb/query/factsets.clj
+++ b/src/puppetlabs/puppetdb/query/factsets.clj
@@ -18,15 +18,10 @@
 (pls/defn-validated rtj->fact :- factsets/fact-query-schema
   "Converts from the PG row_to_json format back to something real."
   [facts :- {s/Str s/Any}]
-  (facts/convert-row-type
-   [:type :depth :value_integer :value_float]
-   (-> facts
-       (set/rename-keys {"f1" :name
-                         "f2" :value
-                         "f3" :value_integer
-                         "f4" :value_float
-                         "f5" :type})
-       (update-in [:name] facts/unencode-path-segment))))
+  (-> facts
+      (set/rename-keys {"f1" :name
+                        "f2" :value})
+      (update-in [:value] json/parse-string)))
 
 (pls/defn-validated facts->expansion :- factsets/facts-expanded-query-schema
   "Surround the facts response in the href/data format."
@@ -48,14 +43,10 @@
 (pls/defn-validated munge-result-rows
   "Reassemble rows from the database into the final expected format."
   [version :- s/Keyword
-   projected-fields :- [s/Keyword]
-   _
    url-prefix :- s/Str]
   (let [base-url (str url-prefix "/" (name version))]
     (fn [rows]
-      (map (comp (qe/basic-project projected-fields)
-                 (row->factset base-url))
-           rows))))
+      (map (row->factset base-url) rows))))
 
 ;; QUERY
 

--- a/src/puppetlabs/puppetdb/query/nodes.clj
+++ b/src/puppetlabs/puppetdb/query/nodes.clj
@@ -32,14 +32,6 @@
      (paging/validate-order-by! (node-columns version) paging-options)
      (qe/compile-user-query->sql qe/nodes-query query paging-options)))
 
-(pls/defn-validated munge-result-rows
-  [_
-   projected-fields :- [s/Keyword]
-   _
-   _]
-  (fn [rows]
-    (map (qe/basic-project projected-fields) rows)))
-
 (defn query-nodes
   "Search for nodes satisfying the given SQL filter."
   [version query-sql url-prefix]
@@ -48,11 +40,10 @@
    :post [(map? %)
           (sequential? (:result %))]}
   (let [{[sql & params] :results-query
-         count-query    :count-query
-         projections    :projections} query-sql
+         count-query    :count-query} query-sql
          result {:result (query/streamed-query-result
                           version sql params
-                          (comp doall (munge-result-rows version projections {} url-prefix)))}]
+                          doall)}]
     (if count-query
       (assoc result :count (jdbc/get-result-count count-query))
       result)))

--- a/src/puppetlabs/puppetdb/query/reports.clj
+++ b/src/puppetlabs/puppetdb/query/reports.clj
@@ -59,14 +59,10 @@
 (pls/defn-validated munge-result-rows
   "Reassemble report rows from the database into the final expected format."
   [version :- s/Keyword
-   projected-fields :- [s/Keyword]
-   _
    url-prefix :- s/Str]
   (let [base-url (str url-prefix "/" (name version))]
     (fn [rows]
-      (map (comp (qe/basic-project projected-fields)
-                 (row->report base-url))
-           rows))))
+      (map (row->report base-url) rows))))
 
 ;; QUERY
 
@@ -111,13 +107,12 @@
   [version url-prefix query-sql]
   {:pre [(map? query-sql)]}
   (let [{[sql & params] :results-query
-         count-query    :count-query
-         projections    :projections} query-sql
+         count-query    :count-query} query-sql
          result {:result (query/streamed-query-result
                           version sql params
                           ;; The doall simply forces the seq to be traversed
                           ;; fully.
-                          (comp doall (munge-result-rows version projections {} url-prefix)))}]
+                          (comp doall (munge-result-rows version url-prefix)))}]
     (if count-query
       (assoc result :count (jdbc/get-result-count count-query))
       result)))

--- a/src/puppetlabs/puppetdb/query/resources.clj
+++ b/src/puppetlabs/puppetdb/query/resources.clj
@@ -64,16 +64,11 @@
 (pls/defn-validated munge-result-rows
   "Munge the result rows so that they will be compatible with the version
   specified API specification"
-  [_
-   projected-fields :- [s/Keyword]
-   _
-   _]
+  [_ _]
   (fn [rows]
     (if (empty? rows)
       []
-      (map (comp (qe/basic-project projected-fields)
-                 row->resource)
-           rows))))
+      (map row->resource rows))))
 
 ;; QUERY
 
@@ -107,13 +102,12 @@
   [version query-sql url-prefix]
   {:pre [(map? query-sql)]}
   (let [{[sql & params] :results-query
-         count-query    :count-query
-         projections    :projections} query-sql
+         count-query    :count-query} query-sql
          result {:result (query/streamed-query-result
                           version sql params
                           ;; The doall simply forces the seq to be traversed
                           ;; fully.
-                          (comp doall (munge-result-rows version projections {} url-prefix)))}]
+                          (comp doall (munge-result-rows version url-prefix)))}]
     (if count-query
       (assoc result :count (jdbc/get-result-count count-query))
       result)))

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -41,7 +41,7 @@
           :fact-contents [fact-contents/query->sql fact-contents/munge-result-rows]
           :fact-paths [facts/fact-paths-query->sql facts/munge-path-result-rows]
           :events [events/query->sql events/munge-result-rows]
-          :nodes [nodes/query->sql nodes/munge-result-rows]
+          :nodes [nodes/query->sql (ignore-engine-params identity)]
           :environments [environments/query->sql (ignore-engine-params identity)]
           :reports [reports/query->sql reports/munge-result-rows]
           :report-metrics [report-data/metrics-query->sql (ignore-engine-params (report-data/munge-result-rows :metrics))]
@@ -53,10 +53,7 @@
 
     (jdbc/with-transacted-connection db
       (let [{[sql & params] :results-query
-             count-query :count-query
-             projected-fields :projected-fields} (query->sql version query
-                                                             paging-options)
-
+             count-query :count-query} (query->sql version query paging-options)
              query-error (promise)
              resp (output-fn
                    (fn [f]
@@ -69,7 +66,7 @@
                                 (first %)
                                 (deliver query-error nil)
                                 %)
-                             (munge-fn version projected-fields paging-options url-prefix))))
+                             (munge-fn version url-prefix))))
                        (catch java.sql.SQLException e
                          (deliver query-error e)
                          nil))))]

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -71,11 +71,11 @@
                 ;; so we have to ensure the first element and the rest have been realized, not just the first
                 ;; element on its own.
                 (reset! before-slurp? (and (realized? result-set) (realized? (rest result-set))))
-                (reset! results result-set)
+                (reset! results (vec result-set))
                 (reset! after-slurp? (and (realized? result-set) (realized? (rest result-set))))))))
     (is (false? @before-slurp?))
     (check-result @results)
-    (is (false? @after-slurp?))))
+    (is (true? @after-slurp?))))
 
 (deftest query-via-puppdbserver-service
   (svc-utils/with-puppetdb-instance

--- a/test/puppetlabs/puppetdb/http/environments_test.clj
+++ b/test/puppetlabs/puppetdb/http/environments_test.clj
@@ -60,8 +60,10 @@
     (doseq [env ["foo" "bar" "baz"]]
       (storage/ensure-environment env))
 
-    (are [query expected] (= expected (json/parse-string (slurp (:body (fixt/*app* (get-request endpoint query))))
-                                                         true))
+    (are [query expected] (= expected
+                             (-> (:body (fixt/*app* (get-request endpoint query)))
+                                 slurp
+                                 (json/parse-string true)))
 
          ["in" "name"
           ["extract" "environment"

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -999,6 +999,12 @@
                              :producer_timestamp test-time})
       (scf-store/deactivate-node! "foo4"))))
 
+(def db {:classname "org.postgresql.Driver"
+           :subprotocol "postgresql"
+           :subname "//localhost:5432/puppetdb"
+           :username "puppetdb"
+           :password "puppetdb"})
+
 ;; FACTSETS TRANSFORMATION
 
 (defn strip-expanded

--- a/test/puppetlabs/puppetdb/testutils/nodes.clj
+++ b/test/puppetlabs/puppetdb/testutils/nodes.clj
@@ -9,10 +9,11 @@
 (defn change-certname
   "Changes [:certname certname] anywhere in `data` to `new-certname`"
   [data new-certname]
-  (:node (zip/post-order-transform (zip/tree-zipper data) [(fn [node]
-                                                             (when (and (map? node)
-                                                                        (contains? node :certname))
-                                                               (assoc node :certname new-certname)))])))
+  (:node (zip/post-order-transform
+           (zip/tree-zipper data) [(fn [node]
+                                     (when (and (map? node)
+                                                (contains? node :certname))
+                                       (assoc node :certname new-certname)))])))
 
 (defn basic-report-for-node
   "Creates a report from `reports` for `node-name`"
@@ -29,33 +30,47 @@
         puppet "puppet.example.com"
         db "db.example.com"
         catalog (:empty catalogs)
-        web1-catalog (update-in catalog [:resources]
-                                conj {{:type "Class" :title "web"} {:type "Class" :title "web1" :exported false}})
+        web1-catalog (update-in catalog [:resources] conj
+                                {{:type "Class" :title "web"}
+                                 {:type "Class" :title "web1" :exported false}})
         puppet-catalog  (update-in catalog [:resources]
-                                   conj {{:type "Class" :title "puppet"} {:type "Class" :title "puppetmaster" :exported false}})
+                                   conj {{:type "Class" :title "puppet"}
+                                         {:type "Class" :title "puppetmaster"
+                                          :exported false}})
         db-catalog  (update-in catalog [:resources]
-                               conj {{:type "Class" :title "db"} {:type "Class" :title "mysql" :exported false}})]
+                               conj {{:type "Class" :title "db"}
+                                     {:type "Class" :title "mysql" :exported false}})]
     (scf-store/add-certname! web1)
     (scf-store/add-certname! web2)
     (scf-store/add-certname! puppet)
     (scf-store/add-certname! db)
     (scf-store/add-facts! {:certname web1
-                           :values {"ipaddress" "192.168.1.100" "hostname" "web1" "operatingsystem" "Debian" "uptime_seconds" 10000}
+                           :values {"ipaddress" "192.168.1.100"
+                                    "hostname" "web1"
+                                    "operatingsystem" "Debian"
+                                    "uptime_seconds" 10000}
                            :timestamp (now)
                            :environment "DEV"
                            :producer_timestamp (now)})
     (scf-store/add-facts! {:certname web2
-                           :values {"ipaddress" "192.168.1.101" "hostname" "web2" "operatingsystem" "Debian" "uptime_seconds" 13000}
+                           :values {"ipaddress" "192.168.1.101"
+                                    "hostname" "web2"
+                                    "operatingsystem" "Debian"
+                                    "uptime_seconds" 13000}
                            :timestamp (plus (now) (seconds 1))
                            :environment "DEV"
                            :producer_timestamp (now)})
     (scf-store/add-facts! {:certname puppet
-                           :values {"ipaddress" "192.168.1.110" "hostname" "puppet" "operatingsystem" "RedHat" "uptime_seconds" 15000}
+                           :values {"ipaddress" "192.168.1.110"
+                                    "hostname" "puppet" "operatingsystem"
+                                    "RedHat" "uptime_seconds" 15000}
                            :timestamp (plus (now) (seconds 2))
                            :environment "DEV"
                            :producer_timestamp (now)})
     (scf-store/add-facts! {:certname db
-                           :values {"ipaddress" "192.168.1.111" "hostname" "db" "operatingsystem" "Debian"}
+                           :values {"ipaddress" "192.168.1.111"
+                                    "hostname" "db"
+                                    "operatingsystem" "Debian"}
                            :timestamp (plus (now) (seconds 3))
                            :environment "DEV"
                            :producer_timestamp (now)})


### PR DESCRIPTION
This commit adds a migration to change the value_json column of facts to a TEXT
"value" column, which stores a json-serialized copy of the properly typed fact.
This field is returned by facts queries and deserialized in code to avoid
dragging type information out of the database. Doing this allows us to remove
the concept of late-project.