### PR TITLE
(maint) Detangle query-eng database and http streaming

### DIFF
--- a/src/puppetlabs/puppetdb/http.clj
+++ b/src/puppetlabs/puppetdb/http.clj
@@ -17,8 +17,8 @@
 
 (def http-constants
   (->> java.net.HttpURLConnection
-       (r/reflect)
-       (:members)
+       r/reflect
+       :members
        (map :name)
        (map str)
        (filter #(.startsWith % "HTTP_"))))
@@ -29,11 +29,11 @@
   [name]
   (-> name
       (s/split #"HTTP_")
-      (second)
+      second
       ((partial str "status-"))
       (.replace "_" "-")
       (.toLowerCase)
-      (symbol)))
+      symbol))
 
 ;; Define constants for all of the HTTP status codes defined in the
 ;; java class
@@ -91,7 +91,7 @@
     (if (acceptable-content-type content-type (headers "accept"))
       (f req)
       (-> (format "must accept %s" content-type)
-          (rr/response)
+          rr/response
           (rr/status status-not-acceptable)))))
 
 (defn json-response*
@@ -103,7 +103,7 @@
      (json-response* body status-ok))
   ([body code]
      (-> body
-         (rr/response)
+         rr/response
          (rr/header "Content-Type" "application/json")
          (rr/charset "utf-8")
          (rr/status code))))
@@ -197,35 +197,6 @@
           (catch Exception e#
             (log/error e# "Error streaming response")))))))
 
-(defn stream-json-response
-  "Converts streaming results from function `f` into a streaming Ring response.
-
-  This works in tandem with query/query-stream-results. So usually `f` is the
-  result of a call to this function, normally to achieve streaming from a DB
-  cursor.
-
-  It wraps the execution of `f` and subsequent results in a Ring
-  piped-input-stream thread allowing the cursor stream and JSON encoding to
-  continue while the web server starts serving the content immediately (using
-  chunked encoding usually).
-
-  `f` is a function of one argument, which is another function. The
-  the function `f` will accept one argument that is a LazySeq
-  result set. This result set will be piped through a JSON stream.
-
-  Returns a Ring response map with the :body containing a Buffer. Processing
-  and conversion into the JSON stream will continue in another thread and update
-  the Buffer as results are returned."
-  [f]
-  {:post [(rr/response? %)]}
-  ;; json-response here creates a Ring response putting the Buffer into
-  ;; the :body so that ring can stream from it.
-  (json-response*
-   (streamed-response buffer
-     ;; We pass the stream function back to the stream-query-result so that
-     ;; it gets executed inside the cursor function.
-     (f #(stream-json % buffer)))))
-
 (defn parse-boolean-query-param
   "Utility method for parsing a query parameter whose value is expected to be
   a boolean.  In the case where the HTTP request contains the query parameter but
@@ -276,6 +247,5 @@
   {:pre [(map? query-result)
          (contains? query-result :result)]
    :post [(rr/response? %)]}
-  (->
-   (json-response (:result query-result))
-   (add-headers (dissoc query-result :result))))
+  (-> (json-response (:result query-result))
+      (add-headers (dissoc query-result :result))))

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -744,5 +744,7 @@
    If all you want is an unstreamed Seq, pass the function `doall` as `f` to
    convert the LazySeq to a Seq by full traversing it. This is useful for tests,
    that cannot analyze results easily in a streamed way."
-  [version sql params f]
-  (jdbc/with-query-results-cursor sql params rs (f rs)))
+  ([[sql & params] f]
+   (streamed-query-result nil sql params f))
+  ([version sql params f]
+   (jdbc/with-query-results-cursor sql params rs (f rs))))

--- a/src/puppetlabs/puppetdb/query/aggregate_event_counts.clj
+++ b/src/puppetlabs/puppetdb/query/aggregate_event_counts.clj
@@ -37,11 +37,14 @@
           (= (count %) 1)]}
   (jdbc/query-to-vec (apply vector sql params)))
 
+(defn munge-result-rows
+  [_ _]
+  (comp (partial kitchensink/mapvals #(if (nil? %) 0 %)) first))
+
 (defn query-aggregate-event-counts
   "Given a SQL query and its parameters, return the single matching result map."
   [{:keys [results-query]}]
   {:pre  [(string? (first results-query))]
    :post [(map? %)]}
   (->> (perform-query results-query)
-       first
-       (kitchensink/mapvals #(if (nil? %) 0 %))))
+       ((munge-result-rows nil nil))))

--- a/src/puppetlabs/puppetdb/query/report_data.clj
+++ b/src/puppetlabs/puppetdb/query/report_data.clj
@@ -9,10 +9,11 @@
   "Intended to be used for parsing the results
   from either the report :metrics or :logs queries."
   [data :- s/Keyword]
-  (fn [rows]
-    (if-let [maybe-json (-> rows first data)]
-      (sutils/parse-db-json maybe-json)
-      [])))
+  (fn [_ _]
+   (fn [rows]
+     (if-let [maybe-json (-> rows first data)]
+       (sutils/parse-db-json maybe-json)
+       []))))
 
 (pls/defn-validated logs-query->sql :- jdbc/valid-results-query-schema
   "Converts a vector-structured `query` to a corresponding SQL query which will

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -64,15 +64,13 @@
         before-slurp? (atom nil)
         after-slurp? (atom nil)]
     (query pdb-service endpoint version q pagination
-           (fn [f]
-             (f
-              (fn [result-set]
-                ;; We evaluate the first element from lazy-seq just to check if DB query was successful or not
-                ;; so we have to ensure the first element and the rest have been realized, not just the first
-                ;; element on its own.
-                (reset! before-slurp? (and (realized? result-set) (realized? (rest result-set))))
-                (reset! results (vec result-set))
-                (reset! after-slurp? (and (realized? result-set) (realized? (rest result-set))))))))
+           (fn [result-set]
+             ;; We evaluate the first element from lazy-seq just to check if DB query was successful or not
+             ;; so we have to ensure the first element and the rest have been realized, not just the first
+             ;; element on its own.
+             (reset! before-slurp? (and (realized? result-set) (realized? (rest result-set))))
+             (reset! results (vec result-set))
+             (reset! after-slurp? (and (realized? result-set) (realized? (rest result-set))))))
     (is (false? @before-slurp?))
     (check-result @results)
     (is (true? @after-slurp?))))


### PR DESCRIPTION
This commit addresses the "callback hell" of the query_eng.clj. Prior to
this commit the query-eng stream-query-result function had an output-fn
arguement whose interface was as follows, "output-fn takes a function
(f) as an argument and applies that funtion to another function (g),
(g) must realize the values of a lazy sequence of database rows."
This was primarily do to the fact the we need to stream results from the
database as well as stream results of http, which had to be done in a
separate thread. Another layer of complexity was that the http streaming
that we did also needed access to the count-query vector only available
int the stream-query result vector. All this complexity makes it very
confusing developing callbacks for querying puppetdb in process
directly, such as from PE extensions. This commit moves the http
streaming up a functional layer into produce-streaming body, passing
stream-query-result a promise to retrieve the count-query.