### PR TITLE
(maint) fix /v4/catalogs/<node> so version isn't repeated in the href

### DIFF
--- a/src/puppetlabs/puppetdb/http/catalogs.clj
+++ b/src/puppetlabs/puppetdb/http/catalogs.clj
@@ -45,7 +45,7 @@
     [node]
     (fn [{:keys [globals]}]
       (catalog-status version node (:scf-read-db globals)
-                      (str (:url-prefix globals) "/" (name version))))
+                      (str (:url-prefix globals))))
 
     [node "edges" &]
     (comp (edges/edges-app version) (partial http-q/restrict-query-to-node node))


### PR DESCRIPTION
Previously we were passing the url-prefix *and* the version to catalog-status as
the url-prefix, which was causing the version to be doubled in the href urls
(i.e foo/v4/v4/catalogs/node/edges).