### PR TITLE
(re-4451) Do not override main-namespace for pe builds

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -136,7 +136,6 @@
                   :lein-ezbake {:vars {:user "pe-puppetdb"
                                        :group "pe-puppetdb"
                                        :build-type "pe"
-                                       :main-namespace "puppetlabs.puppetdb.core"
                                        :create-varlib true}
                                 :config-dir "ext/config/pe"}
                   :version ~pdb-version


### PR DESCRIPTION
The ezbake pe profile is currently overriding the main-namespace
for the project.

This removes that variable definition, taking the default for the
project.