### PR TITLE
(maint) allow ordering on non-extracted fields

### DIFF
--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -162,7 +162,7 @@
   (let [limit-clause     (if limit (format " LIMIT %s" limit) "")
         offset-clause    (if offset (format " OFFSET %s" offset) "")
         order-by-clause  (order-by->sql order_by)]
-    (format "SELECT paged_results.* FROM (%s) paged_results%s%s%s"
+    (format "SELECT paged_results.* FROM (%s %s%s%s) paged_results"
             sql order-by-clause limit-clause offset-clause)))
 
 (pls/defn-validated count-sql :- String

--- a/src/puppetlabs/puppetdb/query/facts.clj
+++ b/src/puppetlabs/puppetdb/query/facts.clj
@@ -77,17 +77,15 @@
 
 (defn fact-names
   "Returns the distinct list of known fact names, ordered alphabetically
-  ascending. This includes facts which are known only for deactivated nodes."
+   ascending. This includes facts which are known only for deactivated nodes."
   ([]
-     (fact-names {}))
+   (fact-names {}))
   ([paging-options]
-     {:post [(map? %)
-             (coll? (:result %))
-             (every? string? (:result %))]}
-     (paging/validate-order-by! [:name] paging-options)
-     (let [facts (query/execute-query
-                  ["SELECT DISTINCT name
-                   FROM fact_paths
-                   ORDER BY name"]
-                  paging-options)]
-       (update-in facts [:result] #(map :name %)))))
+   {:post [(map? %)
+           (coll? (:result %))
+           (every? string? (:result %))]}
+   (paging/validate-order-by! [:name] paging-options)
+   (let [order-by-clause (if (:order_by paging-options) "" "ORDER BY name")
+         query (format "SELECT DISTINCT name FROM fact_paths %s" order-by-clause)
+         facts (query/execute-query [query] paging-options)]
+     (update-in facts [:result] #(map :name %)))))


### PR DESCRIPTION
This changes our paged sql function to do
```
select paged_results.* from (select blah from facts order by baz)
```
instead of
```
select paged_results.* from (select blah from facts) order by baz
```

the latter of which will not work without a late projection.