### PR TITLE
(PDB-1310) Don't check reports in deactivate

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -91,9 +91,8 @@
              (format-period node-ttl))
      (with-transacted-connection db
        (doseq [node (scf-store/stale-nodes (ago node-ttl))]
-         (enqueue-command! mq-connection
-                           mq-endpoint
-                           (command-names :deactivate-node) 3 {:certname node}))))
+         (log/infof "Auto-deactivating node %s" node)
+         (scf-store/deactivate-node! node))))
     (catch Exception e
       (log/error e "Error while deactivating stale nodes"))))
 

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -223,7 +223,7 @@
     (jdbc/with-transacted-connection db
       (when-not (scf-storage/certname-exists? certname)
         (scf-storage/add-certname! certname))
-      (when (not-any? newer-record-exists? [:catalogs :factsets :reports])
+      (when (not-any? newer-record-exists? [:catalogs :factsets])
         (scf-storage/deactivate-node! certname producer_timestamp)))
     (log/info (format "[%s] [%s] %s" id (command-names :deactivate-node) certname))))
 


### PR DESCRIPTION
Report start_time comes from the agent, so it doesn't make sense to
compare it to the producer_timestamp on the deactivate command. The
real fix to this is to add a producer_timestamp to the store report
command, but as a stopgap we'll just revert to the old behavior for
these records.