### PR TITLE
(maint) Remove redirect to PuppetDB dashboard

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -89,8 +89,8 @@ body {
 }
 </style>
 
-<script src="d3.v2.js"></script>
-<script src="charts.js"></script>
+<script src="dashboard/d3.v2.js"></script>
+<script src="dashboard/charts.js"></script>
 
 <div id="version-info">
   PuppetDB <span id="version">(unknown version)</span>

--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -31,15 +31,20 @@
     (format "The %s API has been retired; please use v4" version)
     404)))
 
+(defn dashboard []
+  (let [index (ring.util.response/file-response "public/index.html" {:root "resources"})]
+    (-> (app [""] {:get (constantly index)}
+             ["dashboard/index.html"] {:get (constantly index)})
+        (wrap-resource "public"))))
+
 (defn routes
-  [url-prefix]
+  []
   (app
    ["v4" &] {:any v4-app}
    ["v1" &] {:any (refuse-retired-api "v1")}
    ["v2" &] {:any (refuse-retired-api "v2")}
    ["v3" &] {:any (refuse-retired-api "v3")}
-   [""] {:get (constantly
-               (redirect (format "%s/dashboard/index.html" url-prefix)))}))
+   [&] (dashboard)))
 
 (defn build-app
   "Generate a Ring application that handles PuppetDB requests
@@ -50,9 +55,8 @@
   * `authorizer` - a function that takes a request and returns a
     :authorized if the request is authorized, or a user-visible reason if not.
     If not supplied, we default to authorizing all requests."
-  [{:keys [authorizer url-prefix] :as globals}]
-  (-> (routes url-prefix)
+  [{:keys [authorizer] :as globals}]
+  (-> (routes)
       (wrap-with-puppetdb-middleware authorizer)
-      (wrap-resource "public")
       (wrap-with-metrics (atom {}) http/leading-uris)
       (wrap-with-globals globals)))


### PR DESCRIPTION
This commit changes the PuppetDB dashboard to be served as a file
response on "/" explicitly instead of a redirect to
"/dashboard/index.html". This allows us to refrain from passing
url-prefix to the main PuppetDB app `routes` function, as well as
modularize the dashboard to its own handler so it can be served
separately from the PuppetDB query app.