### PR TITLE
(PDB-1485) Deprecate url-prefix setting

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -177,6 +177,8 @@ When this is set to true, debugging information will be written to `<vardir>/deb
 
 ### `url-prefix`
 
+> **Deprecated:** This setting should not be necessary in most cases and will not be supported in a future release.
+
 This optional setting may be used to mount the PuppetDB web application at a URL other than "/".  This should not be necessary
 unless you intend to run additional web applications in the same server with your PuppetDB instance.  **NOTE:** if you change
 this setting, you must also set the corresponding setting in your Puppet Master's [puppetdb.conf][puppetdb.conf] file.

--- a/src/com/puppetlabs/puppetdb/config.clj
+++ b/src/com/puppetlabs/puppetdb/config.clj
@@ -323,6 +323,8 @@
         url-prefix   (normalize-url-prefix (get global :url-prefix ""))]
     (when (:event-query-limit global)
       (log/warn "The configuration item `event-query-limit` in the [global] section is deprecated and now ignored. It will be removed in the future."))
+    (when url-prefix
+      (log/warn "The configuration item `url-prefix` in the [global] section is deprecated. It will be removed in the future."))
     (update-in config [:global]
                (fn [global-config]
                  (-> global-config


### PR DESCRIPTION
This commit deprecates the url-prefix setting under the `[global]`
header. This configuration is not necessary and done differently
for other trapperkeeper services.