### PR TITLE
(PDB-1479) deprecate event counts and aggregate event counts

### DIFF
--- a/documentation/api/query/v3/aggregate-event-counts.markdown
+++ b/documentation/api/query/v3/aggregate-event-counts.markdown
@@ -9,6 +9,9 @@ canonical: "/puppetdb/latest/api/query/v3/aggregate-event-counts.html"
 [curl]: ../curl.html
 [query]: ./query.html
 
+> **Experimental Endpoint**: The aggregate-event-counts endpoint is designated
+> as experimental. It may be altered or removed in a future release.
+
 Puppet agent nodes submit reports after their runs, and the puppet master forwards these to PuppetDB. Each report includes:
 
 * Some data about the entire run

--- a/documentation/api/query/v3/event-counts.markdown
+++ b/documentation/api/query/v3/event-counts.markdown
@@ -9,6 +9,9 @@ canonical: "/puppetdb/latest/api/query/v3/event-counts.html"
 [curl]: ../curl.html
 [query]: ./query.html
 
+> **Experimental Endpoint**: The event-counts endpoint is designated
+> as experimental. It may be altered or removed in a future release.
+
 Puppet agent nodes submit reports after their runs, and the puppet master forwards these to PuppetDB. Each report includes:
 
 * Some data about the entire run

--- a/documentation/api/query/v4/aggregate-event-counts.markdown
+++ b/documentation/api/query/v4/aggregate-event-counts.markdown
@@ -9,6 +9,9 @@ canonical: "/puppetdb/latest/api/query/v4/aggregate-event-counts.html"
 [curl]: ../curl.html
 [query]: ./query.html
 
+> **Experimental Endpoint**: The aggregate-event-counts endpoint is designated
+> as experimental. It may be altered or removed in a future release.
+
 Puppet agent nodes submit reports after their runs, and the puppet master forwards these to PuppetDB. Each report includes:
 
 * Some data about the entire run

--- a/documentation/api/query/v4/event-counts.markdown
+++ b/documentation/api/query/v4/event-counts.markdown
@@ -9,6 +9,9 @@ canonical: "/puppetdb/latest/api/query/v4/event-counts.html"
 [curl]: ../curl.html
 [query]: ./query.html
 
+> **Experimental Endpoint**: The event-counts endpoint is designated
+> as experimental. It may be altered or removed in a future release.
+
 Puppet agent nodes submit reports after their runs, and the puppet master forwards these to PuppetDB. Each report includes:
 
 * Some data about the entire run

--- a/src/com/puppetlabs/puppetdb/http/aggregate_event_counts.clj
+++ b/src/com/puppetlabs/puppetdb/http/aggregate_event_counts.clj
@@ -5,6 +5,7 @@
             [com.puppetlabs.puppetdb.http.events :as events-http]
             [com.puppetlabs.jdbc :refer [with-transacted-connection]]
             [com.puppetlabs.middleware :refer [verify-accepts-json validate-query-params]]
+            [clojure.tools.logging :as log]
             [net.cgrand.moustache :refer [app]]))
 
 (defn produce-body
@@ -45,6 +46,7 @@
 (defn aggregate-event-counts-app
   "Ring app for querying for aggregated summary information about resource events."
   [version]
+  (log/warn "The aggregate-event-counts endpoint is experimental and may be altered or removed in the future.")
   (-> (routes version)
       verify-accepts-json
       (validate-query-params {:required ["query" "summarize-by"]

--- a/src/com/puppetlabs/puppetdb/http/event_counts.clj
+++ b/src/com/puppetlabs/puppetdb/http/event_counts.clj
@@ -3,6 +3,7 @@
             [com.puppetlabs.puppetdb.query.event-counts :as event-counts]
             [com.puppetlabs.cheshire :as json]
             [com.puppetlabs.puppetdb.http.events :as events-http]
+            [clojure.tools.logging :as log]
             [com.puppetlabs.puppetdb.query.paging :as paging]
             [com.puppetlabs.jdbc :as jdbc]
             [com.puppetlabs.middleware :refer [verify-accepts-json validate-query-params
@@ -59,11 +60,12 @@
 (defn event-counts-app
   "Ring app for querying for summary information about resource events."
   [version]
+  (log/warn "The event-counts endpoint is experimental and may be altered or removed in the future.")
   (-> (routes version)
       verify-accepts-json
       (validate-query-params {:required ["query" "summarize-by"]
                               :optional (concat ["counts-filter" "count-by"
                                                  "distinct-resources" "distinct-start-time"
                                                  "distinct-end-time"]
-                                          paging/query-params) })
+                                          paging/query-params)})
       wrap-with-paging-options))


### PR DESCRIPTION
This adds a deprecation message in the docs for event-counts and
aggregate-event-counts, and also introduces a warning when the endpoints are used.