### PR TITLE
(PDB-1513) Clean up log-format calls

### DIFF
--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -61,7 +61,7 @@
   (try
     (json/parse-string (slurp file))
     (catch Exception e
-      (log/error (format "Error parsing %s; skipping" file)))))
+      (log/errorf "Error parsing %s; skipping" file))))
 
 (defn error-if
   [pred msg x]
@@ -199,23 +199,23 @@
         (future
           (try
             (client/submit-catalog base-url 6 (json/generate-string catalog))
-            (log/info (format "[%s] submitted catalog" host))
+            (log/infof "[%s] submitted catalog" host)
             (catch Exception e
-              (log/error (format "[%s] failed to submit catalog: %s" host e))))))
+              (log/errorf "[%s] failed to submit catalog: %s" host e)))))
       (when report
         (future
           (try
             (client/submit-report base-url 5 (json/generate-string report))
-            (log/info (format "[%s] submitted report" host))
+            (log/infof "[%s] submitted report" host)
             (catch Exception e
-              (log/error (format "[%s] failed to submit report: %s" host e))))))
+              (log/errorf "[%s] failed to submit report: %s" host e)))))
       (when factset
         (future
           (try
             (client/submit-facts base-url 4 (json/generate-string factset))
-            (log/info (format "[%s] submitted factset" host))
+            (log/infof "[%s] submitted factset" host)
             (catch Exception e
-              (log/error (format "[%s] failed to submit factset: %s" host e))))))
+              (log/errorf "[%s] failed to submit factset: %s" host e)))))
       (assoc state
         :lastrun clock
         :catalog catalog))
@@ -244,8 +244,8 @@
    is recursive to accumulate possible catalog mutations (i.e. changing a previously
    mutated catalog as opposed to different mutations of the same catalog)."
   [hosts num-msgs]
-  (log/info (format "Sending %s messages for %s hosts, will exit upon completion"
-                    num-msgs (count hosts)))
+  (log/infof "Sending %s messages for %s hosts, will exit upon completion"
+             num-msgs (count hosts))
   (loop [mutated-hosts hosts
          msgs-to-send num-msgs]
     (when-not (zero? msgs-to-send)
@@ -265,7 +265,7 @@
       (doseq [host hosts]
         (send host timed-update-host curr-time)
         (when-let [error (agent-error host)]
-          (log/error error (format "[%s] agent failed; restarting" host))
+          (log/errorf error "[%s] agent failed; restarting" host)
           ;; Restart it with exactly the same state. Hopefully that's okay!
           (restart-agent host @host)))
 

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -155,7 +155,7 @@
   (let [{:keys [version newer link]} (try
                                        (update-info update-server db)
                                        (catch Throwable e
-                                         (log/debug e (format "Could not retrieve update information (%s)" update-server))))
+                                         (log/debugf e "Could not retrieve update information (%s)" update-server)))
         link-str                     (if link
                                        (format " Visit %s for details." link)
                                        "")
@@ -263,7 +263,7 @@
                  :catalog-hash-debug-dir catalog-hash-debug-dir}]
 
     (when (version)
-      (log/info (format "PuppetDB version %s" (version))))
+      (log/infof "PuppetDB version %s" (version)))
 
     ;; Ensure the database is migrated to the latest version, and warn
     ;; if it's deprecated, log and exit if it's unsupported. We do

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -184,12 +184,12 @@
       ;; Only store a catalog if it's newer than the current catalog
       (if-not (scf-storage/catalog-newer-than? certname timestamp)
         (scf-storage/replace-catalog! catalog timestamp catalog-hash-debug-dir)))
-    (log/info (format "[%s] [%s] %s" id (command-names :replace-catalog) certname))))
+    (log/infof "[%s] [%s] %s" id (command-names :replace-catalog) certname)))
 
 (defn warn-deprecated
   "Logs a deprecation warning message for the given `command` and `version`"
   [version command]
-  (log/warn (format "command '%s' version %s is deprecated, use the latest version" command version)))
+  (log/warnf "command '%s' version %s is deprecated, use the latest version" command version))
 
 (defmethod process-command! [(command-names :replace-catalog) 6]
   [{:keys [version] :as command} options]
@@ -210,7 +210,7 @@
     (jdbc/with-transacted-connection' db :repeatable-read
       (scf-storage/maybe-activate-node! certname timestamp)
       (scf-storage/replace-facts! fact-data))
-    (log/info (format "[%s] [%s] %s" id (command-names :replace-facts) certname))))
+    (log/infof "[%s] [%s] %s" id (command-names :replace-facts) certname)))
 
 ;; Node deactivation
 
@@ -225,7 +225,7 @@
         (scf-storage/add-certname! certname))
       (when (not-any? newer-record-exists? [:catalogs :factsets])
         (scf-storage/deactivate-node! certname producer_timestamp)))
-    (log/info (format "[%s] [%s] %s" id (command-names :deactivate-node) certname))))
+    (log/infof "[%s] [%s] %s" id (command-names :deactivate-node) certname)))
 
 ;; Report submission
 
@@ -240,9 +240,9 @@
     (jdbc/with-transacted-connection db
       (scf-storage/maybe-activate-node! certname timestamp)
       (scf-storage/add-report! report timestamp))
-    (log/info (format "[%s] [%s] puppet v%s - %s"
-                      id (command-names :store-report)
-                      puppet_version certname))))
+    (log/infof "[%s] [%s] puppet v%s - %s"
+               id (command-names :store-report)
+               puppet_version certname)))
 
 (defmethod process-command! [(command-names :store-report) 5]
   [{:keys [version] :as command} {:keys [db]}]

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -27,7 +27,7 @@
 (defn warn-unknown-keys
   [schema data]
   (doseq [k (pls/unknown-keys schema data)]
-    (log/warn (format "The configuration item `%s` does not exist and should be removed from the config." k))))
+    (log/warnf "The configuration item `%s` does not exist and should be removed from the config." k)))
 
 (defn warn-and-validate
   "Warns a user about unknown configurations items, removes them and validates the config."
@@ -251,10 +251,10 @@
   (try
     (str (fs/mkdirs path))
     (catch SecurityException e
-      (log/warn e
-                (format (str "catalog-hash-conflig-debugging was enabled, "
-                             "but PuppetDB was not able to create a directory at %s")
-                        path)))))
+      (log/warnf e
+                (str "catalog-hash-conflig-debugging was enabled, "
+                     "but PuppetDB was not able to create a directory at %s")
+                path))))
 
 (def ^{:doc "Create the directory for catalog debug info if it does not already
               exist, returning the path if successful (or it already exists)"}

--- a/src/puppetlabs/puppetdb/http/version.clj
+++ b/src/puppetlabs/puppetdb/http/version.clj
@@ -37,13 +37,12 @@
 
                             :else
                             (do
-                              (log/debug (format
-                                          "Unable to determine latest version via update-server: '%s'"
-                                          update-server))
+                              (log/debugf "Unable to determine latest version via update-server: '%s'"
+                                          update-server)
                               (http/error-response "Could not find version" 404)))
 
       (catch java.io.IOException e
-        (log/debug (format "Error when checking for latest version: %s" e))
+        (log/debugf "Error when checking for latest version: %s" e)
         (http/error-response
          (format "Error when checking for latest version: %s" e))))))
 

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -221,12 +221,12 @@
 
    :else
    (do
-     (log/debug (format "Caught %s: '%s'. SQL Error code: '%s'. Attempt: %s of %s."
-                        (.getName (class exception))
-                        (.getMessage exception)
-                        (.getSQLState exception)
-                        (inc current)
-                        (+ current remaining)))
+     (log/debugf "Caught %s: '%s'. SQL Error code: '%s'. Attempt: %s of %s."
+                 (.getName (class exception))
+                 (.getMessage exception)
+                 (.getSQLState exception)
+                 (inc current)
+                 (+ current remaining))
      (exponential-sleep! current 1.3)
      false)))
 

--- a/src/puppetlabs/puppetdb/jdbc/internal.clj
+++ b/src/puppetlabs/puppetdb/jdbc/internal.clj
@@ -34,12 +34,12 @@
   "Called *after* a query completes, if the elapsed time of a query exceeds
    the configure timeout."
   [conn stmt sql params time-elapsed log-statements? query-execution-limit]
-  (log/warn (format (str "Query slower than %ss threshold:  "
-                         "actual execution time: %.4f seconds; Query: %s; "
-                         (query-params->str log-statements? params))
-                    query-execution-limit
-                    (/ time-elapsed 1000000000.0)
-                    sql)))
+  (log/warnf (str "Query slower than %ss threshold:  "
+                  "actual execution time: %.4f seconds; Query: %s; "
+                  (query-params->str log-statements? params))
+             query-execution-limit
+             (/ time-elapsed 1000000000.0)
+             sql))
 
 (defn connection-hook
   "Helper method for building up a `ConnectionHook` for our connection pool.

--- a/src/puppetlabs/puppetdb/mq_listener.clj
+++ b/src/puppetlabs/puppetdb/mq_listener.clj
@@ -237,12 +237,12 @@
   [{:keys [command annotations] :as msg} discard]
   (let [attempts (count (:attempts annotations))
         id       (:id annotations)]
-    (log/error (format "[%s] [%s] Exceeded max %d attempts" id command attempts))
+    (log/errorf "[%s] [%s] Exceeded max %d attempts" id command attempts)
     (discard msg nil)))
 
 (defn handle-parse-error
   [msg e discard]
-  (log/error e (format "Fatal error parsing command" msg))
+  (log/errorf e "Fatal error parsing command: %s" msg)
   (discard msg e))
 
 (defn handle-command-failure
@@ -252,7 +252,7 @@
   (let [attempt (count (:attempts annotations))
         id      (:id annotations)
         msg     (annotate-with-attempt msg e)]
-    (log/error e (format "[%s] [%s] Fatal error on attempt %d" id command attempt))
+    (log/errorf e "[%s] [%s] Fatal error on attempt %d" id command attempt)
     (discard msg e)))
 
 ;; The number of times a message can be retried before we discard it
@@ -396,4 +396,4 @@
     (if-let [handler-fn (matching-handler @(:listeners (service-context this))
                                           message)]
       (handler-fn message)
-      (log/warn (format "No message handler found for %s" message)))))
+      (log/warnf "No message handler found for %s" message))))

--- a/src/puppetlabs/puppetdb/scf/hash_debug.clj
+++ b/src/puppetlabs/puppetdb/scf/hash_debug.clj
@@ -98,7 +98,7 @@
         uuid (kitchensink/uuid)
         file-path-fn #(debug-file-path debug-output-dir certname uuid %)]
 
-    (log/warn (format "Writing catalog debugging info for %s to %s" certname debug-output-dir))
+    (log/warnf "Writing catalog debugging info for %s to %s" certname debug-output-dir)
     (json/spit-json (file-path-fn "catalog-metadata.json")
                     (-> {"new catalog hash" new-hash
                          "old catalog hash" (-> old-catalog json/generate-string kitchensink/utf8-string->sha1)

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1384,7 +1384,7 @@
   (if-let [pending (seq (pending-migrations))]
     (sql/transaction
      (doseq [[version migration] pending]
-       (log/info (format "Applying database migration version %d" version))
+       (log/infof "Applying database migration version %d" version)
        (try
          (migration)
          (record-migration! version)


### PR DESCRIPTION
(log/error (format ...)) can be better written as (log/errorf ...).
The same goes for other levels as well.