### PR TITLE
(maint) Do not build stable or testing

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,7 +2,7 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-squeeze-i386.cow'
-cows: 'base-precise-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-trusty-i386.cow base-wheezy-i386.cow'
+cows: 'base-precise-i386.cow base-squeeze-i386.cow base-trusty-i386.cow base-wheezy-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_name: 'info@puppetlabs.com'


### PR DESCRIPTION
Currently, we are being redundant with which debian platforms we are
building. Debian has releases that correspond to certain names that
indicate where they are in the release lifecycle. For instance, at this
moment, Debian Jessie is the same this as Debian Stable. As they
progress the different releases through their respective lifecycles, the
codename corresponding to the lifecycle stage changes. For instance,
currently, Debian Testing corresponds to Debian Stretch. At some point,
this platform will drop, and become the new Debian Stable, and Debian
Jessie will become the new Debian Oldstable. Rather than continually
updating our packages to deal with these changes every time the Debian
release cycle is moved forward, we will only be building packages based
on Codename (i.e., Debian Wheezy).

In order to follow these new standards, this commit removes both stable
and testing from the build targets. That, and PuppetDB 2.x will not be
released on either Debian Jessie or Debian Stretch. These two platforms
instead will see releases in the PuppetDB 3.x series.