### PR TITLE
(PDB-1269) extractable-only fields

### DIFF
--- a/acceptance/tests/reports/report_storage.rb
+++ b/acceptance/tests/reports/report_storage.rb
@@ -72,9 +72,9 @@ test_name "basic validation of puppet report submission" do
       total_events = metrics.detect {|m| m["name"] == "total" && m["category"] == "events"}
       total_changes = metrics.detect {|m| m["name"] == "total" && m["category"] == "changes"}
       resources_changed = metrics.detect {|m| m["name"] == "changed" && m["category"] == "resources"}
-      assert(total_events["value"] == 1, "metrics do not match")
-      assert(total_changes["value"] == 1, "metrics do not match")
-      assert(total_changes["value"] == 1, "metrics do not match")
+      assert(total_events["value"] == 1, "metric total in events category should be 1")
+      assert(total_changes["value"] == 1, "metric total in changes category should be 1")
+      assert(resources_changed["value"] == 1, "metric changed in resources category should be 1")
     end
 
     step "ensure that logs check out for #{agent}" do

--- a/src/puppetlabs/puppetdb/query/factsets.clj
+++ b/src/puppetlabs/puppetdb/query/factsets.clj
@@ -23,22 +23,13 @@
                         "f2" :value})
       (update-in [:value] json/parse-string)))
 
-(pls/defn-validated facts->expansion :- factsets/facts-expanded-query-schema
-  "Surround the facts response in the href/data format."
-  [obj :- (s/maybe PGobject)
-   certname :- s/Str
-   base-url :- s/Str]
-  (let [data-obj {:href (str base-url "/factsets/" certname "/facts")}]
-    (if obj
-      (assoc data-obj :data (map rtj->fact
-                                 (json/parse-string (.getValue obj))))
-      data-obj)))
-
 (pls/defn-validated row->factset
   "Convert factset query row into a final factset format."
   [base-url :- s/Str]
   (fn [row]
-    (utils/update-when row [:facts] facts->expansion (:certname row) base-url)))
+    (-> row
+        (utils/update-when [:facts] utils/child->expansion :factsets :facts base-url)
+        (utils/update-when [:facts :data] (partial map rtj->fact)))))
 
 (pls/defn-validated munge-result-rows
   "Reassemble rows from the database into the final expected format."

--- a/src/puppetlabs/puppetdb/query/reports.clj
+++ b/src/puppetlabs/puppetdb/query/reports.clj
@@ -35,26 +35,15 @@
       (update-in [:old_value] json/parse-string)
       (update-in [:new_value] json/parse-string)))
 
-(pls/defn-validated child->expansion :- {:href s/Str (s/optional-key :data) [s/Any]}
-  "Convert child to the expanded format."
-  [data :- (s/maybe (s/either PGobject s/Str))
-   child :- s/Keyword
-   hash :- s/Str
-   base-url :- s/Str]
-  (let [data-obj {:href (str base-url "/reports/" hash "/" (name child))}]
-    (if data
-      (assoc data-obj :data (sutils/parse-db-json data))
-      data-obj)))
-
 (pls/defn-validated row->report
   "Convert a report query row into a final report format."
   [base-url :- s/Str]
-  (fn [{:keys [hash] :as row}]
+  (fn [row]
     (-> row
-        (utils/update-when [:resource_events] child->expansion :events hash base-url)
+        (utils/update-when [:resource_events] utils/child->expansion :reports :events base-url)
         (utils/update-when [:resource_events :data] (partial map rtj->event))
-        (utils/update-when [:metrics] child->expansion :metrics hash base-url)
-        (utils/update-when [:logs] child->expansion :logs hash base-url))))
+        (utils/update-when [:metrics] utils/child->expansion :reports :metrics base-url)
+        (utils/update-when [:logs] utils/child->expansion :reports :logs base-url))))
 
 (pls/defn-validated munge-result-rows
   "Reassemble report rows from the database into the final expected format."

--- a/test/puppetlabs/puppetdb/http/catalogs_test.clj
+++ b/test/puppetlabs/puppetdb/http/catalogs_test.clj
@@ -102,6 +102,15 @@
          #{{:certname "myhost.localdomain"}
            {:certname "host2.localdomain"}}
 
+         ["extract" ["edges"] ["=" "certname" "host2.localdomain"]]
+         #{{:edges (merge {:href "/v4/catalogs/host2.localdomain/edges"}
+                          (when (sutils/postgres?)
+                            {:data [{:source_type "Apt::Pin"
+                                     :source_title "puppetlabs"
+                                     :target_type "File"
+                                     :target_title "/etc/apt/preferences.d/puppetlabs.pref"
+                                     :relationship "contains"}]}))}}
+
          ["extract" [["function" "count"] "environment"]
           ["~" "certname" ""]
           ["group_by" "environment"]]

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -11,6 +11,7 @@
             [puppetlabs.puppetdb.examples.reports :refer [reports]]
             [puppetlabs.puppetdb.fixtures :as fixt]
             [puppetlabs.puppetdb.http :as http :refer [status-bad-request]]
+            [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.reports :as reports]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.testutils :refer [response-equal?
@@ -111,6 +112,20 @@
        (get-response endpoint ["extract" "hash"
                                ["=" "certname" (:certname basic)]])
        #{{:hash report-hash}}))
+
+    (testing "logs projected"
+      (response-equal?
+        (get-response endpoint ["extract" "logs"
+                                ["=" "certname" (:certname basic)]])
+        #{{:logs (merge {:href (utils/as-path "/v4/reports" report-hash "logs")}
+                         (when (sutils/postgres?) {:data (:logs basic)}))}}))
+
+    (testing "metrics projected"
+      (response-equal?
+        (get-response endpoint ["extract" "metrics"
+                                ["=" "certname" (:certname basic)]])
+        #{{:metrics (merge {:href (utils/as-path "/v4/reports" report-hash "metrics")}
+                         (when (sutils/postgres?) {:data (:metrics basic)}))}}))
 
     (testing "one projected column with a not"
       (response-equal?


### PR DESCRIPTION
Without this commit, our expanded fields required both the (possibly empty)
data field and either the hash or certname as an identier to form the href.
With this commit, we return essentially the desired data/href structure in the
postgres case, and in the hsqldb case, we overload the field name with the
identifier to retain the ability to create the href.