### PR TITLE
(maint) Bump clojure to 1.7.0-beta3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.7.0-beta2"]
+  :dependencies [[org.clojure/clojure "1.7.0-beta3"]
                  [cheshire "5.4.0"]
                  [org.clojure/core.match "0.2.0-rc5"]
                  [org.clojure/math.combinatorics "0.0.4"]


### PR DESCRIPTION
This just bumps Clojure to 1.7.0-beta3 so we keep on the trail of this pending
release.

Signed-off-by: Ken Barber <ken@bob.sh>