### PR TITLE
(PDB-1482) allow ordering on non-extracted fields

### DIFF
--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -118,7 +118,6 @@
   return the SQL string representing this term for use in an ORDER BY clause."
   [[field order]]
   {:pre [(keyword? field)
-         (re-find #"^[\w\-]+$" (name field))
          (contains? #{:ascending :descending} order)]
    :post [(string? %)]}
   (let [field (dashes->underscores (name field))]
@@ -162,7 +161,7 @@
   (let [limit-clause     (if limit (format " LIMIT %s" limit) "")
         offset-clause    (if offset (format " OFFSET %s" offset) "")
         order-by-clause  (order-by->sql order_by)]
-    (format "SELECT paged_results.* FROM (%s) paged_results%s%s%s"
+    (format "SELECT paged_results.* FROM (%s %s%s%s) paged_results"
             sql order-by-clause limit-clause offset-clause)))
 
 (pls/defn-validated count-sql :- String

--- a/src/puppetlabs/puppetdb/query/facts.clj
+++ b/src/puppetlabs/puppetdb/query/facts.clj
@@ -70,15 +70,13 @@
   ascending. This includes facts which are known only for deactivated and
   expired nodes."
   ([]
-     (fact-names {}))
+   (fact-names {}))
   ([paging-options]
-     {:post [(map? %)
-             (coll? (:result %))
-             (every? string? (:result %))]}
-     (paging/validate-order-by! [:name] paging-options)
-     (let [facts (query/execute-query
-                  ["SELECT DISTINCT name
-                   FROM fact_paths
-                   ORDER BY name"]
-                  paging-options)]
-       (update-in facts [:result] #(map :name %)))))
+   {:post [(map? %)
+           (coll? (:result %))
+           (every? string? (:result %))]}
+   (paging/validate-order-by! [:name] paging-options)
+   (let [order-by-clause (if (:order_by paging-options) "" "ORDER BY name")
+         query (format "SELECT DISTINCT name FROM fact_paths %s" order-by-clause)
+         facts (query/execute-query [query] paging-options)]
+     (update-in facts [:result] #(map :name %)))))

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -1334,22 +1334,24 @@
 
 (defn compile-user-query->sql
   "Given a user provided query and a Query instance, convert the
-  user provided query to SQL and extract the parameters, to be used
-  in a prepared statement"
+   user provided query to SQL and extract the parameters, to be used
+   in a prepared statement"
   [query-rec user-query & [{:keys [count?] :as paging-options}]]
   ;; Call the query-rec so we can evaluate query-rec functions
   ;; which depend on the db connection type
-  (let [query-rec (query-rec)]
-    (when paging-options
-      (paging/validate-order-by! (map keyword (queryable-fields query-rec)) paging-options))
-    (let [{:keys [plan params]} (->> user-query
-                                     (push-down-context query-rec)
-                                     expand-user-query
-                                     (convert-to-plan query-rec paging-options)
-                                     extract-all-params)
-          sql (plan->sql plan)
-          paged-sql (jdbc/paged-sql sql paging-options)
-          result-query {:results-query (apply vector paged-sql params)}]
-      (if count?
-        (assoc result-query :count-query (apply vector (jdbc/count-sql sql) params))
-        result-query))))
+  (let [query-rec (query-rec)
+        allowed-fields (map keyword (queryable-fields query-rec))
+        paging-options (some->> paging-options
+                                (paging/validate-order-by! allowed-fields)
+                                (paging/dealias-order-by query-rec))
+        {:keys [plan params]} (->> user-query
+                                   (push-down-context query-rec)
+                                   expand-user-query
+                                   (convert-to-plan query-rec paging-options)
+                                   extract-all-params)
+        sql (plan->sql plan)
+        paged-sql (jdbc/paged-sql sql paging-options)
+        result-query {:results-query (apply vector paged-sql params)}]
+    (if count?
+      (assoc result-query :count-query (apply vector (jdbc/count-sql sql) params))
+      result-query)))

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -680,10 +680,11 @@
               include_total true
               offset 0}}  paging-options
               {:keys [headers body]} (paged-results* (assoc paging-options
-                                                       :app-fn  *app*
-                                                       :path    endpoint
-                                                       :offset  offset
-                                                       :limit   limit
+                                                       :app-fn *app*
+                                                       :query query
+                                                       :path endpoint
+                                                       :offset offset
+                                                       :limit limit
                                                        :include_total include_total))]
     {:results body
      :count (when-let [rec-count (get headers "X-Records")]
@@ -704,8 +705,10 @@
                                  (unkeywordize-values (get m x)))) (keys m)))))
 
 (defn- query-endpoint
-  [endpoint paging-options]
-  (:results (raw-query-endpoint endpoint nil paging-options)))
+  ([endpoint paging-options]
+   (:results (raw-query-endpoint endpoint nil paging-options)))
+  ([endpoint query paging-options]
+   (:results (raw-query-endpoint endpoint query paging-options))))
 
 (deftestseq paging-results
   [[version endpoint] facts-endpoints]
@@ -772,6 +775,21 @@
               (compare-structured-response (map unkeywordize-values actual)
                                            expected
                                            version)))))
+
+      (testing "unextracted field with alias"
+        (doseq [[order expected] [["ASC" [f1 f2 f3 f4 f5]]
+                                  ["DESC" [f5 f4 f3 f2 f1]]]]
+          (testing order
+            (let [actual (query-endpoint
+                           endpoint
+                           ["extract" "environment" ["~" "certname" ".*"]]
+                           {:params {:order_by
+                                     (json/generate-string
+                                       [{"field" "certname" "order" order}])}})]
+              (compare-structured-response
+                (map (comp :environment unkeywordize-values) actual)
+                (map :environment expected)
+                version)))))
 
       (testing "multiple fields"
         (doseq [[[name-order certname-order] expected] [[["DESC" "ASC"]  [f2 f4 f5 f1 f3]]
@@ -1109,6 +1127,21 @@
             (let [ordering {:order_by (json/generate-string [{"field" "hash" "order" order}])}
                   actual (json/parse-string (slurp (:body (get-response endpoint nil ordering))))]
               (is (= (munge-factsets-response actual) expected))))))
+
+      (testing "order on unextracted field with function alias"
+        (doseq
+          [[order expected] [["ASC" (sort-by #(get % "hash")
+                                             (factset-results version))]
+                             ["DESC" (reverse (sort-by #(get % "hash")
+                                                       (factset-results version)))]]]
+          (testing order
+            (let [ordering {:order_by
+                            (json/generate-string [{"field" "hash" "order" order}])}
+                  query ["extract" "certname" ["~" "certname" ".*"]]
+                  actual (json/parse-string
+                           (slurp (:body (get-response endpoint query ordering))))]
+              (is (= (map :certname (munge-factsets-response actual))
+                     (map :certname expected)))))))
 
       (testing "multiple fields"
         (doseq [[[env-order certname-order] expected-order] [[["DESC" "ASC"]  [2 0 1]]


### PR DESCRIPTION
Previously you couldn't order on a field that you weren't extracting.
This changes our paged sql function to do
select paged_results.* from (select blah from facts order by baz)
instead of select paged_results.* from (select blah from facts) order by baz,
and also ensures that we never order on column aliases -- always on the column
name or function application itself.