### PR TITLE
(PDB-1453) don't allow numeric comparisons with strings

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -969,6 +969,14 @@
   (let [query-context (:query-context (meta node))]
     (cm/match [node]
 
+              [["=" field value]]
+              (let [col-type (get-in query-context [:projections field :type])]
+                (when (and (= :number col-type) (string? value))
+                  (throw
+                    (IllegalArgumentException.
+                      (format "Argument \"%s\" is incompatible with numeric field \"%s\"."
+                              value (name field))))))
+
               [[(:or ">" ">=" "<" "<=") field _]]
               (let [col-type (get-in query-context [:projections field :type])]
                 (when-not (or (vec? field)
@@ -1074,9 +1082,7 @@
                :number
                (map->BinaryExpression {:operator :=
                                        :column field
-                                       :value (if (string? value)
-                                                (ks/parse-number (str value))
-                                                value)})
+                                       :value value})
 
                :path
                (map->BinaryExpression {:operator :=
@@ -1094,21 +1100,16 @@
 
             [[(op :guard #{">" "<" ">=" "<="}) column value]]
             (let [{:keys [type field]} (get-in query-rec [:projections column])]
-              (if value
-                (case type
-                  :multi
-                  (map->BinaryExpression {:operator (keyword op)
-                                          :column (columns->fields ["value_integer" "value_float"])
-                                          :value (if (number? value) [value value]
-                                                     (map ks/parse-number [value value]))})
-
-                  (map->BinaryExpression {:operator (keyword op)
-                                          :column field
-                                          :value  (if (= :timestamp type)
-                                                    (to-timestamp value)
-                                                    (ks/parse-number (str value)))}))
-                (throw (IllegalArgumentException.
-                        (format "Value %s must be a number for %s comparison." value op)))))
+              (if (or (= :timestamp type) (and (= :number type) (number? value)))
+                (map->BinaryExpression {:operator (keyword op)
+                                        :column field
+                                        :value  (if (= :timestamp type)
+                                                  (to-timestamp value)
+                                                  value)})
+                (throw
+                  (IllegalArgumentException.
+                    (format "Argument \"%s\" and operator \"%s\" have incompatible types."
+                            value op)))))
 
 
             [["null?" column value]]

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -213,9 +213,12 @@
                                                                             ["=" "type" "Class"]]]]
                 "Can't match on unknown 'facts' fields: 'nothing', 'nothing2' for 'in'. Acceptable fields are: [\"certname\",\"environment\",\"name\",\"value\"]")))
 
-(def versioned-invalid-projections
+(def versioned-invalid-queries
   (omap/ordered-map
    "/v4/facts" (omap/ordered-map
+                 ;; comparison applied to a string should throw an error
+                 ["<" "value" "100"]
+                 #"Argument \"100\" and operator \"<\" have incompatible types."
                 ;; Top level extract using invalid fields should throw an error
                 ["extract" "nothing" ["~" "certname" ".*"]]
                 #"Can't extract unknown 'facts' field 'nothing'.*Acceptable fields are.*"
@@ -226,7 +229,7 @@
 (deftestseq invalid-projections
   [[version endpoint] facts-endpoints]
 
-  (doseq [[query msg] (get versioned-invalid-projections endpoint)]
+  (doseq [[query msg] (get versioned-invalid-queries endpoint)]
     (testing (str "query: " query " should fail with msg: " msg)
       (let [{:keys [status body] :as result} (get-response endpoint query)]
         (is (re-find msg body))

--- a/test/puppetlabs/puppetdb/http/resources_test.clj
+++ b/test/puppetlabs/puppetdb/http/resources_test.clj
@@ -195,11 +195,6 @@ to the result of the form supplied to this method."
                    [">" "line" 21]
                    ["<" "line" 23]]
             result #{bar2}]
-        (is-response-equal (get-response endpoint query) result))
-      (let [query ["and"
-                   [">" "line" "21"]
-                   ["<" "line" "23"]]
-            result #{bar2}]
         (is-response-equal (get-response endpoint query) result)))))
 
 (deftestseq resource-query-paging
@@ -272,20 +267,23 @@ to the result of the form supplied to this method."
       (is (is-response-equal (get-response endpoint ["=" "type" "File"]) #{foo1 bar1}))
       (is (is-response-equal (get-response endpoint ["=" "type" "Notify"]) #{foo2 bar2})))))
 
-(def versioned-invalid-projections
+(def versioned-invalid-queries
   (omap/ordered-map
     "/v4/resources" (omap/ordered-map
-                   ;; Top level extract using invalid fields should throw an error
-                   ["extract" "nothing" ["~" "certname" ".*"]]
-                   #"Can't extract unknown 'resources' field 'nothing'.*Acceptable fields are.*"
+                      ;; inequality operator with string
+                      ["<" "line" "22"]
+                      #"Argument \"22\" and operator \"<\" have incompatible types."
+                      ;; Top level extract using invalid fields should throw an error
+                      ["extract" "nothing" ["~" "certname" ".*"]]
+                      #"Can't extract unknown 'resources' field 'nothing'.*Acceptable fields are.*"
 
-                   ["extract" ["certname" "nothing" "nothing2"] ["~" "certname" ".*"]]
-                   #"Can't extract unknown 'resources' fields: 'nothing', 'nothing2'.*Acceptable fields are.*")))
+                      ["extract" ["certname" "nothing" "nothing2"] ["~" "certname" ".*"]]
+                      #"Can't extract unknown 'resources' fields: 'nothing', 'nothing2'.*Acceptable fields are.*")))
 
-(deftestseq invalid-projections
+(deftestseq invalid-queries
   [[version endpoint] endpoints]
 
-  (doseq [[query msg] (get versioned-invalid-projections endpoint)]
+  (doseq [[query msg] (get versioned-invalid-queries endpoint)]
     (testing (str "query: " query " should fail with msg: " msg)
       (let [{:keys [status body] :as result} (get-response endpoint query)]
         (is (re-find msg body))


### PR DESCRIPTION
Previously we were converting strings to numeric on the equality operator when
used on a field other than fact values, and exposing an error when the inequality
operators were used with a non-timestamp string.