### PR TITLE
(maint) Lint with `eastwood` and improve syntax in services.clj

### DIFF
--- a/src/puppetlabs/puppetdb/honeysql.clj
+++ b/src/puppetlabs/puppetdb/honeysql.clj
@@ -16,29 +16,29 @@
 ;; COMMMON DIRECT SQL FUNCTIONS
 
 (pls/defn-validated coalesce :- SqlCall
-  [& args :- [(s/one key-or-sql "Keyword") key-or-sql]]
   "coalesce(arg, ...) sql function"
+  [& args :- [(s/one key-or-sql "Keyword") key-or-sql]]
   (apply hcore/call :coalesce args))
 
 (pls/defn-validated scast :- SqlCall
+  "cast(source AS target) sql function"
   [source :- s/Keyword
    target :- s/Keyword]
-  "cast(source AS target) sql function"
   (hcore/call :cast source target))
 
 (pls/defn-validated json-agg :- SqlCall
-  [expr :- key-or-sql]
   "json_agg(expr) sql function"
+  [expr :- key-or-sql]
   (hcore/call :json_agg expr))
 
 (pls/defn-validated row-to-json :- SqlCall
-  [record :- key-or-sql]
   "row_to_json(record) sql function"
+  [record :- key-or-sql]
   (hcore/call :row_to_json record))
 
 (pls/defn-validated row :- SqlCall
-  [& expr :- [(s/one key-or-sql "Keyword") key-or-sql]]
   "row(expr, ...) sql function"
+  [& expr :- [(s/one key-or-sql "Keyword") key-or-sql]]
   (apply hcore/call :row expr))
 
 (pls/defn-validated regexp-substring :- SqlCall

--- a/src/puppetlabs/puppetdb/mq.clj
+++ b/src/puppetlabs/puppetdb/mq.clj
@@ -158,7 +158,7 @@
    (let [^BytesMessage bytes-message message]
      (.readUTF8 bytes-message))
    :else
-   (throw (ex-info (str "Expected a text message, instead found: " (class message))))))
+   (throw (ex-info (str "Expected a text message, instead found: " (class message)) {}))))
 
 (defn convert-jms-message [m]
   {:headers (extract-headers m) :body (convert-message-body m)})
@@ -177,8 +177,8 @@
                          (.setStringProperty message name value))})
 
 (defn set-jms-property!
-  [message name value]
   "Sets the named JMS message property to value."
+  [message name value]
   (-set-jms-property! value name message))
 
 (defprotocol ToJmsMessage

--- a/src/puppetlabs/puppetdb/query/edges.clj
+++ b/src/puppetlabs/puppetdb/query/edges.clj
@@ -55,7 +55,7 @@
 (defn query-edges
   "Search for edges satisfying the given SQL filter."
   [version query-sql url-prefix]
-  {:pre [[(map? query-sql)]]}
+  {:pre [(map? query-sql)]}
   (let [{[sql & params] :results-query
          count-query    :count-query} query-sql
          result {:result (query/streamed-query-result

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -48,7 +48,7 @@
 
 ;; Size of the cache is based on the number of unique resources in a
 ;; "medium" site persona
-(def resource-identity-hash* (kitchensink/bounded-memoize resource-identity-hash* 40000))
+(def memoized-resource-identity-hash* (kitchensink/bounded-memoize resource-identity-hash* 40000))
 
 (defn resource-identity-hash
   "Compute a hash for a given resource that will uniquely identify it
@@ -60,7 +60,7 @@
   [{:keys [type title parameters] :as resource}]
   {:pre  [(map? resource)]
    :post [(string? %)]}
-  (resource-identity-hash* type title parameters))
+  (memoized-resource-identity-hash* type title parameters))
 
 (defn catalog-resource-identity-format
   "Narrow `resource` to only contain the needed key/values for computing the hash of

--- a/test/puppetlabs/puppetdb/scf/migration_legacy_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migration_legacy_test.clj
@@ -1,4 +1,4 @@
-(ns puppetlabs.puppetdb.scf.migration-legacy
+(ns puppetlabs.puppetdb.scf.migration-legacy-test
   (:require [puppetlabs.puppetdb.scf.migration-legacy :as legacy]
             [clojure.test :refer :all]))
 


### PR DESCRIPTION
This commit makes some linting corrections found via the `eastwood` lein
plugin. This commit also makes some syntactic improvements to
services.clj, such as checking conditions before executing business
logic and not redefing varibales in let bindings.