### PR TITLE
(PDB-1520) Use subselect with row-to-json aggregates

### DIFF
--- a/src/puppetlabs/puppetdb/query/reports.clj
+++ b/src/puppetlabs/puppetdb/query/reports.clj
@@ -18,22 +18,10 @@
 
 (pls/defn-validated rtj->event :- reports/resource-event-query-schema
   "Convert row_to_json format to real data."
-  [event :- {s/Str s/Any}]
+  [event :- {s/Keyword s/Any}]
   (-> event
-      (set/rename-keys {"f1" :status
-                        "f2" :timestamp
-                        "f3" :resource_type
-                        "f4" :resource_title
-                        "f5" :property
-                        "f6" :new_value
-                        "f7" :old_value
-                        "f8" :message
-                        "f9" :file
-                        "f10" :line
-                        "f11" :containment_path
-                        "f12" :containing_class})
-      (update-in [:old_value] json/parse-string)
-      (update-in [:new_value] json/parse-string)))
+      (update :old_value json/parse-string)
+      (update :new_value json/parse-string)))
 
 (pls/defn-validated row->report
   "Convert a report query row into a final report format."

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -295,7 +295,7 @@ must be supplied as the value to be matched."
   (if-let [json (if (postgres?)
                   (when db-json (.getValue db-json))
                   db-json)]
-    (json/parse-string json)))
+    (json/parse-string json true)))
 
 (pls/defn-validated str->pgobject :- PGobject
   [type :- s/Str

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -256,5 +256,4 @@
       ;; if it's a string it's just an identifier
       {:href (to-href data)}
       (-> (sutils/parse-db-json data)
-          (set/rename-keys {"f1" :data "f2" :href})
           (update :href to-href)))))


### PR DESCRIPTION
This commit changes the json-aggregates in the query-eng to use
subselects instead of the `row` function, this means that we can "name"
columns directly from the (honey)SQL and get rid of the json
post-processing munging.