### PR TITLE
(PDB-1485) Add default context root `/pdb/query` for PuppetDB Query API

### DIFF
--- a/acceptance/tests/db_garbage_collection/report_ttl.rb
+++ b/acceptance/tests/db_garbage_collection/report_ttl.rb
@@ -1,6 +1,7 @@
 require 'json'
   confd = "#{puppetdb_confdir(database)}/conf.d"
 
+puppetdb_query_url = "http://localhost:8080/pdb/query"
 test_name "validate that reports are deleted based on report-ttl setting" do
   step "setup a test manifest for the master and perform agent runs" do
     manifest = <<-MANIFEST
@@ -19,7 +20,7 @@ test_name "validate that reports are deleted based on report-ttl setting" do
   step "Verify that we have reports for every agent" do
     agents.each do |agent|
       # Query for all of the reports for this node:
-      result = on database, %Q|curl -G http://localhost:8080/v4/reports --data 'query=["=",%20"certname",%20"#{agent.node_name}"]'|
+      result = on database, %Q|curl -G #{puppetdb_query_url}/v4/reports --data 'query=["=",%20"certname",%20"#{agent.node_name}"]'|
       reports = JSON.parse(result.stdout)
       assert(reports.length > 0, "Expected at least one report for node '#{agent.node_name}'")
     end
@@ -51,7 +52,7 @@ test_name "validate that reports are deleted based on report-ttl setting" do
   step "Verify that the reports for every agent have been deleted" do
     agents.each do |agent|
       # Query for all of the reports for this node:
-      result = on database, %Q|curl -G http://localhost:8080/v4/reports --data 'query=["=",%20"certname",%20"#{agent.node_name}"]'|
+      result = on database, %Q|curl -G #{puppetdb_query_url}/v4/reports --data 'query=["=",%20"certname",%20"#{agent.node_name}"]'|
       reports = JSON.parse(result.stdout)
       assert(0, "Expected zero reports for node '#{agent.node_name}'")
     end

--- a/acceptance/tests/db_resilience/db_fallback.rb
+++ b/acceptance/tests/db_resilience/db_fallback.rb
@@ -1,4 +1,5 @@
 if databases.count > 1
+  puppetdb_query_url = "http://localhost:8080/pdb/query"
   test_name "test database fallback" do
 
     step "clear puppetdb databases" do
@@ -14,7 +15,7 @@ if databases.count > 1
     end
 
     step "Verify that the number of active nodes is what we expect" do
-      result = on databases[0], %Q|curl -G http://localhost:8080/v4/nodes|
+      result = on databases[0], %Q|curl -G #{puppetdb_query_url}/v4/nodes|
       parsed_result = JSON.parse(result.stdout)
       assert_equal(agents.length, parsed_result.length,
                    "Expected query to return '#{agents.length}' active nodes; returned '#{parsed_result.length}'")
@@ -25,7 +26,7 @@ if databases.count > 1
     end
 
     step "check that the fallback db is responsive to queries and has no nodes" do
-      result = on databases[1], %Q|curl -G http://localhost:8080/v4/nodes|
+      result = on databases[1], %Q|curl -G #{puppetdb_query_url}/v4/nodes|
       parsed_result = JSON.parse(result.stdout)
       assert_equal(0, parsed_result.length,
                    "Expected query to return 0 active nodes; returned '#{parsed_result.length}'")
@@ -38,7 +39,7 @@ if databases.count > 1
     end
 
     step "Verify that fallback occurred" do
-      result = on databases[1], %Q|curl -G http://localhost:8080/v4/nodes|
+      result = on databases[1], %Q|curl -G #{puppetdb_query_url}/v4/nodes|
       parsed_result = JSON.parse(result.stdout)
       assert_equal(agents.length, parsed_result.length,
                    "Expected query to return '#{agents.length}' active nodes; returned '#{parsed_result.length}'")
@@ -56,7 +57,7 @@ if databases.count > 1
     end
 
     step "check that the first db is responsive to queries" do
-      result = on databases[0], %Q|curl -G http://localhost:8080/v4/nodes|
+      result = on databases[0], %Q|curl -G #{puppetdb_query_url}/v4/nodes|
       parsed_result = JSON.parse(result.stdout)
       assert_equal(agents.length, parsed_result.length,
                    "Expected query to return '#{agents.length}' active nodes; returned '#{parsed_result.length}'")
@@ -92,7 +93,7 @@ if databases.count > 1
     end
 
     step "Verify that fallback occurred" do
-      result = on databases[1], %Q|curl -G http://localhost:8080/v4/nodes|
+      result = on databases[1], %Q|curl -G #{puppetdb_query_url}/v4/nodes|
       parsed_result = JSON.parse(result.stdout)
       assert_equal(agents.length, parsed_result.length,
                    "Expected query to return '#{agents.length}' active nodes; returned '#{parsed_result.length}'")

--- a/acceptance/tests/db_resilience/postgres_restart.rb
+++ b/acceptance/tests/db_resilience/postgres_restart.rb
@@ -1,4 +1,5 @@
 if (test_config[:database] == :postgres)
+  puppetdb_query_url = "http://localhost:8080/pdb/query"
   test_name "test postgresql database restart handling to ensure we recover from a restart" do
     step "clear puppetdb database" do
       clear_and_restart_puppetdb(database)
@@ -14,7 +15,7 @@ if (test_config[:database] == :postgres)
     end
 
     step "Verify that the number of active nodes is what we expect" do
-      result = on database, %Q|curl -G http://localhost:8080/v4/nodes|
+      result = on database, %Q|curl -G #{puppetdb_query_url}/v4/nodes|
       result_node_statuses = JSON.parse(result.stdout)
       assert_equal(agents.length, result_node_statuses.length, "Expected query to return '#{agents.length}' active nodes; returned '#{result_node_statuses.length}'")
     end
@@ -22,7 +23,7 @@ if (test_config[:database] == :postgres)
     restart_postgres(database)
 
     step "Verify that the number of active nodes is what we expect" do
-      result = on database, %Q|curl -G http://localhost:8080/v4/nodes|
+      result = on database, %Q|curl -G #{puppetdb_query_url}/v4/nodes|
       result_node_statuses = JSON.parse(result.stdout)
       assert_equal(agents.length, result_node_statuses.length, "Expected query to return '#{agents.length}' active nodes; returned '#{result_node_statuses.length}'")
     end

--- a/acceptance/tests/import_export/import_export_facts_only.rb
+++ b/acceptance/tests/import_export/import_export_facts_only.rb
@@ -1,3 +1,4 @@
+puppetdb_query_url = "http://localhost:8080/pdb/query"
 test_name "export and import tools" do
   bin_loc = puppetdb_bin_dir(database)
 
@@ -55,7 +56,7 @@ test_name "export and import tools" do
 
 
   step "Verify that the number of active nodes is what we expect" do
-    result = on database, %Q|curl -G http://localhost:8080/v4/nodes|
+    result = on database, %Q|curl -G #{puppetdb_query_url}/v4/nodes|
     result_node_statuses = parse_json_with_error(result.stdout)
     assert_equal(agents.length, result_node_statuses.length, "Should only have 1 node")
 
@@ -91,7 +92,7 @@ test_name "export and import tools" do
   end
 
   step "Verify that the number of active nodes is what we expect" do
-    result = on database, %Q|curl -G http://localhost:8080/v4/nodes|
+    result = on database, %Q|curl -G #{puppetdb_query_url}/v4/nodes|
     result_node_statuses = parse_json_with_error(result.stdout)
     assert_equal(agents.length, result_node_statuses.length, "Should only have 1 node")
 

--- a/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
+++ b/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
@@ -1,3 +1,4 @@
+puppetdb_query_url = "http://localhost:8080/pdb/query"
 test_name "storeconfigs export and import" do
 
   confine :except, :platform => 'ubuntu-10.04-amd64'
@@ -64,7 +65,7 @@ test_name "storeconfigs export and import" do
 
   step "Verify imported catalogs" do
     hosts.each do |host|
-      result = on database, %Q|curl -G http://localhost:8080/v4/catalogs/#{host.node_name}|
+      result = on database, %Q|curl -G #{puppetdb_query_url}/v4/catalogs/#{host.node_name}|
       result_catalog = JSON.parse(result.stdout)
       assert_equal(host.node_name, result_catalog['certname'], "Catalog for node #{host.node_name} not found")
     end

--- a/acceptance/tests/inventory/basic_fact_retrieval.rb
+++ b/acceptance/tests/inventory/basic_fact_retrieval.rb
@@ -1,5 +1,6 @@
 require 'json'
 
+puppetdb_query_url = "http://localhost:8080/pdb/query"
 test_name "structured and trusted facts should be available through facts terminus" do
 
   structured_data = {"foo"=>[1, 2, 3],
@@ -34,7 +35,7 @@ test_name "structured and trusted facts should be available through facts termin
 
     step "Query the database for trusted facts" do
       query = CGI.escape('["=","name","trusted"]')
-      result = on database, %Q|curl -G 'http://localhost:8080/v4/facts' --data 'query=#{query}'|
+      result = on database, %Q|curl -G '#{puppetdb_query_url}/v4/facts' --data 'query=#{query}'|
       facts = parse_json_with_error(result.stdout)
       assert_equal("remote", facts.first["value"]["authenticated"])
     end
@@ -47,7 +48,7 @@ test_name "structured and trusted facts should be available through facts termin
       "payload":{"environment":"DEV","certname":"#{master}", \
       "timestamp": "#{time}", \
       "producer_timestamp": "#{time}", \
-      "values":{"my_structured_fact":#{JSON.generate(structured_data)}}}}' http://localhost:8080/v4/commands
+      "values":{"my_structured_fact":#{JSON.generate(structured_data)}}}}' #{puppetdb_query_url}/v4/commands
       EOM
       on database, %Q|curl -X POST #{payload}|
     end
@@ -58,7 +59,7 @@ test_name "structured and trusted facts should be available through facts termin
 
     step "Ensure that the structured fact is passed through properly" do
       query = CGI.escape('["=","name","my_structured_fact"]')
-      result = on database, %Q|curl -G 'http://localhost:8080/v4/facts' --data 'query=#{query}'|
+      result = on database, %Q|curl -G '#{puppetdb_query_url}/v4/facts' --data 'query=#{query}'|
       facts = parse_json_with_error(result.stdout)
       assert_equal(structured_data, facts.first["value"])
     end

--- a/acceptance/tests/reports/basic_event_query.rb
+++ b/acceptance/tests/reports/basic_event_query.rb
@@ -2,6 +2,7 @@ require 'json'
 require 'time'
 require 'cgi'
 
+puppetdb_query_url = "http://localhost:8080/pdb/query"
 test_name "validation of basic PuppetDB resource event queries" do
 
   # NOTE: this implementation assumes that the test coordinator machine and
@@ -46,7 +47,7 @@ EOM
       query = CGI.escape(query)
 
       # Now query for all of the event for this agent
-      result = on database, %Q|curl -G 'http://localhost:8080/v4/events' --data 'query=#{query}'|
+      result = on database, %Q|curl -G '#{puppetdb_query_url}/v4/events' --data 'query=#{query}'|
       events = JSON.parse(result.stdout)
 
       assert_equal(1, events.length, "Expected exactly one matching 'Notify' event for host '#{agent.node_name}'; found #{events.length}.")

--- a/acceptance/tests/reports/event_query_with_read_db.rb
+++ b/acceptance/tests/reports/event_query_with_read_db.rb
@@ -2,6 +2,7 @@ require 'json'
 require 'time'
 require 'cgi'
 
+puppetdb_query_url = "http://localhost:8080/pdb/query"
 test_name "validation of basic PuppetDB resource event queries" do
 
   skip_test "Skipping read-db test for HyperSQL.  This feature is only available for Postgres" if test_config[:database] == :embedded
@@ -121,7 +122,7 @@ EOM
       query = CGI.escape(query)
 
       # Now query for all of the event for this agent
-      result = on database, %Q|curl -G 'http://localhost:8080/v4/events' --data 'query=#{query}'|
+      result = on database, %Q|curl -G '#{puppetdb_query_url}/v4/events' --data 'query=#{query}'|
 
       events = JSON.parse(result.stdout)    
 

--- a/acceptance/tests/reports/report_query_by_timestamp.rb
+++ b/acceptance/tests/reports/report_query_by_timestamp.rb
@@ -2,6 +2,7 @@ require 'json'
 require 'time'
 require 'cgi'
 
+puppetdb_query_url = "http://localhost:8080/pdb/query"
 test_name "basic validation of puppet report query by timestamp" do
   start_times = agents.inject({}) do |hash, agent|
     hash[agent.node_name] = current_time_on agent
@@ -10,7 +11,7 @@ test_name "basic validation of puppet report query by timestamp" do
 
   agents.each do |agent|
     # Query for all of the events after the start time
-    result = on database, %Q|curl -G http://localhost:8080/v4/events --data 'query=["and",%20["=",%20"certname",%20"#{agent.node_name}"],%20[">",%20"timestamp",%20"#{start_times[agent.node_name]}"]]'|
+    result = on database, %Q|curl -G #{puppetdb_query_url}/v4/events --data 'query=["and",%20["=",%20"certname",%20"#{agent.node_name}"],%20[">",%20"timestamp",%20"#{start_times[agent.node_name]}"]]'|
 
     # We expect no results (assuming all of the machines' timestamps are relatively sane),
     # because we haven't done any agent runs after the specified time.
@@ -35,7 +36,7 @@ test_name "basic validation of puppet report query by timestamp" do
     start_time = start_times[agent.node_name]
 
     # Query for all of the events after the start time
-    result = on database, %Q|curl -G http://localhost:8080/v4/events --data 'query=["and",%20["=",%20"certname",%20"#{agent.node_name}"],%20[">",%20"timestamp",%20"#{start_time}"]]'|
+    result = on database, %Q|curl -G #{puppetdb_query_url}/v4/events --data 'query=["and",%20["=",%20"certname",%20"#{agent.node_name}"],%20[">",%20"timestamp",%20"#{start_time}"]]'|
 
     # This time, we do expect results because we've done agent runs more recently than the timestamp
     events = JSON.parse(result.stdout)
@@ -46,7 +47,7 @@ test_name "basic validation of puppet report query by timestamp" do
     # previous query.
 
     end_time = current_time_on agent
-    result = on database, %Q|curl -G http://localhost:8080/v4/events --data 'query=["and",%20["=",%20"certname",%20"#{agent.node_name}"],%20["and",%20[">",%20"timestamp",%20"#{start_time}"],%20["<",%20"timestamp",%20"#{end_time}"]]]'|
+    result = on database, %Q|curl -G #{puppetdb_query_url}/v4/events --data 'query=["and",%20["=",%20"certname",%20"#{agent.node_name}"],%20["and",%20[">",%20"timestamp",%20"#{start_time}"],%20["<",%20"timestamp",%20"#{end_time}"]]]'|
     events2 = JSON.parse(result.stdout)
     assert(events.length == events2.length, "Expected compound event time query to return the same number of results as the previous query")
   end

--- a/acceptance/tests/reports/transaction_uuid.rb
+++ b/acceptance/tests/reports/transaction_uuid.rb
@@ -1,5 +1,6 @@
 require 'json'
 
+puppetdb_query_url = "http://localhost:8080/pdb/query"
 test_name "validate matching transaction UUIDs in agent report and catalog" do
   step "setup a test manifest for the master and perform agent runs" do
     manifest = <<-MANIFEST
@@ -17,11 +18,11 @@ test_name "validate matching transaction UUIDs in agent report and catalog" do
 
   agents.each do |agent|
     # Query for all of the reports for this node, but we only care about the most recent one
-    result = on database, %Q|curl -G http://localhost:8080/v4/reports --data 'query=["=",%20"certname",%20"#{agent.node_name}"]' --data 'order_by=[{"field":"receive_time","order":"desc"}]'|
+    result = on database, %Q|curl -G #{puppetdb_query_url}/v4/reports --data 'query=["=",%20"certname",%20"#{agent.node_name}"]' --data 'order_by=[{"field":"receive_time","order":"desc"}]'|
     report = JSON.parse(result.stdout)[0]
 
     # Query for the most recent catalog for this node
-    result = on database, %Q|curl -G http://localhost:8080/v4/catalogs/#{agent.node_name}|
+    result = on database, %Q|curl -G #{puppetdb_query_url}/v4/catalogs/#{agent.node_name}|
     catalog = JSON.parse(result.stdout)
 
     report_uuid = report['transaction_uuid']

--- a/acceptance/tests/storeconfigs/file_with_binary_template.rb
+++ b/acceptance/tests/storeconfigs/file_with_binary_template.rb
@@ -1,3 +1,4 @@
+puppetdb_query_url = "http://localhost:8080/pdb/query"
 test_name "submit a catalog that contains a file built from a binary template" do
 
   # This test came about as a result of ticket #14873 .  The issue was that
@@ -52,7 +53,7 @@ file { "/tmp/myfile":
 
   sleep_until_queue_empty database
 
-  on database, %Q|curl -G -H 'Accept: application/json' http://localhost:8080/v4/resources --data 'query=["=",%20"tag",%20"binary_file"]' > binary_file.json|
+  on database, %Q|curl -G -H 'Accept: application/json' #{puppetdb_query_url}/v4/resources --data 'query=["=",%20"tag",%20"binary_file"]' > binary_file.json|
   # We redirected this output to a file because if the invalid binary data was printed to the log from 
   # the curl statement, then Jenkins would try to parse it at the end of the run and fail.
   scp_from(database, "binary_file.json", ".")

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -171,15 +171,6 @@ and override this setting to point to your proxy server.
 
 When this is set to true, debugging information will be written to `<vardir>/debug/catalog-hashes` every time a catalog is received with a hash that is different than the previously received catalog for that host. Note that this should only be enabled when troubleshooting performance related issues with PuppetDB and the database server. This will output many files and could potentially slow down a production PuppetDB instance. See the [Troubleshooting Low Catalog Duplication guide][low_catalog_dupe] for more information on the outputted files and debugging this problem.
 
-### `url-prefix`
-
-> **Deprecated:** This setting should not be necessary in most cases and will not be supported in a future release.
-
-This optional setting may be used to mount the PuppetDB web application at a URL other than "/".  This should not be necessary
-unless you intend to run additional web applications in the same server with your PuppetDB instance.  **NOTE:** if you change
-this setting, you must also set the corresponding setting in your Puppet Master's [puppetdb.conf][puppetdb.conf] file.
-
-
 `[puppetdb]` Settings
 -----
 
@@ -665,15 +656,3 @@ The port to use for the REPL.
 ### `host`
 
 Specifies the host or IP address for the repl service to listen on. By default this is `127.0.0.1` only, as this is an insecure channel this is the only recommended setting for production environments. Although this is generally not recommended for production, you can listen on all interfaces, you can specify `0.0.0.0` for example.
-
-`:web-router-service` Settings
------
-
-
-The `:web-router-service` section is used to configure the routes at which applications running with your PuppetDB instance are mounted. This configuration section must be done in a `.conf` file (this is the [Human-Optimized Config Object Notation](https://github.com/typesafehub/config/blob/master/HOCON.md) format; a flexible superset of JSON defined by the [typesafe config library](https://github.com/typesafehub/config)). For more information on configuring the `web-router-service` see the [trapperkeeper-webserver-jetty9 docs](https://github.com/puppetlabs/trapperkeeper-webserver-jetty9/blob/master/doc/webrouting-service.md).
-
-### `:puppetlabs.puppetdb.cli.services/puppetdb-service`
-
-This setting may be used to mount the PuppetDB web application at a URL other than "/".  This should not be necessary
-unless you intend to run additional web applications in the same server with your PuppetDB instance.  **NOTE:** if you change
-this setting, you must also set the corresponding setting in your Puppet Master's [puppetdb.conf][puppetdb.conf] file.

--- a/documentation/puppetdb_connection.markdown
+++ b/documentation/puppetdb_connection.markdown
@@ -8,8 +8,6 @@ canonical: "/puppetdb/latest/puppetdb_connection.html"
 [connect_to_puppetdb]: ./connect_puppet_master.html
 [confdir]: /puppet/latest/reference/dirs_confdir.html
 [puppetdb_conf]: ./connect_puppet_master.html#edit-puppetdb\.conf
-[url_prefix_setting]: ./configure.html#url-prefix
-[web_router_setting]: ./configure.html#:web-router-service
 
 The `puppetdb.conf` file contains the hostname and port of the [PuppetDB][puppetdb_root] server. It is only used if you are using PuppetDB and have [connected your Puppet master to it][connect_to_puppetdb].
 
@@ -27,7 +25,7 @@ The location of the `confdir` varies; it depends on the OS, Puppet distribution,
 ## Example
 
     [main]
-    server_urls = https://puppetdb.example.com:8081/
+    server_urls = https://puppetdb.example.com:8081
 
 ## Format
 
@@ -42,17 +40,17 @@ The `[main]` section defines all of the PuppetDB terminus settings.
 
 This setting specifies how the Puppet master should connect to PuppetDB. The configuration should look something like this example:
 
-    server_urls = https://puppetdb.example.com:8081/
+    server_urls = https://puppetdb.example.com:8081
 
-Puppet _requires_ the use of PuppetDB's secure, HTTPS port. You cannot use the unencrypted, plain HTTP port. If you have specified a [`web-router-service` setting in your PuppetDB configuration][web_router_setting], that prefix must be reflected in your URLs. (You might have also used the deprecated [`url-prefix` setting][url_prefix_setting] to change PuppetDB's URLs.
+Puppet _requires_ the use of PuppetDB's secure, HTTPS port. You cannot use the unencrypted, plain HTTP port.
 
 You can use a comma separated list of URLs if there are multiple PuppetDB instances available. A `server_urls` config that supports two PuppetDBs would look like:
 
-    server_urls = https://puppetdb1.example.com:8081/,https://puppetdb2.example.com:8081/
+    server_urls = https://puppetdb1.example.com:8081,https://puppetdb2.example.com:8081
 
 The PuppetDB terminus will always attempt to connect to the first PuppetDB instance specified (listed above as puppetdb1). If a server-side exception occurs, or the request takes too long (see [`server_url_timeout`](#server_url_timeout)), the PuppetDB terminus will attempt the same operation on the next instance in the list.
 
-The default value is https://puppetdb:8081/
+The default value is https://puppetdb:8081
 
 ### `server_url_timeout`
 
@@ -66,20 +64,9 @@ This setting can let the Puppet master stay partially available during a PuppetD
 
 The default value is false.
 
-### `server`
+### `server` and `port`
 
-> **Deprecated:** `server_urls` replaces this setting. This setting will be removed in the future.
+> **Deprecated:** `server_urls` replaces these setting. These settings will be removed in the future.
 
-Hostname of the PuppetDB instance. `server_urls` takes precedence if both are defined.
+Hostname and port of the PuppetDB instance. `server_urls` takes precedence if both are defined.
 
-### `port`
-
-> **Deprecated:** `server_urls` replaces this setting. This setting will be removed in the future.
-
-SSL port of the PuppetDB instance. `server_urls` takes precedence if both are defined.
-
-### `url_prefix`
-
-> **Deprecated:** `server_urls` replaces this setting. This setting will be removed in the future.
-
-You may also, optionally, specify a setting named url_prefix if you have configured your PuppetDB server to run the web application at a URL other than “/”. This should not be necessary in most cases, and should only be used if you have modified the corresponding [url-prefix setting in your PuppetDB configuration][url_prefix_setting]. `server_urls` takes precedence if both are defined.

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -143,7 +143,7 @@ stable release of PuppetDB, which included an experimental v4 API.
     An example expanded block would look something like this:
 
         {
-          "href": "/v4/reports/32c821673e647b0650717db467abc51d9949fd9a/events",
+          "href": "/pdb/query/v4/reports/32c821673e647b0650717db467abc51d9949fd9a/events",
           "data": [ ... ]
         }
 
@@ -191,25 +191,6 @@ stable release of PuppetDB, which included an experimental v4 API.
     * Many symlinks were removed from /usr/share/puppetdb that were pointing
       at the /var/lib/puppetdb and /etc/puppetdb/ spaces. This finishes a partially
       completed migration from the past.
-
-### Deprecations
-
-* Deprecate `[global]` configuration key url-prefix ([PDB-1070](https://tickets.puppetlabs.com/browse/PDB-1070))
-
-    This commit deprecates the use of the `url-prefix` config setting
-    under the `[global]` header. If you are currently using this
-    setting, you should migrate your configuration as follows:
-
-    * Move your config file to a new directory, called `config` for example.
-    * Create a new file in the same directory called `jetty.conf` with this content:
-        ```
-        web-router-service: {
-            "puppetlabs.puppetdb.cli.services/puppetdb-service": "/my-prefix"
-        }
-        ```
-
-    * Remove the `url-prefix` key from your main config file.
-    * When starting puppetdb, pass your new config _directory_ after `-c` instead of your old config file.
 
 ### New Features
 

--- a/puppet/spec/unit/face/node/status_spec.rb
+++ b/puppet/spec/unit/face/node/status_spec.rb
@@ -24,7 +24,7 @@ describe "node face: status" do
 
     nodes = %w[a b c d e]
     nodes.each do |node|
-      http.expects(:get).with("/v4/nodes/#{node}", headers)
+      http.expects(:get).with("/pdb/query/v4/nodes/#{node}", headers)
     end
 
     subject.status(*nodes)
@@ -36,7 +36,7 @@ describe "node face: status" do
 
     node = "foo/+*&bar"
 
-    http.expects(:get).with("/v4/nodes/foo%2F%2B%2A%26bar", headers)
+    http.expects(:get).with("/pdb/query/v4/nodes/foo%2F%2B%2A%26bar", headers)
 
     subject.status(node)
   end

--- a/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
@@ -30,7 +30,7 @@ describe Puppet::Resource::Puppetdb do
       query = CGI.escape(["and", ["=", "type", "exec"], ["=", "exported", true], ["not", ["=", "certname", "default.local"]]].to_json)
       http = stub 'http'
       Puppet::Network::HttpPool.stubs(:http_instance).returns(http)
-      http.stubs(:get).with("/v4/resources?query=#{query}",  subject.headers).returns response
+      http.stubs(:get).with("/pdb/query/v4/resources?query=#{query}",  subject.headers).returns response
 
       search("exec").should == []
     end
@@ -44,7 +44,7 @@ describe Puppet::Resource::Puppetdb do
       query = CGI.escape(["and", ["=", "type", "exec"], ["=", "exported", true], ["not", ["=", "certname", "default.local"]]].to_json)
       http = stub 'http'
       Puppet::Network::HttpPool.stubs(:http_instance).returns(http)
-      http.stubs(:get).with("/v4/resources?query=#{query}",  subject.headers).returns response
+      http.stubs(:get).with("/pdb/query/v4/resources?query=#{query}",  subject.headers).returns response
 
       Puppet.expects(:deprecation_warning).with do |msg|
         msg =~ /Deprecated, yo\./
@@ -89,7 +89,7 @@ describe Puppet::Resource::Puppetdb do
 
         http = stub 'http'
         Puppet::Network::HttpPool.stubs(:http_instance).returns(http)
-        http.stubs(:get).with("/v4/resources?query=#{CGI.escape(query.to_json)}",  subject.headers).returns response
+        http.stubs(:get).with("/pdb/query/v4/resources?query=#{CGI.escape(query.to_json)}",  subject.headers).returns response
       end
 
       context "with resources from a single host" do

--- a/puppet/spec/unit/util/puppetdb/command_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/command_spec.rb
@@ -55,28 +55,6 @@ describe Puppet::Util::Puppetdb::Command do
       end
     end
 
-    context "when an alternate url_prefix is configured" do
-      let(:httpok) { Net::HTTPOK.new('1.1', 200, '') }
-
-      it "should make a request to the correct url" do
-        tempconfig = Tempfile.new('config')
-        File.open(tempconfig.path, 'w') {|f| f.write('[main]
-url_prefix = /puppetdb
-server = puppetdb
-port = 8081
-soft_write_failure = false
-ignore_blacklisted_events = true') }
-        config = Puppet::Util::Puppetdb::Config.load(tempconfig.path)
-        Puppet::Util::Puppetdb.expects(:config).at_least_once.returns(config)
-
-        httpok.stubs(:body).returns '{"uuid": "a UUID"}'
-        http.expects(:post).with { |path, payload, headers|
-          path.start_with?("/puppetdb" + Puppet::Util::Puppetdb::Command::CommandsUrl)
-        }.returns httpok
-
-        subject.submit
-      end
-    end
   end
 
 end

--- a/resources/public/dashboard/index.html
+++ b/resources/public/dashboard/index.html
@@ -123,7 +123,7 @@ body {
   };
 
   function setVersion() {
-    d3.json("../v4/version", function (res) {
+    d3.json("/pdb/query/v4/version", function (res) {
       if (res != null && res.version != null) {
         d3.select('#version').html('v' + res.version);
       }
@@ -134,7 +134,7 @@ body {
   };
 
   function checkForUpdates() {
-    d3.json("../v4/version/latest", function (res) {
+    d3.json("/pdb/query/v4/version/latest", function (res) {
       console.log(res);
       if (res != null && res.newer) {
         d3.select('#latest-version').html('v' + res.version);
@@ -155,7 +155,7 @@ body {
   var height = getParameter("height") || 60;
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/java.lang:type=Memory")
+  .url("/metrics/v1/mbeans/java.lang:type=Memory")
   .snag(function(res) { return res["HeapMemoryUsage"]["used"]; })
   .format(d3.format(",.3s"))
   .description("JVM Heap")
@@ -168,7 +168,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.query.population:type=default,name=num-nodes")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.query.population:type=default,name=num-nodes")
   .snag(function(res) { return res["Value"]; })
   .format(d3.format(","))
   .description("Nodes")
@@ -181,7 +181,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.query.population:type=default,name=num-resources")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.query.population:type=default,name=num-resources")
   .snag(function(res) { return res["Value"]; })
   .format(d3.format(","))
   .description("Resources")
@@ -194,7 +194,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.query.population:type=default,name=pct-resource-dupes")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.query.population:type=default,name=pct-resource-dupes")
   .snag(function(res) { return res["Value"]; })
   .format(d3.format(",.1%"))
   .description("Resource duplication")
@@ -207,7 +207,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.scf.storage:type=default,name=duplicate-pct")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.scf.storage:type=default,name=duplicate-pct")
   .snag(function(res) { return res["Value"]; })
   .format(d3.format(",.1%"))
   .description("Catalog duplication")
@@ -220,7 +220,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=puppetlabs.puppetdb.commands")
+  .url("/metrics/v1/mbeans/org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=puppetlabs.puppetdb.commands")
   .snag(function(res) { return res["QueueSize"]; })
   .format(d3.format(",s"))
   .description("Command Queue")
@@ -233,7 +233,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.command:type=global,name=processing-time")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.command:type=global,name=processing-time")
   .snag(function(res) { return res["50thPercentile"] / 1000; })
   .format(d3.format(",.3s"))
   .description("Command Processing")
@@ -246,7 +246,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.command:type=global,name=processed")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.command:type=global,name=processed")
   .snag(function(res) { return res["FiveMinuteRate"]; })
   .format(clampToZero(d3.format(",.3s"), 0.001))
   .description("Command Processing")
@@ -259,7 +259,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.command:type=global,name=processed")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.command:type=global,name=processed")
   .snag(function(res) { return res["Count"]; })
   .format(d3.format(","))
   .description("Processed")
@@ -272,7 +272,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.command:type=global,name=retried")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.command:type=global,name=retried")
   .snag(function(res) { return res["Count"]; })
   .format(d3.format(","))
   .description("Retried")
@@ -285,7 +285,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.command:type=global,name=discarded")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.command:type=global,name=discarded")
   .snag(function(res) { return res["Count"]; })
   .format(d3.format(","))
   .description("Discarded")
@@ -298,7 +298,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.command:type=global,name=fatal")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.command:type=global,name=fatal")
   .snag(function(res) { return res["Count"]; })
   .format(d3.format(","))
   .description("Rejected")
@@ -311,7 +311,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.http.server:type=../v4/commands,name=service-time")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.http.server:type=/pdb/query/v4/commands,name=service-time")
   .snag(function(res) { return res["50thPercentile"] / 1000; })
   .format(d3.format(",.3s"))
   .description("Enqueueing")
@@ -324,7 +324,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.http.server:type=../v4/resources,name=service-time")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.http.server:type=/pdb/query/v4/resources,name=service-time")
   .snag(function(res) { return res["50thPercentile"] / 1000; })
   .format(d3.format(",.3s"))
   .description("Collection Queries")
@@ -337,7 +337,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.scf.storage:type=default,name=gc-time")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.scf.storage:type=default,name=gc-time")
   .snag(function(res) { return res["50thPercentile"] / 1000; })
   .format(d3.format(",.3s"))
   .description("DB Compaction")
@@ -350,7 +350,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.command.dlo:type=global,name=compression")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.command.dlo:type=global,name=compression")
   .snag(function(res) { return res["50thPercentile"] / 1000; })
   .format(d3.format(",.3s"))
   .description("DLO Compression")
@@ -363,7 +363,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.command.dlo:type=global,name=filesize")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.command.dlo:type=global,name=filesize")
   .snag(function(res) { return res["Value"]; })
   .format(d3.format(",.3s"))
   .description("DLO Size on Disk")
@@ -376,7 +376,7 @@ body {
   .call();
 
   counterAndSparkline()
-  .url("../metrics/v1/mbeans/puppetlabs.puppetdb.command.dlo:type=global,name=messages")
+  .url("/metrics/v1/mbeans/puppetlabs.puppetdb.command.dlo:type=global,name=messages")
   .snag(function(res) { return res["Value"]; })
   .format(d3.format(","))
   .description("Discarded Messages")

--- a/resources/puppetlabs/puppetdb/bootstrap.cfg
+++ b/resources/puppetlabs/puppetdb/bootstrap.cfg
@@ -12,6 +12,7 @@ puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-servi
 # PuppetDB Services
 puppetlabs.puppetdb.cli.services/puppetdb-service
 puppetlabs.puppetdb.metrics/metrics-service
+puppetlabs.puppetdb.dashboard/dashboard-service
 puppetlabs.puppetdb.mq-listener/message-listener-service
 puppetlabs.puppetdb.command/command-service
 

--- a/src/puppetlabs/puppetdb/cli/export.clj
+++ b/src/puppetlabs/puppetdb/cli/export.clj
@@ -259,22 +259,20 @@
   (let [specs    [["-o" "--outfile OUTFILE" "Path to backup file (required)"]
                   ["-H" "--host HOST" "Hostname of PuppetDB server" :default "localhost"]
                   ["-p" "--port PORT" "Port to connect to PuppetDB server (HTTP protocol only)"
-                   :parse-fn #(Integer. %) :default 8080]
-                  ["" "--url-prefix PREFIX" "Server prefix (HTTP protocol only)"
-                   :default ""]]
+                   :parse-fn #(Integer. %) :default 8080]]
         required [:outfile]]
     (try+
      (kitchensink/cli! args specs required)
      (catch map? m
        (println (:message m))
        (case (:type m)
-         :puppetlabs.kitchensink.core/cli-error (System/exit 1)
-         :puppetlabs.kitchensink.core/cli-help  (System/exit 0))))))
+         ::kitchensink/cli-error (System/exit 1)
+         ::kitchensink/cli-help  (System/exit 0))))))
 
 (defn- main
   [& args]
-  (let [[{:keys [outfile host port url-prefix] :as opts} _] (validate-cli! args)
-        src {:protocol "http" :host host :port port :prefix url-prefix}
+  (let [[{:keys [outfile host port] :as opts} _] (validate-cli! args)
+        src {:protocol "http" :host host :port port :prefix "/pdb/query"}
         _ (when-let [why (utils/describe-bad-base-url src)]
             (throw+ {:type ::invalid-url :utils/exit-status 1}
                     (format "Invalid source (%s)" why)))

--- a/src/puppetlabs/puppetdb/dashboard.clj
+++ b/src/puppetlabs/puppetdb/dashboard.clj
@@ -1,0 +1,30 @@
+(ns puppetlabs.puppetdb.dashboard
+  (:require [clojure.tools.logging :as log]
+            [net.cgrand.moustache :refer [app]]
+            [puppetlabs.puppetdb.middleware :refer [wrap-with-puppetdb-middleware]]
+            [puppetlabs.trapperkeeper.core :refer [defservice]]
+            [ring.middleware.resource :refer [wrap-resource]]
+            [ring.util.request :as rreq]
+            [ring.util.response :as rr]
+            [compojure.core :as compojure]))
+
+(def dashboard
+  (let [index-handler #(->> %
+                            rreq/request-url
+                            (format "%s/dashboard/index.html")
+                            rr/redirect)]
+    (-> (app [""] {:get index-handler})
+        (wrap-resource "public"))))
+
+(defservice dashboard-service
+  [[:PuppetDBServer shared-globals]
+   [:WebroutingService add-ring-handler get-route]]
+
+  (start [this context]
+         (let [app (-> dashboard
+                       (wrap-with-puppetdb-middleware (:authorizer (shared-globals))))]
+           (log/info "Starting dashboard service")
+           (->> app
+                (compojure/context (get-route this) [])
+                (add-ring-handler this))
+           context)))

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1277,7 +1277,7 @@
    received-timestamp :- pls/Timestamp]
   (add-report!* report received-timestamp true))
 
-(defn fail-on-unsupported
+(defn validate-database-version
   "Log an error message to the log and console if the currently
   configured database is unsupported, then call fail-fn  (probably to
   exit)."
@@ -1287,12 +1287,6 @@
       (utils/println-err attn-msg)
       (log/error attn-msg)
       (fail-fn))))
-
-(defn validate-database-version
-  "Checks to ensure that the database is supported, fails if supported, logs
-  if deprecated"
-  [action-for-unsupported-fn]
-  (fail-on-unsupported action-for-unsupported-fn))
 
 (def ^:dynamic *orphaned-path-gc-limit* 200)
 (def ^:dynamic *orphaned-value-gc-limit* 200)

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -212,18 +212,10 @@
     (is (thrown-with-msg? IllegalArgumentException #"product-name puppet is illegal"
                           (normalize-product-name "puppet")))))
 
-(deftest warn-url-prefix-deprecation-test
-  (testing "output to standard out"
-    (let [bad-config {:global {:url-prefix "/bwahaha"}}
-          out-str (with-out-str
-                    (binding [*err* *out*]
-                      (warn-url-prefix-deprecation bad-config)))]
-      (is (.contains out-str "[global] section is deprecated")))))
-
-(deftest warn-repl-retirements-test
+(deftest warn-retirements-test
   (testing "output to standard out"
     (let [bad-config {:repl {:port 123}}
           out-str (with-out-str
                     (binding [*err* *out*]
-                      (warn-repl-retirement bad-config)))]
+                      (warn-retirements bad-config)))]
       (is (.contains out-str "[repl] is now retired")))))

--- a/test/puppetlabs/puppetdb/dashboard_test.clj
+++ b/test/puppetlabs/puppetdb/dashboard_test.clj
@@ -1,0 +1,15 @@
+(ns puppetlabs.puppetdb.dashboard-test
+  (:require [puppetlabs.puppetdb.dashboard :as dashboard]
+            [puppetlabs.puppetdb.http :as http]
+            [clojure.test :refer :all]
+            [ring.mock.request :refer :all]
+            [puppetlabs.puppetdb.testutils.services :as svc-utils]
+            [clojure.java.io :refer [file]]))
+
+(deftest dashboard-resource-requests
+  (testing "serving the dashboard works correctly"
+    (let [{:keys [status body]} (dashboard/dashboard (request :get "/dashboard/index.html"))]
+      (is (= status http/status-ok))
+      (is (instance? java.io.File body))
+      (is (= (file (System/getProperty "user.dir")
+                   "resources/public/dashboard/index.html") body)))))

--- a/test/puppetlabs/puppetdb/http/server_test.clj
+++ b/test/puppetlabs/puppetdb/http/server_test.clj
@@ -3,8 +3,7 @@
             [puppetlabs.puppetdb.testutils :refer [deftestseq]]
             [clojure.test :refer :all]
             [ring.mock.request :refer :all]
-            [puppetlabs.puppetdb.fixtures :refer :all]
-            [clojure.java.io :refer [file]]))
+            [puppetlabs.puppetdb.fixtures :refer :all]))
 
 ;; This test file is for tests that aren't for any specific end-point.
 
@@ -23,18 +22,3 @@
           {:keys [status body]} (*app* request)]
       (is (= status http/status-bad-method))
       (is (= body (str "The POST method is not allowed for " endpoint))))))
-
-(deftest misc-resource-requests
-  (testing "/ redirects to the dashboard"
-    (let [request (request :get "/")
-          {:keys [status headers]} (*app* request)]
-      (is (= status http/status-moved-temp))
-      (is (= (headers "Location") "/dashboard/index.html"))))
-
-  (testing "serving the dashboard works correctly"
-    (let [request (request :get "/dashboard/index.html")
-          {:keys [status body]} (*app* request)
-          pwd (System/getProperty "user.dir")]
-      (is (= status http/status-ok))
-      (is (instance? java.io.File body))
-      (is (= (file pwd "resources/public/dashboard/index.html") body)))))


### PR DESCRIPTION
This commit changes PuppetDB to server its query API at `/pdb/query`
instead of `/` by default, making similar default configuration changes
to the terminus. We do not expect, nor do we want or support, users
changing this setting so this commit also removes documentation about
how to configure this from PuppetDB.