### PR TITLE
(PE-9827) Override ezbake version in PE profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -137,7 +137,9 @@
                                        :create-varlib true}
                                 :config-dir "ext/config/pe"}
                   :version ~pdb-version
-                  :name "pe-puppetdb"}
+                  :name "pe-puppetdb"
+                  :plugins [[puppetlabs/lein-ezbake "0.3.5"
+                                 :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}
 


### PR DESCRIPTION
There are changes in ezbake 0.3.5 that are required to integrate
puppetdb into PE, which includes a bugfix related to systemd and the
defaults file. This commit copies the plugin definition from the ezbake
profile into the pe profile so that the ezbake version can be moved from
0.2.9 to 0.3.5.