### PR TITLE
(PDB-1455) Update package dependencies and postinst for Puppet 4

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -3,7 +3,7 @@ ezbake: {
   foss: {
     redhat: { dependencies: ["puppet >= 3.7.3", "puppet < 5.0.0"],
               postinst: ["/usr/bin/puppetdb ssl-setup"] },
-    debian: { dependencies: ["puppet (>= 3.7.3-1puppetlabs1)", "puppet (<< 5.0.0-1puppetlabs1)"],
+    debian: { dependencies: ["puppet (>= 3.7.3-1puppetlabs1)  | puppet-agent", "puppet (<< 5.0.0-1puppetlabs1) | puppet-agent"],
               postinst: ["/usr/bin/puppetdb ssl-setup"] }
   }
 }


### PR DESCRIPTION
In Puppet 4, the filesystem paths were updated and package names were
changed. This commit updates both the dependencies and postinst of
puppetdb to accomodate this change. On debian, versioned dependencies
cannot be satisfied with a package that uses Provides tags to enable
those capabilities (this is fixed in bleeding edge deb and ubuntu), so
the debian dependencies have an `| puppet-agent` added to cover this.
The puppetdb binaries will be laid down in /opt/puppetlabs/bin in the
new filesystem world, so to ensure that both new and old paths work, the
path is updated for the postinst so that both PDB 2.x and 3.x scripts
will be correctly found.