### PR TITLE
(maint) Use transducers for database streaming

### DIFF
--- a/src/puppetlabs/puppetdb/http.clj
+++ b/src/puppetlabs/puppetdb/http.clj
@@ -165,13 +165,6 @@
                          (conj strs (str delimiter (s/join delimiter segs')))]))]
        (second (reduce f [[] []] segments)))))
 
-(defn stream-json
-  "Serializes the supplied sequence to `buffer`, which is a `Writer`
-  object."
-  [coll buffer]
-  {:pre [(instance? Writer buffer)]}
-  (json/generate-pretty-stream coll buffer))
-
 (defmacro streamed-response
   "Evaluates `body` in a thread, with a local variable (`writer-var`)
   bound to a fresh, UTF-8 Writer object.

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -732,20 +732,3 @@
     (cond
      (= "=" op) compile-event-count-equality
      (#{">" "<" ">=" "<="} op) (partial compile-event-count-inequality op))))
-
-(defn streamed-query-result
-  "Uses a cursored resultset (for streaming). Returns the results
-   after running the function `f` with the resultset.
-
-   That function will get the results of the query. Ordinarily some sort of
-   munging and finally serialization is performed within this function. See
-   http/stream-json-response for a function to provide JSON streaming for
-   example.
-
-   If all you want is an unstreamed Seq, pass the function `doall` as `f` to
-   convert the LazySeq to a Seq by full traversing it. This is useful for tests,
-   that cannot analyze results easily in a streamed way."
-  ([[sql & params] f]
-   (streamed-query-result nil sql params f))
-  ([version sql params f]
-   (jdbc/with-query-results-cursor sql params rs (f rs))))

--- a/src/puppetlabs/puppetdb/query/catalogs.clj
+++ b/src/puppetlabs/puppetdb/query/catalogs.clj
@@ -67,15 +67,12 @@
           (jdbc/valid-jdbc-query? (:results-query query-sql))]
    :post [(map? %)
           (sequential? (:result %))]}
-  (let [{[sql & params] :results-query
-         count-query    :count-query} query-sql
-         result {:result (query/streamed-query-result
-                          version sql params
-                          (comp doall
-                                (munge-result-rows version url-prefix)))}]
-    (if count-query
-      (assoc result :count (jdbc/get-result-count count-query))
-      result)))
+  (let [{:keys [results-query count-query]} query-sql
+        munge-fn (munge-result-rows version url-prefix)]
+    (cond-> {:result (->> (jdbc/with-query-results-cursor results-query)
+                          munge-fn
+                          (into []))}
+        count-query (assoc :count (jdbc/get-result-count count-query)))))
 
 (defn status
   [version node url-prefix]

--- a/src/puppetlabs/puppetdb/query/environments.clj
+++ b/src/puppetlabs/puppetdb/query/environments.clj
@@ -24,18 +24,14 @@
           (jdbc/valid-jdbc-query? (:results-query query-sql))]
    :post [(map? %)
           (sequential? (:result %))]}
-  (let [{[sql & params] :results-query
-         count-query    :count-query} query-sql
-         result {:result (query/streamed-query-result
-                          version sql params doall)}]
-    (if count-query
-      (assoc result :count (jdbc/get-result-count count-query))
-      result)))
+  (let [{:keys [results-query count-query]} query-sql]
+    (cond-> {:result (into [] (jdbc/with-query-results-cursor results-query))}
+      count-query (assoc :count (jdbc/get-result-count count-query)))))
 
 (defn status
   "Given an environment's name, return the results for the single environment."
   [version environment]
   {:pre  [string? environment]}
-  (let [sql     (query->sql version ["=" "name" environment])
+  (let [sql (query->sql version ["=" "name" environment])
         results (:result (query-environments version sql))]
     (first results)))

--- a/src/puppetlabs/puppetdb/query/nodes.clj
+++ b/src/puppetlabs/puppetdb/query/nodes.clj
@@ -39,14 +39,9 @@
           (jdbc/valid-jdbc-query? (:results-query query-sql))]
    :post [(map? %)
           (sequential? (:result %))]}
-  (let [{[sql & params] :results-query
-         count-query    :count-query} query-sql
-         result {:result (query/streamed-query-result
-                          version sql params
-                          doall)}]
-    (if count-query
-      (assoc result :count (jdbc/get-result-count count-query))
-      result)))
+  (let [{:keys [results-query count-query]} query-sql]
+    (cond-> {:result (into [] (jdbc/with-query-results-cursor results-query))}
+      count-query (assoc :count (jdbc/get-result-count count-query)))))
 
 (defn status
   "Given a node's name, return the current status of the node.  Results

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -68,9 +68,9 @@
              ;; We evaluate the first element from lazy-seq just to check if DB query was successful or not
              ;; so we have to ensure the first element and the rest have been realized, not just the first
              ;; element on its own.
-             (reset! before-slurp? (and (realized? result-set) (realized? (rest result-set))))
-             (reset! results (vec result-set))
-             (reset! after-slurp? (and (realized? result-set) (realized? (rest result-set))))))
+             (reset! before-slurp? (realized? result-set))
+             (reset! results (into [] result-set))
+             (reset! after-slurp? (realized? result-set))))
     (is (false? @before-slurp?))
     (check-result @results)
     (is (true? @after-slurp?))))

--- a/test/puppetlabs/puppetdb/http_test.clj
+++ b/test/puppetlabs/puppetdb/http_test.clj
@@ -129,18 +129,6 @@
                      (json/parse-string))
                  "N�rnberg")))))))
 
-(deftest streaming-json
-  (testing "empty seq should return []"
-    (let [w (StringWriter.)]
-      (stream-json [] w)
-      (is (empty? (parse-string (str w))))))
-
-  (testing "should jsonify all items in the seq"
-    (let [w    (StringWriter.)
-          test [nil 1 "a" [1 2] {"foo" 123}]]
-      (stream-json test w)
-      (is (= (parse-string (str w)) test)))))
-
 (deftest response-streaming
   (testing "can read back what we've written"
     (let [istream (streamed-response writer (spit writer "foo bar baz"))]

--- a/test/puppetlabs/puppetdb/jdbc_test.clj
+++ b/test/puppetlabs/puppetdb/jdbc_test.clj
@@ -4,6 +4,7 @@
             [puppetlabs.puppetdb.fixtures :as fixt]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.testutils :refer [test-db]]
+            [clojure.java.jdbc :as sql]
             [puppetlabs.puppetdb.testutils.db :refer [antonym-data with-antonym-test-database insert-map *db-spec*]]))
 
 (use-fixtures :each with-antonym-test-database)


### PR DESCRIPTION
This commit changes the database streaming we do for the query-eng to
use transducers which allows us to significantly simplify the interface
for our streaming functions.