### PR TITLE
(maint) Bump to clojure 1.7.0-RC1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.7.0-beta3"]
+  :dependencies [[org.clojure/clojure "1.7.0-RC1"]
                  [cheshire "5.4.0"]
                  [org.clojure/core.match "0.2.2"]
                  [org.clojure/math.combinatorics "0.0.4"]


### PR DESCRIPTION
We're just following closely behind the release cycle of Clojure 1.7.0.

Signed-off-by: Ken Barber <ken@bob.sh>