### PR TITLE
(maint) Memoize the database connection name

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -31,12 +31,14 @@
 
 ;; FUNCTIONS
 
-(defn sql-current-connection-database-name
+(defn sql-current-connection-database-name*
   "Return the database product name currently in use."
   []
   (.. (sql/find-connection)
       (getMetaData)
       (getDatabaseProductName)))
+
+(def sql-current-connection-database-name (memoize sql-current-connection-database-name*))
 
 (pls/defn-validated sql-current-connection-database-version :- db-version
   "Return the version of the database product currently in use."


### PR DESCRIPTION
This commit changes the function which finds the database connection
name to be memoized so we don't attempt to get the connection metadata
every time we want to whether we're on postgres or hsql.