### PR TITLE
(maint) Fix factset up-to-date checks

### DIFF
--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -70,7 +70,7 @@
 
       (is (nil?
            (sql/transaction
-            (factset-timestamp "some_certname"))))
+            (timestamp-of-newest-record :factsets "some_certname"))))
       (is (empty? (factset-map "some_certname")))
 
       (add-facts! {:certname certname
@@ -100,7 +100,7 @@
                 {:certname certname :name "operatingsystem" :value "Debian"}]))
 
         (is (sql/transaction
-             (factset-timestamp "some_certname")))
+             (timestamp-of-newest-record :factsets  "some_certname")))
         (is (= facts (factset-map "some_certname"))))
 
       (testing "should add the certname if necessary"
@@ -234,7 +234,7 @@
 
       (is (nil?
            (sql/transaction
-            (factset-timestamp "some_certname"))))
+            (timestamp-of-newest-record :factsets "some_certname"))))
       (is (empty? (factset-map "some_certname")))
       (is (nil? (environment-id "PROD")))
 


### PR DESCRIPTION
To allow sync convergence when there are conflicting writes to two 
nodes, the factset up-to-date check needs to allow records whose
producer_timestamp is equal to the existing producer_timestamp. This is
the same as the replace-catalog command's current behavior. 

Also include reports in the deactivate-node up-to-date check, using
their producer_timestamp field.