### PR TITLE
(PDB-1485) Add a test_url param for upgrade testing

### DIFF
--- a/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
+++ b/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
@@ -3,8 +3,8 @@ if (test_config[:install_mode] == :upgrade and not test_config[:skip_presuite_pr
   step "Install most recent released PuppetDB on the PuppetDB server for upgrade test" do
     databases.each do |database|
       install_puppetdb(database, test_config[:database], 'latest')
-      start_puppetdb(database)
-      install_puppetdb_termini(master, database, 'latest', 'puppetdb-terminus')
+      start_puppetdb(database, "/v3/version")
+      install_puppetdb_termini(master, database, 'latest', 'puppetdb-terminus', "/v3/version")
     end
   end
 end


### PR DESCRIPTION
This commit adds a test_url and ssl_test_url param for checking whether
PuppetDB is up on Beaker upgrade testing. This allows us to check
different urls across PuppetDB versions.