### PR TITLE
(PDB-1469) Remove rubygem-json dependency

### DIFF
--- a/ext/redhat/puppetdb.spec.erb
+++ b/ext/redhat/puppetdb.spec.erb
@@ -139,7 +139,6 @@ Group: Development/Libraries
 Requires: pe-puppet >= %{puppetminversion}
 <% else -%>
 Requires: puppet >= %{puppetminversion}
-Requires: rubygem-json
 <% end -%>
 
 %description terminus


### PR DESCRIPTION
We were pulling in the rubygem-json dependency, but this is unnecessary
since Puppet requires it. With the dependency there, the consumer needs
to include the puppetlabs-deps repo, but this doesn't match well with
Puppet 4 & AIO requirements.

So this removes it, Puppet 3.x will pull in the dependency automatically,
and Puppet 4 AIO will include it anyway.

Signed-off-by: Ken Barber <ken@bob.sh>