### PR TITLE
(PDB-1454) Handle IOException while starting MQ

### DIFF
--- a/documentation/trouble_kahadb_corruption.markdown
+++ b/documentation/trouble_kahadb_corruption.markdown
@@ -17,10 +17,18 @@ The KahaDB storage for PuppetDB is located in a sub-directory underneath your co
 Why does corruption occur?
 -----
 
-In some cases this database may corrupt. Lots of things may cause this:
+In some cases KahaDB's storage may become corrupt or simply unreadable
+by the version of PuppetDB that you've launched.  There are a number
+of possible causes, for example:
 
 * Your disk may fill up, so writes are not finalised within the journal or database index.
+
 * There might be a bug in the KahaDB code that the developers haven't catered for.
+
+* You might downgrade PuppetDB to a version that uses an incompatible
+  ActiveMQ without clearing the queue directory.  If so, you can
+  simply remove the `mq/localhost` directory inside `<vardir>`, but
+  note that any unprocessed data will be lost.
 
 How do I recover?
 -----

--- a/src/com/puppetlabs/mq.clj
+++ b/src/com/puppetlabs/mq.clj
@@ -132,10 +132,17 @@
     (start-broker! (build-embedded-broker brokername dir config))
     (catch java.io.EOFException e
       (log/warn
-        (str "Caught EOFException on broker startup, trying to restart it "
-             "again to see if that solves it. This is probably due to "
-             "KahaDB corruption."))
-      (start-broker! (build-embedded-broker brokername dir config)))))
+       "Caught EOFException on broker startup, trying again."
+       "This is probably due to KahaDB corruption"
+       "(see \"KahaDB Corruption\" in the PuppetDB manual).")
+      (start-broker! (build-embedded-broker brokername dir config)))
+    (catch java.io.IOException e
+      (throw (java.io.IOException.
+              (str "Unable to start broker in " (str (pr-str dir) ".")
+                   " This is probably due to KahaDB corruption"
+                   " or version incompatibility after a PuppetDB downgrade"
+                   " (see \"KahaDB Corruption\" in the PuppetDB manual)."))
+             e))))
 
 (defn connect-and-publish!
   "Construct an MQ producer and send the indicated message.


### PR DESCRIPTION
In the KahaDB corruption documentation, mention the possibility that MQ
related errors might be caused by downgrading PuppetDB (and by
extension, the ActiveMQ version), and if we hit an IOException while
starting the MQ broker (one of the known symptoms), suggest looking at
that documentation.

This PR pairs with master PR: #1417 
