### PR TITLE
(PDB-1473) Present 404 errors on missing parent data

### DIFF
--- a/documentation/api/query/v4/upgrading-from-v3.markdown
+++ b/documentation/api/query/v4/upgrading-from-v3.markdown
@@ -35,6 +35,12 @@ Each change below is marked with the corresponding release version. Changes mark
   underscore-separated. This change does not apply to dash-separated endpoint
   names such as `aggregate-event-counts`.
 
+* (3.0) All endpoints with child rest queries (for example `/pdb/query/v4/environments/<env_name>/facts`)
+  will now return a 404 if the parent data does not exist. In the past we were
+  returning an empty array, but this gave off the impression there was a parent
+  but the particular child data was empty. Now, we return a 404 Not Found status
+  code and a proper JSON error.
+
 #### /pdb/query/v4/catalogs
 
 * (3.0) The v4 catalogs endpoint has changed the response of the

--- a/src/puppetlabs/puppetdb/http/catalogs.clj
+++ b/src/puppetlabs/puppetdb/http/catalogs.clj
@@ -10,7 +10,7 @@
             [schema.core :as s]
             [puppetlabs.puppetdb.query.paging :as paging]
             [puppetlabs.puppetdb.middleware :refer [verify-accepts-json validate-query-params
-                                                    wrap-with-paging-options]]
+                                                    wrap-with-paging-options wrap-with-parent-check]]
             [puppetlabs.puppetdb.jdbc :refer [with-transacted-connection]]
             [net.cgrand.moustache :refer [app]]))
 
@@ -53,10 +53,12 @@
                       (str (:url-prefix globals))))
 
     [node "edges" &]
-    (comp (edges/edges-app version false) (partial http-q/restrict-query-to-node node))
+    (-> (comp (edges/edges-app version false) (partial http-q/restrict-query-to-node node))
+        (wrap-with-parent-check version :catalog node))
 
     [node "resources" &]
-    (comp (resources/resources-app version false) (partial http-q/restrict-query-to-node node))))
+    (-> (comp (resources/resources-app version false) (partial http-q/restrict-query-to-node node))
+        (wrap-with-parent-check version :catalog node))))
 
 (defn catalog-app
   [version]

--- a/src/puppetlabs/puppetdb/http/factsets.clj
+++ b/src/puppetlabs/puppetdb/http/factsets.clj
@@ -3,7 +3,7 @@
             [puppetlabs.puppetdb.http.facts :as facts]
             [puppetlabs.puppetdb.http.query :as http-q]
             [puppetlabs.puppetdb.middleware :refer [verify-accepts-json validate-query-params
-                                                    wrap-with-paging-options]]
+                                                    wrap-with-paging-options wrap-with-parent-check]]
             [puppetlabs.puppetdb.query.paging :as paging]
             [puppetlabs.puppetdb.query-eng :refer [produce-streaming-body]]))
 
@@ -26,7 +26,8 @@
                http-q/restrict-query-to-active-nodes)}
 
    [node "facts" &]
-   (comp (facts/facts-app version false) (partial http-q/restrict-query-to-node node))))
+   (-> (comp (facts/facts-app version false) (partial http-q/restrict-query-to-node node))
+       (wrap-with-parent-check version :factset node))))
 
 (defn factset-app
   [version]

--- a/src/puppetlabs/puppetdb/http/nodes.clj
+++ b/src/puppetlabs/puppetdb/http/nodes.clj
@@ -8,7 +8,7 @@
             [puppetlabs.puppetdb.http :as pl-http]
             [net.cgrand.moustache :refer [app]]
             [puppetlabs.puppetdb.middleware :refer [verify-accepts-json validate-query-params
-                                                    wrap-with-paging-options]]
+                                                    wrap-with-paging-options wrap-with-parent-check]]
             [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.puppetdb.http :as http]))
 
@@ -53,10 +53,12 @@
         (validate-query-params {}))}
 
    [node "facts" &]
-   (comp (f/facts-app version) (partial http-q/restrict-query-to-node node))
+   (-> (comp (f/facts-app version) (partial http-q/restrict-query-to-node node))
+       (wrap-with-parent-check version :node node))
 
    [node "resources" &]
-   (comp (r/resources-app version) (partial http-q/restrict-query-to-node node))))
+   (-> (comp (r/resources-app version) (partial http-q/restrict-query-to-node node))
+       (wrap-with-parent-check version :node node))))
 
 (defn node-app
   [version]

--- a/src/puppetlabs/puppetdb/query/catalogs.clj
+++ b/src/puppetlabs/puppetdb/query/catalogs.clj
@@ -1,7 +1,6 @@
 (ns puppetlabs.puppetdb.query.catalogs
   "Catalog retrieval"
-  (:require [clojure.set :as set]
-            [puppetlabs.kitchensink.core :as kitchensink]
+  (:require [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.catalogs :as catalogs]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.jdbc :as jdbc]

--- a/test/puppetlabs/puppetdb/query/environments_test.clj
+++ b/test/puppetlabs/puppetdb/query/environments_test.clj
@@ -65,7 +65,16 @@
          '[and
            ["~" name f.*]
            ["~" name .*o]]
-         #{{:name "foo"}})))
+         #{{:name "foo"}}))
+
+  (testing "environment-exists? function"
+    (doseq [env ["bobby" "dave" "charlie"]]
+      (storage/ensure-environment env))
+
+    (is (= true (eng/object-exists? :environment "bobby")))
+    (is (= true (eng/object-exists? :environment "dave")))
+    (is (= true (eng/object-exists? :environment "charlie")))
+    (is (= false (eng/object-exists? :environment "ussr")))))
 
 (deftest test-failed-comparison
   (are [query] (thrown-with-msg? IllegalArgumentException

--- a/test/puppetlabs/puppetdb/query/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/query/nodes_test.clj
@@ -101,7 +101,12 @@
     (testing "environment testing"
       (let [test-cases {["=" "facts_environment" "production"]
                         #{"node_a" "node_b" "node_c" "node_d" "node_e"}}]
-        (combination-tests [:v4] test-cases)))))
+        (combination-tests [:v4] test-cases)))
+
+    (testing "node-exists? function"
+      (is (= true (eng/object-exists? :node "node_a")))
+      (is (= true (eng/object-exists? :node "node_d")))
+      (is (= false (eng/object-exists? :node "rikmayall"))))))
 
 (deftest paging-results
   (let [right-now (now)]

--- a/test/puppetlabs/puppetdb/query/reports_test.clj
+++ b/test/puppetlabs/puppetdb/query/reports_test.clj
@@ -9,6 +9,7 @@
             [puppetlabs.puppetdb.fixtures :refer :all]
             [puppetlabs.puppetdb.query :as query]
             [puppetlabs.puppetdb.query.reports :as r]
+            [puppetlabs.puppetdb.query-eng :as qe]
             [puppetlabs.puppetdb.reports :as reports]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.testutils.reports :refer :all]))
@@ -97,7 +98,11 @@
     (testing "should return reports based on hash"
       (let [actual (reports-query-result :v4 ["=" "hash" report-hash])]
         (is (= (munge-expected-reports [basic])
-               (munge-actual-reports actual)))))))
+               (munge-actual-reports actual)))))
+
+    (testing "report-exists? function"
+      (is (= true (qe/object-exists? :report report-hash)))
+      (is (= false (qe/object-exists? :report "chrissyamphlett"))))))
 
 (deftest paging-results
   (let [{report1 :basic


### PR DESCRIPTION
Before this patch, for paths that contain child data:

* nodes
* environments
* factsets
* catalogs
* reports

Child data for missing parent data (for example factets/<node>/facts, where
<node> is unknown) used to return an empty array.

This patch does a small existance check for its parent, and instead returns
a 404 for missing child data. This means consumers can request child
information directly without having to first check if the parent exists.

Signed-off-by: Ken Barber <ken@bob.sh>