### PR TITLE
(maint) Stop reencoding json catalog in benchmarking tool

### DIFF
--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -195,29 +195,29 @@
   (if-not (> (- clock lastrun) run-interval)
     state
     (let [base-url {:protocol "http" :host puppetdb-host :port puppetdb-port :prefix "/pdb/query"}
-          catalog (some-> catalog update-catalog (maybe-tweak-catalog rand-percentage) json/generate-string)
-          report (some-> report update-report-run-fields json/generate-string)
-          factset (some-> factset (update-factset rand-percentage) json/generate-string)]
+          catalog (some-> catalog update-catalog (maybe-tweak-catalog rand-percentage))
+          report (some-> report update-report-run-fields)
+          factset (some-> factset (update-factset rand-percentage))]
       ;; Submit the catalog and reports in separate threads, so as to not
       ;; disturb the world-loop and otherwise distort the space-time continuum.
       (when catalog
         (future
           (try
-            (client/submit-catalog base-url 6 catalog)
+            (client/submit-catalog base-url 6 (json/generate-string catalog))
             (log/infof "[%s] submitted catalog" host)
             (catch Exception e
               (log/errorf "[%s] failed to submit catalog: %s" host e)))))
       (when report
         (future
           (try
-            (client/submit-report base-url 5 report)
+            (client/submit-report base-url 5 (json/generate-string report))
             (log/infof "[%s] submitted report" host)
             (catch Exception e
               (log/errorf "[%s] failed to submit report: %s" host e)))))
       (when factset
         (future
           (try
-            (client/submit-facts base-url 4 factset)
+            (client/submit-facts base-url 4 (json/generate-string factset))
             (log/infof "[%s] submitted factset" host)
             (catch Exception e
               (log/errorf "[%s] failed to submit factset: %s" host e)))))
@@ -232,12 +232,12 @@
    based on the clock)"
   [{:keys [host lastrun catalog report factset puppetdb-host puppetdb-port run-interval rand-percentage] :as state}]
   (let [base-url {:protocol "http" :host puppetdb-host :port puppetdb-port :prefix "/pdb/query"}
-        catalog (some-> catalog (maybe-tweak-catalog rand-percentage) json/generate-string)
-        report (some-> report update-report-run-fields json/generate-string)
-        factset (some-> factset (update-factset rand-percentage) json/generate-string)]
-    (when catalog (client/submit-catalog base-url 6 catalog))
-    (when report (client/submit-report base-url 5 report))
-    (when factset (client/submit-facts base-url 4 factset))
+        catalog (some-> catalog (maybe-tweak-catalog rand-percentage))
+        report (some-> report update-report-run-fields)
+        factset (some-> factset (update-factset rand-percentage))]
+    (when catalog (client/submit-catalog base-url 6 (json/generate-string catalog)))
+    (when report (client/submit-report base-url 5 (json/generate-string report)))
+    (when factset (client/submit-facts base-url 4 (json/generate-string factset)))
     (assoc state :catalog catalog)))
 
 (defn submit-n-messages


### PR DESCRIPTION
This commit fixes a regression in the benchmarking tool that caused a
catalog to be reencoded to json every iteration of the benchmarking
tool.