### PR TITLE
(maint) don't activate the node when it's already active

### DIFF
--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -1159,9 +1159,10 @@
     (add-certname! certname))
   (let [timestamp (to-timestamp time)
         replaced  (sql/update-values :certnames
-                                     ["name=? AND (deactivated<? OR deactivated IS NULL)" certname timestamp]
-                                     {:deactivated nil})]
-    (pos? (first replaced))))
+                                     ["name=? AND deactivated<?" certname timestamp]
+                                     {:deactivated nil})
+        num-updated (first replaced)]
+    (pos? num-updated)))
 
 (pls/defn-validated deactivate-node!
   "Deactivate the given host, recording the current time. If the node is

--- a/test/com/puppetlabs/puppetdb/test/command.clj
+++ b/test/com/puppetlabs/puppetdb/test/command.clj
@@ -3,6 +3,7 @@
             [clojure.java.jdbc :as sql]
             [cheshire.core :as json]
             [com.puppetlabs.puppetdb.scf.storage :as scf-store]
+            [com.puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [com.puppetlabs.puppetdb.catalogs :as catalog]
             [com.puppetlabs.puppetdb.examples.reports :as report-examples]
             [com.puppetlabs.puppetdb.scf.hash :as shash]
@@ -966,8 +967,11 @@
 
           (test-msg-handler new-facts-cmd publish discard-dir
             (reset! second-message? true)
-            (is (re-matches #".*BatchUpdateException.*(rollback|abort).*"
-                            (extract-error-message publish))))
+            (is (re-matches
+                  (if (sutils/postgres?)
+                    #"(?sm).*ERROR: could not serialize access due to concurrent update.*"
+                    #".*BatchUpdateException.*(rollback|abort).*")
+                  (extract-error-message publish))))
           @fut
           (is (true? @first-message?))
           (is (true? @second-message?)))))))

--- a/test/com/puppetlabs/puppetdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/storage.clj
@@ -1166,7 +1166,7 @@
 
         (testing "should do nothing if the node is already active"
           (activate-node! certname)
-          (is (= true (maybe-activate-node! certname (now))))
+          (is (= false (maybe-activate-node! certname (now))))
           (is (= (query-certnames) [{:name certname :deactivated nil}])))))))
 
 (deftest node-staleness-age


### PR DESCRIPTION
Before this commit we were updating the deactivated column of certnames to null
even if it was already null. This caused unnecessary contention on the certnames
table with each command submission, causing more frequent retries than needed.

Also corrects the corresponding test logic: if nothing happens, then no records
are updated, and the result of maybe-activate-node should *not* be positive.