### PR TITLE
(maint) Remove unneccesary querying macro to improve streaming syntax

### DIFF
--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -732,20 +732,3 @@
     (cond
      (= "=" op) compile-event-count-equality
      (#{">" "<" ">=" "<="} op) (partial compile-event-count-inequality op))))
-
-(defn streamed-query-result
-  "Uses a cursored resultset (for streaming). Returns the results
-   after running the function `f` with the resultset.
-
-   That function will get the results of the query. Ordinarily some sort of
-   munging and finally serialization is performed within this function. See
-   http/stream-json-response for a function to provide JSON streaming for
-   example.
-
-   If all you want is an unstreamed Seq, pass the function `doall` as `f` to
-   convert the LazySeq to a Seq by full traversing it. This is useful for tests,
-   that cannot analyze results easily in a streamed way."
-  ([[sql & params] f]
-   (streamed-query-result nil sql params f))
-  ([version sql params f]
-   (jdbc/with-query-results-cursor sql params rs (f rs))))

--- a/src/puppetlabs/puppetdb/query/catalogs.clj
+++ b/src/puppetlabs/puppetdb/query/catalogs.clj
@@ -5,7 +5,6 @@
             [puppetlabs.puppetdb.catalogs :as catalogs]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.jdbc :as jdbc]
-            [puppetlabs.puppetdb.query :as query]
             [puppetlabs.puppetdb.query.paging :as paging]
             [puppetlabs.puppetdb.query-eng.engine :as qe]
             [puppetlabs.puppetdb.schema :as pls]
@@ -67,12 +66,10 @@
           (jdbc/valid-jdbc-query? (:results-query query-sql))]
    :post [(map? %)
           (sequential? (:result %))]}
-  (let [{[sql & params] :results-query
-         count-query    :count-query} query-sql
-         result {:result (query/streamed-query-result
-                          version sql params
-                          (comp doall
-                                (munge-result-rows version url-prefix)))}]
+  (let [{:keys [count-query results-query]} query-sql
+         result {:result (jdbc/with-query-results-cursor
+                           results-query (comp doall
+                                               (munge-result-rows version url-prefix)))}]
     (if count-query
       (assoc result :count (jdbc/get-result-count count-query))
       result)))

--- a/src/puppetlabs/puppetdb/query/edges.clj
+++ b/src/puppetlabs/puppetdb/query/edges.clj
@@ -3,7 +3,6 @@
   (:require [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.facts :as facts]
             [puppetlabs.puppetdb.jdbc :as jdbc]
-            [puppetlabs.puppetdb.query :as query]
             [puppetlabs.puppetdb.query.paging :as paging]
             [puppetlabs.puppetdb.query-eng.engine :as qe]
             [puppetlabs.puppetdb.schema :as pls]
@@ -56,11 +55,10 @@
   "Search for edges satisfying the given SQL filter."
   [version query-sql url-prefix]
   {:pre [(map? query-sql)]}
-  (let [{[sql & params] :results-query
-         count-query    :count-query} query-sql
-         result {:result (query/streamed-query-result
-                          version sql params
-                          (comp doall (munge-result-rows version url-prefix)))}]
+  (let [{:keys [count-query results-query]} query-sql
+         result {:result (jdbc/with-query-results-cursor
+                           results-query (comp doall
+                                               (munge-result-rows version url-prefix)))}]
     (if count-query
       (assoc result :count (jdbc/get-result-count count-query))
       result)))

--- a/src/puppetlabs/puppetdb/query/environments.clj
+++ b/src/puppetlabs/puppetdb/query/environments.clj
@@ -1,6 +1,5 @@
 (ns puppetlabs.puppetdb.query.environments
   (:require [puppetlabs.puppetdb.jdbc :as jdbc]
-            [puppetlabs.puppetdb.query :as query]
             [puppetlabs.puppetdb.query-eng.engine :as qe]))
 
 (defn query->sql
@@ -24,10 +23,8 @@
           (jdbc/valid-jdbc-query? (:results-query query-sql))]
    :post [(map? %)
           (sequential? (:result %))]}
-  (let [{[sql & params] :results-query
-         count-query    :count-query} query-sql
-         result {:result (query/streamed-query-result
-                          version sql params doall)}]
+  (let [{:keys [count-query results-query]} query-sql
+         result {:result (jdbc/with-query-results-cursor results-query doall)}]
     (if count-query
       (assoc result :count (jdbc/get-result-count count-query))
       result)))

--- a/src/puppetlabs/puppetdb/query/nodes.clj
+++ b/src/puppetlabs/puppetdb/query/nodes.clj
@@ -5,7 +5,6 @@
    spec](../spec/node.md)."
   (:require [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.jdbc :as jdbc]
-            [puppetlabs.puppetdb.query :as query]
             [puppetlabs.puppetdb.query.paging :as paging]
             [puppetlabs.puppetdb.query-eng.engine :as qe]
             [puppetlabs.puppetdb.schema :as pls]
@@ -39,11 +38,8 @@
           (jdbc/valid-jdbc-query? (:results-query query-sql))]
    :post [(map? %)
           (sequential? (:result %))]}
-  (let [{[sql & params] :results-query
-         count-query    :count-query} query-sql
-         result {:result (query/streamed-query-result
-                          version sql params
-                          doall)}]
+  (let [{:keys [count-query results-query]} query-sql
+         result {:result (jdbc/with-query-results-cursor results-query doall)}]
     (if count-query
       (assoc result :count (jdbc/get-result-count count-query))
       result)))

--- a/src/puppetlabs/puppetdb/query/resources.clj
+++ b/src/puppetlabs/puppetdb/query/resources.clj
@@ -101,13 +101,10 @@
   "Search for resources satisfying the given SQL filter."
   [version query-sql url-prefix]
   {:pre [(map? query-sql)]}
-  (let [{[sql & params] :results-query
-         count-query    :count-query} query-sql
-         result {:result (query/streamed-query-result
-                          version sql params
-                          ;; The doall simply forces the seq to be traversed
-                          ;; fully.
-                          (comp doall (munge-result-rows version url-prefix)))}]
+  (let [{:keys [count-query results-query]} query-sql
+         result {:result (jdbc/with-query-results-cursor
+                          results-query (comp doall
+                                              (munge-result-rows version url-prefix)))}]
     (if count-query
       (assoc result :count (jdbc/get-result-count count-query))
       result)))

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -306,19 +306,20 @@
   (log/warn "Building resource parameters cache. This make take a few minutes, but faster resource queries are worth it.")
 
   ;; Loop over all parameters, and insert a cache entry for each resource
-  (let [query    "SELECT resource, name, value from resource_params ORDER BY resource"
+  (let [query    ["SELECT resource, name, value from resource_params ORDER BY resource"]
         collapse (fn [rows]
                    (let [resource (:resource (first rows))
                          params   (into {} (map #(vector (:name %) (json/parse-string (:value %))) rows))]
                      [resource params]))]
 
-    (jdbc/with-query-results-cursor query [] rs
-      (let [param-sets (->> rs
-                            (partition-by :resource)
-                            (map collapse))]
-        (doseq [[resource params] param-sets]
-          (sql/insert-record :resource_params_cache {:resource   resource
-                                                     :parameters (json/generate-string params)})))))
+    (jdbc/with-query-results-cursor query
+      (fn [rs]
+        (let [param-sets (->> rs
+                              (partition-by :resource)
+                              (map collapse))]
+          (doseq [[resource params] param-sets]
+            (sql/insert-record :resource_params_cache {:resource   resource
+                                                       :parameters (json/generate-string params)}))))))
 
   ;; Create NULL entries for resources that have no parameters
   (sql/do-commands
@@ -1317,15 +1318,16 @@
 
 (defn coalesce-fact-values
   []
-  (let [query "select * from fact_values"
+  (let [query ["select * from fact_values"]
         value-keys [:value_string :value_integer
                     :value_json :value_boolean
                     :value_float]]
-    (jdbc/with-query-results-cursor query [] rs
-      (->> rs
-           (map (partial coalesce-values value-keys))
-           (map update-value-json)
-           dorun))
+    (jdbc/with-query-results-cursor query
+      (fn [rs]
+        (->> rs
+             (map (partial coalesce-values value-keys))
+             (map update-value-json)
+             dorun)))
     (sql/do-commands
       (if (sutils/postgres?)
         "ALTER TABLE fact_values RENAME COLUMN value_json TO value"


### PR DESCRIPTION
This commit removes the `with-query-results-cursor` macro, as it was
functionally unused. The macro wrapped `with-query-results-cursor*` with a
different interface, but the only thing that used the macro was
`streamed-query-results` which wrapped the macro in the original
interface of `with-query-results-cursor*`. This commit collapses these
functions/macros.
This commit also cleans up some syntax in jdbc, removing unnecessary
parens.