### PR TITLE
(PDB-1537) dashboard redirect at root

### DIFF
--- a/resources/puppetlabs/puppetdb/bootstrap.cfg
+++ b/resources/puppetlabs/puppetdb/bootstrap.cfg
@@ -18,3 +18,6 @@ puppetlabs.puppetdb.command/command-service
 
 # NREPL
 puppetlabs.trapperkeeper.services.nrepl.nrepl-service/nrepl-service
+
+# Dashboard redirect: remove to disable
+puppetlabs.puppetdb.dashboard/dashboard-redirect-service

--- a/src/puppetlabs/puppetdb/dashboard.clj
+++ b/src/puppetlabs/puppetdb/dashboard.clj
@@ -28,3 +28,16 @@
                 (compojure/context (get-route this) [])
                 (add-ring-handler this))
            context)))
+
+(def dashboard-redirect
+  (app ["" &] {:get (fn [req] (rr/redirect "/pdb/dashboard/index.html"))}))
+
+(defservice dashboard-redirect-service
+  [[:PuppetDBServer shared-globals]
+   [:WebroutingService add-ring-handler get-route]]
+
+  (start [this context]
+         (log/info "Redirecting / to the PuppetDB dashboard")
+         (->> dashboard-redirect
+              (add-ring-handler this))
+         context))

--- a/test/puppetlabs/puppetdb/dashboard_test.clj
+++ b/test/puppetlabs/puppetdb/dashboard_test.clj
@@ -12,4 +12,9 @@
       (is (= status http/status-ok))
       (is (instance? java.io.File body))
       (is (= (file (System/getProperty "user.dir")
-                   "resources/public/dashboard/index.html") body)))))
+                   "resources/public/dashboard/index.html") body))))
+
+  (testing "dashboard redirect works"
+    (let [{:keys [status headers]} (dashboard/dashboard-redirect (request :get "/"))]
+      (is (= status 302))
+      (is (= "/pdb/dashboard/index.html" (get headers "Location"))))))


### PR DESCRIPTION
This changes our default bootstrap.cfg to include a new service that redirects
/ to the dashboard at /pdb. The service is injected into the webrouting config
depending on the presence or absence of the service in the bootstrap.cfg,
so to disable the redirect users will need to remove the line from bootstrap.cfg.