### PR TITLE
(PDB-1300) Include AIO paths to puppet in ssl-setup

### DIFF
--- a/resources/ext/cli/ssl-setup
+++ b/resources/ext/cli/ssl-setup
@@ -224,7 +224,7 @@ then
   done
 else
   # This should be run on the host with PuppetDB
-  PATH=/opt/puppet/bin:$PATH
+  PATH=/opt/puppetlabs/bin:/opt/puppet/bin:$PATH
   agent_confdir=`puppet agent --configprint confdir`
   agent_vardir=`puppet agent --configprint vardir`
 


### PR DESCRIPTION
Previously we didn't include the AIO puppet in our PATH setup, we had this
fixed in stable but not in master, since the files changed so dramatically this
was lost in a rollup.

Signed-off-by: Ken Barber <ken@bob.sh>