### PR TITLE
(maint) Remove dead code and replace testing utility functions

### DIFF
--- a/acceptance/tests/db_garbage_collection/node_ttl.rb
+++ b/acceptance/tests/db_garbage_collection/node_ttl.rb
@@ -102,7 +102,7 @@ test_name "validate that nodes are expired and deleted based on ttl settings" do
       result = on database, %Q|curl -G #{puppetdb_query_url}/v4/nodes/#{agent.node_name}|
       result_node_status = JSON.parse(result.stdout)
 
-      assert_equal({"error" => "No information is known about #{agent.node_name}"}, result_node_status, "Got a result back for #{agent.node_name} when it shouldn't exist")
+      assert_equal({"error" => "No information is known about node #{agent.node_name}"}, result_node_status, "Got a result back for #{agent.node_name} when it shouldn't exist")
     end
   end
 

--- a/src/puppetlabs/puppetdb/http.clj
+++ b/src/puppetlabs/puppetdb/http.clj
@@ -249,3 +249,8 @@
    :post [(rr/response? %)]}
   (-> (json-response (:result query-result))
       (add-headers (dissoc query-result :result))))
+
+(defn status-not-found-response
+  "Produces a json response for when an entity (catalog/nodes/environment/...) is not found."
+  [type id]
+  (json-response {:error (format "No information is known about %s %s" type id)} status-not-found))

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -254,7 +254,7 @@
   (retry-sql 5
              (sql/with-connection db-spec
                (when-let [isolation-level (get isolation-levels tx-isolation-level)]
-                 (.setTransactionIsolation (:connection jint/*db*) isolation-level))
+                 (.setTransactionIsolation (jint/find-connection*) isolation-level))
                (sql/transaction (f)))))
 
 (defmacro with-transacted-connection'

--- a/src/puppetlabs/puppetdb/query/catalogs.clj
+++ b/src/puppetlabs/puppetdb/query/catalogs.clj
@@ -56,27 +56,3 @@
    (paging/validate-order-by! catalog-columns paging-options)
    (qe/compile-user-query->sql
     qe/catalog-query query paging-options)))
-
-;; QUERY + MUNGE
-
-(defn query-catalogs
-  "Search for catalogs satisfying the given SQL filter."
-  [version query-sql url-prefix]
-  {:pre  [(map? query-sql)
-          (jdbc/valid-jdbc-query? (:results-query query-sql))]
-   :post [(map? %)
-          (sequential? (:result %))]}
-  (let [{:keys [count-query results-query]} query-sql
-         result {:result (jdbc/with-query-results-cursor
-                           results-query (comp doall
-                                               (munge-result-rows version url-prefix)))}]
-    (if count-query
-      (assoc result :count (jdbc/get-result-count count-query))
-      result)))
-
-(defn status
-  [version node url-prefix]
-  {:pre [string? node]}
-  (let [sql (query->sql version ["=" "certname" node])
-        results (:result (query-catalogs version sql url-prefix))]
-    (first results)))

--- a/src/puppetlabs/puppetdb/query/edges.clj
+++ b/src/puppetlabs/puppetdb/query/edges.clj
@@ -48,17 +48,3 @@
      (paging/validate-order-by! edge-columns paging-options)
      (qe/compile-user-query->sql
       qe/edges-query query paging-options)))
-
-;; QUERY + MUNGE
-
-(defn query-edges
-  "Search for edges satisfying the given SQL filter."
-  [version query-sql url-prefix]
-  {:pre [(map? query-sql)]}
-  (let [{:keys [count-query results-query]} query-sql
-         result {:result (jdbc/with-query-results-cursor
-                           results-query (comp doall
-                                               (munge-result-rows version url-prefix)))}]
-    (if count-query
-      (assoc result :count (jdbc/get-result-count count-query))
-      result)))

--- a/src/puppetlabs/puppetdb/query/environments.clj
+++ b/src/puppetlabs/puppetdb/query/environments.clj
@@ -15,24 +15,3 @@
               (not (:count? paging-options))
               (jdbc/valid-jdbc-query? (:count-query %)))]}
      (qe/compile-user-query->sql qe/environments-query query paging-options)))
-
-(defn query-environments
-  "Search for environments satisfying the given SQL filter."
-  [version query-sql]
-  {:pre  [(map? query-sql)
-          (jdbc/valid-jdbc-query? (:results-query query-sql))]
-   :post [(map? %)
-          (sequential? (:result %))]}
-  (let [{:keys [count-query results-query]} query-sql
-         result {:result (jdbc/with-query-results-cursor results-query doall)}]
-    (if count-query
-      (assoc result :count (jdbc/get-result-count count-query))
-      result)))
-
-(defn status
-  "Given an environment's name, return the results for the single environment."
-  [version environment]
-  {:pre  [string? environment]}
-  (let [sql     (query->sql version ["=" "name" environment])
-        results (:result (query-environments version sql))]
-    (first results)))

--- a/src/puppetlabs/puppetdb/query/event_counts.clj
+++ b/src/puppetlabs/puppetdb/query/event_counts.clj
@@ -155,17 +155,3 @@
        (conj {:results-query (apply vector paged-select params)}
              (when (:count? paging-options)
                [:count-query (apply vector (jdbc/count-sql sql) params)])))))
-
-(defn query-event-counts
-  "Given a SQL query and its parameters, return a vector of matching results."
-  [version summarize_by query-sql]
-  {:pre  [(map? query-sql)]}
-  (let [{:keys [count-query results-query]} query-sql
-        munge-fn (munge-result-rows summarize_by)
-        result {:result
-                (jdbc/with-query-results-cursor
-                  results-query (comp doall
-                                      (munge-fn nil nil)))}]
-    (if count-query
-      (assoc result :count (jdbc/get-result-count count-query))
-      result)))

--- a/src/puppetlabs/puppetdb/query/nodes.clj
+++ b/src/puppetlabs/puppetdb/query/nodes.clj
@@ -30,26 +30,3 @@
               (jdbc/valid-jdbc-query? (:count-query %)))]}
      (paging/validate-order-by! (node-columns version) paging-options)
      (qe/compile-user-query->sql qe/nodes-query query paging-options)))
-
-(defn query-nodes
-  "Search for nodes satisfying the given SQL filter."
-  [version query-sql url-prefix]
-  {:pre  [(map? query-sql)
-          (jdbc/valid-jdbc-query? (:results-query query-sql))]
-   :post [(map? %)
-          (sequential? (:result %))]}
-  (let [{:keys [count-query results-query]} query-sql
-         result {:result (jdbc/with-query-results-cursor results-query doall)}]
-    (if count-query
-      (assoc result :count (jdbc/get-result-count count-query))
-      result)))
-
-(defn status
-  "Given a node's name, return the current status of the node.  Results
-  include whether it's active and the timestamp of its most recent catalog, facts,
-  and report."
-  [version node url-prefix]
-  {:pre  [string? node]}
-  (let [sql (query->sql version ["=" "certname" node])
-        results (:result (query-nodes version sql url-prefix))]
-    (first results)))

--- a/src/puppetlabs/puppetdb/query/reports.clj
+++ b/src/puppetlabs/puppetdb/query/reports.clj
@@ -71,25 +71,7 @@
            (or (not (:count? paging-options))
                (jdbc/valid-jdbc-query? (:count-query %)))]}
    (paging/validate-order-by! report-columns paging-options)
-   (qe/compile-user-query->sql
-    qe/reports-query query paging-options)))
-
-;; QUERY + MUNGE
-
-(defn query-reports
-  "Queries reports and unstreams, used mainly for testing.
-
-  This wraps the existing streaming query code but returns results
-  and count (if supplied)."
-  [version url-prefix query-sql]
-  {:pre [(map? query-sql)]}
-  (let [{:keys [count-query results-query]} query-sql
-         result {:result (jdbc/with-query-results-cursor
-                          results-query (comp doall
-                                              (munge-result-rows version url-prefix)))}]
-    (if count-query
-      (assoc result :count (jdbc/get-result-count count-query))
-      result)))
+   (qe/compile-user-query->sql qe/reports-query query paging-options)))
 
 ;; SPECIAL
 

--- a/src/puppetlabs/puppetdb/query/resources.clj
+++ b/src/puppetlabs/puppetdb/query/resources.clj
@@ -94,17 +94,3 @@
      (paging/validate-order-by! (map keyword (keys query/resource-columns)) paging-options)
      (qe/compile-user-query->sql
       qe/resources-query query paging-options)))
-
-;; QUERY + MUNGE
-
-(defn query-resources
-  "Search for resources satisfying the given SQL filter."
-  [version query-sql url-prefix]
-  {:pre [(map? query-sql)]}
-  (let [{:keys [count-query results-query]} query-sql
-         result {:result (jdbc/with-query-results-cursor
-                          results-query (comp doall
-                                              (munge-result-rows version url-prefix)))}]
-    (if count-query
-      (assoc result :count (jdbc/get-result-count count-query))
-      result)))

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -42,11 +42,14 @@
 (defn stream-query-result
   "Given a query, and database connection, return a Ring response with the query
   results."
-  [entity version query paging-options db url-prefix row-fn]
-  (let [[query->sql munge-fn] (entity->sql-fns entity version paging-options url-prefix)]
-    (jdbc/with-transacted-connection db
-      (let [{:keys [results-query]} (query->sql query)]
-        (jdbc/with-query-results-cursor results-query (comp row-fn munge-fn))))))
+  ([entity version query paging-options db url-prefix]
+   ;; We default to doall because tests need this for the most part
+   (stream-query-result entity version query paging-options db url-prefix doall))
+  ([entity version query paging-options db url-prefix row-fn]
+   (let [[query->sql munge-fn] (entity->sql-fns entity version paging-options url-prefix)]
+     (jdbc/with-transacted-connection db
+       (let [{:keys [results-query]} (query->sql query)]
+         (jdbc/with-query-results-cursor results-query (comp row-fn munge-fn)))))))
 
 (defn produce-streaming-body
   "Given a query, and database connection, return a Ring response with the query

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -698,8 +698,8 @@
                                (reduce-kv (fn [acc k v]
                                             (assoc acc k (shash/resource-identity-hash v)))
                                           {} resources))
-         hash           (time! (:catalog-hash performance-metrics)
-                               (shash/catalog-similarity-hash catalog))
+         hash (time! (:catalog-hash performance-metrics)
+                     (shash/catalog-similarity-hash catalog))
          {id :id
           stored-hash :hash} (catalog-metadata certname)]
 

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -83,11 +83,12 @@
   "Assoc to `m` only when `k` is not already present in `m`"
   [m & kvs]
   {:pre [(even? (count kvs))]}
-  (let [missing-map-entries (for [[k v] (partition 2 kvs)
-                                  :when (= ::not-found (get m k ::not-found))]
-                              [k v])]
+  (let [missing-map-entries (into {}
+                                  (for [[k v] (partition 2 kvs)
+                                        :when (not (contains? m k))]
+                                    [k v]))]
     (if (seq missing-map-entries)
-      (apply assoc m (apply concat missing-map-entries))
+      (merge m missing-map-entries)
       m)))
 
 (pls/defn-validated kwd->str

--- a/test/puppetlabs/puppetdb/http/explore_test.clj
+++ b/test/puppetlabs/puppetdb/http/explore_test.clj
@@ -92,7 +92,7 @@
       (testing "/nodes/<node> should return a 404 for unknown nodes"
         (let [response (get-response "nodes/host4")]
           (is (= 404 (:status response)))
-          (is (= {:error "No information is known about host4"} (json/parse-string (:body response) true)))))
+          (is (= {:error "No information is known about node host4"} (json/parse-string (:body response) true)))))
 
       (testing "/nodes/<node>/resources should return the resources just for that node"
         (doseq [host ["host1" "host2"]]

--- a/test/puppetlabs/puppetdb/query/environments_test.clj
+++ b/test/puppetlabs/puppetdb/query/environments_test.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.puppetdb.query.environments-test
   (:require [puppetlabs.puppetdb.query.environments :refer :all]
+            [puppetlabs.puppetdb.query-eng :as eng]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.scf.storage :as storage]
             [puppetlabs.puppetdb.fixtures :as fixt]
@@ -7,9 +8,13 @@
 
 (fixt/defixture super-fixture :each fixt/with-test-db)
 
+(defn query-environments
+  [version & [query]]
+  (eng/stream-query-result :environments version query {} fixt/*db* ""))
+
 (deftest test-all-environments
   (testing "without environments"
-    (is (empty? (:result (query-environments :v4 (query->sql :v4 nil))))))
+    (is (empty? (query-environments :v4))))
 
   (testing "with environments"
     (doseq [env ["foo" "bar" "baz"]]
@@ -18,19 +23,19 @@
     (is (= #{{:name "foo"}
              {:name "bar"}
              {:name "baz"}}
-           (set (:result (query-environments :v4 (query->sql :v4 nil))))))))
+           (set (query-environments :v4))))))
 
 (def jsonify (comp json/parse-strict-string json/generate-string))
 
 (deftest test-environment-queries
   (testing "without environments"
-    (is (empty? (:result (query-environments :v4 (query->sql :v4 nil))))))
+    (is (empty? (query-environments :v4))))
 
   (testing "with environments"
     (doseq [env ["foo" "bar" "baz"]]
       (storage/ensure-environment env))
 
-    (are [query result] (= result (set (:result (query-environments :v4 (query->sql :v4 (jsonify query))))))
+    (are [query result] (= result (set (query-environments :v4 (jsonify query))))
 
          '[= name foo]
          #{{:name "foo"}}
@@ -65,7 +70,7 @@
 (deftest test-failed-comparison
   (are [query] (thrown-with-msg? IllegalArgumentException
                                  #"Query operators >,>=,<,<= are not allowed on field name"
-                                 (query-environments :v4 (query->sql :v4 (jsonify query))))
+                                 (query-environments :v4 (jsonify query)))
 
        '[<= name foo]
        '[>= name foo]

--- a/test/puppetlabs/puppetdb/query/reports_test.clj
+++ b/test/puppetlabs/puppetdb/query/reports_test.clj
@@ -100,20 +100,16 @@
                (munge-actual-reports actual)))))))
 
 (deftest paging-results
-  (let [report1      (:basic my-reports)
-        report2      (:basic2 my-reports)
-        report3      (:basic3 my-reports)
-        report4      (:basic4 my-reports)
+  (let [{report1 :basic
+         report2 :basic2
+         report3 :basic3
+         report4 :basic4} my-reports
         report-count 4]
 
     (store-example-report! report1 (now))
     (store-example-report! report2 (now))
     (store-example-report! report3 (now))
     (store-example-report! report4 (now))
-
-    (testing "include total results count"
-      (let [actual (:count (raw-reports-query-result :v4 ["=" "certname" "foo.local"] {:count? true}))]
-        (is (= actual report-count))))
 
     (testing "limit results"
       (doseq [[limit expected] [[1 1] [2 2] [100 report-count]]]

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1380,7 +1380,7 @@
             certname      (:certname report1)
             _             (delete-reports-older-than! (-> 3 days ago))
             expected      #{}
-            actual        (resource-events-query-result :latest ["=" "report" report1-hash])]
+            actual (set (query-resource-events :latest ["=" "report" report1-hash]))]
         (is (= expected actual))))))
 
 (defn with-db-version [db version f]


### PR DESCRIPTION
This commit removes dead code from each of the query/* namespaces whic
was only used in testing code. Previously we were duplicating the
efforts of the produce-streaming-body/streamed-query-results on each of
our endpoints, this commit changes the utility functions in our tests to
use the updated pattern. This commit also removes corresponding unnecessary tests that were testing code we weren't using in production.
This commit also changes a number of update-in calls to update that we're within eyesight while making these changes.