### PR TITLE
(PDB-1536) Support POST queries for nodes

### DIFF
--- a/src/puppetlabs/puppetdb/cheshire.clj
+++ b/src/puppetlabs/puppetdb/cheshire.clj
@@ -66,6 +66,23 @@
 
 (def parse-stream core/parse-stream)
 
+(defn coerce-from-json
+  "Parses as json if `s` is a string/stream/reader, otherwise return `s`"
+  [obj]
+  (cond
+   (string? obj)
+   (parse-strict-string obj true)
+
+   (instance? java.io.Reader obj)
+   (parse-stream obj true)
+
+   (instance? java.io.InputStream obj)
+   (with-open [reader (clojure.java.io/reader obj)]
+     (coerce-from-json reader))
+
+   :else
+   obj))
+
 (defn spit-json
   "Similar to clojure.core/spit, but writes the Clojure
    datastructure as JSON to `f`"

--- a/src/puppetlabs/puppetdb/http/nodes.clj
+++ b/src/puppetlabs/puppetdb/http/nodes.clj
@@ -30,16 +30,7 @@
   [version]
   (app
    []
-   {:get (comp
-          (fn [{:keys [params globals paging-options]}]
-            (produce-streaming-body
-             :nodes
-             version
-             (params "query")
-             paging-options
-             (:scf-read-db globals)
-             (:url-prefix globals)))
-          http-q/restrict-query-to-active-nodes)}
+   (http-q/query-route :nodes version http-q/restrict-query-to-active-nodes')
 
    [node]
    {:get

--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -4,12 +4,43 @@
    Functions that aid in the parsing, serialization, and manipulation
    of PuppetDB queries embedded in HTTP parameters."
   (:require [puppetlabs.puppetdb.cheshire :as json]
-            [clojure.core.match :as cm]))
+            [clojure.core.match :as cm]
+            [puppetlabs.puppetdb.query-eng :refer [produce-streaming-body produce-streaming-body']]
+            [net.cgrand.moustache :refer [app]]
+            [schema.core :as s]
+            [puppetlabs.puppetdb.schema :as pls]
+            [puppetlabs.puppetdb.query.paging :refer [parse-limit' parse-offset' parse-order-by']]
+            [puppetlabs.puppetdb.utils :as utils]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Schemas
+
+(def puppetdb-query-schema
+  "This schema defines a PuppetDB query and its available
+  parameters. In a GET request this is contained in various query
+  parameters, for POST requests this should be contained in the body
+  of the request"
+  {:query (s/maybe [s/Any])
+   :count? s/Bool
+   (s/optional-key :order_by) (s/maybe [[(s/one s/Keyword "field")
+                                         (s/one (s/enum :ascending :descending) "order")]])
+   (s/optional-key :limit) (s/maybe s/Int)
+   (s/optional-key :offset) (s/maybe s/Int)})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Query munging functions
 
 (defn- are-queries-different?
+  "DEPRECATED - only works on GET requests, will be replaced by are-queries-different?'"
+  {:deprecated "3.0.0"}
   [req1 req2]
   (not= (get-in req1 [:params "query"])
         (get-in req2 [:params "query"])))
+
+(defn- are-queries-different?'
+  [req1 req2]
+  (not= (:puppetdb-query req1)
+        (:puppetdb-query req2)))
 
 (defn query-criteria
   "Extract the 'criteria' (select) part of the given query"
@@ -50,9 +81,12 @@
             crit)))
 
 (defn restrict-query
-  "Given a criteria that will restrict a query, modify the supplied
+  "DEPRECATED - this function only works on GETs, will be replaced by restrict-query'
+
+  Given a criteria that will restrict a query, modify the supplied
   request so that its query parameter is now restricted according to
   the criteria."
+  {:deprecated "3.0.0"}
   [restriction {:keys [params] :as req}]
   {:pre  [(coll? restriction)]
    :post [(are-queries-different? req %)]}
@@ -61,16 +95,40 @@
                            (add-criteria restriction q))]
     (assoc-in req [:params "query"] (json/generate-string restricted-query))))
 
+(defn restrict-query'
+  "Given a criteria that will restrict a query, modify the supplied
+  request so that its query parameter is now restricted according to
+  `restriction`"
+  [restriction req]
+  {:pre  [(coll? restriction)]
+   :post [(are-queries-different?' req %)]}
+  (update-in req [:puppetdb-query :query] #(add-criteria restriction %)))
+
 (defn restrict-query-to-active-nodes
-  "Restrict the query parameter of the supplied request so that it only returns
+  "DEPRECATED - only works on GET requests, will be replaced by restrict-query-to-active-nodes'
+
+  Restrict the query parameter of the supplied request so that it only returns
   results for the supplied node, unless a node-active criteria is already
   explicitly specified."
+  {:deprecated "3.0.0"}
   [req]
   (if (some-> (get-in req [:params "query"])
               (json/parse-strict-string true)
               find-active-node-restriction-criteria)
     req
     (restrict-query ["=" ["node" "active"] true] req)))
+
+(defn restrict-query-to-active-nodes'
+  "Restrict the query parameter of the supplied request so that it only returns
+  results for the supplied node, unless a node-active criteria is already
+  explicitly specified."
+  [req]
+  (if (some-> req
+              :puppetdb-query
+              :query
+              find-active-node-restriction-criteria)
+    req
+    (restrict-query' ["=" ["node" "active"] true] req)))
 
 
 (defn restrict-query-to-node
@@ -153,3 +211,86 @@
    :post [(are-queries-different? req %)]}
   (restrict-query ["=" "title" title]
                   req))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Conversion/validation of query parameters
+
+(defn coerce-to-boolean
+  "Parses `b` to a boolean unless it's already a boolean"
+  [b]
+  (if (instance? Boolean b)
+    b
+    (Boolean/parseBoolean b)))
+
+(defn count?
+  "If the original query contains the include_total w/o a a value, it
+  will show up here as nil.  We assume that in that case, the caller
+  intended to use it as a flag"
+  [query-map]
+  (let [total (get query-map :include_total ::not-found)]
+    (if (= total ::not-found)
+      false
+      (coerce-to-boolean total))))
+
+(pls/defn-validated convert-query-params :- puppetdb-query-schema
+  "This will update a query map to contain the parsed and validated query parameters"
+  [{:keys [order_by limit offset] :as full-query}]
+  (-> full-query
+      (update :order_by parse-order-by')
+      (update :limit parse-limit')
+      (update :offset parse-offset')
+      (assoc :count? (count? full-query))
+      (dissoc :include_total)))
+
+(defn get-req->query
+  "Converts parameters of a GET request to a pdb query map"
+  [{:keys [params] :as req}]
+  (conj {:query (json/parse-strict-string (get params "query") true)
+         :order_by (json/parse-strict-string (get params "order_by") true)
+         :limit (get params "limit")
+         :offset (get params "offset")}
+        (let [include-total? (get params "include_total" ::not-found)]
+          (when (not= include-total? ::not-found)
+            [:include_total include-total?]))))
+
+(defn post-req->query
+  "Takes a POST body and parses the JSON to create a pdb query map"
+  [req]
+  (with-open [reader (-> req :body clojure.java.io/reader)]
+    (json/parse-stream reader true)))
+
+(pls/defn-validated create-query-map :- puppetdb-query-schema
+  "Takes a ring request map and extracts the puppetdb query from the
+  request. GET and POST are accepted, all other requests throw an
+  exception"
+  [req]
+  (convert-query-params
+   (case (:request-method req)
+     :get (get-req->query req)
+     :post (post-req->query req)
+     (throw (IllegalArgumentException. "PuppetDB queries must be made via GET/POST")))))
+
+(defn extract-query
+  "Query handler that converts the incoming request (GET or POST)
+  parameters/body to a pdb query map"
+  [handler]
+  (fn [{:keys [request-method body params puppetdb-query] :as req}]
+    (handler (assoc req :puppetdb-query (create-query-map req)))))
+
+(defn query-route
+  "Returns a route for querying PuppetDB that supports the standard
+  paging parameters. Also accepts GETs and POSTs. Composes
+  `optional-handlers` with the middleware function that executes the
+  query."
+  [entity version & optional-handlers]
+  (app
+   extract-query
+   (apply comp
+          (fn [{:keys [params globals puppetdb-query] :as foo}]
+            (produce-streaming-body'
+             entity
+             version
+             puppetdb-query
+             (:scf-read-db globals)
+             (:url-prefix globals)))
+          optional-handlers)))

--- a/test/puppetlabs/puppetdb/http/server_test.clj
+++ b/test/puppetlabs/puppetdb/http/server_test.clj
@@ -17,7 +17,7 @@
   [version versions]
 
   (testing "provides a useful error message"
-    (let [endpoint (str "/" (name version) "/nodes")
+    (let [endpoint (str "/" (name version) "/reports")
           request (header (request :post endpoint) "Accept" c-t)
           {:keys [status body]} (*app* request)]
       (is (= status http/status-bad-method))


### PR DESCRIPTION
Webservers have limits on the length of GET request. This commit adds to
the nodes endpoint (root of the endpoint only) the ability to instead
issue the query as a POST, with a JSON document representation of the
query as the body. This new feature needs to be added to all endpoints
eventually, but the one where we see this problem the most is the root
of the nodes endpoint, so this commit starts there. This patch puts new
code in place to centralize handling of the PuppetDB query and related
parameters so that all endpoints can share the same code for handling
GETs and POSTs of queries. Currently only the nodes endpoint calls this
new centralized code. A bigger refactor will need to be made in the
future to switch other endpoints over to the new code.