### PR TITLE
(maint) Provide /factsets/<node> endpoint

### DIFF
--- a/documentation/api/query/v4/factsets.markdown
+++ b/documentation/api/query/v4/factsets.markdown
@@ -139,6 +139,36 @@ which returns
       "hash" : "d118d161990f202e911b6fda09f79d24f3a5d4f4"
     } ]
 
+## `GET /pdb/query/v4/factsets/<NODE>`
+
+This will return the most recent factset for the given node. Supplying a node
+this way will restrict any given query to only apply to that node, but in
+practice this endpoint is typically used without a query string or URL
+parameters.
+
+The result will be a single map of the factset structure described above, or
+a JSON error message if the factset is not found:
+
+### Examples
+
+    curl 'http://localhost:8080/pdb/query/v4/factsets/kb.local'
+
+    {
+      "certname" : "kb.local",
+      "environment" : "production",
+      "facts" : {...},
+      "hash" : "93253d31af6d718cf81f5bc028be2a671f23ed78",
+      "producer_timestamp" : "2015-06-04T15:27:56.893Z",
+      "timestamp" : "2015-06-04T15:27:56.979Z"
+    }
+
+    curl -X GET http://localhost:8080/pdb/query/v4/factsets/my_fake_hostname
+
+    {
+      "error" : "No information is known about factset my_fake_hostname"
+    }
+
+
 ## `GET /pdb/query/v4/factsets/<NODE>/facts`
 
 This will return all facts for a particular factset, designated by a node certname.

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -1319,6 +1319,25 @@
              [{"certname" "foo1"
                "hash" "b966980c39a141ab3c82b51951bb51a2e3787ac7"}])))))
 
+(deftestseq factset-single-response
+  [[version endpoint] factsets-endpoints]
+  (populate-for-structured-tests reference-time)
+
+  (testing "querying singleton endpoint should return a single result"
+    (let [response (json/parse-string (:body (get-response (str endpoint "/foo1"))))]
+      (is (= (munge-factset-response response)
+             (strip-expanded {"certname" "foo1"
+                              "environment" "DEV"
+                              "facts" {"data" #{{"name" "my_structured_fact", "value" {"a" 1, "b" 3.14, "c" ["a" "b" "c"], "d" {"n" ""}, "e" "1", "f" nil}}
+                                                {"name" "domain", "value" "testing.com"}
+                                                {"name" "test#~delimiter", "value" "foo"}
+                                                {"name" "uptime_seconds", "value" "4000"}}
+                                       "href" "/v4/factsets/foo1/facts"}
+                              "hash" "b966980c39a141ab3c82b51951bb51a2e3787ac7"
+                              "producer_timestamp" "2014-10-28T20:26:21.727Z"
+                              "timestamp" "2014-10-28T20:26:21.727Z"}))))))
+
+
 ;; STRUCTURED FACTS TESTS
 
 (defn structured-fact-results


### PR DESCRIPTION
We had missed this as a singleton query endpoint, this patch adds it.

Signed-off-by: Ken Barber <ken@bob.sh>