### PR TITLE
(PDB-1601) Only submit catalog and factset once in benchmark

### DIFF
--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -70,7 +70,7 @@
 
 (defn load-sample-data
   "Load all .json files contained in `dir`."
-  [dir & [from-classpath?]]
+  [dir from-classpath?]
   (let [target-files (if from-classpath?
                        (remove #(.isDirectory %) (file-seq (io/file (io/resource dir))))
                        (fs/glob (fs/file dir "*.json")))]
@@ -126,7 +126,7 @@
 (defn maybe-tweak-catalog
   "Slightly tweak the given catalog, returning a new catalog, `rand-percentage`
   percent of the time."
-  [catalog rand-percentage]
+  [rand-percentage catalog]
   (if (< (rand 100) rand-percentage)
     (rand-catalog-mutation catalog)
     catalog))
@@ -194,7 +194,7 @@
   [{:keys [host lastrun catalog report factset base-url run-interval rand-percentage] :as state} clock]
   (if-not (> (- clock lastrun) run-interval)
     state
-    (let [catalog (some-> catalog update-catalog (maybe-tweak-catalog rand-percentage))
+    (let [catalog (some->> catalog update-catalog (maybe-tweak-catalog rand-percentage))
           report (some-> report update-report-run-fields json/generate-string)
           factset (some->> factset (update-factset rand-percentage) json/generate-string)]
       ;; Submit the catalog and reports in separate threads, so as to not
@@ -230,7 +230,7 @@
   [{:keys [catalog factset base-url rand-percentage]}]
   (some->> catalog
            update-catalog
-           maybe-tweak-catalog
+           (maybe-tweak-catalog rand-percentage)
            json/generate-string
            (client/submit-catalog base-url 6))
   (some->> factset
@@ -260,7 +260,7 @@
     (doseq [host hosts]
       (update-host-report host)))
   (doseq [host hosts]
-    (update-host-catalog-and-report host)))
+    (update-host-catalog-and-factset host)))
 
 (defn world-loop
   "Sends out new _clock tick_ messages to all agents.
@@ -299,9 +299,8 @@
 
 (defn activate-logging!
   [options]
-  (-> (:config options)
-      (get-in [:global :logging-config])
-      logutils/configure-logging!))
+  (logutils/configure-logging!
+   (get-in options [:config :global :logging-config])))
 
 (defn validate-options
   [options action-on-error-fn]
@@ -354,32 +353,30 @@
 
 (defn process-tar-entry
   [archive-path tar-reader]
-  (let [catalog-pattern (re-pattern "catalogs.*\\.json$")
-        report-pattern (re-pattern "reports.*\\.json$")
-        facts-pattern (re-pattern "facts.*\\.json$")]
+  (let [matches-pattern? (fn [path pattern]
+                           (re-find (re-pattern pattern) path))]
     (fn [acc entry]
       (let [path (.getName entry)
             parsed-entry (-> tar-reader
                              archive/read-entry-content
                              json/parse-string)]
-        (cond
-          (re-find catalog-pattern path) (update acc :catalogs conj parsed-entry)
-          (re-find report-pattern path) (update acc :reports conj parsed-entry)
-          (re-find facts-pattern path) (update acc :facts conj parsed-entry)
+        (condp matches-pattern? path
+          "catalogs.*\\.json$" (update acc :catalogs conj parsed-entry)
+          "reports.*\\.json$" (update acc :reports conj parsed-entry)
+          "facts.*\\.json$" (update acc :facts conj parsed-entry)
           :else acc)))))
 
 (defn load-data-from-options
-  [{:keys [catalogs facts reports archive from-cp?]}]
+  [{:keys [archive] :as options}]
   (if archive
     (let [tar-reader (archive/tarball-reader archive)
           process-entries-fn (process-tar-entry archive tar-reader)]
       (->> (archive/all-entries tar-reader)
-           (reduce process-entries-fn {:catalogs [] :reports [] :facts []})
-           (remove (comp empty? val))
-           (into {})))
-    {:catalogs (when catalogs (load-sample-data catalogs from-cp?))
-     :facts (when facts (load-sample-data facts from-cp?))
-     :reports (when reports (load-sample-data reports from-cp?))}))
+           (reduce process-entries-fn {})))
+    (let [{:keys [catalogs facts reports from-cp?]} options]
+      {:catalogs (when catalogs (load-sample-data catalogs from-cp?))
+       :facts (when facts (load-sample-data facts from-cp?))
+       :reports (when reports (load-sample-data reports from-cp?))})))
 
 (defn -main
   [& args]


### PR DESCRIPTION
This commit changes the untimed mode for the benchmarking tool to only
submit the catalog and factset for a node once since we will only ever
use the latest.