### PR TITLE
(PDB-1605) Don't log 404s in the terminus

### DIFF
--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -76,7 +76,6 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
           raise "[#{response.code} #{response.message}] #{response.body.gsub(/[\r\n]/, '')}"
         end
       rescue NotFoundError => e
-        Puppet.warning("Unable to find results for #{request.key} error: #{e.message}")
         # This is what the inventory service expects when there is no data
         return nil
       rescue => e


### PR DESCRIPTION
There are many cases when a 404 from puppetdb is a perfectly
legitimate response, and a scary error message should not be logged.

- In the failover http layer, only treat 'real-looking' 404s as
  not-found responses. Others are treated as errors. 

- In the facts terminus, no longer log a warning on not-found responses.