### PR TITLE
(PDB-1590) Support two previous versions of all commands (for upgrades)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -76,7 +76,8 @@
                  [fast-zip-visit "1.0.2"]
                  [robert/hooke "1.3.0"]
                  [honeysql "0.5.2"]
-                 [org.clojure/data.xml "0.0.8"]]
+                 [org.clojure/data.xml "0.0.8"]
+                 [com.rpl/specter "0.5.2"]]
 
   :jvm-opts ["-XX:MaxPermSize=128M"]
 

--- a/src/puppetlabs/puppetdb/catalog/utils.clj
+++ b/src/puppetlabs/puppetdb/catalog/utils.clj
@@ -6,7 +6,8 @@
   (:require [puppetlabs.puppetdb.catalogs :as cat]
             [clojure.walk :as walk]
             [puppetlabs.puppetdb.random :refer [random-resource random-kw-resource
-                                                random-parameters]]))
+                                                random-parameters]]
+            [clj-time.core :refer [now]]))
 
 (defn convert-to-wire
   "Converts a catalog in the internal format to the wire format"
@@ -24,7 +25,7 @@
   (fn [wire-catalog]
     (-> wire-catalog
         walk/keywordize-keys
-        (cat/parse-catalog 6)
+        (cat/parse-catalog 6 (now))
         f
         convert-to-wire)))
 

--- a/src/puppetlabs/puppetdb/facts.clj
+++ b/src/puppetlabs/puppetdb/facts.clj
@@ -244,3 +244,18 @@
            factpath-regexp-elements-to-regexp
            factpath-to-string)
        "$"))
+
+(defn v3-wire->v4-wire
+  "Takes a v3 formatted replace facts command and upgrades it to a v4 facts command"
+  [command]
+  (-> command
+      (assoc :version 4)
+      (update :payload #(set/rename-keys % {:producer-timestamp :producer_timestamp
+                                            :name :certname}))))
+
+(defn v2-wire->v4-wire
+  "Takes a v2 formatted replace facts command and upgrades it to a v4 facts command"
+  [command received-time]
+  (-> command
+      (assoc-in [:payload :producer-timestamp] received-time)
+      v3-wire->v4-wire))

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -33,30 +33,6 @@
    #(and (map? %)
          (valid-jdbc-query? (:results-query %)))))
 
-;; ## String operations
-
-(defn dashes->underscores
-  "Accepts a string or a keyword as an argument, replaces all occurrences of the
-  dash/hyphen character with an underscore, and returns the same type (string
-  or keyword) that was passed in.  This is useful for translating data structures
-  from their wire format to the format that is needed for JDBC."
-  [str]
-  (let [result (string/replace (name str) \- \_)]
-    (if (keyword? str)
-      (keyword result)
-      result)))
-
-(defn underscores->dashes
-  "Accepts a string or a keyword as an argument, replaces all occurrences of the
-  underscore character with a dash, and returns the same type (string
-  or keyword) that was passed in.  This is useful for translating data structures
-  from their JDBC-compatible representation to their wire format representation."
-  [str]
-  (let [result (string/replace (name str) \_ \-)]
-    (if (keyword? str)
-      (keyword result)
-      result)))
-
 (defn convert-result-arrays
   "Converts Java and JDBC arrays in a result set using the provided function
   (eg. vec, set). Values which aren't arrays are unchanged."

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -62,7 +62,6 @@
    applying ordering constraints."
   (:require [clojure.string :as str]
             [puppetlabs.kitchensink.core :as kitchensink]
-            [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.puppetdb.time :refer [to-timestamp]]
             [puppetlabs.kitchensink.core :refer [parse-number keyset valset order-by-expr?]]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils
@@ -70,7 +69,8 @@
             [puppetlabs.puppetdb.jdbc
              :refer [valid-jdbc-query? limited-query-to-vec query-to-vec paged-sql count-sql get-result-count]]
             [puppetlabs.puppetdb.query.paging :refer [requires-paging?]]
-            [clojure.core.match :refer [match]]))
+            [clojure.core.match :refer [match]]
+            [puppetlabs.puppetdb.utils :as utils]))
 
 (defn execute-paged-query*
   "Helper function to executed paged queries.  Builds up the paged sql string,
@@ -558,7 +558,7 @@
             (string? (:where %))]}
     (when-not (= (count args) 2)
       (throw (IllegalArgumentException. (format "= requires exactly two arguments, but %d were supplied" (count args)))))
-    (let [path (jdbc/dashes->underscores path)]
+    (let [path (utils/dashes->underscores path)]
       (match [path]
              ["certname"]
              {:where "reports.certname = ?"
@@ -608,7 +608,7 @@
             (string? (:where %))]}
     (when-not (= (count args) 2)
       (throw (IllegalArgumentException. (format "~ requires exactly two arguments, but %d were supplied" (count args)))))
-    (let [path (jdbc/dashes->underscores path)]
+    (let [path (utils/dashes->underscores path)]
       (match [path]
              ["certname"]
              {:where (sql-regexp-match "reports.certname")
@@ -642,7 +642,7 @@
           (string? (:where %))]}
   (when-not (= (count args) 2)
     (throw (IllegalArgumentException. (format "= requires exactly two arguments, but %d were supplied" (count args)))))
-  (let [db-field (jdbc/dashes->underscores path)]
+  (let [db-field (utils/dashes->underscores path)]
     (match [db-field]
            [(field :guard #{"successes" "failures" "noops" "skips"})]
            {:where (format "%s = ?" field)

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -959,7 +959,7 @@
             [op field (su/db-serialize value)]
 
             [["=" field nil]]
-            ["null?" (jdbc/dashes->underscores field) true]
+            ["null?" (utils/dashes->underscores field) true]
 
             [[op "tag" array-value]]
             [op "tags" (string/lower-case array-value)]
@@ -1313,7 +1313,7 @@
   [node state]
   (cm/match [node]
             [[(op :guard binary-operators) (field :guard string?) value]]
-            {:node (with-meta [op (jdbc/dashes->underscores field) value]
+            {:node (with-meta [op (utils/dashes->underscores field) value]
                      (meta node))
              :state state}
             :else {:node node :state state}))

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -41,7 +41,7 @@
             [metrics.gauges :refer [gauge]]
             [metrics.histograms :refer [histogram update!]]
             [metrics.timers :refer [timer time!]]
-            [puppetlabs.puppetdb.jdbc :refer [query-to-vec dashes->underscores]]
+            [puppetlabs.puppetdb.jdbc :refer [query-to-vec]]
             [puppetlabs.puppetdb.time :refer [to-timestamp]]
             [honeysql.core :as hcore]))
 

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -11,7 +11,8 @@
             [clojure.java.io :as io]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [clojure.walk :as walk]
-            [slingshot.slingshot :refer [try+]])
+            [slingshot.slingshot :refer [try+]]
+            [com.rpl.specter :as sp])
   (:import [java.net MalformedURLException URISyntaxException URL]
            [org.postgresql.util PGobject]))
 
@@ -279,3 +280,19 @@
     (if (keyword? str)
       (keyword result)
       result)))
+
+(defn dash->underscore-keys
+  "Converts all top-level keys (including nested maps) in `m` to use dashes
+  instead of underscores as word separatators"
+  [m]
+  (sp/update [sp/ALL]
+             #(update % 0 dashes->underscores)
+             m))
+
+(defn underscore->dash-keys
+  "Converts all top-level keys (including nested maps) in `m` to use underscores
+  instead of underscores as word separatators"
+  [m]
+  (sp/update [sp/ALL]
+             #(update % 0 underscores->dashes)
+             m))

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -257,3 +257,25 @@
       {:href (to-href data)}
       (-> (sutils/parse-db-json data)
           (update :href to-href)))))
+
+(defn dashes->underscores
+  "Accepts a string or a keyword as an argument, replaces all occurrences of the
+  dash/hyphen character with an underscore, and returns the same type (string
+  or keyword) that was passed in.  This is useful for translating data structures
+  from their wire format to the format that is needed for JDBC."
+  [str]
+  (let [result (string/replace (name str) \- \_)]
+    (if (keyword? str)
+      (keyword result)
+      result)))
+
+(defn underscores->dashes
+  "Accepts a string or a keyword as an argument, replaces all occurrences of the
+  underscore character with a dash, and returns the same type (string
+  or keyword) that was passed in.  This is useful for translating data structures
+  from their JDBC-compatible representation to their wire format representation."
+  [str]
+  (let [result (string/replace (name str) \_ \-)]
+    (if (keyword? str)
+      (keyword result)
+      result)))

--- a/test/puppetlabs/puppetdb/examples.clj
+++ b/test/puppetlabs/puppetdb/examples.clj
@@ -1,4 +1,5 @@
-(ns puppetlabs.puppetdb.examples)
+(ns puppetlabs.puppetdb.examples
+  (:require [puppetlabs.puppetdb.utils :as utils]))
 
 (def catalogs
   {:empty
@@ -130,7 +131,16 @@
 
 (def wire-catalogs
   "Catalogs keyed by version."
-  {6 {:empty v6-empty-wire-catalog
+  {4 {:empty (-> v6-empty-wire-catalog
+                 (dissoc :producer_timestamp)
+                 (assoc :name (:certname v6-empty-wire-catalog))
+                 (dissoc :certname)
+                 utils/underscore->dash-keys)}
+   5 {:empty (-> v6-empty-wire-catalog
+                 (assoc :name (:certname v6-empty-wire-catalog))
+                 (dissoc :certname)
+                 utils/underscore->dash-keys)}
+   6 {:empty v6-empty-wire-catalog
       :basic
       (-> v6-empty-wire-catalog
           (assoc :certname "basic.wire-catalogs.com")


### PR DESCRIPTION
Note these previous versions are not supported at the API level. The
intent here is if the user has upgraded from PuppetDB 2.0.0 to 3.0.0 and
there are still persisted messages in the queue (POSTed, but not
processed) those messages should be consumable by PuppetDB 3.0.0.

This commit takes a previous version of the command and upgrades it,
filling in anything missing, changing the names of keys as necessary to
conform it to the current (supported) command version.