### PR TITLE
(PDB-1455) Make start_puppetdb/install_puppetdb support legacy installation

### DIFF
--- a/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
+++ b/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
@@ -2,10 +2,9 @@
 if (test_config[:install_mode] == :upgrade and not test_config[:skip_presuite_provisioning])
   step "Install most recent released PuppetDB on the PuppetDB server for upgrade test" do
     databases.each do |database|
-      test_url='/v3/version'
-      install_puppetdb(database, test_config[:database], 'latest', test_url)
-      start_puppetdb(database, test_url)
-      install_puppetdb_termini(master, database, 'latest', 'puppetdb-terminus', test_url)
+      install_puppetdb(database, test_config[:database], 'latest', true)
+      start_puppetdb(database, true)
+      install_puppetdb_termini(master, database, 'latest', true)
     end
   end
 end


### PR DESCRIPTION
After adapting the start_puppetdb/install_puppetdb functions to specify the
newer packages options for the module, we still need a way to flip back to
legacy support for the purposes of upgrades, at least until we ship 3.0.0.

This patch turns all the legacy support flags into 1 flag for those
functions and now also ensures that things like confdir and embedded_path
are set correctly when legacy is true.

Signed-off-by: Ken Barber <ken@bob.sh>