### PR TITLE
(docs) Lose the liquid tags, and use triple tildes for best compatibility

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -110,7 +110,7 @@ If you _do_ need to change rare settings that the module doesn't manage, you can
 
 Create a new class in a new module (something like `site::puppetdb::server::extra`), declare any number of `ini_setting` resources as shown below, set the class to refresh the `puppetdb::server` class, and assign it to your PuppetDB server.
 
-{% highlight ruby %}
+~~~ ruby
     # Site-specific PuppetDB settings. Declare this class on any node that gets the puppetdb::server class.
     class site::puppetdb::server::extra {
 
@@ -134,7 +134,7 @@ Create a new class in a new module (something like `site::puppetdb::server::extr
         value   => 'true',
       }
     }
-{% endhighlight %}
+~~~
 
 `[global]` Settings
 -----

--- a/documentation/connect_puppet_apply.markdown
+++ b/documentation/connect_puppet_apply.markdown
@@ -56,11 +56,11 @@ Currently, Puppet needs extra Ruby plugins in order to use PuppetDB. Unlike cust
 * First, ensure that the appropriate Puppet Labs package repository ([Puppet Enterprise](/guides/puppetlabs_package_repositories.html#puppet-enterprise-repositories), or [open source](/guides/puppetlabs_package_repositories.html#open-source-repositories)) is enabled. You can use a [package][] resource to do this or use the apt::source (from the [puppetlabs-apt][apt] module) and [yumrepo][] types.
 * Next, use Puppet to ensure that the `puppetdb-terminus` package is installed:
 
-{% highlight ruby %}
+~~~ ruby
     package {'puppetdb-terminus':
       ensure => installed,
     }
-{% endhighlight %}
+~~~
 
 
 ### On Platforms Without Packages
@@ -71,7 +71,7 @@ If your puppet master isn't running Puppet from a supported package, you will ne
 * Identify the install location of Puppet on your nodes.
 * Create a [file][] resource in your manifests for each of the plugin files, to move them into place on each node.
 
-{% highlight ruby %}
+~~~ ruby
     # <modulepath>/puppetdb/manifests/terminus.pp
     class puppetdb::terminus {
       $puppetdir = "$rubysitedir/puppet"
@@ -85,7 +85,7 @@ If your puppet master isn't running Puppet from a supported package, you will ne
         mode => 0644,
       }
     }
-{% endhighlight %}
+~~~
 
 ## Step 3: Manage Config Files on Every Puppet Node
 

--- a/documentation/puppetdb-faq.markdown
+++ b/documentation/puppetdb-faq.markdown
@@ -112,10 +112,10 @@ details on how to rememdy this.
 
 ## PuppetDB daemon shuts down, with a "Cannot assign requested address" error. What does this mean, and how do I fix it?
 
-```
+~~~
 FAILED org.eclipse.jetty.server.Server@6b2c636d: java.net.BindException: Cannot assign requested address
 java.net.BindException: Cannot assign requested address
-```
+~~~
 
 PuppetDB will error with this message if the IP address associated with the ssl-host parameter in the
 jetty.ini isn't linked to a known interface - or resolvable.


### PR DESCRIPTION
We recently improved our docs site toolchain to handle syntax highlighting with
fenced code blocks (via prism.js). Yay! But we're still using Kramdown, which
only supports one of the two fenced code block syntaxes specified in CommonMark.
Meh. Anyway, triple tildes good, triple backticks less-good, still best to
use "~~~ ruby" to highlight Puppet snippets for the time being.