### PR TITLE
(PDB-1587) Optimize aggregate event counts

### DIFF
--- a/documentation/api/query/v4/upgrading-from-v3.markdown
+++ b/documentation/api/query/v4/upgrading-from-v3.markdown
@@ -83,6 +83,16 @@ Each change below is marked with the corresponding release version. Changes mark
 * (3.0) The `/pdb/query/v4/factsets/<node>/facts` endpoints will now
   return results even for deactivated or expired nodes.
 
+#### /pdb/query/v4/aggregate-event-counts
+
+* (3.0) the `aggregate-event-counts` endpoint is no longer supported on HSQLDB.
+
+* (3.0) the `aggregate-event-counts` endpoint now accepts multiple `summarize_by`
+  parameters and returns an array of maps instead of a map. An additional
+  `summarize_by` field has also been added to describe the parameter used. For
+  more information see the [aggregate-event-counts
+  documentation](./api/query/v4/aggregate_event_counts).
+
 #### /metrics/v1 (formerly /v3/metrics)
 
 * (3.0) The former metrics endpoint has been split off into a separate service, and

--- a/src/puppetlabs/puppetdb/http/aggregate_event_counts.clj
+++ b/src/puppetlabs/puppetdb/http/aggregate_event_counts.clj
@@ -1,6 +1,8 @@
 (ns puppetlabs.puppetdb.http.aggregate-event-counts
   (:require [puppetlabs.puppetdb.cheshire :as json]
-            [puppetlabs.puppetdb.http.events :as events-http]
+            [puppetlabs.puppetdb.http.events :refer [validate-distinct-options!]]
+            [puppetlabs.puppetdb.http :as http]
+            [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.query-eng :refer [produce-streaming-body]]
             [puppetlabs.puppetdb.middleware :refer [verify-accepts-json validate-query-params]]
             [clojure.tools.logging :as log]
@@ -9,25 +11,32 @@
 (defn routes
   [version]
   (app
-   [""]
-   {:get (fn [{:keys [params globals]}]
-           (let [{:strs [query summarize_by counts_filter count_by] :as query-params} params
-                 distinct-options (events-http/validate-distinct-options! query-params)
-                 query-options (-> {:counts_filter (when counts_filter (json/parse-string counts_filter true))
-                                    :count_by count_by}
-                                   (merge distinct-options))]
-             (produce-streaming-body
-              :aggregate-event-counts
-              version
-              query
-              [summarize_by query-options]
-              (:scf-read-db globals)
-              (:url-prefix globals))))}))
+    [""]
+    {:get (fn [{:keys [params globals]}]
+            (if (utils/hsql? (:scf-read-db globals))
+              (http/json-response
+                {:error "The aggregate-event-counts endpoint does not support HSQLDB."}
+                http/status-not-implemented)
+              (let [{:strs [query summarize_by counts_filter count_by]} params
+                    distinct-options (validate-distinct-options! params)
+                    counts_filter' (json/parse-string counts_filter true)
+                    query-options (-> {:counts_filter counts_filter'
+                                       :count_by count_by}
+                                      (merge distinct-options))]
+                (log/warn
+                  (str "The aggregate-event-counts endpoint is experimental"
+                       " and may be altered or removed in the future."))
+                (produce-streaming-body
+                  :aggregate-event-counts
+                  version
+                  query
+                  [summarize_by query-options]
+                  (:scf-read-db globals)
+                  (:url-prefix globals)))))}))
 
 (defn aggregate-event-counts-app
   "Ring app for querying for aggregated summary information about resource events."
   [version]
-  (log/warn "The aggregate-event-counts endpoint is experimental and may be altered or removed in the future.")
   (-> (routes version)
       verify-accepts-json
       (validate-query-params {:required ["query" "summarize_by"]

--- a/src/puppetlabs/puppetdb/query/aggregate_event_counts.clj
+++ b/src/puppetlabs/puppetdb/query/aggregate_event_counts.clj
@@ -1,50 +1,81 @@
 (ns puppetlabs.puppetdb.query.aggregate-event-counts
   (:require [puppetlabs.puppetdb.query.event-counts :as event-counts]
+            [clojure.string :as str]
+            [puppetlabs.puppetdb.query.events :as events]
             [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.kitchensink.core :as kitchensink]))
 
 (defn- get-aggregate-sql
   "Given the `event-count-sql`, return a SQL string that will aggregate the results."
-  [event-count-sql]
-  {:pre  [(string? event-count-sql)]
+  [event-count-sql summarize_by]
+  {:pre  [(string? event-count-sql)
+          (contains? #{"resource" "containing_class" "certname"} summarize_by)]
    :post [(string? %)]}
-  (format "SELECT SUM(CASE WHEN successes > 0 THEN 1 ELSE 0 END) as successes,
+  (format "(SELECT '%s' as summarize_by,
+           SUM(CASE WHEN successes > 0 THEN 1 ELSE 0 END) as successes,
                   SUM(CASE WHEN failures > 0  THEN 1 ELSE 0 END) as failures,
                   SUM(CASE WHEN noops > 0 THEN 1 ELSE 0 END) as noops,
                   SUM(CASE WHEN skips > 0 THEN 1 ELSE 0 END) as skips,
                   COUNT(*) as total
-           FROM (%s) event_counts" event-count-sql))
+           FROM (%s) event_counts)" summarize_by event-count-sql))
 
-(defn query->sql
-  "Convert an aggregate-event-counts `query` and a value to `summarize_by` into a SQL string.
-  Since all inputs are forwarded to `event-counts/query->sql`, look there for proper documentation."
-  [version query [summarize_by query-options]]
+(defn- assemble-aggregate-sql
+  "Convert an aggregate-event-counts `query` and a value to `summarize_by`
+   into a SQL string."
+  [version query summarize_by query-options]
   {:pre  [(sequential? query)
           (string? summarize_by)
-          ((some-fn map? nil?) query-options)]
-   :post [(jdbc/valid-jdbc-query? (:results-query %))]}
+          ((some-fn map? nil?) query-options)]}
   (let [query-options (if (nil? query-options) {} query-options)
         [count-sql & params] (:results-query
-                              (event-counts/query->sql version query [summarize_by query-options {}]))
-        aggregate-sql        (get-aggregate-sql count-sql)]
-    {:results-query (apply vector aggregate-sql params)}))
+                               (event-counts/query->sql
+                                 true
+                                 version
+                                 query [summarize_by query-options {}]))]
+    (vector (get-aggregate-sql count-sql summarize_by) params)))
+
+(defn query->sql
+  "Convert an aggregate-event-counts `query` and a value(s) to `summarize_by`
+   into a SQL string. Since all inputs are forwarded to
+   `event-counts/query->sql`, look there for proper documentation."
+  [version query [summarize_by {:keys [distinct_resources?] :as query-options}]]
+  {:pre  [(sequential? query)
+          ((some-fn map? nil?) query-options)]
+   :post [(jdbc/valid-jdbc-query? (:results-query %))]}
+  (let [summary-vec (str/split summarize_by #",")
+        nsummarized (count summary-vec)
+        aggregate-fn #(assemble-aggregate-sql version query % query-options)
+        aggregated-sql-and-params (map aggregate-fn summary-vec)
+        common-params (second (first aggregated-sql-and-params))
+        params (if distinct_resources?
+                 ;; when distinct resources is used, the first two parameters
+                 ;; are the distinct start/end times.
+                 ;; extract the distinct start/end times and duplicate the rest
+                 ;; as many times as there are summarize_by's
+                 (concat (take 2 common-params)
+                         (flatten (repeat nsummarized (drop 2 common-params))))
+                 ;; repeat all params as many times as there are summarize_by's
+                 (flatten (repeat nsummarized common-params)))
+        unioned-sql (cond-> (str/join " UNION ALL " (map first aggregated-sql-and-params))
+                      distinct_resources?  events/with-latest-events)]
+    {:results-query (apply vector unioned-sql params)}))
 
 (defn- perform-query
   "Given a SQL query and its parameters, return a vector of matching results."
   [[sql & params]]
   {:pre  [(string? sql)]
-   :post [(vector? %)
-          (= (count %) 1)]}
+   :post [(vector? %)]}
   (jdbc/query-to-vec (apply vector sql params)))
 
 (defn munge-result-rows
   [_ _]
-  (comp (partial kitchensink/mapvals #(if (nil? %) 0 %)) first))
+  (fn [rows]
+    (map (partial kitchensink/mapvals #(if (nil? %) 0 %)) rows)))
 
 (defn query-aggregate-event-counts
   "Given a SQL query and its parameters, return the single matching result map."
   [{:keys [results-query]}]
   {:pre  [(string? (first results-query))]
-   :post [(map? %)]}
+   :post [(seq? %)]}
   (->> (perform-query results-query)
        ((munge-result-rows nil nil))))

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -27,7 +27,8 @@
   (let [[query->sql munge-fn]
         (case entity
           :aggregate-event-counts [aggregate-event-counts/query->sql aggregate-event-counts/munge-result-rows]
-          :event-counts [event-counts/query->sql (event-counts/munge-result-rows (first paging-options))]
+          :event-counts [event-counts/query->sql
+                         (event-counts/munge-result-rows (first paging-options))]
           :facts [facts/query->sql facts/munge-result-rows]
           :fact-contents [fact-contents/query->sql fact-contents/munge-result-rows]
           :fact-paths [facts/fact-paths-query->sql facts/munge-path-result-rows]

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -295,6 +295,10 @@
   [env-name :- s/Str]
   (query-id :environments {:name env-name}))
 
+(pls/defn-validated certname-id :- (s/maybe s/Int)
+  [certname :- s/Str]
+  (query-id :certnames {:certname certname}))
+
 (pls/defn-validated ensure-environment :- (s/maybe s/Int)
   "Check if the given `env-name` exists, creates it if it does not. Always returns
    the id of the `env-name` (whether created or existing)"
@@ -1136,9 +1140,12 @@
                                     :end_time               end_time
                                     :receive_time           (to-timestamp received-timestamp)
                                     :environment_id         (ensure-environment environment)
-                                    :status_id              (ensure-status status)}))]
+                                    :status_id              (ensure-status status)}))
+                   assoc-ids #(assoc %
+                                     :report_id id
+                                     :certname_id (certname-id certname))]
                (->> resource_events
-                    (map (comp convert-containment-path #(assoc % :report_id id)))
+                    (map (comp convert-containment-path assoc-ids))
                     (apply sql/insert-records :resource_events))
                (when update-latest-report?
                  (update-latest-report! certname)))))))

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -257,3 +257,14 @@
       {:href (to-href data)}
       (-> (sutils/parse-db-json data)
           (update :href to-href)))))
+
+(defn hsql?
+  "given a db-spec style database object, determine if hsqldb is being used."
+  [db-spec]
+  (cond
+    (:subprotocol db-spec)
+    (= (:subprotocol db-spec) "hsqldb")
+
+    (:datasource db-spec)
+    (re-matches #"jdbc:hsqldb.*"
+                (.getJdbcUrl (:datasource db-spec)))))


### PR DESCRIPTION
Author: Wyatt Alt <wyaltster@gmail.com>
Date:   Tue Jun 9 08:33:49 2015 -0700

    (PDB-1587) Optimize aggregate event counts
    
    This commit improves performance on aggregate-event-counts queries.
    Included are the following changes:
    * new (large) index on resource_events(resource_type, resource_title, timestamp)
    * aggregate-event-counts now supports multiple comma-separated summarize_by params
    * union all is used to combine results from multiple AEC summaries
    * AEC output is now a map array, with a new key containing the summary param
    * CTE used to improve performance when multiple summarize_by values are provided
    * fairly expensive migration merged with mega-migration #29
    * AEC no longer compatible with HSQLDB