### PR TITLE
(PDB-1455) Install a proper ruby when using AIO on Debian

### DIFF
--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -91,5 +91,20 @@ unless (test_config[:skip_presuite_provisioning])
       # Make sure there isn't a gemrc file, because that could ruin our day.
       on master, "rm -f ~/.gemrc"
     end
+
+    # This works around the fact that puppetlabs-concat 1.2.3 requires a ruby in
+    # the normal path, here we work around this for AIO by just installing one
+    # on the database node that needs it.
+    #
+    # https://github.com/puppetlabs/puppetlabs-concat/blob/1.2.3/files/concatfragments.rb#L1
+    #
+    # This can be removed with concat 2.x onces its re-released, as this doesn't
+    # need an external ruby vm, it uses proper types & providers.
+    if options[:type] == 'aio' && test_config[:os_families][database.name] == :debian &&
+      database['platform'] !~ /ubuntu/ then
+      step "Install rubygems on database for AIO on Debian" do
+        on database, "apt-get install -y rubygems ruby-dev"
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes a problem with puppetlabs-concat requiring a proper ruby vm when we
use puppetlabs-postgresql. Since AIO doesn't install one by default, we install
it especially for this node combination to work around the problem.

This issue should be solved in the 2.x branch of puppetlabs-concat once
released, since puppetlabs-concat 2.x uses proper types and providers, so the
ruby code is now internally called instead of Exec'd from the agent.

Signed-off-by: Ken Barber <ken@bob.sh>