### PR TITLE
(re-4845)(packaging) Change jar name from puppetdb-release.jar to puppetdb.jar

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -221,7 +221,7 @@ module PuppetDBExtensions
 
   def puppetdb_pids(host)
     java_bin = "java"
-    jar_file = "puppetdb-release.jar"
+    jar_file = "puppetdb.jar"
     result = on host, %Q(ps -ef | grep "#{java_bin}" | grep "#{jar_file}" | grep " services -c " | awk '{print $2}')
     pids = result.stdout.chomp.split("\n")
     Beaker::Log.notify "PuppetDB PIDs appear to be: '#{pids}'"

--- a/acceptance/setup/post_suite/01_validate_database.rb
+++ b/acceptance/setup/post_suite/01_validate_database.rb
@@ -25,7 +25,7 @@ step "Verify we've been talking to the correct database" do
       # in the code, and it's just generally moronic.  We should provide a lein task
       # or some way of interrogating the latest expected schema version from
       # the command line so that we can get rid of this crap.
-      source_migration_version = on(database, "java -cp /usr/share/puppetdb/puppetdb-release.jar clojure.main -m puppetlabs.puppetdb.core version |grep target_schema_version|cut -f2 -d'='").stdout.strip
+      source_migration_version = on(database, "java -cp /usr/share/puppetdb/puppetdb.jar clojure.main -m puppetlabs.puppetdb.core version |grep target_schema_version|cut -f2 -d'='").stdout.strip
 
       assert_equal(db_migration_version, source_migration_version,
                    "Expected migration version from source code '#{source_migration_version}' " +

--- a/project.clj
+++ b/project.clj
@@ -98,7 +98,7 @@
   :lein-release {:scm        :git
                  :deploy-via :lein-deploy}
 
-  :uberjar-name "puppetdb-release.jar"
+  :uberjar-name "puppetdb.jar"
   :lein-ezbake {:vars {:user "puppetdb"
                        :group "puppetdb"
                        :build-type "foss"

--- a/resources/ext/cli/anonymize
+++ b/resources/ext/cli/anonymize
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-${JAVA_BIN} ${JAVA_ARGS} -cp ${INSTALL_DIR}/puppetdb-release.jar clojure.main -m puppetlabs.puppetdb.core anonymize "$@"
+${JAVA_BIN} ${JAVA_ARGS} -cp ${INSTALL_DIR}/puppetdb.jar clojure.main -m puppetlabs.puppetdb.core anonymize "$@"

--- a/resources/ext/cli/export
+++ b/resources/ext/cli/export
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-${JAVA_BIN} ${JAVA_ARGS} -cp ${INSTALL_DIR}/puppetdb-release.jar clojure.main -m puppetlabs.puppetdb.core export "$@"
+${JAVA_BIN} ${JAVA_ARGS} -cp ${INSTALL_DIR}/puppetdb.jar clojure.main -m puppetlabs.puppetdb.core export "$@"

--- a/resources/ext/cli/foreground
+++ b/resources/ext/cli/foreground
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-su ${USER} -s /bin/bash -c "${JAVA_BIN} ${JAVA_ARGS} -Dlogappender=STDOUT -cp ${INSTALL_DIR}/puppetdb-release.jar clojure.main -m puppetlabs.puppetdb.core services -c ${CONFIG} ${@}"
+su ${USER} -s /bin/bash -c "${JAVA_BIN} ${JAVA_ARGS} -Dlogappender=STDOUT -cp ${INSTALL_DIR}/puppetdb.jar clojure.main -m puppetlabs.puppetdb.core services -c ${CONFIG} ${@}"

--- a/resources/ext/cli/import
+++ b/resources/ext/cli/import
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-${JAVA_BIN} ${JAVA_ARGS} -cp ${INSTALL_DIR}/puppetdb-release.jar clojure.main -m puppetlabs.puppetdb.core import "$@"
+${JAVA_BIN} ${JAVA_ARGS} -cp ${INSTALL_DIR}/puppetdb.jar clojure.main -m puppetlabs.puppetdb.core import "$@"


### PR DESCRIPTION
This changes the uberjar name to 'puppetdb.jar' to match the 2.x release,
which simplifies some upgrade and init script logic.

This is related to https://github.com/puppetlabs/ezbake/pull/256