### PR TITLE
(PDB-1632) Transfer old AMQP messages at startup

### DIFF
--- a/test/puppetlabs/puppetdb/fixtures.clj
+++ b/test/puppetlabs/puppetdb/fixtures.clj
@@ -10,7 +10,8 @@
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
             [clojure.tools.macro :as tmacro]
             [clojure.test :refer [join-fixtures use-fixtures]]
-            [puppetlabs.puppetdb.testutils :refer [clear-db-for-testing! test-db with-test-broker]]
+            [puppetlabs.puppetdb.testutils
+             :refer [clear-db-for-testing! test-db with-test-broker without-jmx]]
             [puppetlabs.trapperkeeper.logging :refer [reset-logging]]
             [puppetlabs.puppetdb.scf.migrate :refer [migrate!]]))
 
@@ -51,12 +52,13 @@
 
 (defn with-test-mq
   "Calls f after starting an embedded MQ broker that will be available
-  for the duration of the call via *mq*."
+  for the duration of the call via *mq*.  JMX will be disabled."
   [f]
-  (with-test-broker "test" connection
-    (binding [*mq* {:connection connection
-                    :endpoint "puppetlabs.puppetdb.commands"}]
-      (f))))
+  (without-jmx
+   (with-test-broker "test" connection
+     (binding [*mq* {:connection connection
+                     :endpoint "puppetlabs.puppetdb.commands"}]
+       (f)))))
 
 (defn with-command-app
   "A fixture to build a Command app and make it available as `*command-app*` within

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -286,15 +286,6 @@
       (client/get {:as :json})
       (get-in [:body :DispatchCount])))
 
-(defmacro without-jmx
-  "Disable ActiveMQ's usage of JMX. If you start two AMQ brokers in
-  the same instance, their JMX beans will collide. Disabling JMX will
-  allow them both to be started."
-  [& body]
-  `(with-redefs [puppetlabs.puppetdb.mq/enable-jmx (fn [broker# _#]
-                                                     (.setUseJmx broker# false))]
-     (do ~@body)))
-
 (defn sync-command-post
   "Syncronously post a command to PDB by blocking until the message is consumed
    off the queue."


### PR DESCRIPTION
At startup, transfer any messages found in the old
com.puppetlabs.puppetdb.commands queue to puppetlabs.puppetdb.commands
so that pending commands won't be ignored after an upgrade.
