### PR TITLE
(maint) update postgres error message on concurrent fact update

### DIFF
--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -718,11 +718,8 @@
 
           (test-msg-handler new-facts-cmd publish discard-dir
             (reset! second-message? true)
-            (is (re-matches
-                  (if (sutils/postgres?)
-                    #"(?sm).*ERROR: could not serialize access due to concurrent update.*"
-                    #".*BatchUpdateException.*(rollback|abort).*")
-                  (extract-error-message publish))))
+            (is (re-matches #".*BatchUpdateException.*(rollback|abort).*"
+                            (extract-error-message publish))))
           @fut
           (is (true? @first-message?))
           (is (true? @second-message?)))))))


### PR DESCRIPTION
After the last rollup from stable we ended up with an incorrect rollback error
message on postgres in the commands test. The new error still indicates a rollback.