### PR TITLE
(maint) fix rollup issue to reduce certnames contention

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1194,7 +1194,7 @@
     (add-certname! certname))
   (let [timestamp (to-timestamp time)
         replaced  (sql/update-values :certnames
-                                     ["certname=? AND (deactivated<? OR deactivated IS NULL) AND (expired<? OR expired IS NULL)"
+                                     ["certname=? AND (deactivated<? OR expired<?)"
                                       certname timestamp timestamp]
                                      {:deactivated nil, :expired nil})]
     (pos? (first replaced))))

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -718,8 +718,11 @@
 
           (test-msg-handler new-facts-cmd publish discard-dir
             (reset! second-message? true)
-            (is (re-matches #".*BatchUpdateException.*(rollback|abort).*"
-                            (extract-error-message publish))))
+            (is (re-matches
+                  (if (sutils/postgres?)
+                    #"(?sm).*ERROR: could not serialize access due to concurrent update.*"
+                    #".*transaction rollback: serialization failure")
+                  (extract-error-message publish))))
           @fut
           (is (true? @first-message?))
           (is (true? @second-message?)))))))

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1187,7 +1187,7 @@
 
         (testing "should do nothing if the node is already active"
           (activate-node! certname)
-          (is (= true (maybe-activate-node! certname (now))))
+          (is (= false (maybe-activate-node! certname (now))))
           (is (= (query-certnames) [{:certname certname :deactivated nil}])))))))
 
 (deftest node-staleness-age


### PR DESCRIPTION
This fixes an issue from the rollup yesterday. It's effectively a port of
706df77 from stable.