### PR TITLE
(PDB-1638) consider reports in stale-nodes analysis

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -220,11 +220,13 @@
     (map :certname (jdbc/query-to-vec "SELECT c.certname FROM certnames c
                                        LEFT OUTER JOIN catalogs clogs ON c.certname=clogs.certname
                                        LEFT OUTER JOIN factsets fs ON c.certname=fs.certname
+                                       LEFT OUTER JOIN reports r ON c.certname=r.certname
                                        WHERE c.deactivated IS NULL
                                        AND c.expired IS NULL
                                        AND (clogs.producer_timestamp IS NULL OR clogs.producer_timestamp < ?)
-                                       AND (fs.producer_timestamp IS NULL OR fs.producer_timestamp < ?)"
-                                      ts ts))))
+                                       AND (fs.producer_timestamp IS NULL OR fs.producer_timestamp < ?)
+                                       AND (r.producer_timestamp IS NULL OR r.producer_timestamp < ?)"
+                                      ts ts ts))))
 
 (defn node-deactivated-time
   "Returns the time the node specified by `certname` was deactivated, or nil if

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1215,6 +1215,15 @@
         (dorun (map #(%) func-set))
         (is (= (stale-nodes (-> 1 days ago)) ["node1"]))))))
 
+(deftest node-stale-reports
+  (testing "should not return a node with a recent report and nothing else"
+    (let [report (-> (:basic reports)
+                     (assoc :environment "ENV2")
+                     (assoc :end_time (now))
+                     (assoc :producer_timestamp (now)))]
+      (store-example-report! report (now))
+      (is (= (stale-nodes (-> 1 days ago)) [])))))
+
 (deftest node-max-age
   (testing "should only return nodes older than max age, and leave others alone"
     (let [catalog (:empty catalogs)]


### PR DESCRIPTION
We didn't previously have a producer_timestamp field on reports, so they were
not considered in the decision to deactivate a stale node. This corrects that
behavior.