### PR TITLE
(PDB-1646) tighten up regex and subqueries in the legacy query engine

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -153,6 +153,18 @@ The returned SQL fragment will contain *one* parameter placeholder, which
 must be supplied as the value to be matched."
   (fn [column] (sql-current-connection-database-name)))
 
+(defmulti legacy-sql-regexp-match
+  "Returns db-specific code for performing a regexp match"
+  (fn [_] (sql-current-connection-database-name)))
+
+(defmethod legacy-sql-regexp-match "PostgreSQL"
+  [column]
+  (format "(%s ~ ? AND %s IS NOT NULL)" column column))
+
+(defmethod legacy-sql-regexp-match "HSQL Database Engine"
+  [column]
+  (format "REGEXP_SUBSTRING(%s, ?) IS NOT NULL" column))
+
 (defmulti sql-regexp-match
   "Returns db-specific code for performing a regexp match"
   (fn [_] (sql-current-connection-database-name)))

--- a/test/puppetlabs/puppetdb/http/event_counts_test.clj
+++ b/test/puppetlabs/puppetdb/http/event_counts_test.clj
@@ -1,11 +1,14 @@
 (ns puppetlabs.puppetdb.http.event-counts-test
   (:require [puppetlabs.puppetdb.http :as http]
             [puppetlabs.puppetdb.fixtures :as fixt]
+            [clojure.java.io :refer [resource]]
             [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.puppetdb.cheshire :as json]
             [clojure.test :refer :all]
+            [clojure.walk :refer [keywordize-keys]]
             [puppetlabs.puppetdb.examples.reports :refer :all]
             [puppetlabs.puppetdb.testutils.event-counts :refer [get-response]]
+            [puppetlabs.puppetdb.testutils.catalogs :as testcat]
             [puppetlabs.puppetdb.testutils :refer [response-equal? paged-results deftestseq]]
             [puppetlabs.puppetdb.testutils.reports :refer [store-example-report!]]
             [clj-time.core :refer [now]]))
@@ -13,6 +16,12 @@
 (def endpoints [[:v4 "/v4/event-counts"]])
 
 (use-fixtures :each fixt/with-test-db fixt/with-http-app)
+
+(def example-catalog
+  (-> (slurp (resource "puppetlabs/puppetdb/cli/export/tiny-catalog.json"))
+      json/parse-string
+      keywordize-keys
+      (assoc :certname "foo.local")))
 
 (deftestseq query-event-counts
   [[version endpoint] endpoints]
@@ -86,32 +95,132 @@
 
   (store-example-report! (:basic reports) (now))
   (store-example-report! (:basic3 reports) (now))
+  (testcat/replace-catalog (json/generate-string example-catalog))
   (testing "should only count the most recent event for each resource"
-    (let [expected  #{{:subject_type "resource"
-                       :subject {:type "Notify" :title "notify, yo"}
-                       :failures 0
-                       :successes 1
-                       :noops 0
-                       :skips 0}
-                      {:subject_type "resource"
-                       :subject {:type "Notify" :title "notify, yar"}
-                       :failures 1
-                       :successes 0
-                       :noops 0
-                       :skips 0}
-                      {:subject_type "resource"
-                       :subject {:type "Notify" :title "hi"}
-                       :failures 0
-                       :successes 0
-                       :noops 0
-                       :skips 1}}
-          response  (get-response endpoint
-                                  ["=" "certname" "foo.local"]
-                                  "resource"
-                                  {"distinct_resources" true
-                                   "distinct_start_time" 0
-                                   "distinct_end_time" (now)})]
-      (response-equal? response expected))))
+    (are [query result]
+         (response-equal? (get-response endpoint
+                                        query
+                                        "resource"
+                                        {"distinct_resources" true
+                                         "distinct_start_time" 0
+                                         "distinct_end_time" (now)})
+                          result)
+
+         ["=" "certname" "foo.local"]
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 1
+            :successes 0
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :successes 0
+            :noops 0
+            :skips 1}}
+
+         ["~" "certname" ".*"]
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 1
+            :successes 0
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :successes 0
+            :noops 0
+            :skips 1}}
+
+         ["~" "environment" ".*"]
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 1
+            :successes 0
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :successes 0
+            :noops 0
+            :skips 1}}
+
+         ["~" "property" ".*"]
+         #{{:failures 0
+            :successes 1
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}}
+           {:failures 1
+            :successes 0
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}}}
+
+         ["in" "certname" ["extract" "certname"
+                           ["select_resources" ["~" "certname" ".*"]]]]
+         #{{:failures 0
+            :successes 1
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}}
+           {:failures 1
+            :successes 0
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}}
+           {:failures 0
+            :successes 0
+            :noops 0
+            :skips 1
+            :subject_type "resource"
+            :subject {:type "Notify" :title "hi"}}}
+
+         ["in" "certname" ["extract" "certname"
+                           ["select_resources" ["~" "tag" ".*"]]]]
+         #{{:failures 0
+            :successes 1
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}}
+           {:failures 1
+            :successes 0
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}}
+           {:failures 0
+            :successes 0
+            :noops 0
+            :skips 1
+            :subject_type "resource"
+            :subject {:type "Notify" :title "hi"}}})))
 
 (deftestseq query-with-environment
   [[version endpoint] endpoints]

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -147,7 +147,6 @@
   `(let [fixture-fn# (join-fixtures (:clojure.test/each-fixtures (meta ~*ns*)))]
      (fixture-fn# (fn [] ~@body))))
 
-;; TODO: change order of expected/actual?
 (defn response-equal?
   "Test if the HTTP request is a success, and if the result is equal
   to the result of the form supplied to this method.  Arguments:
@@ -172,7 +171,7 @@
                         (json/parse-string true)
                         (body-munge-fn)
                         (set)))]
-       (is (= expected actual)
+       (is (= actual expected)
            (str response)))))
 
 (defmacro =-after?


### PR DESCRIPTION
This fixes a couple issues with the legacy query engine, which is used when
the distinct_resources parameter is passed as true:
* regex queries were broken due to use of honeysql instead of strings
* subqueries were broken because of an ambiguous column alias

I've expanded the distinct_resources testing in http/event-counts-test to cover
the fixed behavior.