### PR TITLE
(PDB-1629) fix relationships on resource aliases

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -1049,7 +1049,7 @@ PP
     remote_path
   end
 
-  def run_agents_with_new_site_pp(host, manifest, env_vars = {})
+  def run_agents_with_new_site_pp(host, manifest, env_vars = {}, extra_cli_args = "")
 
     manifest_path = create_remote_site_pp(host, manifest)
     with_puppet_running_on host, {
@@ -1062,7 +1062,8 @@ PP
         'environmentpath' => manifest_path,
       }} do
       #only some of the opts work on puppet_agent, acceptable exit codes does not
-      agents.each{ |agent| on agent, puppet_agent("--test --server #{host}", { 'ENV' => env_vars }), :acceptable_exit_codes => [0,2] }
+      agents.each{ |agent| on agent, puppet_agent("--test --server #{host} #{extra_cli_args}",
+                                                  { 'ENV' => env_vars }), :acceptable_exit_codes => [0,2] }
 
     end
   end

--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -167,7 +167,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
           end
         end
 
-        resource['parameters']['alias'] = aliases unless aliases.empty?
+        resource['parameters'][:alias] = aliases unless aliases.empty?
       end
     end
 
@@ -214,7 +214,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
     profile("Map aliases to title (resource count: #{resources.count})",
             [:puppetdb, :aliases, :map_to_title]) do
       resources.each do |resource|
-        names = resource['parameters']['alias'] || []
+        names = Array(resource['parameters'][:alias]) || []
         resource_hash = {'type' => resource['type'], 'title' => resource['title']}
         names.each do |name|
           alias_array = [resource['type'], name]

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -143,7 +143,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         end
 
         resource.should_not be_nil
-        resource['parameters']['alias'].should include(name)
+        resource['parameters'][:alias].should include(name)
       end
 
       context "with resource types that provide #title_patterns" do
@@ -184,8 +184,8 @@ describe Puppet::Resource::Catalog::Puppetdb do
             #  this test should cover other resource types that fall into
             #  this category as well.
             resource.should_not be_nil
-            resource['parameters']['alias'].should_not be_nil
-            resource['parameters']['alias'].should include('/tmp/foo')
+            resource['parameters'][:alias].should_not be_nil
+            resource['parameters'][:alias].should include('/tmp/foo')
           end
         end
       end
@@ -199,7 +199,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         end
 
         resource.should_not be_nil
-        resource['parameters']['alias'].should be_nil
+        resource['parameters'][:alias].should be_nil
       end
 
       describe "for resources with composite namevars" do
@@ -218,7 +218,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
           end
 
           resource.should_not be_nil
-          resource['parameters']['alias'].should be_nil
+          resource['parameters'][:alias].should be_nil
         end
       end
 
@@ -236,7 +236,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
           end
 
           resource.should_not be_nil
-          resource['parameters']['alias'].should == ['something awesome']
+          resource['parameters'][:alias].should == ['something awesome']
         end
       end
     end


### PR DESCRIPTION
This corrects a bug where the terminus would scan for resource alias names
using the wrong key, which would cause the list of aliases to fall through to
an empty list.

Correcting this made it clear that we were also incorrectly assuming that
aliases within resources presented as arrays.