### PR TITLE
(PDB-1646) tighten up regex and subqueries in the legacy query engine

### DIFF
--- a/src/puppetlabs/puppetdb/honeysql.clj
+++ b/src/puppetlabs/puppetdb/honeysql.clj
@@ -64,6 +64,10 @@
     (keyword (.s raw-sql))
     s))
 
+(defn sqlraw->str
+  [^SqlRaw raw-sql]
+  (.s raw-sql))
+
 ;; NEW OPERATORS
 
 ; Custom formatter for PostgreSQL's ~ operator

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -62,10 +62,14 @@
    applying ordering constraints."
   (:require [clojure.string :as str]
             [puppetlabs.kitchensink.core :as kitchensink]
+            [puppetlabs.puppetdb.jdbc :as jdbc]
+            [puppetlabs.puppetdb.honeysql :as h]
+            [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.time :refer [to-timestamp]]
             [puppetlabs.kitchensink.core :refer [parse-number keyset valset order-by-expr?]]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils
-             :refer [db-serialize sql-as-numeric sql-array-query-string sql-regexp-match sql-regexp-array-match]]
+             :refer [db-serialize sql-as-numeric sql-array-query-string
+                     legacy-sql-regexp-match sql-regexp-array-match]]
             [puppetlabs.puppetdb.jdbc
              :refer [valid-jdbc-query? limited-query-to-vec query-to-vec paged-sql count-sql get-result-count]]
             [puppetlabs.puppetdb.query.paging :refer [requires-paging?]]
@@ -192,11 +196,6 @@
 (def fact-columns {"certname"         "facts"
                    "name"             "facts"
                    "value"            "facts"
-                   "depth"            "facts"
-                   "value_integer"    "facts"
-                   "value_float"      "facts"
-                   "type"             "facts"
-                   "path"             "facts"
                    "environment"      "facts"})
 
 ;; This map's keys are the queryable fields for factsets, and the values are the
@@ -256,6 +255,12 @@
    "environment"           "reports"
    "status"                "reports"})
 
+(defn qualified-column
+  "given a field and one of the column maps above, produce the fully qualified
+   column name"
+  [field columns]
+  (let [source-table (first (utils/vector-maybe (get columns field)))]
+    (format "%s.%s" source-table field)))
 
 (defn column-map->sql
   "Helper function that converts one of our column maps to a SQL string suitable
@@ -324,8 +329,16 @@
   (when-not (= (first subquery) "extract")
     (throw (IllegalArgumentException.
              (format "The subquery argument of 'in' must be an 'extract', not '%s'" (first subquery)))))
-  (let [{:keys [where] :as compiled-subquery} (compile-term ops subquery)]
-    (assoc compiled-subquery :where (format "%s IN (%s)" field where))))
+  (let [{:keys [where] :as compiled-subquery} (compile-term ops subquery)
+        columns (case kind
+                  :fact fact-columns
+                  :resource resource-columns
+                  :event event-columns
+                  :report report-columns
+                  :factset factset-columns)
+        qualified-field (qualified-column field columns)]
+    (assoc compiled-subquery
+           :where (format "%s IN (%s)" qualified-field where))))
 
 (defn resource-query->sql
   "Compile a resource query, returning a vector containing the SQL and
@@ -422,21 +435,24 @@
           (:where %)]}
   (match [path]
          ["tag"]
-         {:where (sql-regexp-array-match "catalog_resources" "catalog_resources" "tags")
+         {:where (h/sqlraw->str
+                   (sql-regexp-array-match "catalog_resources"
+                                           "catalog_resources"
+                                           "tags"))
           :params [value]}
 
          ;; node join.
          ["certname"]
-         {:where  (sql-regexp-match "catalogs.certname")
+         {:where (legacy-sql-regexp-match "catalogs.certname")
           :params [value]}
 
          ["environment"]
-         {:where  (sql-regexp-match "catalog_resources.environment")
+         {:where (legacy-sql-regexp-match "catalog_resources.environment")
           :params [value]}
 
          ;; metadata match.
          [(metadata :guard #{"type" "title" "exported" "file"})]
-         {:where  (sql-regexp-match (format "catalog_resources.%s" metadata))
+         {:where (legacy-sql-regexp-match (format "catalog_resources.%s" metadata))
           :params [value]}
 
          ;; ...else, failure
@@ -485,7 +501,8 @@
            (string? pattern)]
      :post [(map? %)
             (string? (:where %))]}
-    (let [query (fn [col] {:where (sql-regexp-match col) :params [pattern]})]
+    (let [query (fn [col] {:where (legacy-sql-regexp-match col)
+                           :params [pattern]})]
       (match [path]
              ["certname"]
              (query "facts.certname")
@@ -497,7 +514,8 @@
              (query "facts.name")
 
              ["value"]
-             {:where (format "%s and depth = 0" (sql-regexp-match "facts.value"))
+             {:where (format "%s and depth = 0"
+                             (legacy-sql-regexp-match "facts.value"))
               :params [pattern]}
 
              :else (throw (IllegalArgumentException.
@@ -607,19 +625,20 @@
     {:post [(map? %)
             (string? (:where %))]}
     (when-not (= (count args) 2)
-      (throw (IllegalArgumentException. (format "~ requires exactly two arguments, but %d were supplied" (count args)))))
+      (throw (IllegalArgumentException.
+               (format "~ requires exactly two arguments, but %d were supplied" (count args)))))
     (let [path (utils/dashes->underscores path)]
       (match [path]
              ["certname"]
-             {:where (sql-regexp-match "reports.certname")
+             {:where (legacy-sql-regexp-match "reports.certname")
               :params [pattern]}
 
              ["environment"]
-             {:where (sql-regexp-match "environments.name")
+             {:where (legacy-sql-regexp-match "environments.name")
               :params [pattern]}
 
              [(field :guard #{"report" "resource_type" "resource_title" "status"})]
-             {:where  (sql-regexp-match (format "resource_events.%s" field))
+             {:where  (legacy-sql-regexp-match (format "resource_events.%s" field))
               :params [pattern] }
 
              ;; these fields allow NULL, which causes a change in semantics when
@@ -627,9 +646,9 @@
              ;; about the NULL case.
              [(field :guard #{"property" "message" "file" "line" "containing_class"})]
              {:where (format "%s AND resource_events.%s IS NOT NULL"
-                             (sql-regexp-match (format "resource_events.%s" field))
+                             (legacy-sql-regexp-match (format "resource_events.%s" field))
                              field)
-              :params [pattern] }
+              :params [pattern]}
 
              :else (throw (IllegalArgumentException.
                            (format "'%s' is not a queryable object for version %s of the resource events API" path (last (name version)))))))))

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -153,6 +153,18 @@ The returned SQL fragment will contain *one* parameter placeholder, which
 must be supplied as the value to be matched."
   (fn [column] (sql-current-connection-database-name)))
 
+(defmulti legacy-sql-regexp-match
+  "Returns db-specific code for performing a regexp match"
+  (fn [_] (sql-current-connection-database-name)))
+
+(defmethod legacy-sql-regexp-match "PostgreSQL"
+  [column]
+  (format "(%s ~ ? AND %s IS NOT NULL)" column column))
+
+(defmethod legacy-sql-regexp-match "HSQL Database Engine"
+  [column]
+  (format "REGEXP_SUBSTRING(%s, ?) IS NOT NULL" column))
+
 (defmulti sql-regexp-match
   "Returns db-specific code for performing a regexp match"
   (fn [_] (sql-current-connection-database-name)))

--- a/test/puppetlabs/puppetdb/http/event_counts_test.clj
+++ b/test/puppetlabs/puppetdb/http/event_counts_test.clj
@@ -1,11 +1,14 @@
 (ns puppetlabs.puppetdb.http.event-counts-test
   (:require [puppetlabs.puppetdb.http :as http]
             [puppetlabs.puppetdb.fixtures :as fixt]
+            [clojure.java.io :refer [resource]]
             [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.puppetdb.cheshire :as json]
             [clojure.test :refer :all]
+            [clojure.walk :refer [keywordize-keys]]
             [puppetlabs.puppetdb.examples.reports :refer :all]
             [puppetlabs.puppetdb.testutils.event-counts :refer [get-response]]
+            [puppetlabs.puppetdb.testutils.catalogs :as testcat]
             [puppetlabs.puppetdb.testutils :refer [response-equal? paged-results deftestseq]]
             [puppetlabs.puppetdb.testutils.reports :refer [store-example-report!]]
             [clj-time.core :refer [now]]))
@@ -13,6 +16,12 @@
 (def endpoints [[:v4 "/v4/event-counts"]])
 
 (use-fixtures :each fixt/with-test-db fixt/with-http-app)
+
+(def example-catalog
+  (-> (slurp (resource "puppetlabs/puppetdb/cli/export/tiny-catalog.json"))
+      json/parse-string
+      keywordize-keys
+      (assoc :certname "foo.local")))
 
 (deftestseq query-event-counts
   [[version endpoint] endpoints]
@@ -86,32 +95,132 @@
 
   (store-example-report! (:basic reports) (now))
   (store-example-report! (:basic3 reports) (now))
+  (testcat/replace-catalog (json/generate-string example-catalog))
   (testing "should only count the most recent event for each resource"
-    (let [expected  #{{:subject_type "resource"
-                       :subject {:type "Notify" :title "notify, yo"}
-                       :failures 0
-                       :successes 1
-                       :noops 0
-                       :skips 0}
-                      {:subject_type "resource"
-                       :subject {:type "Notify" :title "notify, yar"}
-                       :failures 1
-                       :successes 0
-                       :noops 0
-                       :skips 0}
-                      {:subject_type "resource"
-                       :subject {:type "Notify" :title "hi"}
-                       :failures 0
-                       :successes 0
-                       :noops 0
-                       :skips 1}}
-          response  (get-response endpoint
-                                  ["=" "certname" "foo.local"]
-                                  "resource"
-                                  {"distinct_resources" true
-                                   "distinct_start_time" 0
-                                   "distinct_end_time" (now)})]
-      (response-equal? response expected))))
+    (are [query result]
+         (response-equal? (get-response endpoint
+                                        query
+                                        "resource"
+                                        {"distinct_resources" true
+                                         "distinct_start_time" 0
+                                         "distinct_end_time" (now)})
+                          result)
+
+         ["=" "certname" "foo.local"]
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 1
+            :successes 0
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :successes 0
+            :noops 0
+            :skips 1}}
+
+         ["~" "certname" ".*"]
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 1
+            :successes 0
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :successes 0
+            :noops 0
+            :skips 1}}
+
+         ["~" "environment" ".*"]
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 1
+            :successes 0
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :successes 0
+            :noops 0
+            :skips 1}}
+
+         ["~" "property" ".*"]
+         #{{:failures 0
+            :successes 1
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}}
+           {:failures 1
+            :successes 0
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}}}
+
+         ["in" "certname" ["extract" "certname"
+                           ["select_resources" ["~" "certname" ".*"]]]]
+         #{{:failures 0
+            :successes 1
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}}
+           {:failures 1
+            :successes 0
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}}
+           {:failures 0
+            :successes 0
+            :noops 0
+            :skips 1
+            :subject_type "resource"
+            :subject {:type "Notify" :title "hi"}}}
+
+         ["in" "certname" ["extract" "certname"
+                           ["select_resources" ["~" "tag" ".*"]]]]
+         #{{:failures 0
+            :successes 1
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}}
+           {:failures 1
+            :successes 0
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}}
+           {:failures 0
+            :successes 0
+            :noops 0
+            :skips 1
+            :subject_type "resource"
+            :subject {:type "Notify" :title "hi"}}})))
 
 (deftestseq query-with-environment
   [[version endpoint] endpoints]

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -155,7 +155,6 @@
   `(let [fixture-fn# (join-fixtures (:clojure.test/each-fixtures (meta ~*ns*)))]
      (fixture-fn# (fn [] ~@body))))
 
-;; TODO: change order of expected/actual?
 (defn response-equal?
   "Test if the HTTP request is a success, and if the result is equal
   to the result of the form supplied to this method.  Arguments:
@@ -180,7 +179,7 @@
                         (json/parse-string true)
                         (body-munge-fn)
                         (set)))]
-       (is (= expected actual)
+       (is (= actual expected)
            (str response)))))
 
 (defmacro =-after?


### PR DESCRIPTION
This fixes a couple issues with the legacy query engine, which is used when
the distinct_resources parameter is passed as true:
* regex queries were broken due to use of honeysql instead of strings
* subqueries were broken because of an ambiguous column alias

I've expanded the distinct_resources testing in http/event-counts-test to cover
the fixed behavior.