### PR TITLE
(PDB-1647) Bump snapshot version to 3.1.0-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def pdb-version "3.0.0-SNAPSHOT")
+(def pdb-version "3.1.0-SNAPSHOT")
 (def pe-pdb-version "0.1.0-SNAPSHOT")
 
 (defn deploy-info


### PR DESCRIPTION
Now we have a branch for 3.0.0, this branch can now designate a 3.1.0 build
formally.

Signed-off-by: Ken Barber <ken@bob.sh>