### PR TITLE
(PDB-1590) Support two previous versions of all commands (for upgrades)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -76,7 +76,8 @@
                  [fast-zip-visit "1.0.2"]
                  [robert/hooke "1.3.0"]
                  [honeysql "0.5.2"]
-                 [org.clojure/data.xml "0.0.8"]]
+                 [org.clojure/data.xml "0.0.8"]
+                 [com.rpl/specter "0.5.2"]]
 
   :jvm-opts ["-XX:MaxPermSize=128M"]
 

--- a/src/puppetlabs/puppetdb/catalog/utils.clj
+++ b/src/puppetlabs/puppetdb/catalog/utils.clj
@@ -6,7 +6,8 @@
   (:require [puppetlabs.puppetdb.catalogs :as cat]
             [clojure.walk :as walk]
             [puppetlabs.puppetdb.random :refer [random-resource random-kw-resource
-                                                random-parameters]]))
+                                                random-parameters]]
+            [clj-time.core :refer [now]]))
 
 (defn convert-to-wire
   "Converts a catalog in the internal format to the wire format"
@@ -24,7 +25,7 @@
   (fn [wire-catalog]
     (-> wire-catalog
         walk/keywordize-keys
-        (cat/parse-catalog 6)
+        (cat/parse-catalog 6 (now))
         f
         convert-to-wire)))
 

--- a/src/puppetlabs/puppetdb/facts.clj
+++ b/src/puppetlabs/puppetdb/facts.clj
@@ -244,3 +244,18 @@
            factpath-regexp-elements-to-regexp
            factpath-to-string)
        "$"))
+
+(defn v3-wire->v4-wire
+  "Takes a v3 formatted replace facts command and upgrades it to a v4 facts command"
+  [command]
+  (-> command
+      (assoc :version 4)
+      (update :payload #(set/rename-keys % {:producer-timestamp :producer_timestamp
+                                            :name :certname}))))
+
+(defn v2-wire->v4-wire
+  "Takes a v2 formatted replace facts command and upgrades it to a v4 facts command"
+  [command received-time]
+  (-> command
+      (assoc-in [:payload :producer-timestamp] received-time)
+      v3-wire->v4-wire))

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -33,30 +33,6 @@
    #(and (map? %)
          (valid-jdbc-query? (:results-query %)))))
 
-;; ## String operations
-
-(defn dashes->underscores
-  "Accepts a string or a keyword as an argument, replaces all occurrences of the
-  dash/hyphen character with an underscore, and returns the same type (string
-  or keyword) that was passed in.  This is useful for translating data structures
-  from their wire format to the format that is needed for JDBC."
-  [str]
-  (let [result (string/replace (name str) \- \_)]
-    (if (keyword? str)
-      (keyword result)
-      result)))
-
-(defn underscores->dashes
-  "Accepts a string or a keyword as an argument, replaces all occurrences of the
-  underscore character with a dash, and returns the same type (string
-  or keyword) that was passed in.  This is useful for translating data structures
-  from their JDBC-compatible representation to their wire format representation."
-  [str]
-  (let [result (string/replace (name str) \_ \-)]
-    (if (keyword? str)
-      (keyword result)
-      result)))
-
 (defn convert-result-arrays
   "Converts Java and JDBC arrays in a result set using the provided function
   (eg. vec, set). Values which aren't arrays are unchanged."

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -62,7 +62,6 @@
    applying ordering constraints."
   (:require [clojure.string :as str]
             [puppetlabs.kitchensink.core :as kitchensink]
-            [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.puppetdb.time :refer [to-timestamp]]
             [puppetlabs.kitchensink.core :refer [parse-number keyset valset order-by-expr?]]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils
@@ -70,7 +69,8 @@
             [puppetlabs.puppetdb.jdbc
              :refer [valid-jdbc-query? limited-query-to-vec query-to-vec paged-sql count-sql get-result-count]]
             [puppetlabs.puppetdb.query.paging :refer [requires-paging?]]
-            [clojure.core.match :refer [match]]))
+            [clojure.core.match :refer [match]]
+            [puppetlabs.puppetdb.utils :as utils]))
 
 (defn execute-paged-query*
   "Helper function to executed paged queries.  Builds up the paged sql string,
@@ -558,7 +558,7 @@
             (string? (:where %))]}
     (when-not (= (count args) 2)
       (throw (IllegalArgumentException. (format "= requires exactly two arguments, but %d were supplied" (count args)))))
-    (let [path (jdbc/dashes->underscores path)]
+    (let [path (utils/dashes->underscores path)]
       (match [path]
              ["certname"]
              {:where "reports.certname = ?"
@@ -608,7 +608,7 @@
             (string? (:where %))]}
     (when-not (= (count args) 2)
       (throw (IllegalArgumentException. (format "~ requires exactly two arguments, but %d were supplied" (count args)))))
-    (let [path (jdbc/dashes->underscores path)]
+    (let [path (utils/dashes->underscores path)]
       (match [path]
              ["certname"]
              {:where (sql-regexp-match "reports.certname")
@@ -642,7 +642,7 @@
           (string? (:where %))]}
   (when-not (= (count args) 2)
     (throw (IllegalArgumentException. (format "= requires exactly two arguments, but %d were supplied" (count args)))))
-  (let [db-field (jdbc/dashes->underscores path)]
+  (let [db-field (utils/dashes->underscores path)]
     (match [db-field]
            [(field :guard #{"successes" "failures" "noops" "skips"})]
            {:where (format "%s = ?" field)

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -959,7 +959,7 @@
             [op field (su/db-serialize value)]
 
             [["=" field nil]]
-            ["null?" (jdbc/dashes->underscores field) true]
+            ["null?" (utils/dashes->underscores field) true]
 
             [[op "tag" array-value]]
             [op "tags" (string/lower-case array-value)]
@@ -1313,7 +1313,7 @@
   [node state]
   (cm/match [node]
             [[(op :guard binary-operators) (field :guard string?) value]]
-            {:node (with-meta [op (jdbc/dashes->underscores field) value]
+            {:node (with-meta [op (utils/dashes->underscores field) value]
                      (meta node))
              :state state}
             :else {:node node :state state}))

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -41,7 +41,7 @@
             [metrics.gauges :refer [gauge]]
             [metrics.histograms :refer [histogram update!]]
             [metrics.timers :refer [timer time!]]
-            [puppetlabs.puppetdb.jdbc :refer [query-to-vec dashes->underscores]]
+            [puppetlabs.puppetdb.jdbc :refer [query-to-vec]]
             [puppetlabs.puppetdb.time :refer [to-timestamp]]
             [honeysql.core :as hcore]))
 

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -11,7 +11,8 @@
             [clojure.java.io :as io]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [clojure.walk :as walk]
-            [slingshot.slingshot :refer [try+]])
+            [slingshot.slingshot :refer [try+]]
+            [com.rpl.specter :as sp])
   (:import [java.net MalformedURLException URISyntaxException URL]
            [org.postgresql.util PGobject]))
 
@@ -290,3 +291,19 @@
     (if (keyword? str)
       (keyword result)
       result)))
+
+(defn dash->underscore-keys
+  "Converts all top-level keys (including nested maps) in `m` to use dashes
+  instead of underscores as word separatators"
+  [m]
+  (sp/update [sp/ALL]
+             #(update % 0 dashes->underscores)
+             m))
+
+(defn underscore->dash-keys
+  "Converts all top-level keys (including nested maps) in `m` to use underscores
+  instead of underscores as word separatators"
+  [m]
+  (sp/update [sp/ALL]
+             #(update % 0 underscores->dashes)
+             m))

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -268,3 +268,25 @@
     (:datasource db-spec)
     (re-matches #"jdbc:hsqldb.*"
                 (.getJdbcUrl (:datasource db-spec)))))
+
+(defn dashes->underscores
+  "Accepts a string or a keyword as an argument, replaces all occurrences of the
+  dash/hyphen character with an underscore, and returns the same type (string
+  or keyword) that was passed in.  This is useful for translating data structures
+  from their wire format to the format that is needed for JDBC."
+  [str]
+  (let [result (string/replace (name str) \- \_)]
+    (if (keyword? str)
+      (keyword result)
+      result)))
+
+(defn underscores->dashes
+  "Accepts a string or a keyword as an argument, replaces all occurrences of the
+  underscore character with a dash, and returns the same type (string
+  or keyword) that was passed in.  This is useful for translating data structures
+  from their JDBC-compatible representation to their wire format representation."
+  [str]
+  (let [result (string/replace (name str) \_ \-)]
+    (if (keyword? str)
+      (keyword result)
+      result)))

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -16,12 +16,14 @@
             [puppetlabs.puppetdb.examples :refer :all]
             [puppetlabs.puppetdb.testutils.reports :refer [munge-example-report-for-storage]]
             [puppetlabs.puppetdb.command.constants :refer [command-names]]
-            [clj-time.coerce :refer [to-timestamp]]
+            [clj-time.coerce :refer [to-timestamp to-date-time to-string]]
             [clj-time.core :as t :refer [days ago now]]
             [clojure.test :refer :all]
             [clojure.tools.logging :refer [*logger-factory*]]
             [slingshot.slingshot :refer [throw+]]
-            [puppetlabs.puppetdb.mq-listener :as mql]))
+            [puppetlabs.puppetdb.mq-listener :as mql]
+            [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.time :as pt]))
 
 (use-fixtures :each with-test-db)
 
@@ -213,7 +215,7 @@
   [row-map]
   (assoc row-map :environment_id (scf-store/environment-id "DEV")))
 
-(defn version-num
+(defn version-kwd->num
   "Converts a version keyword into a correct number (expected by the command).
    i.e. :v4 -> 4"
   [version-kwd]
@@ -241,7 +243,7 @@
     (testing (str (command-names :replace-catalog) " " version)
       (let [certname (get-in command [:payload :certname])
             catalog-hash (shash/catalog-similarity-hash
-                          (catalog/parse-catalog (:payload command) (version-num version)))
+                          (catalog/parse-catalog (:payload command) (version-kwd->num version) (now)))
             command (stringify-payload command)
             one-day      (* 24 60 60 1000)
             yesterday    (to-timestamp (- (System/currentTimeMillis) one-day))
@@ -347,6 +349,55 @@
                                          (sutils/sql-hash-as-str "hash")))))
             (is (= 0 (times-called publish)))
             (is (empty? (fs/list-dir discard-dir)))))))))
+
+;; If there are messages in the user's MQ when they upgrade, we could
+;; potentially have commands of an unsupported format that need to be
+;; processed. Although we don't support the catalog versions below, we
+;; need to test that those commands will be processed properly
+(deftest replace-catalog-with-v5
+  (testing "catalog wireformat v5"
+    (let [command {:command (command-names :replace-catalog)
+                   :version 5
+                   :payload (get-in wire-catalogs [5 :empty])}
+          certname (get-in command [:payload :name])
+          cmd-producer-timestamp (get-in command [:payload :producer-timestamp])
+          current-time (now)]
+      (with-fixtures
+        (test-msg-handler command publish discard-dir
+
+          ;;names in v5 are hyphenated, this check ensures we're sending a v5 catalog
+          (is (contains? (:payload command) :producer-timestamp))
+          (is (= [(with-env {:certname certname})]
+                 (query-to-vec "SELECT certname, environment_id FROM catalogs")))
+          (is (= 0 (times-called publish)))
+          (is (empty? (fs/list-dir discard-dir)))
+
+          ;;this should be the hyphenated producer timestamp provided above
+          (is (= (-> (query-to-vec "SELECT producer_timestamp FROM catalogs")
+                     first
+                     :producer_timestamp)
+                 (to-timestamp cmd-producer-timestamp))))))))
+
+(deftest replace-catalog-with-v4
+  (let [command {:command (command-names :replace-catalog)
+                 :version 4
+                 :payload (get-in wire-catalogs [4 :empty])}
+        certname (get-in command [:payload :name])
+        cmd-producer-timestamp (get-in command [:payload :producer-timestamp])
+        current-time (now)]
+    (with-fixtures
+      (test-msg-handler command publish discard-dir
+        (is (false? (contains? (:payload command) :producer-timestamp)))
+        (is (= [(with-env {:certname certname})]
+               (query-to-vec "SELECT certname, environment_id FROM catalogs")))
+        (is (= 0 (times-called publish)))
+        (is (empty? (fs/list-dir discard-dir)))
+        ;;v4 does not include a producer_timestmap, the backend
+        ;;should use the time the command was received instead
+        (is (t/before? current-time (-> (query-to-vec "SELECT producer_timestamp FROM catalogs")
+                                        first
+                                        :producer_timestamp
+                                        to-date-time)))))))
 
 (defn update-resource
   "Updated the resource in `catalog` with the given `type` and `title`.
@@ -644,6 +695,91 @@
           (is (= 0 (times-called publish)))
           (is (empty? (fs/list-dir discard-dir))))))))
 
+;;v2 and v3 fact commands are only supported when commands are still
+;;sitting in the queue from before upgrading
+(deftest replace-facts-with-v3-wire-format
+  (let [certname  "foo.example.com"
+        producer-time (-> (now)
+                          to-timestamp
+                          json/generate-string
+                          json/parse-string
+                          pt/to-timestamp)
+        facts-cmd {:command (command-names :replace-facts)
+                   :version 3
+                   :payload {:name certname
+                             :environment "DEV"
+                             :producer-timestamp producer-time
+                             :values {"a" "1"
+                                      "b" "2"
+                                      "c" "3"}}}]
+    (test-msg-handler facts-cmd publish discard-dir
+      (is (= (query-to-vec
+              "SELECT fp.path as name,
+                          COALESCE(fv.value_string,
+                                   cast(fv.value_integer as text),
+                                   cast(fv.value_boolean as text),
+                                   cast(fv.value_float as text),
+                                   '') as value,
+                          fs.certname,
+                          e.name as environment,
+                          fs.producer_timestamp
+                   FROM factsets fs
+                     INNER JOIN facts as f on fs.id = f.factset_id
+                     INNER JOIN fact_values as fv on f.fact_value_id = fv.id
+                     INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
+                     INNER JOIN environments as e on fs.environment_id = e.id
+                   WHERE fp.depth = 0
+                   ORDER BY name ASC")
+             [{:certname certname :name "a" :value "1" :producer_timestamp producer-time :environment "DEV"}
+              {:certname certname :name "b" :value "2" :producer_timestamp producer-time :environment "DEV"}
+              {:certname certname :name "c" :value "3" :producer_timestamp producer-time :environment "DEV"}]))
+      (is (= 0 (times-called publish)))
+      (is (empty? (fs/list-dir discard-dir)))
+      (let [result (query-to-vec "SELECT certname,environment_id FROM factsets")]
+        (is (= result [(with-env {:certname certname})]))))))
+
+(deftest replace-facts-with-v2-wire-format
+  (let [certname  "foo.example.com"
+        before-test-starts-time (now)
+        facts-cmd {:command (command-names :replace-facts)
+                   :version 2
+                   :payload {:name certname
+                             :environment "DEV"
+                             :values {"a" "1"
+                                      "b" "2"
+                                      "c" "3"}}}]
+    (test-msg-handler facts-cmd publish discard-dir
+      (is (= (query-to-vec
+              "SELECT fp.path as name,
+                          COALESCE(fv.value_string,
+                                   cast(fv.value_integer as text),
+                                   cast(fv.value_boolean as text),
+                                   cast(fv.value_float as text),
+                                   '') as value,
+                          fs.certname,
+                          e.name as environment
+                   FROM factsets fs
+                     INNER JOIN facts as f on fs.id = f.factset_id
+                     INNER JOIN fact_values as fv on f.fact_value_id = fv.id
+                     INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
+                     INNER JOIN environments as e on fs.environment_id = e.id
+                   WHERE fp.depth = 0
+                   ORDER BY name ASC")
+             [{:certname certname :name "a" :value "1" :environment "DEV"}
+              {:certname certname :name "b" :value "2" :environment "DEV"}
+              {:certname certname :name "c" :value "3" :environment "DEV"}]))
+
+      (is (= (every? (comp #(t/before? before-test-starts-time %)
+                           to-date-time
+                           :producer_timestamp)
+                     (query-to-vec
+                      "SELECT fs.producer_timestamp
+                         FROM factsets fs"))))
+      (is (= 0 (times-called publish)))
+      (is (empty? (fs/list-dir discard-dir)))
+      (let [result (query-to-vec "SELECT certname,environment_id FROM factsets")]
+        (is (= result [(with-env {:certname certname})]))))))
+
 (deftest replace-facts-bad-payload
   (let [bad-command {:command (command-names :replace-facts)
                      :version 4
@@ -882,7 +1018,7 @@
   (testing "Should allow only one replace catalogs update for a given cert at a time"
     (let [test-catalog (get-in catalogs [:empty])
           {certname :certname :as wire-catalog} (get-in wire-catalogs [6 :empty])
-          nonwire-catalog (catalog/parse-catalog wire-catalog 6)
+          nonwire-catalog (catalog/parse-catalog wire-catalog 6 (now))
           command {:command (command-names :replace-catalog)
                    :version 6
                    :payload (json/generate-string wire-catalog)}
@@ -927,7 +1063,7 @@
   (testing "Should allow only one replace catalogs update for a given cert at a time"
     (let [test-catalog (get-in catalogs [:empty])
           {certname :certname :as wire-catalog} (get-in wire-catalogs [6 :empty])
-          nonwire-catalog (catalog/parse-catalog wire-catalog 6)
+          nonwire-catalog (catalog/parse-catalog wire-catalog 6 (now))
           command {:command (command-names :replace-catalog)
                    :version 6
                    :payload (json/generate-string wire-catalog)}
@@ -984,7 +1120,15 @@
               :command {:command (command-names :deactivate-node)
                         :version 3
                         :payload {:certname "bar.example.com"
-                                  :producer_timestamp (now)}}}]]
+                                  :producer_timestamp (now)}}}
+             {:certname "bar.example.com"
+              :command {:command (command-names :deactivate-node)
+                        :version 2
+                        :payload "bar.example.com"}}
+             {:certname "bar.example.com"
+              :command {:command (command-names :deactivate-node)
+                        :version 1
+                        :payload (json/generate-string "bar.example.com")}}]]
 
   (deftest deactivate-node-node-active
     (testing "should deactivate the node"
@@ -1049,6 +1193,57 @@
                  [(with-env {:certname (:certname report) :configuration_version (:configuration_version report)})]))
           (is (= 0 (times-called publish)))
           (is (empty? (fs/list-dir discard-dir))))))))
+
+(let [old-report (-> (:basic report-examples/reports)
+                     (assoc :environment "DEV")
+                     munge-example-report-for-storage
+                     (dissoc :producer_timestamp :metrics :logs :noop)
+                     utils/underscore->dash-keys)
+      current-time (now)]
+  (deftest store-v4-report
+    (let [command {:command (command-names :store-report)
+                   :version 4
+                   :payload old-report}]
+      (test-msg-handler command publish discard-dir
+        (is (= (query-to-vec "SELECT certname,configuration_version,environment_id FROM reports")
+               [(with-env {:certname (:certname old-report)
+                           :configuration_version (:configuration-version old-report)})]))
+
+        ;;Status is present in v4+ (but not in v3)
+        (is (= "unchanged" (-> (query-to-vec "SELECT rs.status FROM reports r inner join report_statuses rs on r.status_id = rs.id")
+                               first
+                               :status)))
+
+        ;;No producer_timestamp is included in v4, message received time (now) is used intead
+        (is (t/before? current-time (-> (query-to-vec "SELECT producer_timestamp FROM reports")
+                                        first
+                                        :producer_timestamp
+                                        to-date-time)))
+        (is (= 0 (times-called publish)))
+        (is (empty? (fs/list-dir discard-dir))))))
+
+  (deftest store-v3-report
+    (let [current-time (now)
+          command {:command (command-names :store-report)
+                   :version 3
+                   :payload (dissoc old-report :status)}]
+      (test-msg-handler command publish discard-dir
+        (is (= (query-to-vec "SELECT certname,configuration_version,environment_id FROM reports")
+               [(with-env {:certname (:certname old-report)
+                           :configuration_version (:configuration-version old-report)})]))
+
+        ;;No producer_timestamp is included in v4, message received time (now) is used intead
+        (is (t/before? current-time (-> (query-to-vec "SELECT producer_timestamp FROM reports")
+                                        first
+                                        :producer_timestamp
+                                        to-date-time)))
+
+        ;;Status is not supported in v3, should be nil
+        (is (nil? (-> (query-to-vec "SELECT status_id FROM reports")
+                      first
+                      :status)))
+        (is (= 0 (times-called publish)))
+        (is (empty? (fs/list-dir discard-dir)))))))
 
 ;; Local Variables:
 ;; mode: clojure

--- a/test/puppetlabs/puppetdb/examples.clj
+++ b/test/puppetlabs/puppetdb/examples.clj
@@ -1,4 +1,5 @@
-(ns puppetlabs.puppetdb.examples)
+(ns puppetlabs.puppetdb.examples
+  (:require [puppetlabs.puppetdb.utils :as utils]))
 
 (def catalogs
   {:empty
@@ -130,7 +131,16 @@
 
 (def wire-catalogs
   "Catalogs keyed by version."
-  {6 {:empty v6-empty-wire-catalog
+  {4 {:empty (-> v6-empty-wire-catalog
+                 (dissoc :producer_timestamp)
+                 (assoc :name (:certname v6-empty-wire-catalog))
+                 (dissoc :certname)
+                 utils/underscore->dash-keys)}
+   5 {:empty (-> v6-empty-wire-catalog
+                 (assoc :name (:certname v6-empty-wire-catalog))
+                 (dissoc :certname)
+                 utils/underscore->dash-keys)}
+   6 {:empty v6-empty-wire-catalog
       :basic
       (-> v6-empty-wire-catalog
           (assoc :certname "basic.wire-catalogs.com")


### PR DESCRIPTION
Note these previous versions are not supported at the API level. The
intent here is if the user has upgraded from PuppetDB 2.0.0 to 3.0.0 and
there are still persisted messages in the queue (POSTed, but not
processed) those messages should be consumable by PuppetDB 3.0.0.

This commit takes a previous version of the command and upgrades it,
filling in anything missing, changing the names of keys as necessary to
conform it to the current (supported) command version.