### PR TITLE
(PDB-1652) support include_total with distinct events

### DIFF
--- a/src/puppetlabs/puppetdb/query/events.clj
+++ b/src/puppetlabs/puppetdb/query/events.clj
@@ -127,7 +127,8 @@
                        (not will-union?) with-latest-events)
         result {:results-query (apply vector paged-select params)}]
     (if (:count? paging-options)
-      (assoc result :count-query (apply vector (jdbc/count-sql sql) params))
+      (let [count-sql (jdbc/count-sql (with-latest-events sql))]
+        (assoc result :count-query (apply vector count-sql params)))
       result)))
 
 (defn query->sql

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -255,6 +255,15 @@
         (assert-success! response)
         (response-equal? response expected munge-event-values)))
 
+    (testing "distinct params should work with include_total"
+      (let [expected  (http-expected-resource-events version basic3-events basic3)
+            response  (get-response endpoint ["=" "certname" "foo.local"] {:distinct_resources true
+                                                                           :distinct_start_time 0
+                                                                           :include_total true
+                                                                           :distinct_end_time (now)})]
+        (assert-success! response)
+        (response-equal? response expected munge-event-values)))
+
     (testing "events should be contained within distinct resource timestamps"
       (let [expected  (http-expected-resource-events version basic-events basic)
             response  (get-response endpoint ["=" "certname" "foo.local"]


### PR DESCRIPTION
This fixes a regression from the aggregate-event-counts optimization patch.
The issue was that the CTE added there for queries with distinct_resources=true
was not being applied to the SQL on which the include_total query was based,
in the case when the include_total param was passed.

include_total has never been supported for event-counts or aggregate-event-counts,
so events is the only thing this will affect and there's no concern about missing
the other endpoints.