### PR TITLE
(PDB-1629) Modify test to use the v4 api

### DIFF
--- a/acceptance/tests/catalog/replace_catalog_debugging.rb
+++ b/acceptance/tests/catalog/replace_catalog_debugging.rb
@@ -112,7 +112,7 @@ MANIFEST
     sleep_until_queue_empty database
 
     result = on database,
-      %Q|curl -G http://localhost:8080/v3/events -d 'query=["=","resource-title","foo"]'|
+      %Q|curl -G http://localhost:8080/pdb/v4/query/events -d 'query=["=","resource_title","foo"]'|
     events = JSON.parse(result.stdout)
     assert_equal(agents.count, events.count)
   end


### PR DESCRIPTION
This test was using /v3/events which is now retired, modified to use v4 instead.

Signed-off-by: Ken Barber <ken@bob.sh>