### PR TITLE
(PDB-1610) deprecate postgres < 9.4

### DIFF
--- a/src/com/puppetlabs/puppetdb/cli/services.clj
+++ b/src/com/puppetlabs/puppetdb/cli/services.clj
@@ -260,6 +260,7 @@
   (let [{:keys [jetty database read-database global command-processing puppetdb]
          :as config}                            (conf/process-config! config)
         product-name                               (:product-name global)
+        enterprise?                                (= "pe-puppetdb" product-name)
         update-server                              (:update-server global)
         url-prefix                                 (:url-prefix global)
         write-db                                   (pl-jdbc/pooled-datasource database)
@@ -288,9 +289,10 @@
     ;; confused if the database doesn't exist but we open and close a
     ;; connection without creating anything.
     (sql/with-connection write-db
-                         (scf-store/validate-database-version #(System/exit 1))
+                         (scf-store/validate-database-version
+                           enterprise? #(System/exit 1))
                          (migrate!)
-                         (indexes! (:product-name globals)))
+                         (indexes! product-name))
 
     ;; Initialize database-dependent metrics and dlo metrics if existent.
     (pop/initialize-metrics write-db)

--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -1126,11 +1126,13 @@
 (defn db-deprecated?
   "Returns a string with an deprecation message if the DB is deprecated,
    nil otherwise."
-  []
+  [enterprise?]
   (when (and (sutils/postgres?)
              (sutils/db-version-newer-than? [8 3])
-             (sutils/db-version-older-than? [9 2]))
-    "PostgreSQL DB versions 8.4 - 9.1 are deprecated and won't be supported in the future."))
+             (sutils/db-version-older-than? [9 4])
+             (not (and enterprise?
+                       (sutils/db-version? [9 2]))))
+    "PostgreSQL DB versions 8.4 - 9.3 are deprecated and won't be supported in the future."))
 
 (defn db-unsupported?
   "Returns a string with an unsupported message if the DB is not supported,
@@ -1220,8 +1222,8 @@
 
 (defn warn-on-db-deprecation
   "Log a warning message if the database is deprecated"
-  []
-  (when-let [deprecated-message (db-deprecated?)]
+  [enterprise?]
+  (when-let [deprecated-message (db-deprecated? enterprise?)]
     (log/warn deprecated-message)))
 
 (defn fail-on-unsupported
@@ -1238,9 +1240,9 @@
 (defn validate-database-version
   "Checks to ensure that the database is supported, fails if supported, logs
    if deprecated"
-  [action-for-unsupported-fn]
+  [enterprise? action-for-unsupported-fn]
   (fail-on-unsupported action-for-unsupported-fn)
-  (warn-on-db-deprecation))
+  (warn-on-db-deprecation enterprise?))
 
 (def ^:dynamic *orphaned-path-gc-limit* 200)
 (def ^:dynamic *orphaned-value-gc-limit* 200)


### PR DESCRIPTION
This patch implements the following policy around deprecation messages

FOSS: messages thrown < 9.4
PE: messages thrown < 9.4 *except* 9.2