### PR TITLE
(PDB-1631) Create the `/pdb/admin` API with import/export endpoints

### DIFF
--- a/documentation/_puppetdb_nav.html
+++ b/documentation/_puppetdb_nav.html
@@ -76,15 +76,20 @@
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/aggregate-event-counts.html">Aggregate Event Counts Endpoint</a></li>
     </ul>
   </li>
-  <li><strong>Metadata API Version 1</strong>
+  <li><strong>Admin API Version 1</strong>
     <ul>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/meta/v1/version.html">Version Endpoint</a></li>
-      <li><a href="/puppetdb/{{ puppetdb_version }}/api/meta/v1/server-time.html">Server Time Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/admin/v1/archive.html">Archive Endpoint</a></li>
     </ul>
   </li>
   <li><strong>Command API Version 1</strong>
     <ul>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/command/v1/commands.html">Commands Endpoint</a></li>
+    </ul>
+  </li>
+  <li><strong>Metadata API Version 1</strong>
+    <ul>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/meta/v1/version.html">Version Endpoint</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/meta/v1/server-time.html">Server Time Endpoint</a></li>
     </ul>
   </li>
   <li><strong>Metrics API Version 1</strong>

--- a/documentation/api/admin/v1/archive.markdown
+++ b/documentation/api/admin/v1/archive.markdown
@@ -1,0 +1,60 @@
+---
+title: "PuppetDB 3.0 » Admin API » v1 » Importing and Exporting PuppetDB Archives"
+layout: default
+canonical: "/puppetdb/latest/api/admin/v1/archive.html"
+---
+
+[curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
+
+The `/archive` endpoint can be used for importing and exporting PuppetDB archives.
+
+## `POST /pdb/admin/v1/archive`
+
+This endpoint can be used for streaming a PuppetDB archive into PuppetDB.
+
+### Request Format
+
+The request should be a multipart POST and have `Content-Type: multipart/mixed`.
+
+### URL Parameters
+
+* `archive`: Required. The archive file to import to the PuppetDB.
+* `command_versions`: Required. A JSON object mapping PuppetDB command-names to their version. The mapping for a given PuppetDB archive can be found in the archive:
+~~~shell
+        tar -xOf <my-pdb-archive>.tar.gz puppetdb-bak/export-metadata.json
+~~~
+
+### Response Format
+
+The response will be in `application/json`, and will return a JSON map
+
+    {"ok": true}
+
+upon successful completion of the importation.
+
+### Examples
+[Using `curl` from localhost][curl]:
+
+        curl -X POST http://localhost:8080/pdb/admin/v1/archive \
+        -F 'command_versions={"replace_facts":4,"store_report":5,"replace_catalog":6}'\
+        -F "archive=@example_backup_archive.tgz"
+
+    {"ok": true}
+
+## `GET /pdb/admin/v1/archive`
+
+This endpoint can be used to stream a tarred, gzipped backup archive of PuppetDB to your local machine.
+
+### URL Parameters
+
+This endpoint takes no URL parameters.
+
+### Response Format
+
+The response will be a `application/octet-stream`, and will return a `tar.gz` archive.
+
+### Examples
+
+[Using `curl` from localhost][curl]:
+
+    curl -X GET http://localhost:8080/pdb/admin/v1/archive -o puppetdb-export.tgz

--- a/resources/puppetlabs/puppetdb/bootstrap.cfg
+++ b/resources/puppetlabs/puppetdb/bootstrap.cfg
@@ -14,6 +14,7 @@ puppetlabs.puppetdb.cli.services/puppetdb-service
 puppetlabs.puppetdb.http.command/puppetdb-command-service
 puppetlabs.puppetdb.metrics/metrics-service
 puppetlabs.puppetdb.dashboard/dashboard-service
+puppetlabs.puppetdb.admin/admin-service
 puppetlabs.puppetdb.mq-listener/message-listener-service
 puppetlabs.puppetdb.command/command-service
 puppetlabs.puppetdb.meta/metadata-service

--- a/src/puppetlabs/puppetdb/admin.clj
+++ b/src/puppetlabs/puppetdb/admin.clj
@@ -1,0 +1,58 @@
+(ns puppetlabs.puppetdb.admin
+  (:require [clojure.java.io :as io]
+            [clojure.tools.logging :as log]
+            [compojure.core :as compojure]
+            [compojure.route :as route]
+            [puppetlabs.kitchensink.core :as kitchensink]
+            [puppetlabs.puppetdb.archive :as archive]
+            [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.cli.export :as export]
+            [puppetlabs.puppetdb.cli.import :as import]
+            [puppetlabs.puppetdb.http :as http]
+            [puppetlabs.puppetdb.middleware :as mid]
+            [puppetlabs.trapperkeeper.core :as trapperkeeper]
+            [ring.middleware.multipart-params :as mp]
+            [clj-time.core :refer [now]]
+            [ring.util.io :as rio]))
+
+(def query-api-version :v4)
+
+(defn munge-nodes-data
+  [nodes]
+  (as-> nodes $
+    (select-keys $ [:certname :facts_timestamp :catalog_timestamp :report_timestamp])
+    (kitchensink/mapvals str $)))
+
+(defn export-app
+  [buffer query-fn]
+  (export/export! buffer
+                  (->> (query-fn :nodes query-api-version nil nil doall)
+                       (map munge-nodes-data)
+                       (mapcat (partial export/get-node-data query-fn)))))
+
+(defn build-app
+  [submit-command-fn query-fn {:keys [authorizer]}]
+  (-> (compojure/routes
+       (mp/wrap-multipart-params
+        (compojure/POST "/v1/archive" request
+                        (let [{{:strs [archive command_versions]} :multipart-params} request]
+                          (import/import! (:tempfile archive)
+                                          (json/parse-string command_versions true)
+                                          submit-command-fn)
+                            (http/json-response {:ok true}))))
+       (compojure/GET "/v1/archive" []
+                      (http/streamed-tar-response #(export-app % query-fn)
+                                                  (format "puppetdb-export-%s.tgz" (now))))
+       (route/not-found "Not Found"))
+      (mid/wrap-with-puppetdb-middleware authorizer)))
+
+(trapperkeeper/defservice admin-service
+  [[:PuppetDBServer shared-globals query]
+   [:PuppetDBCommand submit-command]
+   [:WebroutingService add-ring-handler get-route]]
+
+  (start [this context]
+         (->> (build-app submit-command query (shared-globals))
+              (compojure/context (get-route this) [])
+              (add-ring-handler this))
+         context))

--- a/src/puppetlabs/puppetdb/cli/import.clj
+++ b/src/puppetlabs/puppetdb/cli/import.clj
@@ -7,6 +7,8 @@
             [org.apache.commons.compress.archivers.tar TarArchiveEntry])
   (:require [me.raynes.fs :as fs]
             [puppetlabs.puppetdb.client :as client]
+            [clj-http.client :as http-client]
+            [clojure.tools.logging :as log]
             [puppetlabs.puppetdb.archive :as archive]
             [puppetlabs.puppetdb.cheshire :as json]
             [clojure.java.io :as io]
@@ -15,14 +17,15 @@
             [puppetlabs.puppetdb.utils :as utils
              :refer [base-url-schema export-root-dir]]
             [puppetlabs.kitchensink.core :as kitchensink]
-            [puppetlabs.puppetdb.cli.export :refer [export-metadata-file-name]]
+            [puppetlabs.puppetdb.cli.export :as export]
+            [clj-time.core :refer [now]]
             [schema.core :as s]
             [slingshot.slingshot :refer [try+ throw+]]))
 
 (def cli-description "Import PuppetDB catalog data from a backup file")
 
 (def metadata-path
-  (.getPath (io/file export-root-dir export-metadata-file-name)))
+  (.getPath (io/file export-root-dir export/export-metadata-file-name)))
 
 (defn parse-metadata
   "Parses the export metadata file to determine, e.g., what versions of the
@@ -47,32 +50,34 @@
 (defn-validated process-tar-entry
   "Determine the type of an entry from the exported archive, and process it
   accordingly."
-  [^TarGzReader tar-reader :- TarGzReader
-   ^TarArchiveEntry tar-entry :- TarArchiveEntry
-   dest :- base-url-schema
-   command-versions :- {s/Any s/Any}]
+  [command-fn
+   tar-reader :- TarGzReader
+   tar-entry :- TarArchiveEntry
+   command-versions]
   (let [path (.getName tar-entry)]
     (condp re-find path
       (file-pattern "catalogs")
-      (do (println (format "Importing catalog from archive entry '%s'" path))
+      (do (log/infof "Importing catalog from archive entry '%s'" path)
           ;; NOTE: these submissions are async and we have no guarantee that they
           ;;   will succeed. We might want to add something at the end of the import
           ;;   that polls puppetdb until the command queue is empty, then does a
           ;;   query to the /nodes endpoint and shows the set difference between
           ;;   the list of nodes that we submitted and the output of that query
-          (client/submit-catalog dest
-                                 (:replace_catalog command-versions)
-                                 (archive/read-entry-content tar-reader)))
+          (command-fn :replace-catalog
+                      (:replace_catalog command-versions)
+                      (json/parse-string (archive/read-entry-content tar-reader))))
       (file-pattern "reports")
-      (do (println (format "Importing report from archive entry '%s'" path))
-          (client/submit-report dest
-                                (:store_report command-versions)
-                                (archive/read-entry-content tar-reader)))
+      (do (log/infof "Importing report from archive entry '%s'" path)
+          (command-fn :store-report
+                      (:store_report command-versions)
+                      (-> (archive/read-entry-content tar-reader)
+                          (json/parse-string true)
+                          puppetlabs.puppetdb.reports/sanitize-report)))
       (file-pattern "facts")
-      (do (println (format "Importing facts from archive entry '%s'" path))
-          (client/submit-facts dest
-                               (:replace_facts command-versions)
-                               (archive/read-entry-content tar-reader)))
+      (do (log/infof "Importing facts from archive entry '%s'" path)
+          (command-fn :replace-facts
+                      (:replace_facts command-versions)
+                      (json/parse-string (archive/read-entry-content tar-reader))))
       nil)))
 
 (defn- validate-cli!
@@ -91,7 +96,7 @@
                              options)
         construct-base-url (fn [{:keys [host port] :as options}]
                              (-> options
-                                 (assoc :base-url (utils/pdb-cmd-base-url host port :v1))
+                                 (assoc :base-url (utils/pdb-admin-base-url host port export/admin-api-version))
                                  (dissoc :host :port)))]
     (utils/try+-process-cli!
      (fn []
@@ -102,11 +107,23 @@
            construct-base-url
            utils/validate-cli-base-url!)))))
 
+(defn import!
+  [infile command-versions command-fn]
+  (with-open [tar-reader (archive/tarball-reader infile)]
+    (doseq [tar-entry (archive/all-entries tar-reader)]
+      (process-tar-entry command-fn tar-reader tar-entry command-versions))))
+
 (defn -main
   [& args]
   (let [{:keys [infile base-url]} (validate-cli! args)
-        command-versions (:command_versions (parse-metadata infile))]
-    ;; TODO: do we need to deal with SSL or can we assume this only works over a plaintext port?
-    (with-open [tar-reader (archive/tarball-reader infile)]
-      (doseq [tar-entry (archive/all-entries tar-reader)]
-        (process-tar-entry tar-reader tar-entry base-url command-versions)))))
+        import-archive (fs/normalized-path infile)
+        command-versions (:command_versions (parse-metadata import-archive))]
+    (try
+      (println " Importing " infile " to PuppetDB...")
+      (http-client/post (str (utils/base-url->str base-url) "/archive")
+                        {:multipart [{:name "Content/type" :content "application/octet-stream"}
+                                     {:name "archive" :content import-archive}
+                                     {:name "command_versions" :content (json/generate-pretty-string command-versions)}]})
+      (println " Finished importing " infile " to PuppetDB.")
+      (catch Throwable e
+        (println e "Error importing " infile)))))

--- a/src/puppetlabs/puppetdb/client.clj
+++ b/src/puppetlabs/puppetdb/client.clj
@@ -30,7 +30,7 @@
      (let [message (json/generate-string command-map)
            checksum (kitchensink/utf8-string->sha1 message)
            url (str (utils/base-url->str base-url)
-                    (format "/commands?checksum=%s" checksum))]
+                    (format "?checksum=%s" checksum))]
        (http-client/post url {:body               message
                               :throw-exceptions   false
                               :content-type       :json

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -339,6 +339,7 @@
         {:puppetlabs.puppetdb.cli.services/puppetdb-service "/pdb/query"
          :puppetlabs.puppetdb.http.command/puppetdb-command-service "/pdb/cmd"
          :puppetlabs.puppetdb.meta/metadata-service "/pdb/meta"
+         :puppetlabs.puppetdb.admin/admin-service "/pdb/admin"
          :puppetlabs.puppetdb.dashboard/dashboard-service "/pdb"
          :puppetlabs.puppetdb.metrics/metrics-service "/metrics"}
         bootstrap-cfg (-> (find-bootstrap-config config-data)

--- a/src/puppetlabs/puppetdb/http.clj
+++ b/src/puppetlabs/puppetdb/http.clj
@@ -108,6 +108,28 @@
          (rr/charset "utf-8")
          (rr/status code))))
 
+(defn upload-file!
+  "Copies an octet-stream filetype upload to the local dir."
+  [dir {:keys [tempfile filename]}]
+  (let [local (io/file dir filename)]
+    (io/copy tempfile local)
+    local))
+
+(defn tar-response
+  [body filename]
+  (-> body
+      rr/response
+      (rr/header "Content-Type" "application/octet-stream")
+      (rr/header "Content-Disposition" (str "attachment; filename=" filename))
+      (rr/charset "utf-8")
+      (rr/status status-ok)))
+
+(defn streamed-tar-response
+  [producer filename]
+  (tar-response
+   (rio/piped-input-stream producer)
+   filename))
+
 (defn json-response
   "Returns a Ring response object with the supplied `body` and response `code`,
   and a JSON content type. If unspecified, `code` will default to 200."

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -221,6 +221,14 @@
    :prefix "/pdb/query"
    :version (or version :v4)})
 
+(defn pdb-admin-base-url
+  [host port & [version]]
+  {:protocol "http"
+   :host host
+   :port port
+   :prefix "/pdb/admin"
+   :version (or version :v1)})
+
 (defn pdb-cmd-base-url
   [host port & [version]]
   {:protocol "http"

--- a/test/puppetlabs/puppetdb/admin_test.clj
+++ b/test/puppetlabs/puppetdb/admin_test.clj
@@ -1,0 +1,102 @@
+(ns puppetlabs.puppetdb.admin-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.puppetdb.cli.import-export-roundtrip-test :as roundtrip]
+            [puppetlabs.puppetdb.cli.services :refer :all]
+            [puppetlabs.puppetdb.http.command :refer :all]
+            [puppetlabs.puppetdb.cli.export :as export]
+            [puppetlabs.puppetdb.cli.import :as import]
+            [puppetlabs.puppetdb.admin :as admin]
+            [puppetlabs.trapperkeeper.app :as tk-app]
+            [puppetlabs.puppetdb.testutils :as testutils]
+            [puppetlabs.puppetdb.fixtures :as fixt]
+            [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.examples :as examples]
+            [puppetlabs.puppetdb.examples.reports :as example-reports]
+            [puppetlabs.puppetdb.testutils.reports :as tur]
+            [clj-time.core :as time]
+            [clj-time.coerce :as time-coerce]
+            [puppetlabs.puppetdb.testutils.services :as svc-utils]))
+
+(use-fixtures :each fixt/with-test-logging-silenced)
+
+(deftest test-basic-roundtrip
+  (let [certname "foo.local"
+        facts {:certname certname
+               :environment "DEV"
+               :values {:foo "the foo"
+                        :bar "the bar"
+                        :baz "the baz"
+                        :biz {:a [3.14 2.71] :b "the b" :c [1 2 3] :d {:e nil}}}
+               :producer_timestamp (time-coerce/to-string (time/now))}
+        export-out-file (testutils/temp-file "export-test" ".tar.gz")
+        catalog (-> (get-in examples/wire-catalogs [6 :empty])
+                    (assoc :certname certname
+                           :producer_timestamp (time/now)))
+        report (-> (:basic example-reports/reports)
+                   (assoc :certname certname))]
+
+    (svc-utils/puppetdb-instance
+     (fn []
+       (let [query-fn (partial query (tk-app/get-service svc-utils/*server* :PuppetDBServer))
+             submit-command-fn (partial submit-command (tk-app/get-service svc-utils/*server* :PuppetDBCommand))]
+         (is (empty? (query-fn :nodes admin/query-api-version nil nil doall)))
+
+         (svc-utils/sync-command-post (roundtrip/command-base-url svc-utils/*base-url*) "replace catalog" 6 catalog)
+         (svc-utils/sync-command-post (roundtrip/command-base-url svc-utils/*base-url*) "store report" 5
+                                      (tur/munge-example-report-for-storage report))
+         (svc-utils/sync-command-post (roundtrip/command-base-url svc-utils/*base-url*) "replace facts" 4 facts)
+
+         (is (testutils/=-after? roundtrip/munge-catalog
+                                 catalog
+                                 (->> certname
+                                      (export/catalogs-for-node query-fn)
+                                      roundtrip/parse-tar-entry-contents)))
+
+         (is (testutils/=-after? roundtrip/munge-report
+                                 report
+                                 (->> certname
+                                      (export/reports-for-node query-fn)
+                                      roundtrip/parse-tar-entry-contents)))
+         (is (= facts (->> certname
+                           (export/facts-for-node query-fn)
+                           roundtrip/parse-tar-entry-contents)))
+
+         (admin/export-app export-out-file query-fn))))
+
+    (svc-utils/puppetdb-instance
+     (fn []
+       (let [query-fn (partial query (tk-app/get-service svc-utils/*server* :PuppetDBServer))
+             submit-command-fn (partial submit-command (tk-app/get-service svc-utils/*server* :PuppetDBCommand))]
+         (is (empty? (query-fn :nodes admin/query-api-version nil nil doall)))
+
+         (svc-utils/until-consumed
+          3
+          (fn []
+            (let [command-versions (:command_versions (import/parse-metadata export-out-file))]
+              (import/import! export-out-file command-versions submit-command-fn))))
+
+         ;; For some reason, although the fact's/report's message has
+         ;; been consumed and committed, it's not immediately available
+         ;; for querying. Maybe this is a race condition in our tests?
+         ;; The next two lines ensure that the message is not only
+         ;; consumed but present in the DB before proceeding
+         @(roundtrip/block-until-results 100 (export/catalogs-for-node query-fn certname))
+         @(roundtrip/block-until-results 100 (export/facts-for-node query-fn certname))
+         @(roundtrip/block-until-results 100 (export/reports-for-node query-fn certname))
+
+         (is (testutils/=-after? roundtrip/munge-catalog
+                                 catalog
+                                 (->> certname
+                                      (export/catalogs-for-node query-fn)
+                                      roundtrip/parse-tar-entry-contents)))
+
+
+         (is (= facts (->> certname
+                           (export/facts-for-node query-fn)
+                           roundtrip/parse-tar-entry-contents)))
+
+         (is (testutils/=-after? roundtrip/munge-report
+                                 report
+                                 (->> certname
+                                      (export/reports-for-node query-fn)
+                                      roundtrip/parse-tar-entry-contents))))))))

--- a/test/puppetlabs/puppetdb/cli/export_test.clj
+++ b/test/puppetlabs/puppetdb/cli/export_test.clj
@@ -1,15 +1,15 @@
 (ns puppetlabs.puppetdb.cli.export-test
   (:require [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.cli.export :as export]
+            [clj-time.core :refer [now]]
             [clojure.test :refer :all]))
 
 (deftest export
   (testing "Export metadata"
-    (let [{:keys [msg file-suffix contents]} (export/export-metadata)
+    (let [{:keys [msg file-suffix contents]} (export/export-metadata (now))
           metadata (json/parse-string contents true)]
       (is (= {:replace_catalog 6
               :store_report 5
               :replace_facts 4}
              (:command_versions metadata)))
-      (is (= ["export-metadata.json"] file-suffix))
-      (is (= "Exporting PuppetDB metadata" msg)))))
+      (is (= ["export-metadata.json"] file-suffix)))))

--- a/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
+++ b/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
@@ -1,11 +1,15 @@
 (ns puppetlabs.puppetdb.cli.import-export-roundtrip-test
   (:require [puppetlabs.puppetdb.cli.export :as export]
             [puppetlabs.puppetdb.cli.import :as import]
+            [puppetlabs.puppetdb.cli.anonymize :as anonymize]
+            [puppetlabs.puppetdb.cli.services :refer :all]
+            [puppetlabs.puppetdb.http.command :refer :all]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.testutils :as testutils]
+            [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.puppetdb.fixtures :as fixt]
             [puppetlabs.puppetdb.cheshire :as json]
-            [puppetlabs.puppetdb.command.constants :refer [command-names]]
+            [puppetlabs.puppetdb.archive :as archive]
             [puppetlabs.puppetdb.examples :refer [wire-catalogs]]
             [puppetlabs.puppetdb.testutils.catalogs :as tuc]
             [puppetlabs.puppetdb.examples.reports :refer [reports]]
@@ -14,24 +18,30 @@
             [clj-time.coerce :refer [to-string]]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.client :as pdb-client]
+            [puppetlabs.puppetdb.admin :as admin]
             [slingshot.slingshot :refer [throw+ try+]]
             [slingshot.test]
-            [puppetlabs.puppetdb.testutils.services :as svc-utils :refer [*base-url*]]))
+            [puppetlabs.puppetdb.testutils.services :as svc-utils]))
 
 (use-fixtures :each fixt/with-test-logging-silenced)
 
 (defn munge-report
-  [report]
-  (map (comp tur/munge-report-for-comparison tur/munge-example-report-for-storage)
-       (-> report
-           utils/vector-maybe)))
+  "Munges a catalog of list of reports for comparision.
+  Returns a list of reports."
+  [report-or-reports]
+  (->> report-or-reports
+       utils/vector-maybe
+       (map (comp tur/munge-report-for-comparison
+                  tur/munge-example-report-for-storage))))
 
 (defn munge-catalog
-  [catalog]
-  (map (partial tuc/munge-catalog-for-comparison :v6)
-       (-> catalog
-           (dissoc :hash)
-           utils/vector-maybe)))
+  "Munges a catalog or list of catalogs for comparison.
+  Returns a list of catalogs."
+  [catalog-or-catalogs]
+  (->> catalog-or-catalogs
+       utils/vector-maybe
+       (map (comp (partial tuc/munge-catalog-for-comparison :v6)
+                  #(dissoc % :hash)))))
 
 (defn block-until-queue-empty
   "Blocks the current thread until all messages from the queue have been processed."
@@ -75,6 +85,14 @@
             ;; Ignore
             ))))))
 
+(defn parse-tar-entry-contents
+  "Parses the first of a list of tar-entries :contents"
+  [tar-entries]
+  (-> tar-entries
+      first
+      :contents
+      (json/parse-string true)))
+
 (defn command-base-url
   [base-url]
   (assoc base-url
@@ -82,86 +100,92 @@
          :version :v1))
 
 (deftest test-basic-roundtrip
-  (let [facts {:certname "foo.local"
+  (let [certname "foo.local"
+        facts {:certname certname
                :environment "DEV"
                :values {:foo "the foo"
                         :bar "the bar"
                         :baz "the baz"
                         :biz {:a [3.14 2.71] :b "the b" :c [1 2 3] :d {:e nil}}}
                :producer_timestamp (to-string (now))}
-        export-out-file (testutils/temp-file "export-test" ".tar.gz")
+        export-out-dir (testutils/temp-dir "export-test")
+        export-out-file-path (str (.getPath export-out-dir) "/outfile.tar.gz")
         catalog (-> (get-in wire-catalogs [6 :empty])
-                    (assoc :certname "foo.local"
+                    (assoc :certname certname
                            :producer_timestamp (now)))
-        report (:basic reports)]
+        report (-> (:basic reports)
+                   (assoc :certname certname))]
 
     (svc-utils/puppetdb-instance
-      (fn []
-        (is (empty? (export/get-nodes *base-url*)))
+     (fn []
+       (let [query-fn (partial query (tk-app/get-service svc-utils/*server* :PuppetDBServer))
+             submit-command-fn (partial submit-command (tk-app/get-service svc-utils/*server* :PuppetDBCommand))]
+         (is (empty? (query-fn :nodes admin/query-api-version nil nil doall)))
 
-        (svc-utils/sync-command-post (command-base-url *base-url*) "replace catalog" 6 catalog)
-        (svc-utils/sync-command-post (command-base-url *base-url*) "store report" 5
-                                     (tur/munge-example-report-for-storage report))
-        (svc-utils/sync-command-post (command-base-url *base-url*) "replace facts" 4 facts)
+         (svc-utils/sync-command-post (command-base-url svc-utils/*base-url*) "replace catalog" 6 catalog)
+         (svc-utils/sync-command-post (command-base-url svc-utils/*base-url*) "store report" 5
+                                      (tur/munge-example-report-for-storage report))
+         (svc-utils/sync-command-post (command-base-url svc-utils/*base-url*) "replace facts" 4 facts)
 
-        (is (testutils/=-after? munge-catalog catalog (->> (:certname catalog)
-                                                           (export/catalogs-for-node *base-url*)
-                                                           first)))
+         (is (testutils/=-after? munge-catalog catalog (->> certname
+                                                            (export/catalogs-for-node query-fn)
+                                                            parse-tar-entry-contents)))
 
-        (is (testutils/=-after? munge-report report (->> (:certname report)
-                                                         (export/reports-for-node *base-url*)
-                                                         first)))
-        (is (= facts (->> (:certname facts)
-                          (export/facts-for-node *base-url*)
-                          first)))
+         (is (testutils/=-after? munge-report report (->> certname
+                                                          (export/reports-for-node query-fn)
+                                                          parse-tar-entry-contents)))
+         (is (= facts (->> certname
+                           (export/facts-for-node query-fn)
+                           parse-tar-entry-contents)))
 
-        (#'export/-main "--outfile" export-out-file
-                        "--host" (:host *base-url*)
-                        "--port" (str (:port *base-url*)))))
+         (#'export/-main "--outfile" export-out-file-path
+                         "--host" (:host svc-utils/*base-url*)
+                         "--port" (str (:port svc-utils/*base-url*))))))
 
     (svc-utils/puppetdb-instance
-      (fn []
-        (is (empty? (export/get-nodes *base-url*)))
+     (fn []
+       (let [query-fn (partial query (tk-app/get-service svc-utils/*server* :PuppetDBServer))
+             submit-command-fn (partial submit-command (tk-app/get-service svc-utils/*server* :PuppetDBCommand))]
+         (is (empty? (query-fn :nodes admin/query-api-version nil nil doall)))
 
-        (svc-utils/until-consumed
-         3
-         (fn []
-           (#'import/-main "--infile" export-out-file
-                           "--host" (:host *base-url*)
-                           "--port" (str (:port *base-url*)))))
+         (svc-utils/until-consumed
+          3
+          (fn []
+            (#'import/-main "--infile" export-out-file-path
+                            "--host" (:host svc-utils/*base-url*)
+                            "--port" (str (:port svc-utils/*base-url*)))))
 
-        (is (testutils/=-after? munge-catalog catalog (->> (:certname catalog)
-                                                           (export/catalogs-for-node *base-url*)
-                                                           first)))
+         ;; For some reason, although the fact's/report's message has
+         ;; been consumed and committed, it's not immediately available
+         ;; for querying. Maybe this is a race condition in our tests?
+         ;; The next two lines ensure that the message is not only
+         ;; consumed but present in the DB before proceeding
+         @(block-until-results 100 (export/catalogs-for-node query-fn certname))
+         @(block-until-results 100 (export/facts-for-node query-fn certname))
+         @(block-until-results 100 (export/reports-for-node query-fn certname))
 
-        ;; For some reason, although the fact's/report's message has
-        ;; been consumed and committed, it's not immediately available
-        ;; for querying. Maybe this is a race condition in our tests?
-        ;; The next two lines ensure that the message is not only
-        ;; consumed but present in the DB before proceeding
-        @(block-until-results 100 (->> (:certname facts)
-                                       (export/facts-for-node *base-url*)))
-        @(block-until-results 100 (->> (:certname report)
-                                       (export/reports-for-node *base-url*)))
+         (is (testutils/=-after? munge-catalog catalog (->> certname
+                                                            (export/catalogs-for-node query-fn)
+                                                            parse-tar-entry-contents)))
+         (is (= facts (->> certname
+                           (export/facts-for-node query-fn)
+                           parse-tar-entry-contents)))
 
-        (is (= facts (->> (:certname facts)
-                          (export/facts-for-node *base-url*)
-                          first)))
-        (is (testutils/=-after? munge-report report (->> (:certname report)
-                                                         (export/reports-for-node *base-url*)
-                                                         first)))))))
+         (is (testutils/=-after? munge-report report (->> certname
+                                                          (export/reports-for-node query-fn)
+                                                          parse-tar-entry-contents))))))))
 
 (deftest test-max-frame-size
-  (let [catalog (-> (get-in wire-catalogs [6 :empty])
-                    (assoc :certname "foo.local"))]
+  (let [certname "foo.local"
+        catalog (-> (get-in wire-catalogs [6 :empty])
+                    (assoc :certname certname))]
     (svc-utils/puppetdb-instance
      (assoc-in (svc-utils/create-config) [:command-processing :max-frame-size] "1024")
      (fn []
-       (is (empty? (export/get-nodes *base-url*)))
-       (pdb-client/submit-command-via-http! (command-base-url *base-url*) "replace catalog" 6 catalog)
-       (is (thrown-with-msg?
-            java.util.concurrent.ExecutionException #"Results not found"
-            @(block-until-results 5
-                                  (->> (:certname catalog)
-                                       (export/catalogs-for-node *base-url*)
-                                       first))))))))
+       (let [query-fn (partial query (tk-app/get-service svc-utils/*server* :PuppetDBServer))]
+         (is (empty? (query-fn :nodes admin/query-api-version nil nil doall)))
+         (pdb-client/submit-command-via-http! (command-base-url svc-utils/*base-url*) "replace catalog" 6 catalog)
+         (is (thrown-with-msg?
+              java.util.concurrent.ExecutionException #"Results not found"
+              @(block-until-results 5 (first
+                                       (export/catalogs-for-node query-fn certname))))))))))

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -7,7 +7,8 @@
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :refer [webrouting-service]]
             [puppetlabs.puppetdb.client :as pdb-client]
             [puppetlabs.puppetdb.cli.services :as svcs]
-            [puppetlabs.puppetdb.metrics :as metrics :refer [metrics-service]]
+            [puppetlabs.puppetdb.metrics :as metrics]
+            [puppetlabs.puppetdb.admin :as admin]
             [puppetlabs.puppetdb.mq-listener :refer [message-listener-service]]
             [puppetlabs.puppetdb.command :refer [command-service]]
             [puppetlabs.puppetdb.http.command :refer [puppetdb-command-service]]
@@ -169,7 +170,8 @@
                   svcs/puppetdb-service
                   message-listener-service
                   command-service
-                  metrics-service
+                  metrics/metrics-service
+                  admin/admin-service
                   puppetdb-command-service
                   metadata-service]
                  services)


### PR DESCRIPTION
This PR adds a `puppetlabs.puppetdb.admin` namespace.
The `admin` namespace contains a trapperkeeper service which serves a handler of the new import/export endpoints.

The new endpoints are served under the `/pdb/admin/v1` api root prefix.

The `archive` endpoint will stream you the tarball via a `GET`.
The `archive` endpoint will stream the tarball to PuppetDB for import via a `POST` of the archive in a multipart request with the archive as the `archive=` param. (`curl ... -F "archive=@foo_backup"`)

The CLI tools (import/export) functionality has been moved to these endpoints and the tools themselves essentially just make calls to these endpoints.

TODO and followups for this PR:
Anonymization could also be an endpoint, to anonymize a tarball in the backups directory.
There could be an anonymization option when downloading `GET /export`, so that the data is streamed to a user anonymized. 
Move the import/export logic out of the `cli` namespaces, maybe their own namespaces.
More validation around the compojure app.
Counts of the imported objects.
Don't reimport things that already exist.
More granular testing around the endpoints would be nice.
Add a benchmarking endpoint for data-loading, there is code duplication with the import tool there.