### PR TITLE
(maint) skip legacy storeconfigs import export on AIO

### DIFF
--- a/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
+++ b/acceptance/tests/import_export/legacy_storeconfigs_import_export.rb
@@ -1,8 +1,6 @@
 test_name "storeconfigs export and import" do
 
-  confine :except, :platform => 'ubuntu-10.04-amd64'
-
-  skip_test "storeconfigs not supported in puppet >= 4.0" unless version_is_less(facts(master.name)['puppetversion'], '4.0.0')
+  skip_test "storeconfigs not supported in puppet >= 4.0" if options[:type] == 'aio'
 
   skip_test "Skipping test for PE because sqlite3 isn't available" if master.is_pe?
 


### PR DESCRIPTION
This corrects an issue that cropped up due to a facter version change. There's
no longer a puppetversion fact -- dispatch on AIO status instead.