### PR TITLE
Rename ubuntu 12.04 image name to remove dot

### DIFF
--- a/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
@@ -18,7 +18,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-  ubuntu-12.04-64-1:
+  ubuntu-1204-64-1:
     roles:
       - agent
     vmname: ubuntu-12.04-amd64-west


### PR DESCRIPTION
Puppet didn't like the dot in our ubuntu 1204 hostname for the 3 box test,
this removes the dot.

Signed-off-by: Ken Barber <ken@bob.sh>