### PR TITLE
(PDB-1665) Guard experimental endpoint warnings

### DIFF
--- a/src/puppetlabs/puppetdb/http/aggregate_event_counts.clj
+++ b/src/puppetlabs/puppetdb/http/aggregate_event_counts.clj
@@ -23,9 +23,10 @@
                     query-options (-> {:counts_filter counts_filter'
                                        :count_by count_by}
                                       (merge distinct-options))]
-                (log/warn
-                  (str "The aggregate-event-counts endpoint is experimental"
-                       " and may be altered or removed in the future."))
+                (when-not (= "puppetdb" (:product-name globals))
+                  (log/warn
+                   (str "The aggregate-event-counts endpoint is experimental"
+                        " and may be altered or removed in the future.")))
                 (produce-streaming-body
                   :aggregate-event-counts
                   version

--- a/src/puppetlabs/puppetdb/http/event_counts.clj
+++ b/src/puppetlabs/puppetdb/http/event_counts.clj
@@ -13,6 +13,9 @@
   (app
    [""]
    {:get (fn [{:keys [params globals paging-options]}]
+           (when-not (= "puppetdb" (:product-name globals))
+             (log/warn (str "The aggregate-event-counts endpoint is experimental"
+                            " and may be altered or removed in the future.")))
            (let [{:strs [query summarize_by counts_filter count_by] :as query-params} params
                  query-options (merge {:counts_filter (if counts_filter (json/parse-strict-string counts_filter true))
                                        :count_by count_by}
@@ -28,7 +31,6 @@
 (defn event-counts-app
   "Ring app for querying for summary information about resource events."
   [version]
-  (log/warn "The event-counts endpoint is experimental and may be altered or removed in the future.")
   (-> (routes version)
       verify-accepts-json
       (validate-query-params {:required ["query" "summarize_by"]


### PR DESCRIPTION
Don't warn about event-counts or aggregate-event-counts endpoints if the
product name isn't puppetdb.