### PR TITLE
(PDB-1665) Guard experimental endpoint warnings

### DIFF
--- a/documentation/api/query/v3/aggregate-event-counts.markdown
+++ b/documentation/api/query/v3/aggregate-event-counts.markdown
@@ -76,7 +76,7 @@ event-count results were aggregated.
 
 You can use [`curl`][curl] to query information about aggregated resource event counts like so:
 
-    curl -G 'http://localhost:8080/v3/aggregate-event-counts'
+    curl -G 'http://localhost:8080/v3/aggregate-event-counts' \
             --data-urlencode 'query=["=", "certname", "foo.local"]' \
             --data-urlencode 'summarize-by=containing-class'
 

--- a/src/com/puppetlabs/puppetdb/http/aggregate_event_counts.clj
+++ b/src/com/puppetlabs/puppetdb/http/aggregate_event_counts.clj
@@ -41,12 +41,14 @@
   (app
     [""]
     {:get (fn [{:keys [params globals]}]
+            (when (= "puppetdb" (:product-name globals))
+              (log/warn "The aggregate-event-counts endpoint is experimental"
+                        " and may be altered or removed in the future."))
             (produce-body version params (:scf-read-db globals)))}))
 
 (defn aggregate-event-counts-app
   "Ring app for querying for aggregated summary information about resource events."
   [version]
-  (log/warn "The aggregate-event-counts endpoint is experimental and may be altered or removed in the future.")
   (-> (routes version)
       verify-accepts-json
       (validate-query-params {:required ["query" "summarize-by"]

--- a/src/com/puppetlabs/puppetdb/http/event_counts.clj
+++ b/src/com/puppetlabs/puppetdb/http/event_counts.clj
@@ -51,6 +51,9 @@
   (app
     [""]
     {:get (fn [{:keys [params globals paging-options]}]
+            (when (= "puppetdb" (:product-name globals))
+              (log/warn "The event-counts endpoint is experimental"
+                        " and may be altered or removed in the future."))
             (produce-body
              version
              params
@@ -60,7 +63,6 @@
 (defn event-counts-app
   "Ring app for querying for summary information about resource events."
   [version]
-  (log/warn "The event-counts endpoint is experimental and may be altered or removed in the future.")
   (-> (routes version)
       verify-accepts-json
       (validate-query-params {:required ["query" "summarize-by"]


### PR DESCRIPTION
Don't warn about event-counts or aggregate-event-counts endpoints if the
product name isn't puppetdb.