### PR TITLE
(maint) remove ssl-setup references to AIO pathing

### DIFF
--- a/ext/templates/puppetdb-ssl-setup.erb
+++ b/ext/templates/puppetdb-ssl-setup.erb
@@ -226,7 +226,7 @@ else
   agent_confdir=`puppet agent --configprint confdir`
   agent_vardir=`puppet agent --configprint vardir`
 
-  if [ -d "/etc/puppetlabs/puppetdb" ] ; then
+  if id -u pe-puppetdb > /dev/null 2>&1; then
     puppetdb_confdir="/etc/puppetlabs/puppetdb"
     user=pe-puppetdb
   else


### PR DESCRIPTION
The ssl setup tool uses the existence of the /etc/puppetlabs/puppetdb directory
to assess whether the install target is running PE. This was valid in the olden
days, but with AIO FOSS uses those paths as well. This meant that the ssl
setup tool would set the wrong user in the case of a downgrade from 3.0 to
2.3.x, since at this point the path would exist. This changes the tool to dispatch
on presence of the pe-puppetdb user.