### PR TITLE
(maint) Bump to Clojure 1.7.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.7.0-RC2"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [cheshire "5.4.0"]
                  [org.clojure/core.match "0.2.2"]
                  [org.clojure/math.combinatorics "0.0.4"]


### PR DESCRIPTION
Clojure 1.7.0 was just released, this commit bumps this to this version.