### PR TITLE
(PDB-1674) PuppetDB hangs on shutdown when the database is down 

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -370,6 +370,10 @@ The maximum time (in minutes) a pooled connection should remain open. Any connec
 
 If not supplied, we won't terminate connections based on their age alone.
 
+### `connection-timeout`
+
+The maximum time to wait (in milliseconds) to acquire a connection from the pool of database connections. If not supplied, defaults to 1000.
+
 ###`statements-cache-size`
 
 This setting defines how many prepared statements are cached automatically. For a large amount of dynamic queries this number could be increased to increase performance, at the cost of memory consumption and database resources.
@@ -446,6 +450,10 @@ If not supplied, we default to 45 minutes.
 The maximum time (in minutes) a pooled connection should remain open. Any connections older than this setting will be closed off. Connections currently in use will not be affected until they are returned to the pool.
 
 If not supplied, we won't terminate connections based on their age alone.
+
+### `connection-timeout`
+
+The maximum time to wait (in milliseconds) to acquire a connection from the pool of database connections. If not supplied, defaults to 500.
 
 
 `[command-processing]` Settings

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -63,7 +63,8 @@
      :partition-count (pls/defaulted-maybe s/Int 1)
      :stats (pls/defaulted-maybe String "true")
      :log-statements (pls/defaulted-maybe String "true")
-     :statements-cache-size (pls/defaulted-maybe s/Int 1000)}))
+     :statements-cache-size (pls/defaulted-maybe s/Int 1000)
+     :connection-timeout (pls/defaulted-maybe s/Int 500)}))
 
 (def write-database-config-in
   "Includes the common database config params, also the write-db specific ones"
@@ -72,7 +73,8 @@
            {:gc-interval (pls/defaulted-maybe s/Int 60)
             :report-ttl (pls/defaulted-maybe String "14d")
             :node-purge-ttl (pls/defaulted-maybe String "0s")
-            :node-ttl (pls/defaulted-maybe String "0s")})))
+            :node-ttl (pls/defaulted-maybe String "0s")
+            :connection-timeout (pls/defaulted-maybe s/Int 1000)})))
 
 (def database-config-out
   "Schema for parsed/processed database config"
@@ -89,6 +91,7 @@
    :stats Boolean
    :log-statements Boolean
    :statements-cache-size s/Int
+   :connection-timeout s/Int
    (s/optional-key :conn-lifetime) (s/maybe Minutes)
    (s/optional-key :username) String
    (s/optional-key :user) String

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -282,7 +282,8 @@
   [{:keys [classname subprotocol subname user username password
            partition-conn-min partition-conn-max partition-count
            stats log-statements log-slow-statements statements-cache-size
-           conn-max-age conn-lifetime conn-keep-alive read-only?]
+           conn-max-age conn-lifetime conn-keep-alive read-only?
+           connection-timeout pool-availability-threshold]
     :as db}]
   (let [;; Load the database driver class explicitly, to avoid jar load ordering
         ;; issues.
@@ -302,12 +303,14 @@
                           (.setJdbcUrl (str "jdbc:" subprotocol ":" subname))
                           (.setConnectionHook (connection-hook log-statements log-slow-statements-duration))
                           (.setStatementsCacheSize statements-cache-size)
-                          (.setDefaultReadOnly read-only?))
+                          (.setDefaultReadOnly read-only?)
+                          (.setConnectionTimeoutInMs connection-timeout))
         user (or user username)]
     ;; configurable without default
     (when user (.setUsername config (str user)))
     (when password (.setPassword config (str password)))
     (when conn-lifetime (.setMaxConnectionAge config (pl-time/to-minutes conn-lifetime) TimeUnit/MINUTES))
+    (some->> pool-availability-threshold (.setPoolAvailabilityThreshold config))
     (when log-statements (.setLogStatementsEnabled config log-statements))
 
     (.setQueryExecuteTimeLimit config log-slow-statements-duration (TimeUnit/SECONDS))

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -307,11 +307,11 @@
                           (.setConnectionTimeoutInMs connection-timeout))
         user (or user username)]
     ;; configurable without default
-    (when user (.setUsername config (str user)))
-    (when password (.setPassword config (str password)))
-    (when conn-lifetime (.setMaxConnectionAge config (pl-time/to-minutes conn-lifetime) TimeUnit/MINUTES))
+    (some->> user str (.setUsername config))
+    (some->> password str (.setPassword config))
     (some->> pool-availability-threshold (.setPoolAvailabilityThreshold config))
-    (when log-statements (.setLogStatementsEnabled config log-statements))
+    (some->> log-statements (.setLogStatementsEnabled config))
+    (when conn-lifetime (.setMaxConnectionAge config (pl-time/to-minutes conn-lifetime) TimeUnit/MINUTES))
 
     (.setQueryExecuteTimeLimit config log-slow-statements-duration (TimeUnit/SECONDS))
     ;; ...aaand, create the pool.


### PR DESCRIPTION
This adds connection timeouts to the command processing and query
connection pools. This fixes the problem where the ActiveMQ session
can't be properly shutdown because the command connection pool can't get
a connection to the database (i.e. the database is down). Previously
this would hang, even with a Control-C. This hang was due to the
connection pool software getting caught in a loop trying to get a
connection to the database.

This connection timeout was also applied to the query side of the
application as user provided queries are expected to respond quickly and
a hanging behavior would be bad there as well.

This blocking/retrying behavior is what we want when PuppetDB first
starts up as we need to initialize the schema etc. This commit also
creates a special connection pool (just for startup) that doesn't have
these timeouts. This pool is closed after the startup code that needs a
database connection is finished.