### PR TITLE
(maint) Update specter dependency to remove `update` conflict

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -77,7 +77,7 @@
                  [robert/hooke "1.3.0"]
                  [honeysql "0.5.2"]
                  [org.clojure/data.xml "0.0.8"]
-                 [com.rpl/specter "0.5.2"]]
+                 [com.rpl/specter "0.5.7"]]
 
   :jvm-opts ["-XX:MaxPermSize=128M"]
 

--- a/src/puppetlabs/puppetdb/reports.clj
+++ b/src/puppetlabs/puppetdb/reports.clj
@@ -170,8 +170,8 @@
 (defn dash->underscore-report-keys [report]
   (->> report
        utils/dash->underscore-keys
-       (sp/update [:resource_events sp/ALL sp/ALL]
-                  #(update % 0 utils/dashes->underscores))))
+       (sp/transform [:resource_events sp/ALL sp/ALL]
+                     #(update % 0 utils/dashes->underscores))))
 
 (pls/defn-validated wire-v4->wire-v5
   [report received-time]

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -296,14 +296,14 @@
   "Converts all top-level keys (including nested maps) in `m` to use dashes
   instead of underscores as word separatators"
   [m]
-  (sp/update [sp/ALL]
-             #(update % 0 dashes->underscores)
-             m))
+  (sp/transform [sp/ALL]
+                #(update % 0 dashes->underscores)
+                m))
 
 (defn underscore->dash-keys
   "Converts all top-level keys (including nested maps) in `m` to use underscores
   instead of underscores as word separatators"
   [m]
-  (sp/update [sp/ALL]
-             #(update % 0 underscores->dashes)
-             m))
+  (sp/transform [sp/ALL]
+                #(update % 0 underscores->dashes)
+                m))

--- a/test/puppetlabs/puppetdb/reports_test.clj
+++ b/test/puppetlabs/puppetdb/reports_test.clj
@@ -57,8 +57,8 @@
 (defn underscore->dash-report-keys [m]
   (->> m
        utils/underscore->dash-keys
-       (sp/update [:resource-events sp/ALL sp/ALL]
-                  #(update % 0 utils/underscores->dashes))))
+       (sp/transform [:resource-events sp/ALL sp/ALL]
+                     #(update % 0 utils/underscores->dashes))))
 
 (def v4-example-report
   (-> reports


### PR DESCRIPTION
This commit updates `specter` to the laster version to remove the
conflict with the name `update` in `clojure.core`.