### PR TITLE
(maint) Remove reference to -D switch for benchmark

### DIFF
--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -276,7 +276,7 @@
    ["-F" "--facts FACTS" "Path to a directory containing sample JSON facts (files must end with .json)"]
    ["-C" "--catalogs CATALOGS" "Path to a directory containing sample JSON catalogs (files must end with .json)"]
    ["-R" "--reports REPORTS" "Path to a directory containing sample JSON reports (files must end with .json)"]
-   ["-A" "--archive ARCHIVE" "Path to a PuppetDB export tarball. Incompatible with -C, -F, -R, or -D"]
+   ["-A" "--archive ARCHIVE" "Path to a PuppetDB export tarball. Incompatible with -C, -F or -R"]
    ["-i" "--runinterval RUNINTERVAL" "What runinterval (in minutes) to use during simulation"]
    ["-n" "--numhosts NUMHOSTS" "How many hosts to use during simulation"]
    ["-r" "--rand-perc RANDPERC" "What percentage of submitted catalogs are tweaked (int between 0 and 100)"]


### PR DESCRIPTION
-D was removed however this argument help still contained a reference to it.

Signed-off-by: Ken Barber <ken@bob.sh>