### PR TITLE
(PDB-1701) reject old commands over http

### DIFF
--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -299,11 +299,8 @@
   [{:keys [version] :as command} {:keys [db]}]
   (store-report* 5 db command))
 
-(def supported-commands
-  #{"replace facts" "replace catalog" "store report" "deactivate node"})
-
 (def supported-command?
-  (comp supported-commands :command))
+  (comp (kitchensink/valset command-names) :command))
 
 (defservice command-service
   [[:PuppetDBServer shared-globals]

--- a/src/puppetlabs/puppetdb/http.clj
+++ b/src/puppetlabs/puppetdb/http.clj
@@ -254,3 +254,8 @@
   "Produces a json response for when an entity (catalog/nodes/environment/...) is not found."
   [type id]
   (json-response {:error (format "No information is known about %s %s" type id)} status-not-found))
+
+(defn bad-request-response
+  "Produce a json 400 response with an :error key holding message."
+  [message]
+  (json-response {:error message} status-bad-request))

--- a/test/puppetlabs/puppetdb/http/command_test.clj
+++ b/test/puppetlabs/puppetdb/http/command_test.clj
@@ -1,6 +1,8 @@
 (ns puppetlabs.puppetdb.http.command-test
   (:import [java.io ByteArrayInputStream])
   (:require [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.http.command :refer [min-supported-commands
+                                                      valid-commands-str]]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.fixtures :as fixt]
             [puppetlabs.puppetdb.testutils :refer [get-request post-request
@@ -28,17 +30,27 @@
     (post-request path nil params {"content-type" "application/json"
                                    "accept" "application/json"} body)))
 
+(defn form-command
+  [command version payload]
+  (json/generate-string
+    {:command command
+     :version version
+     :payload payload}))
+
 (deftestseq command-endpoint
   [[version endpoint] endpoints]
 
   (testing "Commands submitted via REST"
 
     (testing "should work when well-formed"
-      (let [payload  "This is a test"
+      (let [payload (form-command "replace facts"
+                                  (get min-supported-commands "replace facts")
+                                  "{}")
             checksum (kitchensink/utf8-string->sha1 payload)
             req (fixt/internal-request {"payload" payload "checksum" checksum})
-            response (fixt/*command-app* (post-request* endpoint {"checksum" checksum}
-                                                payload))]
+            response (fixt/*command-app* (post-request* endpoint
+                                                        {"checksum" checksum}
+                                                        payload))]
         (assert-success! response)
 
         (is (= (content-type response)
@@ -51,7 +63,10 @@
                http/status-bad-request))))
 
     (testing "should not do checksum verification if no checksum is provided"
-      (let [response (fixt/*command-app* (post-request* endpoint nil "my payload!"))]
+      (let [payload (form-command "deactivate node"
+                                  (get min-supported-commands "deactivate node")
+                                  "{}")
+            response (fixt/*command-app* (post-request* endpoint nil payload))]
         (assert-success! response)))
 
     (testing "should return 400 when checksums don't match"
@@ -59,7 +74,40 @@
                                                 {"checksum" "something bad"}
                                                 "Testing"))]
         (is (= (:status response)
-               http/status-bad-request))))))
+               http/status-bad-request))))
+
+    (testing "should 400 when the command is invalid"
+      (let [invalid-command (form-command "foo" 100 "{}")
+            invalid-checksum (kitchensink/utf8-string->sha1 invalid-command)
+            {:keys [status body]} (fixt/*command-app*
+                                    (post-request* endpoint
+                                                   {"checksum" invalid-checksum}
+                                                   invalid-command))]
+        (is (= status
+               http/status-bad-request))
+
+        (is (= (:error (json/parse-string body true))
+               (format "Supported commands are %s. Received 'foo'."
+                       valid-commands-str)))))
+
+    (testing "should 400 when version is retired"
+      (let [min-supported-version (get min-supported-commands "replace facts")
+            misversioned-command (form-command "replace facts"
+                                               (dec min-supported-version)
+                                               "{}")
+            misversioned-checksum (kitchensink/utf8-string->sha1 misversioned-command)
+            {:keys [status body]} (fixt/*command-app*
+                                    (post-request* endpoint
+                                                   {"checksum" misversioned-checksum}
+                                                   misversioned-command))]
+
+        (is (= status
+               http/status-bad-request))
+        (is (= (:error (json/parse-string body true))
+               (format (str "replace facts version %s is retired. "
+                            "The minimum supported version is %s.")
+                       (dec min-supported-version)
+                       min-supported-version)))))))
 
 (defn round-trip-date-time
   "Parse a DateTime string, then emits the string from that DateTime"
@@ -71,23 +119,20 @@
 (deftestseq receipt-timestamping
   [[version endpoint] endpoints]
 
-  (let [good-payload  (json/generate-string {:command "my command" :version 1 :payload "{}"})
+  (let [good-payload  (form-command "replace facts"
+                                    (get min-supported-commands "replace facts")
+                                    "{}")
         good-checksum (kitchensink/utf8-string->sha1 good-payload)
-        bad-payload   "some test message"
-        bad-checksum  (kitchensink/utf8-string->sha1 bad-payload)
         request       (fn [payload checksum]
                         (post-request* endpoint {"checksum" checksum} payload))]
     (fixt/*command-app* (request good-payload good-checksum))
-    (fixt/*command-app* (request bad-payload bad-checksum))
 
-    (let [[good-msg bad-msg] (mq/bounded-drain-into-vec!
-                              (:connection fixt/*mq*)
-                              "puppetlabs.puppetdb.commands"
-                              2)
+    (let [[good-msg] (mq/bounded-drain-into-vec!
+                       (:connection fixt/*mq*)
+                       "puppetlabs.puppetdb.commands"
+                       1)
           good-command (json/parse-string (:body good-msg) true)]
       (testing "should be timestamped when parseable"
         (let [timestamp (get-in good-msg [:headers :received])]
-          (time/parse (time/formatters :date-time) timestamp)))
+          (time/parse (time/formatters :date-time) timestamp))))))
 
-      (testing "should be left alone when not parseable"
-        (is (= (:body bad-msg) bad-payload))))))


### PR DESCRIPTION
This adds some validation on our command handler to reject retired versions of
commands and commands that we don't recognize before enqueuing when submitted
over http.