### PR TITLE
(PDB-1731) broken dashboard

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -263,8 +263,7 @@
                                                            ;; Only allocate connections when needed
                                                            :pool-availability-threshold 0))]
     (let [db-pool-map {:datasource init-db-pool}]
-      (initialize-schema db-pool-map product-name)
-      (pop/initialize-metrics db-pool-map))))
+      (initialize-schema db-pool-map product-name))))
 
 (defn start-puppetdb
   [context config service add-ring-handler get-route shutdown-on-error]
@@ -298,6 +297,7 @@
       (log/infof "PuppetDB version %s" v))
 
     (init-with-db database product-name)
+    (pop/initialize-metrics write-db)
 
     (when (.exists discard-dir)
       (dlo/create-metrics-for-dlo! discard-dir))


### PR DESCRIPTION
We had been initializing dashboard metrics on an ephemeral database connection,
which meant that the connection would be closed when the metrics were accessed.