### PR TITLE
(maint) Pin the module version we use in acceptance tests

### DIFF
--- a/acceptance/setup/pre_suite/50_install_modules.rb
+++ b/acceptance/setup/pre_suite/50_install_modules.rb
@@ -3,5 +3,5 @@ require 'beaker/dsl/install_utils'
 extend Beaker::DSL::InstallUtils
 
 step "Install the puppetdb module and dependencies" do
-  on master, "puppet module install puppetlabs/puppetdb"
+  on master, "puppet module install puppetlabs/puppetdb --version 4.3.0"
 end


### PR DESCRIPTION
This commit pins the module version we use in acceptance tests as v5 of
the module was released today and contained breaking changes. This
commit is a temporary fix for the issue until we can upgrade to v5 of
the puppetdb module.