### PR TITLE
[PDB 135] improve utf8 warning

### DIFF
--- a/puppet/lib/puppet/util/puppetdb/char_encoding.rb
+++ b/puppet/lib/puppet/util/puppetdb/char_encoding.rb
@@ -81,8 +81,8 @@ module CharEncoding
         analyser.write_summary
 
         Puppet.warning "See #{fn} for details of last occurence"
-      rescue NameError => e
-        Puppet.warning "EncodingAnalyser could not be started"
+      rescue => e
+        Puppet.warning "EncodingAnalyser failed because of #{e.class.name}"
         Puppet.warning e
       end
     end

--- a/puppet/lib/puppet/util/puppetdb/char_encoding.rb
+++ b/puppet/lib/puppet/util/puppetdb/char_encoding.rb
@@ -257,6 +257,9 @@ module CharEncoding
 
       private
 
+      # Splitting the string does the following two things:
+      #   - split hashes and array that are values from their keys
+      #   - split lists of hashes into new lines
       def split
         @string.gsub(/(['"]:)({|\[)/, "\\1\n\\2").gsub(/(}|\]),({|\[)/, "\\1,\n\\2")
       end
@@ -284,7 +287,6 @@ module CharEncoding
 
         file.puts "diff of #{orig_fn} and #{conv_fn}"
         file.puts ""
-
         file.puts `diff -u5 #{orig_fn} #{conv_fn}`
 
         file.puts diff_footer
@@ -293,6 +295,8 @@ module CharEncoding
         file.flock(File::LOCK_UN)
       end
     end
+
+    private
 
     def diff_header
       <<-EOSTRING

--- a/puppet/lib/puppet/util/puppetdb/char_encoding.rb
+++ b/puppet/lib/puppet/util/puppetdb/char_encoding.rb
@@ -227,7 +227,6 @@ module CharEncoding
   # In most circumstances the diff should give enough context to understand the
   # issue better.
   class EncodingAnalyser
-
     class String
       attr_reader :filename
 
@@ -255,13 +254,26 @@ module CharEncoding
         filename
       end
 
+      def errors
+        if @errors.any?
+          ["Errors in #{@type} string", @errors].join("\n")
+        else
+          ''
+        end
+      end
+
       private
 
       # Splitting the string does the following two things:
       #   - split hashes and array that are values from their keys
       #   - split lists of hashes into new lines
       def split
-        @string.gsub(/(['"]:)({|\[)/, "\\1\n\\2").gsub(/(}|\]),({|\[)/, "\\1,\n\\2")
+        begin
+          @string.gsub(/(['"]:)({|\[)/, "\\1\n\\2").gsub(/(}|\]),({|\[)/, "\\1,\n\\2")
+        rescue ArgumentError => e
+          @string.encode!(@string.encoding, :invalid => :replace, :undef => :replace, :replace => "?")
+          split
+        end
       end
     end
 

--- a/puppet/spec/unit/util/puppetdb/char_encoding_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/char_encoding_spec.rb
@@ -122,6 +122,7 @@ describe Puppet::Util::Puppetdb::CharEncoding do
       # UndefinedConversionError
       it "should replace undefined characters and warn when converting from binary" do
         Puppet.expects(:warning).with {|msg| msg =~ /Ignoring invalid UTF-8 byte sequences/}
+        Puppet.expects(:warning).with {|msg| msg =~ %r!See /tmp/puppetdb-invalid-utf8-sequences for details of last occurence!}
 
         str = "an invalid binary string \xff".force_encoding('binary')
         # \ufffd == unicode replacement character
@@ -131,6 +132,7 @@ describe Puppet::Util::Puppetdb::CharEncoding do
       # InvalidByteSequenceError
       it "should replace undefined characters and warn if the string is invalid UTF-8" do
         Puppet.expects(:warning).with {|msg| msg =~ /Ignoring invalid UTF-8 byte sequences/}
+        Puppet.expects(:warning).with {|msg| msg =~ %r!See /tmp/puppetdb-invalid-utf8-sequences for details of last occurence!}
 
         str = "an invalid utf-8 string \xff".force_encoding('utf-8')
         subject.utf8_string(str).should == "an invalid utf-8 string \ufffd"


### PR DESCRIPTION
### Background

I was puzzled by the warning message and a bit worried that something could go wrong with the exported/collected resources.

### Changes

If the strings don't match, I now emit a second warning which includes a hint a file with further information. Since the string sent to PuppetDB is a JSON-string oneliner, I decided to split it up on a few known locations. This enabled the used of standard diff'ing tools for linewise diffing. In turn, I could compile a summary of the mismatching parts of the JSON.

In order to not build big or many files, I decided to only keep the last output. Each warning produces now 2 warnings in the puppet-log and 3 files in /tmp.  

In my personal case, I could determine the problematic areas and change them. 

### Problems / Loose Ends

I have not yet run the tests, so I half-way expect errors.

I also have not written any specs for the ruby-extension. If needed, I can add full spec-coverage to the internal classes.

Currently, I depend on the `diff(1)` command being in `$PATH`.

Since my installation has the puppetmaster and PuppetDB on the same machine, I don't know where the log will be written. As the terminus is writing the file, I expect it be on the puppetmaster's machine.

The current version is intended as a starting point for discussion and further improvement.