### PR TITLE
(maint) make install_puppetdb and install_puppetdb_terminus versions nil

### DIFF
--- a/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
+++ b/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
@@ -1,8 +1,8 @@
 # We skip this step entirely unless we are running in :upgrade mode.
 if (test_config[:install_mode] == :upgrade)
   step "Install most recent released PuppetDB on the PuppetDB server for upgrade test" do
-    install_puppetdb(database, test_config[:database], 'latest')
+    install_puppetdb(database, test_config[:database])
     start_puppetdb(database)
-    install_puppetdb_termini(master, database, 'latest')
+    install_puppetdb_termini(master, database)
   end
 end


### PR DESCRIPTION
This will cause installs to fall through to the expectedrpm and expecteddeb
version.