### PR TITLE
(RE-5033) Update Ezbake to new 0.3.14

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -125,7 +125,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "0.3.13"
+                      :plugins [[puppetlabs/lein-ezbake "0.3.14"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}


### PR DESCRIPTION
Due to an odd issue with PuppetDB, when PuppetDB 2.3.z and PuppetDB
3.0.0 are in the same repository (e.g. PC1) you can not install
PuppetDB 2.3.z because the terminus package is oboleted and therefore
brings in the 3.0.0 version of temini. That means you can't really run
2.3.5. This is bad since the tests for PuppetDB 2.3.z test against the
AIO and Puppet 3.8 and so they need access to PC1.

As a fix, we're creating a new metapackage 'puppetdb-terminus' at
version 3 that wil require puppetdb-termini to allow for easier
transistion and upgrades. That, combined with the removal of
Obsoletes/Provides in the PuppetDB package will allow a user to use a
2.3.z or 3.0.0 release of PuppetDB.