### PR TITLE
(maint) Fix upgrade tests

### DIFF
--- a/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
+++ b/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
@@ -1,8 +1,9 @@
 # We skip this step entirely unless we are running in :upgrade mode.
 if (test_config[:install_mode] == :upgrade)
   step "Install most recent released PuppetDB on the PuppetDB server for upgrade test" do
-    install_puppetdb(database, test_config[:database], 'latest')
+    last_released_verison = `git describe --abbrev=0`.chomp
+    install_puppetdb(database, test_config[:database], last_released_verison)
     start_puppetdb(database)
-    install_puppetdb_termini(master, database, 'latest')
+    install_puppetdb_termini(master, database, last_released_verison)
   end
 end


### PR DESCRIPTION
Use 'git describe' to find the most recent released version and use that
to find the base version to install for upgrade tests. 