### PR TITLE
(maint) update preinst for redhat to check for 2.x if upgrading

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -2,7 +2,7 @@ ezbake: {
   pe: {}
   foss: {
     redhat: { dependencies: ["puppet >= 3.8.1", "puppet < 5.0.0"],
-              preinst:  ["if [ $1 -eq 2 ] ; then tar -czf /tmp/puppetdb-upgrade-config-files.tgz -C /etc/puppetdb/conf.d config.ini database.ini jetty.ini ; fi"],
+              preinst:  ["if rpm -q puppetdb | grep ^puppetdb-2.* > /dev/null && [ $1 -eq 2 ] ; then tar -czf /tmp/puppetdb-upgrade-config-files.tgz -C /etc/puppetdb/conf.d config.ini database.ini jetty.ini ; fi" ],
               postinst: ["/opt/puppetlabs/server/bin/puppetdb config-migration",
                          "/opt/puppetlabs/server/bin/puppetdb ssl-setup"] },
     debian: { dependencies: ["puppet (>= 3.8.1-1puppetlabs1)  | puppet-agent",


### PR DESCRIPTION
This should fix the issue where we attempted to tar a nonexistent directory in
preinst when upgrading from 3.0.0 -> 3.0.x