### PR TITLE
(PDB-1313) Update deactivated timestamp if newer

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1213,9 +1213,10 @@
   currently inactive, no change is made."
   [certname :- String & [timestamp :- pls/Timestamp]]
   (let [timestamp (to-timestamp (or timestamp (now)))]
-   (sql/do-prepared "UPDATE certnames SET deactivated = ?
-                    WHERE certname=? AND deactivated IS NULL"
-                    [timestamp certname])))
+    (sql/do-prepared "UPDATE certnames SET deactivated = ?
+                        WHERE certname=?
+                           AND (deactivated IS NULL OR deactivated < ?)"
+                     [timestamp certname timestamp])))
 
 (pls/defn-validated expire-node!
   "Expire the given host, recording the current time. If the node is

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1158,7 +1158,12 @@
       (testing "should not change the node if it's already inactive"
         (let [original (query-certnames)]
           (deactivate-node! certname)
-          (is (= original (query-certnames))))))
+          ;; Convert any :deactivated values to #t for comparison
+          ;; since we only care about the state.
+          (letfn [(deactivated->truthy [x]
+                    (assoc x :deactivated (when (:deactivated x) true)))]
+            (is (= (map deactivated->truthy original)
+                   (map deactivated->truthy (query-certnames))))))))
 
     (testing "activating a node"
       (testing "should activate the node if it was inactive"


### PR DESCRIPTION
If the incoming "deactivate node" timestamp is newer than the one in the
database, replace the database value.  While perhaps reasonable in
general, this is particularly important for pdb sync, i.e. state
convergence.