### PR TITLE
Coerce version symbols to strings

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -256,9 +256,9 @@ module PuppetDBExtensions
 
   def expected_version_for_platform(platform)
     if platform_is_rpm_based(platform)
-      PuppetDBExtensions.config[:expected_rpm_version]
+      PuppetDBExtensions.config[:expected_rpm_version].to_s
     elsif platform_is_deb_based(platform)
-      PuppetDBExtensions.config[:expected_deb_version]
+      PuppetDBExtensions.config[:expected_deb_version].to_s
     else
       raise ArgumentError, "Unsupported platform: '#{platform}'"
     end


### PR DESCRIPTION
This is meant to fix https://jenkins.puppetlabs.com/job/platform_puppetdb_int-sys-legacystable/708/BEAKER_CONFIG=ec2-west-debian6-64mda-64a,BEAKER_OPTIONS=postgres,BEAKER_TYPE=foss,PUPPETDB_INSTALL_MODE=upgrade,label=beaker-ec2/testReport/junit/(root)/_var_lib_jenkins_workspace_platform_puppetdb_int-sys-legacystable_BEAKER_CONFIG_ec2-west-debian6-64mda-64a_BEAKER_OPTIONS_postgres_BEAKER_TYPE_foss_PUPPETDB_INSTALL_MODE_upgrade_label_beaker-ec2_acceptance_setup_pre_suite/90_install_devel_puppetdb_rb/