### PR TITLE
(PDB-1791) Upgrade to version 5 of the PuppetDB module

### DIFF
--- a/acceptance/setup/pre_suite/50_install_modules.rb
+++ b/acceptance/setup/pre_suite/50_install_modules.rb
@@ -4,6 +4,6 @@ extend Beaker::DSL::InstallUtils
 
 unless (test_config[:skip_presuite_provisioning])
   step "Install the puppetdb module and dependencies" do
-    on databases, "puppet module install puppetlabs/puppetdb --version 4.3.0"
+    on databases, "puppet module install puppetlabs/puppetdb"
   end
 end

--- a/acceptance/tests/reports/event_query_with_read_db.rb
+++ b/acceptance/tests/reports/event_query_with_read_db.rb
@@ -24,7 +24,6 @@ test_name "validation of basic PuppetDB resource event queries" do
       require  => Class['::postgresql::server'],
     }
     EOS
-
     apply_manifest_on(database, second_db_manifest)
     sleep_until_started(database)
   end


### PR DESCRIPTION
This commit upgrades PuppetDB to use v5 of the PuppetDB module (latest
at the time of this commit). This consists of using the new `globals`
class to specify the PuppetDB version.