### PR TITLE
(maint) Add access to packaging repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ version
 junit
 tmp
 vendor
+ext/packaging
+

--- a/Rakefile
+++ b/Rakefile
@@ -62,3 +62,40 @@ namespace :beaker do
     sh 'aws ec2 describe-instances  --filters "Name=key-name,Values=Beaker-${USER}*" --query "Reservations[*].Instances[*].[InstanceId, State.Name, PublicIpAddress]" --output table'
   end
 end
+
+build_defs_file = File.join(RAKE_ROOT, 'ext', 'build_defaults.yaml')
+if File.exist?(build_defs_file)
+  begin
+    require 'yaml'
+    @build_defaults ||= YAML.load_file(build_defs_file)
+  rescue Exception => e
+    STDERR.puts "Unable to load yaml from #{build_defs_file}:"
+    raise e
+  end
+  @packaging_url  = @build_defaults['packaging_url']
+  @packaging_repo = @build_defaults['packaging_repo']
+  raise "Could not find packaging url in #{build_defs_file}" if @packaging_url.nil?
+  raise "Could not find packaging repo in #{build_defs_file}" if @packaging_repo.nil?
+
+  namespace :package do
+    desc "Bootstrap packaging automation, e.g. clone into packaging repo"
+    task :bootstrap do
+      if File.exist?(File.join(RAKE_ROOT, "ext", @packaging_repo))
+        puts "It looks like you already have ext/#{@packaging_repo}. If you don't like it, blow it away with package:implode."
+      else
+        cd File.join(RAKE_ROOT, 'ext') do
+          %x{git clone #{@packaging_url}}
+        end
+      end
+    end
+    desc "Remove all cloned packaging automation"
+    task :implode do
+      rm_rf File.join(RAKE_ROOT, "ext", @packaging_repo)
+    end
+  end
+end
+
+begin
+  load File.join(RAKE_ROOT, 'ext', 'packaging', 'packaging.rake')
+rescue LoadError
+end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,0 +1,3 @@
+---
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_repo: 'packaging'


### PR DESCRIPTION
This commit allows access to the packaging repo automation. Although
this is no longer needed or used to build packages (in favor of ezbake),
we still have some automation in that packaging repo that we should have
access to. For example, the automation to create release tickets lives
there.