### PR TITLE
(PDB-1791) Remove option confdir to fix tests

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -326,7 +326,7 @@ module PuppetDBExtensions
       manifest = puppetdb_manifest
       apply_manifest_on(host, manifest)
     end
-    print_ini_files(host, confdir)
+    print_ini_files(host)
     sleep_until_started(host)
   end
 


### PR DESCRIPTION
Var confdir was removed from the code scope, but not from the optional argument
to print_ini_files.

Signed-off-by: Ken Barber <ken@bob.sh>