### PR TITLE
(PDB-1812) Analyze all pg tables at least once

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -246,7 +246,7 @@
   [db-conn-pool product-name]
   (sql/with-connection db-conn-pool
     (scf-store/validate-database-version #(System/exit 1))
-    (migrate!)
+    (migrate! db-conn-pool)
     (indexes! product-name)))
 
 (defn init-with-db

--- a/test/puppetlabs/puppetdb/fixtures.clj
+++ b/test/puppetlabs/puppetdb/fixtures.clj
@@ -26,7 +26,7 @@
       (sql/with-connection *db*
         (sql/transaction
          (clear-db-for-testing!)
-         (migrate!)))
+         (migrate! *db*)))
       (pjdbc/pooled-datasource (assoc db :read-only? read-only?)))))
 
 (defn with-test-db
@@ -35,7 +35,7 @@
   (binding [*db* (test-db)]
     (sql/with-connection *db*
       (clear-db-for-testing!)
-      (migrate!)
+      (migrate! *db*)
       (f))))
 
 (defn without-db-var

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -36,7 +36,7 @@
 (defn reset-db!
   []
   (tu/clear-db-for-testing!)
-  (migrate/migrate!))
+  (migrate/migrate! *db*))
 
 (defn-validated factset-map :- {s/Str s/Str}
   "Return all facts and their values for a given certname as a map"


### PR DESCRIPTION
Investigation of a performance problem revealed that analyzing the
value_types table improved a PostgreSQL backed http:/.../fact-values
query by a factor of about 4x when run against a ~10m fact benchmark DB
on a tmpfs on Linux.

It appeared that some tables had never been analyzed, and further
testing revealed that the autovacuum process ignored them.  In some
cases, it looks like this is because it ignores small tables that don't
change much, like value_types, which has 6 rows and effectively never
changes.

So make sure that all tables are analyzed at least once (after any
structure changes) by running a "vacuum (analyze, verbose)" whenever we
have to run any migration, and add a dummy migration so that all
existing databases will run the analysis too.