### PR TITLE
(PDB-1809) improve aggregate event counts performance

### DIFF
--- a/documentation/api/query/v4/aggregate-event-counts.markdown
+++ b/documentation/api/query/v4/aggregate-event-counts.markdown
@@ -37,12 +37,13 @@ results into a single map.
 
 This endpoint builds on top of the [`event-counts`][event-counts] endpoint, and it uses all of the same URL parameters. The supported parameters are re-listed below for reference.
 
-* `query`: Required. A JSON array of query predicates in prefix form (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`).
-This query is forwarded to the [`events`][events] endpoint - see there for additional documentation. For general info about queries, see [the page on query structure.][query]
-
 * `summarize_by`: Required. A string specifying which object types you'd like counted. Supported values are
 `resource`, `containing_class`, and `certname`, or any comma-separated
 combination thereof.
+
+* `query`: Optional. A JSON array of query predicates in prefix form (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`).
+This query is forwarded to the [`events`][events] endpoint - see there for additional documentation.
+For general info about queries, see [the page on query structure.][query]
 
 * `count_by`: Optional. A string specifying what type of object is counted when building up the counts of
 `successes`, `failures`, `noops`, and `skips`. Supported values are `resource` (default) and `certname`.

--- a/documentation/api/query/v4/event-counts.markdown
+++ b/documentation/api/query/v4/event-counts.markdown
@@ -35,7 +35,7 @@ See the [`events`][events] endpoint for additional documentation as this endpoin
 
 ### URL Parameters
 
-* `query`: Required. A JSON array of query predicates in prefix form (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`).
+* `query`: Optional. A JSON array of query predicates in prefix form (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`).
 This query is forwarded to the [`events`][events] endpoint - see there for additional documentation. For general info about queries, see [the page on query structure.][query]
 
 * `summarize_by`: Required. A string specifying which type of object you'd like to see counts for.

--- a/src/puppetlabs/puppetdb/http/aggregate_event_counts.clj
+++ b/src/puppetlabs/puppetdb/http/aggregate_event_counts.clj
@@ -42,6 +42,7 @@
   [version]
   (-> (routes version)
       verify-accepts-json
-      (validate-query-params {:required ["query" "summarize_by"]
-                              :optional ["counts_filter" "count_by" "distinct_resources"
+      (validate-query-params {:required ["summarize_by"]
+                              :optional ["query"
+                                         "counts_filter" "count_by" "distinct_resources"
                                          "distinct_start_time" "distinct_end_time"]})))

--- a/src/puppetlabs/puppetdb/http/event_counts.clj
+++ b/src/puppetlabs/puppetdb/http/event_counts.clj
@@ -33,8 +33,9 @@
   [version]
   (-> (routes version)
       verify-accepts-json
-      (validate-query-params {:required ["query" "summarize_by"]
-                              :optional (concat ["counts_filter" "count_by"
+      (validate-query-params {:required ["summarize_by"]
+                              :optional (concat ["query"
+                                                 "counts_filter" "count_by"
                                                  "distinct_resources" "distinct_start_time"
                                                  "distinct_end_time"]
                                                 paging/query-params) })

--- a/src/puppetlabs/puppetdb/query/aggregate_event_counts.clj
+++ b/src/puppetlabs/puppetdb/query/aggregate_event_counts.clj
@@ -23,7 +23,7 @@
   "Convert an aggregate-event-counts `query` and a value to `summarize_by`
    into a SQL string."
   [version query summarize_by query-options]
-  {:pre  [(sequential? query)
+  {:pre  [((some-fn nil? sequential?) query)
           (string? summarize_by)
           ((some-fn map? nil?) query-options)]}
   (let [query-options (if (nil? query-options) {} query-options)
@@ -39,14 +39,14 @@
    into a SQL string. Since all inputs are forwarded to
    `event-counts/query->sql`, look there for proper documentation."
   [version query [summarize_by {:keys [distinct_resources?] :as query-options}]]
-  {:pre  [(sequential? query)
+  {:pre  [((some-fn nil? sequential?) query)
           ((some-fn map? nil?) query-options)]
    :post [(jdbc/valid-jdbc-query? (:results-query %))]}
   (let [summary-vec (str/split summarize_by #",")
         nsummarized (count summary-vec)
         aggregate-fn #(assemble-aggregate-sql version query % query-options)
         aggregated-sql-and-params (map aggregate-fn summary-vec)
-        common-params (second (first aggregated-sql-and-params))
+        common-params (or (second (first aggregated-sql-and-params)) [])
         params (if distinct_resources?
                  ;; when distinct resources is used, the first two parameters
                  ;; are the distinct start/end times.

--- a/src/puppetlabs/puppetdb/query/event_counts.clj
+++ b/src/puppetlabs/puppetdb/query/event_counts.clj
@@ -130,7 +130,7 @@
     version
     query
     [summarize_by {:keys [counts_filter count_by] :as query-options} paging-options]]
-     {:pre  [(sequential? query)
+     {:pre  [((some-fn nil? sequential?) query)
              (string? summarize_by)
              ((some-fn nil? sequential?) counts_filter)
              ((some-fn nil? string?) count_by)]

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -26,7 +26,8 @@
   [entity version paging-options url-prefix]
   (let [[query->sql munge-fn]
         (case entity
-          :aggregate-event-counts [aggregate-event-counts/query->sql aggregate-event-counts/munge-result-rows]
+          :aggregate-event-counts [aggregate-event-counts/query->sql
+                                   aggregate-event-counts/munge-result-rows]
           :event-counts [event-counts/query->sql
                          (event-counts/munge-result-rows (first paging-options))]
           :facts [facts/query->sql facts/munge-result-rows]

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1126,7 +1126,8 @@
                        status noop metrics logs] :as report} (normalize-report orig-report)
                 report-hash (shash/report-identity-hash report)]
            (sql/transaction
-             (let [{:keys [id]} (sql/insert-record :reports
+             (let [certname-id (certname-id certname)
+                   {:keys [id]} (sql/insert-record :reports
                                  (maybe-environment
                                    {:hash                   (sutils/munge-hash-for-storage report-hash)
                                     :transaction_uuid       (sutils/munge-uuid-for-storage transaction_uuid)
@@ -1145,7 +1146,7 @@
                                     :status_id              (ensure-status status)}))
                    assoc-ids #(assoc %
                                      :report_id id
-                                     :certname_id (certname-id certname))]
+                                     :certname_id certname-id)]
                (->> resource_events
                     (map (comp convert-containment-path assoc-ids))
                     (apply sql/insert-records :resource_events))

--- a/test/puppetlabs/puppetdb/http/aggregate_event_counts_test.clj
+++ b/test/puppetlabs/puppetdb/http/aggregate_event_counts_test.clj
@@ -91,6 +91,7 @@
                                                         "distinct_end_time" (now)})
                         :body
                         (json/parse-string true)))
+         nil
          ["=" "certname" "foo.local"]
          ["<=" "report_receive_time" current-time-str]
          ["<=" "run_start_time" current-time-str]
@@ -105,10 +106,7 @@
                            :environment "PROD") (now))
   (are [result query] (= result (-> (get-response endpoint
                                                   query
-                                                  "resource"
-                                                  {"distinct_resources" false
-                                                   "distinct_start_time" 0
-                                                   "distinct_end_time" (now)})
+                                                  "resource")
                                     :body
                                     (json/parse-string true)))
        [{:successes 2
@@ -118,6 +116,14 @@
         :total 3
         :summarize_by "resource"}]
        ["=" "environment" "DEV"]
+
+       [{:successes 5
+        :skips 1
+        :failures 0
+        :noops 0
+        :total 6
+        :summarize_by "resource"}]
+       nil
 
        [{:successes 2
         :skips 1

--- a/test/puppetlabs/puppetdb/http/event_counts_test.clj
+++ b/test/puppetlabs/puppetdb/http/event_counts_test.clj
@@ -126,6 +126,26 @@
             :noops 0
             :skips 1}}
 
+         nil
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 1
+            :successes 0
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :successes 0
+            :noops 0
+            :skips 1}}
+
          ["~" "certname" ".*"]
          #{{:subject_type "resource"
             :subject {:type "Notify" :title "notify, yo"}
@@ -231,11 +251,47 @@
                            :environment "PROD") (now))
   (are [result query] (response-equal? (get-response endpoint
                                                      query
-                                                     "resource"
-                                                     {"distinct_resources" false
-                                                      "distinct_start_time" 0
-                                                      "distinct_end_time" (now)})
+                                                     "resource")
                                        result)
+       #{{:subject_type "resource"
+          :subject {:type "Notify" :title "notify, yo"}
+          :failures 0
+          :successes 1
+          :noops 0
+          :skips 0}
+         {:subject_type "resource"
+          :subject {:type "Notify" :title "notify, yar"}
+          :failures 0
+          :successes 1
+          :noops 0
+          :skips 0}
+         {:subject_type "resource"
+          :subject {:type "Notify" :title "hi"}
+          :failures 0
+          :successes 0
+          :noops 0
+          :skips 1}
+         {:subject_type "resource",
+          :noops 0,
+          :skips 0,
+          :successes 1,
+          :failures 0,
+          :subject {:type "File", :title "tmp-directory"}}
+         {:subject_type "resource",
+          :noops 0,
+          :skips 0,
+          :successes 1,
+          :failures 0,
+          :subject {:type "File", :title "puppet-managed-file"}}
+         {:subject_type "resource",
+          :noops 0,
+          :skips 0,
+          :successes 1,
+          :failures 0,
+          :subject
+          {:type "Notify", :title "Creating tmp directory at /Users/foo/tmp"}}}
+       nil
+
        #{{:subject_type "resource"
           :subject {:type "Notify" :title "notify, yo"}
           :failures 0

--- a/test/puppetlabs/puppetdb/query/events_test.clj
+++ b/test/puppetlabs/puppetdb/query/events_test.clj
@@ -24,7 +24,7 @@
     (let [ops (query/resource-event-ops version)]
       (testing "should succesfully compile a valid equality query"
         (is (= (query/compile-term ops ["=" "report" "blah"])
-               {:where   (format "%s = ?" (sutils/sql-hash-as-str "reports.hash"))
+               {:where   (format "%s = ?" (sutils/sql-hash-as-str "latest_events.hash"))
                 :params  ["blah"]})))
       (testing "should fail with an invalid equality query"
         (is (thrown-with-msg?


### PR DESCRIPTION
    (PDB-1809) improve aggregate event counts performance
    
    This series of commits attempts to improve the performance of aggregate event
    counts with the following actions:
    
    * explicit C collation in group by used for with-latest-events
    * query parameter for aggregate event counts endpoint is now optional
    * moved some things from distinct-select into with-latest-events so they can be
      reused across multiple summarize_by's