### PR TITLE
(PDB-1731) Add `clean all` step for FOSS el6 repos setup

### DIFF
--- a/acceptance/setup/pre_suite/15_setup_repos.rb
+++ b/acceptance/setup/pre_suite/15_setup_repos.rb
@@ -18,6 +18,7 @@ def initialize_repo_on_host(host, os)
       on host, "curl -O http://yum.puppetlabs.com/puppetlabs-release-pc1-#{variant}-#{version}.noarch.rpm"
       on host, "rpm -i puppetlabs-release-pc1-#{variant}-#{version}.noarch.rpm"
     else
+      on host, "yum clean all -y"
       create_remote_file host, '/etc/yum.repos.d/puppetlabs-dependencies.repo', <<-REPO.gsub(' '*8, '')
 [puppetlabs-dependencies]
 name=Puppet Labs Dependencies - $basearch


### PR DESCRIPTION
This commit fixes an issue on el6 foss acceptance tests (non-aio) where
`yum install puppet -y` was getting:
```sh
el6-64-1 06:18:18$ yum install -y puppet
Loaded plugins: fastestmirror, presto
Determining fastest mirrors
Error: Cannot retrieve metalink for repository: epel. Please verify its
path and try again
```
This commit returns the `yum clean all -y` step before installing the
Puppet Labs repos so that we won't see these issues.