### PR TITLE
(PDB-1731) Upgrade distros only on el6 non-aio acceptance tests

### DIFF
--- a/acceptance/setup/pre_suite/15_setup_repos.rb
+++ b/acceptance/setup/pre_suite/15_setup_repos.rb
@@ -19,6 +19,7 @@ def initialize_repo_on_host(host, os)
       on host, "rpm -i puppetlabs-release-pc1-#{variant}-#{version}.noarch.rpm"
     else
       on host, "yum clean all -y"
+      on host, "yum upgrade -y"
       create_remote_file host, '/etc/yum.repos.d/puppetlabs-dependencies.repo', <<-REPO.gsub(' '*8, '')
 [puppetlabs-dependencies]
 name=Puppet Labs Dependencies - $basearch


### PR DESCRIPTION
This commit reverts e4fe882b79a9dad2fa76e581385f62e4354c192d for el6 on
non-aio acceptance testing until we can find exactly what kind of
side-effects `yum upgrade -y` is having on installing our repositories
causing the error mentioned in 109c1a66d26cfceb78234452f94c41479bea4ec0.