### PR TITLE
(PDB-1739) Upgrade to the latest clojure.java.jdbc `0.3.7`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -49,7 +49,7 @@
 
                  ;; Database connectivity
                  [com.jolbox/bonecp "0.7.1.RELEASE" :exclusions [org.slf4j/slf4j-api]]
-                 [org.clojure/java.jdbc "0.1.1"]
+                 [org.clojure/java.jdbc "0.3.7"]
                  [org.hsqldb/hsqldb "2.2.8"]
                  [org.postgresql/postgresql "9.2-1003-jdbc4"]
 

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -44,7 +44,7 @@
      maintain acceptable performance."
   (:require [clj-time.core :refer [ago]]
             [clojure.java.io :as io]
-            [clojure.java.jdbc :as sql]
+            [clojure.java.jdbc.deprecated :as sql]
             [clojure.tools.logging :as log]
             [compojure.core :as compojure]
             [overtone.at-at :refer [mk-pool interspaced]]
@@ -54,8 +54,7 @@
             [puppetlabs.puppetdb.command.dlo :as dlo]
             [puppetlabs.puppetdb.config :as conf]
             [puppetlabs.puppetdb.http.server :as server]
-            [puppetlabs.puppetdb.jdbc :as pl-jdbc]
-            [puppetlabs.puppetdb.jdbc :refer [with-transacted-connection]]
+            [puppetlabs.puppetdb.jdbc :as pl-jdbc :refer [with-transacted-connection]]
             [puppetlabs.puppetdb.meta.version :as version]
             [puppetlabs.puppetdb.mq :as mq]
             [puppetlabs.puppetdb.query-eng :as qeng]

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -2,8 +2,7 @@
   "Database utilities"
   (:import (com.jolbox.bonecp BoneCPDataSource BoneCPConfig)
            (java.util.concurrent TimeUnit))
-  (:require [clojure.java.jdbc :as sql]
-            [clojure.java.jdbc.internal :as jint]
+  (:require [clojure.java.jdbc.deprecated :as sql]
             [clojure.string :as string]
             [clojure.tools.logging :as log]
             [puppetlabs.kitchensink.core :as kitchensink]
@@ -230,7 +229,7 @@
   (retry-sql 5
              (sql/with-connection db-spec
                (when-let [isolation-level (get isolation-levels tx-isolation-level)]
-                 (.setTransactionIsolation (jint/find-connection*) isolation-level))
+                 (.setTransactionIsolation (sql/find-connection) isolation-level))
                (sql/transaction (f)))))
 
 (defmacro with-transacted-connection'

--- a/src/puppetlabs/puppetdb/meta/version.clj
+++ b/src/puppetlabs/puppetdb/meta/version.clj
@@ -3,7 +3,7 @@
 
    This namespace contains some utility functions relating to checking version
    numbers of various fun things."
-  (:require [clojure.java.jdbc :as sql]
+  (:require [clojure.java.jdbc.deprecated :as sql]
             [clojure.string :as string]
             [clj-http.client :as client]
             [ring.util.codec :as ring-codec]

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.puppetdb.query-eng
-  (:require [clojure.java.jdbc :as sql]
+  (:require [clojure.java.jdbc.deprecated :as sql]
             [clojure.tools.logging :as log]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.cheshire :as json]

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -47,7 +47,7 @@
       in the migrations array in the old branch, but that is not a problem.
 
    _TODO: consider using multimethods for migration funcs_"
-  (:require [clojure.java.jdbc :as sql]
+  (:require [clojure.java.jdbc.deprecated :as sql]
             [clojure.tools.logging :as log]
             [clojure.string :as string]
             [puppetlabs.puppetdb.scf.migration-legacy :as legacy]

--- a/src/puppetlabs/puppetdb/scf/migration_legacy.clj
+++ b/src/puppetlabs/puppetdb/scf/migration_legacy.clj
@@ -6,7 +6,7 @@
              :refer [flatten-facts-with
                      path->pathmap]]
             [puppetlabs.puppetdb.jdbc :as jdbc]
-            [clojure.java.jdbc :as sql]
+            [clojure.java.jdbc.deprecated :as sql]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.scf.hash :as hash]

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -25,7 +25,7 @@
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.jdbc :as jdbc]
-            [clojure.java.jdbc :as sql]
+            [clojure.java.jdbc.deprecated :as sql]
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.puppetdb.scf.storage-utils
-  (:require [clojure.java.jdbc :as sql]
+  (:require [clojure.java.jdbc.deprecated :as sql]
             [honeysql.core :as hcore]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.honeysql :as h]

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.puppetdb.command-test
   (:require [me.raynes.fs :as fs]
-            [clojure.java.jdbc :as sql]
+            [clojure.java.jdbc.deprecated :as sql]
             [cheshire.core :as json]
             [puppetlabs.puppetdb.scf.storage :as scf-store]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]

--- a/test/puppetlabs/puppetdb/fixtures.clj
+++ b/test/puppetlabs/puppetdb/fixtures.clj
@@ -1,7 +1,6 @@
 (ns puppetlabs.puppetdb.fixtures
   (:import [java.io ByteArrayInputStream])
-  (:require [clojure.java.jdbc :as sql]
-            [clojure.java.jdbc.internal :as jint]
+  (:require [clojure.java.jdbc.deprecated :as sql]
             [puppetlabs.puppetdb.http.server :as server]
             [puppetlabs.puppetdb.http.command :as command]
             [puppetlabs.puppetdb.jdbc :as pjdbc]
@@ -47,7 +46,7 @@
    route testing code to ensure that the route has it's own db
    connection."
   [f]
-  (binding [jint/*db* nil]
+  (binding [sql/*db* nil]
     (f)))
 
 (defn with-test-mq

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -2,7 +2,7 @@
   (:require [cheshire.core :as json]
             [clj-time.coerce :refer [to-timestamp to-string]]
             [clj-time.core :refer [now]]
-            [clojure.java.jdbc :as sql]
+            [clojure.java.jdbc.deprecated :as sql]
             [clojure.java.io :as io]
             [clojure.test :refer :all]
             [flatland.ordered.map :as omap]

--- a/test/puppetlabs/puppetdb/jdbc_test.clj
+++ b/test/puppetlabs/puppetdb/jdbc_test.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.puppetdb.jdbc-test
   (:require [puppetlabs.puppetdb.jdbc :as subject]
-            [clojure.java.jdbc.internal :as jint]
+            [clojure.java.jdbc.deprecated :as sql]
             [puppetlabs.puppetdb.fixtures :as fixt]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.testutils :refer [test-db]]
@@ -83,15 +83,15 @@
         db (test-db)]
 
     (subject/with-transacted-connection' db nil
-      (let [conn (:connection jint/*db*)]
-        (is (false? (.getAutoCommit (:connection jint/*db*))))
+      (let [conn (sql/find-connection)]
+        (is (false? (.getAutoCommit (sql/find-connection))))
         (is (= java.sql.Connection/TRANSACTION_READ_COMMITTED (.getTransactionIsolation conn)))
         (reset! evaled-body? true)))
 
     (is (true? @evaled-body?))
 
     (are [isolation-level isolation-level-kwd] (subject/with-transacted-connection' db isolation-level-kwd
-                                                 (let [conn (:connection jint/*db*)]
+                                                 (let [conn (sql/find-connection)]
                                                    (= isolation-level (.getTransactionIsolation conn))))
 
          java.sql.Connection/TRANSACTION_REPEATABLE_READ :repeatable-read

--- a/test/puppetlabs/puppetdb/query/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/query/nodes_test.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.puppetdb.query.nodes-test
   (:require [clojure.set :as set]
             [puppetlabs.puppetdb.query-eng :as eng]
-            [clojure.java.jdbc :as sql]
+            [clojure.java.jdbc.deprecated :as sql]
             [puppetlabs.puppetdb.scf.storage :as scf-store]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [clojure.test :refer :all]

--- a/test/puppetlabs/puppetdb/query/population_test.clj
+++ b/test/puppetlabs/puppetdb/query/population_test.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.puppetdb.query.population-test
   (:require [puppetlabs.puppetdb.query.population :as pop]
-            [clojure.java.jdbc :as sql]
+            [clojure.java.jdbc.deprecated :as sql]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.scf.storage :refer [deactivate-node!]]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils :refer [to-jdbc-varchar-array]]

--- a/test/puppetlabs/puppetdb/query/resources_test.clj
+++ b/test/puppetlabs/puppetdb/query/resources_test.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.puppetdb.query.resources-test
   (:require [puppetlabs.puppetdb.query-eng :as eng]
-            [clojure.java.jdbc :as sql]
+            [clojure.java.jdbc.deprecated :as sql]
             [puppetlabs.puppetdb.scf.storage :refer [ensure-environment]]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.fixtures :refer :all]

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -6,7 +6,7 @@
             [puppetlabs.puppetdb.scf.storage-utils :as sutils
              :refer [db-serialize postgres?]]
             [cheshire.core :as json]
-            [clojure.java.jdbc :as sql]
+            [clojure.java.jdbc.deprecated :as sql]
             [puppetlabs.puppetdb.scf.migrate :refer :all]
             [clj-time.coerce :refer [to-timestamp]]
             [clj-time.core :refer [now ago days]]

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.puppetdb.scf.storage-test
-  (:require [clojure.java.jdbc :as sql]
+  (:require [clojure.java.jdbc.deprecated :as sql]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.scf.hash :as shash]
             [puppetlabs.puppetdb.facts :as facts

--- a/test/puppetlabs/puppetdb/scf/storage_utils_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_utils_test.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.puppetdb.scf.storage-utils-test
-  (:require [clojure.java.jdbc :as sql]
+  (:require [clojure.java.jdbc.deprecated :as sql]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.scf.storage-utils :refer :all]
             [cheshire.core :as json]

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -4,7 +4,7 @@
             [puppetlabs.puppetdb.http :as http]
             [puppetlabs.puppetdb.query.paging :as paging]
             [clojure.string :as string]
-            [clojure.java.jdbc :as sql]
+            [clojure.java.jdbc.deprecated :as sql]
             [cheshire.core :as json]
             [me.raynes.fs :as fs]
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-log-output]]

--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.puppetdb.testutils.db
-  (:require [clojure.java.jdbc :as sql]
+  (:require [clojure.java.jdbc.deprecated :as sql]
             [puppetlabs.puppetdb.testutils :refer [clear-db-for-testing! test-db]]))
 
 (def antonym-data {"absence"    "presence"

--- a/test/puppetlabs/puppetdb/testutils/resources.clj
+++ b/test/puppetlabs/puppetdb/testutils/resources.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.puppetdb.testutils.resources
-  (:require [clojure.java.jdbc :as sql]
+  (:require [clojure.java.jdbc.deprecated :as sql]
             [clj-time.core :refer [now]]
             [clj-time.coerce :refer [to-timestamp]]
             [puppetlabs.puppetdb.fixtures :refer :all]


### PR DESCRIPTION
This commit upgrades PuppetDB to use the latest clojure.java.jdbc which
consists of using the deprecated namespace in the new version as well as
removing some test fixtures that reached into the old internals
namespace of jdbc to bind the *db* dynamic var.