### PR TITLE
(PDB-1313) Add statistics to puppetdb.commands

### DIFF
--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -69,7 +69,8 @@
             [slingshot.slingshot :refer [try+ throw+]]
             [cheshire.custom :refer [JSONable]]
             [puppetlabs.puppetdb.command.constants :refer [command-names]]
-            [puppetlabs.trapperkeeper.services :refer [defservice]]
+            [puppetlabs.trapperkeeper.services
+             :refer [defservice service-context]]
             [schema.core :as s]
             [puppetlabs.puppetdb.time :refer [to-timestamp]]
             [clj-time.core :refer [now]]
@@ -123,7 +124,7 @@
 
 ;; ## Command submission
 
-(defn-validated enqueue-raw-command! :- s/Str
+(defn-validated ^:private do-enqueue-raw-command :- s/Str
   "Submits raw-command to the mq-endpoint of mq-connection and returns
   its id."
   [mq-connection :- mq/connection-schema
@@ -135,7 +136,7 @@
                       {"received" (kitchensink/timestamp) "id" id})
     id))
 
-(defn-validated enqueue-command! :- s/Str
+(defn-validated ^:private do-enqueue-command :- s/Str
   "Submits command to the mq-endpoint of mq-connection and returns
   its id. Annotates the command via annotate-command."
   [mq-connection :- mq/connection-schema
@@ -302,11 +303,51 @@
 (def supported-command?
   (comp (kitchensink/valset command-names) :command))
 
+(defprotocol PuppetDBCommandDispatcher
+  (enqueue-command [this connection endpoint command version payload]
+    "Annotates the command via annotate-command, submits it to the
+    endpoint of the connection, and then returns its unique id.")
+  (enqueue-raw-command [this connection endpoint raw-command]
+    "Submits the raw-command to the endpoint of the connection and
+    returns the command's unique id.")
+  (stats [this]
+    "Returns command processing statistics as a map
+    containing :received-commands (a count of the commands received so
+    far by the current service instance), and :executed-commands (a
+    count of the commands that the current instance has processed
+    without triggering an exception)."))
+
 (defservice command-service
+  PuppetDBCommandDispatcher
   [[:PuppetDBServer shared-globals]
    [:MessageListenerService register-listener]]
+  (init [this context]
+    (assoc context :stats (atom {:received-commands 0
+                                 :executed-commands 0})))
   (start [this context]
-         (let [{:keys [scf-write-db catalog-hash-debug-dir]} (shared-globals)]
-           (register-listener supported-command? #(process-command! % {:db scf-write-db
-                                                                       :catalog-hash-debug-dir catalog-hash-debug-dir}))
-           context)))
+    (let [{:keys [scf-write-db catalog-hash-debug-dir]} (shared-globals)
+          config {:db scf-write-db
+                  :catalog-hash-debug-dir catalog-hash-debug-dir}]
+      (register-listener
+       supported-command?
+       (fn [cmd]
+         (let [result (process-command! cmd config)]
+           (swap! (:stats context) update :executed-commands inc)
+           result)))
+      context))
+
+  (stats [this]
+    @(:stats (service-context this)))
+
+  (enqueue-command [this connection endpoint command version payload]
+    (let [result (do-enqueue-command connection endpoint
+                                     command version payload)]
+      ;; Obviously assumes that if do-* doesn't throw, msg is in
+      (swap! (:stats (service-context this)) update :received-commands inc)
+      result))
+
+  (enqueue-raw-command [this connection endpoint raw-command]
+    (let [result (do-enqueue-raw-command connection endpoint raw-command)]
+      ;; Obviously assumes that if do-* doesn't throw, msg is in
+      (swap! (:stats (service-context this)) update :received-commands inc)
+      result)))

--- a/test/puppetlabs/puppetdb/fixtures.clj
+++ b/test/puppetlabs/puppetdb/fixtures.clj
@@ -2,6 +2,7 @@
   (:import [java.io ByteArrayInputStream])
   (:require [clojure.java.jdbc.deprecated :as sql]
             [puppetlabs.puppetdb.http.server :as server]
+            [puppetlabs.puppetdb.command :as dispatch]
             [puppetlabs.puppetdb.http.command :as command]
             [puppetlabs.puppetdb.jdbc :as pjdbc]
             [puppetlabs.puppetdb.schema :as pls]
@@ -65,7 +66,9 @@
   is available. Note this means this fixture should be nested _within_
   `with-test-mq`."
   ([f]
-   (binding [*command-app* (command/command-app {:command-mq *mq*})]
+   (binding [*command-app* (command/command-app
+                            {:command-mq *mq*}
+                            #'dispatch/do-enqueue-raw-command)]
      (f))))
 
 (defn with-http-app


### PR DESCRIPTION
Arrange for all command submission and execution to go through the
command-service, so that it can track received and executed command
counts.  This makes it possible to know that all outstanding commands
have been executed by waiting until:

```clojure
  (let [{:keys [received-commands executed-commands]} (stats cmd-service)]
    (= executed-commands received-commands))
```

To make that possible, add a PuppetDBCommandDispatcher protocol for
command-service that provides enqueue-command, enqueue-raw-command, and
stats, and make the previous enqueue-command! and enqueue-raw-command!
functions private.  Ensure that all command submissions and executions
update the new stats.