### PR TITLE
(PDB-1313) Add some-newer-record-for-certname

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1245,6 +1245,15 @@
              (timestamp-of-newest-record certname)
              (.after time)))))
 
+(pls/defn-validated have-newer-record-for-certname?
+  [certname :- String
+   timestamp :- pls/Timestamp]
+  "Returns a truthy value indicating whether a record exists that has
+  a producer_timestamp newer than the given timestamp."
+  (some (fn [entity]
+          (have-record-produced-after? entity certname timestamp))
+        [:catalogs :factsets :reports]))
+
 (pls/defn-validated catalog-newer-than?
   "Returns true if the most current catalog for `certname` is more recent than
   `time`."


### PR DESCRIPTION
Pull the "should we actually allow this deactivation" guard out of the
:deactivate-node process-command! and make it a new public function,
allowing other code to determine whether a timely deactivate node
command is likely to do anything.