### PR TITLE
(PDB-1313) Uniformly format json dates

### DIFF
--- a/src/puppetlabs/puppetdb/cheshire.clj
+++ b/src/puppetlabs/puppetdb/cheshire.clj
@@ -38,19 +38,32 @@
 
 (add-common-json-encoders!)
 
-(def default-pretty-opts {:date-format "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" :pretty true})
+(def default-opts {:date-format "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"})
+(def default-pretty-opts (assoc default-opts :pretty true))
 
-(def generate-string core/generate-string)
-
-(def generate-stream core/generate-stream)
+(defn generate-string
+  "Thinly wraps cheshire.core/generate-string, adding the PuppetDB
+  default date format."
+  ([obj]
+   (core/generate-string obj default-opts))
+  ([obj opts]
+   (core/generate-string obj (merge default-opts opts))))
 
 (defn generate-pretty-string
-  "Thinly wraps cheshire.core/generate-string, adding the PuppetDB default date format
-   and pretty printing from `default-pretty-opts`"
+  "Thinly wraps cheshire.core/generate-string, adding the PuppetDB
+  default date format and pretty printing from `default-pretty-opts`"
   ([obj]
-     (generate-pretty-string obj default-pretty-opts))
+   (core/generate-string obj default-pretty-opts))
   ([obj opts]
-     (generate-string obj (merge default-pretty-opts opts))))
+   (core/generate-string obj (merge default-pretty-opts opts))))
+
+(defn generate-stream
+  "Thinly wraps cheshire.core/generate-stream, adding the PuppetDB
+  default date format."
+  ([obj writer]
+   (core/generate-stream obj writer default-opts))
+  ([obj writer opts]
+   (core/generate-stream obj writer (merge default-opts opts))))
 
 (defn generate-pretty-stream
   "Thinly wraps cheshire.core/generate-stream, adding the PuppetDB default date format

--- a/test/puppetlabs/puppetdb/cheshire_test.clj
+++ b/test/puppetlabs/puppetdb/cheshire_test.clj
@@ -1,9 +1,11 @@
 (ns puppetlabs.puppetdb.cheshire-test
-  (:import (java.io StringWriter StringReader))
   (:require [clj-time.core :as clj-time]
             [puppetlabs.puppetdb.testutils :as tu]
             [clojure.test :refer :all]
-            [puppetlabs.puppetdb.cheshire :refer :all]))
+            [puppetlabs.puppetdb.cheshire :refer :all])
+  (:import [java.io StringWriter StringReader]
+           [java.sql Timestamp]
+           [org.joda.time DateTime]))
 
 (deftest test-generate-string
   (testing "should generate a json string"
@@ -34,6 +36,17 @@
       (generate-pretty-stream (sorted-map :a 1 :b 2) sw)
       (is (= (.toString sw)
              "{\n  \"a\" : 1,\n  \"b\" : 2\n}")))))
+
+(deftest test-date-generation
+  (let [t (java.util.Date. 5928174905781)]
+    (is (= "\"2157-11-09T03:15:05.781Z\""
+           (generate-string t))))
+  (let [t (DateTime. 5928174905781)]
+    (is (= "\"2157-11-09T03:15:05.781Z\""
+           (generate-string t))))
+  (let [t (Timestamp. 5928174905781)]
+    (is (= "\"2157-11-09T03:15:05.781Z\""
+           (generate-string t)))))
 
 (deftest test-parse-string
   (testing "should return a map from parsing a json string"

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -349,7 +349,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "99ec099bed6dfb9bff2c7df7828270e95f590147"
+       :report "7d0cfa08901e1e1d80cf2f2f814d356d0e457e09"
        :resource_title "hi"
        :property nil
        :file "bar"
@@ -374,7 +374,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "99ec099bed6dfb9bff2c7df7828270e95f590147"
+       :report "7d0cfa08901e1e1d80cf2f2f814d356d0e457e09"
        :resource_title "hi"
        :property nil
        :file "bar"
@@ -401,7 +401,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "99ec099bed6dfb9bff2c7df7828270e95f590147"
+       :report "7d0cfa08901e1e1d80cf2f2f814d356d0e457e09"
        :resource_title "hi"
        :property nil
        :file "bar"


### PR DESCRIPTION
Previously puppetdb's generate-string just redirected to
cheshire/generate-string, whereas generate-pretty-string would add
puppetdb-specific date formatting (that rendered seconds at "full"
precision) in addition to setting :pretty to true.

Change generate-string to include the puppetdb-specific date formatting,
since not pretty shouldn't also mean not accurate.

This was causing trouble because information (accuracy) was being lost
in transit (say across http).

One of the tests may fail right now, due to an undesirable interaction between pdb-instance and the log tests, but that appears to be a preexisting issue that can be reproduced via `lein test :only puppetlabs.puppetdb.command-test puppetlabs.puppetdb.testutils.services-test`.  One possible fix: https://github.com/puppetlabs/puppetdb/pull/1567
