### PR TITLE
(PDB-1721) memory starvation with large structured facts

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -11,6 +11,10 @@
 
 ;; SCHEMA
 
+(defn array-to-param
+  [col-type java-type values]
+  (.createArrayOf (sql/connection) col-type (into-array java-type values)))
+
 (def pg-extension-map
   "Maps to the table definition in postgres, but only includes some of the
    columns:


### PR DESCRIPTION
Our fact storage mechanism previously created some very large prepared
statements when very large structured facts were updated. This changes things
so that our fact-storage related prepared statements use a single array-valued
parameter, so that a single statement should be applicable to all scenarios.

This change appears to have eased the original problem and also improves fact
command processing speed significantly.