### PR TITLE
(maint) Treat the log config as a global resource

### DIFF
--- a/test/puppetlabs/puppetdb/testutils/log.clj
+++ b/test/puppetlabs/puppetdb/testutils/log.clj
@@ -1,0 +1,55 @@
+(ns puppetlabs.puppetdb.testutils.log
+  (:require [puppetlabs.kitchensink.core :as kitchensink])
+  (:import [ch.qos.logback.core spi.LifeCycle Appender]
+           [ch.qos.logback.classic Level Logger]
+           [org.slf4j LoggerFactory]))
+
+(defmacro with-log-level
+  "Sets the (logback) log level for the logger specified by logger-id
+  during the execution of body.  If logger-id is not a class, it is
+  converted via str, and the level must be a clojure.tools.logging
+  key, i.e. :info, :error, etc."
+  [logger-id level & body]
+  ;; Assumes use of logback (i.e. logger supports Levels).
+  `(let [logger-id# ~logger-id
+         logger-id# (if (class? logger-id#) logger-id# (str logger-id#))
+         logger# (.getLogger (LoggerFactory/getILoggerFactory) logger-id#)
+         original-level# (.getLevel logger#)]
+     (.setLevel logger# (case ~level
+                          :trace Level/TRACE
+                          :debug Level/DEBUG
+                          :info Level/INFO
+                          :warn Level/WARN
+                          :error Level/ERROR
+                          :fatal Level/ERROR))
+     (try
+       (do ~@body)
+       (finally (.setLevel logger# original-level#)))))
+
+(defn create-log-appender-to-atom
+  [destination-atom]
+  ;; No clue yet if we're supposed to start with a default name.
+  (let [name (atom (str "log-appender-to-atom-" (kitchensink/uuid)))]
+    (reify
+      Appender
+      (doAppend [this event] (swap! destination-atom conj event))
+      (getName [this] @name)
+      (setName [this x] (reset! name x))
+      LifeCycle
+      (start [this] true)
+      (stop [this] true))))
+
+(defmacro with-logging-to-atom
+  "Conjoins all logger-id events produced during the execution of the
+  body to the destination atom, which must contain a collection.  If
+  logger-id is not a class, it is converted via str."
+  [logger-id destination & body]
+  ;; Specify the root logger via org.slf4j.Logger/ROOT_LOGGER_NAME.
+  `(let [logger-id# ~logger-id
+         logger-id# (if (class? logger-id#) logger-id# (str logger-id#))
+         logger# (.getLogger (LoggerFactory/getILoggerFactory) logger-id#)
+         appender# (doto (create-log-appender-to-atom ~destination) .start)]
+     (.addAppender logger# appender#)
+     (try
+       (do ~@body)
+       (finally (.detachAppender logger# appender#)))))

--- a/test/puppetlabs/puppetdb/testutils/log.clj
+++ b/test/puppetlabs/puppetdb/testutils/log.clj
@@ -1,8 +1,20 @@
 (ns puppetlabs.puppetdb.testutils.log
-  (:require [puppetlabs.kitchensink.core :as kitchensink])
-  (:import [ch.qos.logback.core spi.LifeCycle Appender]
-           [ch.qos.logback.classic Level Logger]
-           [org.slf4j LoggerFactory]))
+  (:require
+   [puppetlabs.kitchensink.core :as kitchensink]
+   [puppetlabs.puppetdb.testutils :refer [temp-file]]
+   [me.raynes.fs :as fs])
+  (:import
+   [ch.qos.logback.core Appender FileAppender]
+   [ch.qos.logback.core.filter EvaluatorFilter]
+   [ch.qos.logback.core.spi FilterReply LifeCycle]
+   [ch.qos.logback.classic Level Logger]
+   [ch.qos.logback.classic.boolex JaninoEventEvaluator]
+   [ch.qos.logback.classic.encoder PatternLayoutEncoder]
+   [org.slf4j LoggerFactory]))
+
+(defn- find-logger [id]
+  (.getLogger (LoggerFactory/getILoggerFactory)
+              (if (class? id) id (str id))))
 
 (defmacro with-log-level
   "Sets the (logback) log level for the logger specified by logger-id
@@ -10,10 +22,9 @@
   converted via str, and the level must be a clojure.tools.logging
   key, i.e. :info, :error, etc."
   [logger-id level & body]
+  ;; Specify the root logger via org.slf4j.Logger/ROOT_LOGGER_NAME.
   ;; Assumes use of logback (i.e. logger supports Levels).
-  `(let [logger-id# ~logger-id
-         logger-id# (if (class? logger-id#) logger-id# (str logger-id#))
-         logger# (.getLogger (LoggerFactory/getILoggerFactory) logger-id#)
+  `(let [logger# (#'puppetlabs.puppetdb.testutils.log/find-logger ~logger-id)
          original-level# (.getLevel logger#)]
      (.setLevel logger# (case ~level
                           :trace Level/TRACE
@@ -26,18 +37,67 @@
        (do ~@body)
        (finally (.setLevel logger# original-level#)))))
 
-(defn create-log-appender-to-atom
-  [destination-atom]
+(defn- log-event-listener
+  "Returns a log Appender that will call (listen event) for each log event."
+  [listen]
   ;; No clue yet if we're supposed to start with a default name.
-  (let [name (atom (str "log-appender-to-atom-" (kitchensink/uuid)))]
+  (let [name (atom (str "log-listener-" (kitchensink/uuid)))]
     (reify
       Appender
-      (doAppend [this event] (swap! destination-atom conj event))
+      (doAppend [this event] (listen event))
       (getName [this] @name)
       (setName [this x] (reset! name x))
       LifeCycle
       (start [this] true)
       (stop [this] true))))
+
+(defn- with-additional-log-appenders-fn [logger-id appenders body]
+  (let [logger (find-logger logger-id)]
+    (try
+      (doseq [appender appenders]
+        (.addAppender logger appender))
+      (body)
+      (finally
+        (doseq [appender appenders]
+          (.detachAppender logger appender))))))
+
+(defmacro with-additional-log-appenders
+  "Runs body with the appenders temporarily added to the logger
+  specified by logger-id.  If logger-id is not a class, it is
+  converted via str."
+  [logger-id appenders & body]
+  `(#'puppetlabs.puppetdb.testutils.log/with-additional-log-appenders-fn
+     ~logger-id ~appenders (fn [] ~@body)))
+
+(defn- with-log-appenders-fn [logger-id appenders body]
+  (let [logger (find-logger logger-id)
+        original-appenders (iterator-seq (.iteratorForAppenders logger))]
+    (try
+      (doseq [appender original-appenders]
+        (.detachAppender logger appender))
+      (with-additional-log-appenders-fn logger-id appenders body)
+      (finally
+        (doseq [appender original-appenders]
+          (.addAppender logger appender))))))
+
+(defmacro with-log-appenders
+  "Runs body with the current appenders of the logger specified by
+  logger-id replaced by the specified appenders.  If logger-id is not
+  a class, it is converted via str."
+  [logger-id appenders & body]
+  `(#'puppetlabs.puppetdb.testutils.log/with-log-appenders-fn
+     ~logger-id ~appenders (fn [] ~@body)))
+
+(defmacro with-log-event-listener
+  "Calls (listen event) for each logger-id event produced during the
+  execution of the body.  If logger-id is not a class, it is converted
+  via str."
+  [logger-id listen & body]
+  ;; Specify the root logger via org.slf4j.Logger/ROOT_LOGGER_NAME.
+  `(with-additional-log-appenders ~logger-id
+     [(doto (#'puppetlabs.puppetdb.testutils.log/log-event-listener ~listen)
+        .start)]
+     (do ~@body)))
 
 (defmacro with-logging-to-atom
   "Conjoins all logger-id events produced during the execution of the
@@ -45,11 +105,69 @@
   logger-id is not a class, it is converted via str."
   [logger-id destination & body]
   ;; Specify the root logger via org.slf4j.Logger/ROOT_LOGGER_NAME.
-  `(let [logger-id# ~logger-id
-         logger-id# (if (class? logger-id#) logger-id# (str logger-id#))
-         logger# (.getLogger (LoggerFactory/getILoggerFactory) logger-id#)
-         appender# (doto (create-log-appender-to-atom ~destination) .start)]
-     (.addAppender logger# appender#)
-     (try
-       (do ~@body)
-       (finally (.detachAppender logger# appender#)))))
+  `(with-log-event-listener
+     ~logger-id
+     (fn [event#] (swap! ~destination conj event#))
+     ~@body))
+
+(def ^:private amqp-error-filter
+  (str "String m = throwable.getMessage(); "
+       "return javax.jms.JMSException.class.isInstance(throwable) && "
+       "  m.contains(\"peer\") && "
+       "  m.contains(\"stopped\"); "))
+
+(defn- suppressing-appender
+  [log-path]
+  (let [pattern "%-4relative [%thread] %-5level %logger{35} - %msg%n"
+        context (LoggerFactory/getILoggerFactory)]
+    (doto (FileAppender.)
+      (.setFile log-path)
+      (.setAppend true)
+      (.setEncoder (doto (PatternLayoutEncoder.)
+                     (.setPattern pattern)
+                     (.setContext context)
+                     .start))
+      ;; Haven't checked the filter yet.
+      (.addFilter (doto (EvaluatorFilter.)
+                    (.setContext context)
+                    (.setEvaluator (doto (JaninoEventEvaluator.)
+                                     (.setContext context)
+                                     (.setExpression amqp-error-filter)
+                                     .start))
+                    (.setOnMatch FilterReply/DENY)
+                    (.setOnMismatch FilterReply/NEUTRAL)
+                    .start))
+      (.setContext context)
+      .start)))
+
+(defn- suppressing-log-unless-error-fn [f]
+  (let [problem (atom false)
+        detector (doto (#'puppetlabs.puppetdb.testutils.log/log-event-listener
+                        (fn [event]
+                          (let [level (.getLevel event)]
+                            (when (.isGreaterOrEqual level Level/ERROR)
+                              (reset! problem true)))))
+                   .start)
+        log-path (fs/absolute-path (temp-file "pdb-suppressed" ".log"))
+        appender (suppressing-appender log-path)]
+    (try
+      (with-log-appenders org.slf4j.Logger/ROOT_LOGGER_NAME
+        [appender detector]
+        (f))
+      (finally
+        (.stop appender)
+        (when @problem
+          (binding [*out* *err*]
+            (print (slurp log-path))
+            (println "From error log: " log-path)))
+        (when-not @problem (fs/delete log-path))))))
+
+(defmacro suppressing-log-unless-error
+  "Executes the body with all logging suppressed.  If a
+  \"significant\" error is logged, dumps the full log to *err* along
+  with its path.  Assumes that the logging level is already set as
+  desired."
+  [& body]
+  ;; Assumes the log level is as desired
+  `(#'puppetlabs.puppetdb.testutils.log/suppressing-log-unless-error-fn
+    (fn [] ~@body)))

--- a/test/puppetlabs/puppetdb/testutils/log_test.clj
+++ b/test/puppetlabs/puppetdb/testutils/log_test.clj
@@ -1,7 +1,7 @@
-(ns puppetlabs.puppetdb.testutils.services-test
+(ns puppetlabs.puppetdb.testutils.log-test
   (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
-            [puppetlabs.puppetdb.testutils.services :as tgt])
+            [puppetlabs.puppetdb.testutils.log :as tgt])
   (:import [org.slf4j Logger LoggerFactory]))
 
 (defn- event->map [event]

--- a/test/puppetlabs/puppetdb/testutils/log_test.clj
+++ b/test/puppetlabs/puppetdb/testutils/log_test.clj
@@ -1,6 +1,8 @@
 (ns puppetlabs.puppetdb.testutils.log-test
   (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
+            [puppetlabs.kitchensink.core :as kitchensink]
+            [puppetlabs.puppetdb.testutils :refer [temp-file]]
             [puppetlabs.puppetdb.testutils.log :as tgt])
   (:import [org.slf4j Logger LoggerFactory]))
 
@@ -21,3 +23,53 @@
         (log/info "wlta-test"))
       (is (some #(= {:level "INFO" :message "wlta-test"} %)
                 (map event->map @log))))))
+
+(deftest with-additional-log-appenders
+  ;; Definitely incomplete
+  (let [log (atom [])
+        uuid (kitchensink/uuid)]
+    (tgt/with-additional-log-appenders org.slf4j.Logger/ROOT_LOGGER_NAME
+      [(#'puppetlabs.puppetdb.testutils.log/log-event-listener
+        (fn [event] (swap! log conj event)))]
+      (log/error uuid))
+    (is (some #(= {:level "ERROR" :message uuid} %)
+              (map event->map @log)))))
+
+(deftest with-log-appenders
+  ;; Definitely incomplete
+  (let [log (atom [])
+        uuid (kitchensink/uuid)]
+    (tgt/with-additional-log-appenders org.slf4j.Logger/ROOT_LOGGER_NAME
+      [(#'puppetlabs.puppetdb.testutils.log/log-event-listener
+        (fn [event] (swap! log conj event)))]
+      (log/error uuid))
+    (is (some #(= {:level "ERROR" :message uuid} %)
+              (map event->map @log)))))
+
+(deftest with-log-listener
+  (let [log (atom [])
+        uuid (kitchensink/uuid)]
+    (tgt/with-log-level Logger/ROOT_LOGGER_NAME :info
+      (tgt/with-log-event-listener Logger/ROOT_LOGGER_NAME
+        (fn [event] (swap! log conj event))
+        (log/info uuid))
+      (is (is (some #(= {:level "INFO" :message uuid} %)
+                    (map event->map @log)))))))
+
+(deftest suppressing-log-unless-error
+  (tgt/suppressing-log-unless-error
+   (log/info "shouldn't see this"))
+  (let [uuid (kitchensink/uuid)
+        expected (format "shouldn't see this %s" uuid)]
+    (is (not (re-matches (re-pattern (str expected ".*"))
+                         (with-out-str
+                           (binding [*err* *out*]
+                             (tgt/suppressing-log-unless-error
+                              (log/info expected))))))))
+  (let [uuid (kitchensink/uuid)
+        expected (format "not really an error, but should be shown %s" uuid)]
+    (is (re-find (re-pattern expected)
+                 (with-out-str
+                   (binding [*err* *out*]
+                     (tgt/suppressing-log-unless-error
+                      (log/error expected))))))))

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -21,10 +21,7 @@
             [me.raynes.fs :as fs]
             [slingshot.slingshot :refer [throw+]]
             [clojure.tools.logging :as log]
-            [clojure.data.xml :as xml])
-  (:import [ch.qos.logback.core Appender spi.LifeCycle]
-           [ch.qos.logback.classic Level Logger]
-           [org.slf4j LoggerFactory]))
+            [clojure.data.xml :as xml]))
 
 ;; See utils.clj for more information about base-urls.
 (def ^:dynamic *base-url* nil) ; Will not have a :version.
@@ -35,56 +32,6 @@
 (def ^:dynamic *log-levels* {}) ; a map like {"puppetlabs.puppetdb.command" "ERROR"}
 (def ^:dynamic *extra-log-config* nil)
 (def ^:dynamic *extra-appender-config* nil)
-
-(defmacro with-log-level
-  "Sets the (logback) log level for the logger specified by logger-id
-  during the execution of body.  If logger-id is not a class, it is
-  converted via str, and the level must be a clojure.tools.logging
-  key, i.e. :info, :error, etc."
-  [logger-id level & body]
-  ;; Assumes use of logback (i.e. logger supports Levels).
-  `(let [logger-id# ~logger-id
-         logger-id# (if (class? logger-id#) logger-id# (str logger-id#))
-         logger# (.getLogger (LoggerFactory/getILoggerFactory) logger-id#)
-         original-level# (.getLevel logger#)]
-     (.setLevel logger# (case ~level
-                          :trace Level/TRACE
-                          :debug Level/DEBUG
-                          :info Level/INFO
-                          :warn Level/WARN
-                          :error Level/ERROR
-                          :fatal Level/ERROR))
-     (try
-       (do ~@body)
-       (finally (.setLevel logger# original-level#)))))
-
-(defn create-log-appender-to-atom
-  [destination-atom]
-  ;; No clue yet if we're supposed to start with a default name.
-  (let [name (atom (str "log-appender-to-atom-" (kitchensink/uuid)))]
-    (reify
-      Appender
-      (doAppend [this event] (swap! destination-atom conj event))
-      (getName [this] @name)
-      (setName [this x] (reset! name x))
-      LifeCycle
-      (start [this] true)
-      (stop [this] true))))
-
-(defmacro with-logging-to-atom
-  "Conjoins all logger-id events produced during the execution of the
-  body to the destination atom, which must contain a collection.  If
-  logger-id is not a class, it is converted via str."
-  [logger-id destination & body]
-  ;; Specify the root logger via org.slf4j.Logger/ROOT_LOGGER_NAME.
-  `(let [logger-id# ~logger-id
-         logger-id# (if (class? logger-id#) logger-id# (str logger-id#))
-         logger# (.getLogger (LoggerFactory/getILoggerFactory) logger-id#)
-         appender# (doto (create-log-appender-to-atom ~destination) .start)]
-     (.addAppender logger# appender#)
-     (try
-       (do ~@body)
-       (finally (.detachAppender logger# appender#)))))
 
 (defn log-config
   "Returns a logback.xml string with the specified `log-file` `log-level`."

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -26,34 +26,6 @@
 ;; See utils.clj for more information about base-urls.
 (def ^:dynamic *base-url* nil) ; Will not have a :version.
 
-;; Some useful knobs to control logging in your tests
-(def ^:dynamic *log-level* "ERROR")
-(def ^:dynamic *pdb-log-level* "ERROR")
-(def ^:dynamic *log-levels* {}) ; a map like {"puppetlabs.puppetdb.command" "ERROR"}
-(def ^:dynamic *extra-log-config* nil)
-(def ^:dynamic *extra-appender-config* nil)
-
-(defn log-config
-  "Returns a logback.xml string with the specified `log-file` `log-level`."
-  [log-file]
-  (-> [:configuration
-       [:appender {:name "FILE" :class "ch.qos.logback.core.FileAppender"}
-        [:file log-file]
-        [:append true]
-        [:encoder
-         [:pattern "%-4relative [%thread] %-5level %logger{35} - %msg%n"]]
-        *extra-appender-config*]
-
-       (map (fn [[k v]] [:logger {:name k :level (name v)}])
-            *log-levels*)
-       [:logger {:name "puppetlabs.puppetdb" :level *pdb-log-level*}]
-       *extra-log-config*
-
-       [:root {:level *log-level*}
-        [:appender-ref {:ref "FILE"}]]]
-      xml/sexp-as-element
-      xml/emit-str))
-
 (defn create-config
   "Creates a default config, populated with a temporary vardir and
   a fresh hypersql instance"
@@ -63,15 +35,6 @@
    :jetty {:port 0}
    :database (fixt/create-db-map)
    :command-processing {}})
-
-(defn assoc-logging-config
-  "Adds a dynamically created logback.xml with a test log. The
-  generated log file name is returned for printing to the console."
-  [config]
-  (let [logback-file (fs/absolute-path (temp-file "logback" ".xml"))
-        log-file (fs/absolute-path (temp-file "jett-test" ".log"))]
-    (spit logback-file (log-config log-file))
-    [log-file (assoc-in config [:global :logging-config] logback-file)]))
 
 (defn open-port-num
   "Returns a currently open port number"
@@ -100,10 +63,9 @@
   ([config services attempts f]
    (when (zero? attempts)
      (throw (RuntimeException. "Repeated attempts to bind port failed, giving up")))
-   (let [[log-file config] (-> config
-                               conf/adjust-and-validate-tk-config
-                               assoc-open-port
-                               assoc-logging-config)
+   (let [config (-> config
+                    conf/adjust-and-validate-tk-config
+                    assoc-open-port)
          port (get-in config [:jetty :port])
          base-url {:protocol "http"
                    :host "localhost"
@@ -128,14 +90,7 @@
            (f)))
        (catch java.net.BindException e
          (log/errorf e "Error occured when Jetty tried to bind to port %s, attempt #%s" port attempts)
-         (puppetdb-instance config services (dec attempts) f))
-       (finally
-         (let [log-contents (slurp log-file)]
-           (when-not (str/blank? log-contents)
-             (utils/println-err
-               "-------Begin PuppetDB Instance Log--------------------\n"
-               log-contents
-               "\n-------End PuppetDB Instance Log----------------------"))))))))
+         (puppetdb-instance config services (dec attempts) f))))))
 
 (defmacro with-puppetdb-instance
   "Convenience macro to launch a puppetdb instance"


### PR DESCRIPTION
 (maint) Treat the log config as a global resource

Previously pdb-instance invocations would pass a custom config to
trapperkeeper.  Although it probably intended for the changes to be
per-instance, the logging configuration is global, and so whatever
changes were made would apply to everyone, and the original
configuration would never be restored.

As an alternative, add a new suppressing-log-unless-error macro that can
wrap the dynamic lifetime of any number of pdb-instances.  It will
suppress all logging unless there's an event of error level or higher,
in which case it will dump the log to *err* and provide a path to the
temporary log file.

In support of that, add with-additional-log-appenders and
with-log-appenders (and because it was trivial and seems useful,
with-log-event-listener).

Finally, rework the existing operations to use the new ones when
appropriate.

This is unfinished; in particular, the existing pdb-instance invocations
need to be wrapped by suppressing-log-unless-error, and Russell's amqp
suppression filter hasn't been tested yet.

For now I'd just like to know if the approach seems plausible.  If so, I'll adjust the current pdb-instance invocations.