### PR TITLE
(PDB-1845) Treat the log config as a global resource 

### DIFF
--- a/test/puppetlabs/puppetdb/admin_test.clj
+++ b/test/puppetlabs/puppetdb/admin_test.clj
@@ -36,7 +36,7 @@
         report (-> (:basic example-reports/reports)
                    (assoc :certname certname))]
 
-    (svc-utils/puppetdb-instance
+    (svc-utils/call-with-single-quiet-pdb-instance
      (fn []
        (let [query-fn (partial query (tk-app/get-service svc-utils/*server* :PuppetDBServer))
              submit-command-fn (partial submit-command (tk-app/get-service svc-utils/*server* :PuppetDBCommand))]
@@ -71,7 +71,7 @@
 
          (admin/export-app export-out-file query-fn))))
 
-    (svc-utils/puppetdb-instance
+    (svc-utils/call-with-single-quiet-pdb-instance
      (fn []
        (let [query-fn (partial query (tk-app/get-service svc-utils/*server* :PuppetDBServer))
              submit-command-fn (partial submit-command (tk-app/get-service svc-utils/*server* :PuppetDBCommand))]

--- a/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
+++ b/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
@@ -51,7 +51,7 @@
         report (-> (:basic reports)
                    (assoc :certname certname))]
 
-    (svc-utils/puppetdb-instance
+    (svc-utils/call-with-single-quiet-pdb-instance
      (fn []
        (let [query-fn (partial query (tk-app/get-service svc-utils/*server* :PuppetDBServer))
              submit-command-fn (partial submit-command (tk-app/get-service svc-utils/*server* :PuppetDBCommand))]
@@ -88,7 +88,7 @@
                          "--host" (:host svc-utils/*base-url*)
                          "--port" (str (:port svc-utils/*base-url*))))))
 
-    (svc-utils/puppetdb-instance
+    (svc-utils/call-with-single-quiet-pdb-instance
      (fn []
        (let [query-fn (partial query (tk-app/get-service svc-utils/*server* :PuppetDBServer))
              submit-command-fn (partial submit-command (tk-app/get-service svc-utils/*server* :PuppetDBCommand))]
@@ -128,7 +128,7 @@
   (let [certname "foo.local"
         catalog (-> (get-in wire-catalogs [6 :empty])
                     (assoc :certname certname))]
-    (svc-utils/puppetdb-instance
+    (svc-utils/call-with-single-quiet-pdb-instance
      (assoc-in (svc-utils/create-config) [:command-processing :max-frame-size] "1024")
      (fn []
        (let [query-fn (partial query (tk-app/get-service svc-utils/*server* :PuppetDBServer))]

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -56,7 +56,7 @@
     (is (true? @after-slurp?))))
 
 (deftest query-via-puppdbserver-service
-  (svc-utils/with-puppetdb-instance
+  (svc-utils/with-single-quiet-pdb-instance
     (let [pdb-cmd-service (get-service svc-utils/*server* :PuppetDBCommand)
           query-fn (partial query (get-service svc-utils/*server* :PuppetDBServer))]
       (submit-command pdb-cmd-service :replace-facts 4 {:certname "foo.local"

--- a/test/puppetlabs/puppetdb/dashboard_test.clj
+++ b/test/puppetlabs/puppetdb/dashboard_test.clj
@@ -33,7 +33,7 @@
   (.contains body "<title>PuppetDB: Dashboard</title>"))
 
 (deftest dashboard-routing
-  (svc-utils/puppetdb-instance
+  (svc-utils/call-with-single-quiet-pdb-instance
    (fn []
      (let [pdb-resp (client/get (base-url->str' (assoc svc-utils/*base-url*
                                                   :prefix "/pdb")))

--- a/test/puppetlabs/puppetdb/testutils/log.clj
+++ b/test/puppetlabs/puppetdb/testutils/log.clj
@@ -1,0 +1,55 @@
+(ns puppetlabs.puppetdb.testutils.log
+  (:require [puppetlabs.kitchensink.core :as kitchensink])
+  (:import [ch.qos.logback.core spi.LifeCycle Appender]
+           [ch.qos.logback.classic Level Logger]
+           [org.slf4j LoggerFactory]))
+
+(defmacro with-log-level
+  "Sets the (logback) log level for the logger specified by logger-id
+  during the execution of body.  If logger-id is not a class, it is
+  converted via str, and the level must be a clojure.tools.logging
+  key, i.e. :info, :error, etc."
+  [logger-id level & body]
+  ;; Assumes use of logback (i.e. logger supports Levels).
+  `(let [logger-id# ~logger-id
+         logger-id# (if (class? logger-id#) logger-id# (str logger-id#))
+         logger# (.getLogger (LoggerFactory/getILoggerFactory) logger-id#)
+         original-level# (.getLevel logger#)]
+     (.setLevel logger# (case ~level
+                          :trace Level/TRACE
+                          :debug Level/DEBUG
+                          :info Level/INFO
+                          :warn Level/WARN
+                          :error Level/ERROR
+                          :fatal Level/ERROR))
+     (try
+       (do ~@body)
+       (finally (.setLevel logger# original-level#)))))
+
+(defn create-log-appender-to-atom
+  [destination-atom]
+  ;; No clue yet if we're supposed to start with a default name.
+  (let [name (atom (str "log-appender-to-atom-" (kitchensink/uuid)))]
+    (reify
+      Appender
+      (doAppend [this event] (swap! destination-atom conj event))
+      (getName [this] @name)
+      (setName [this x] (reset! name x))
+      LifeCycle
+      (start [this] true)
+      (stop [this] true))))
+
+(defmacro with-logging-to-atom
+  "Conjoins all logger-id events produced during the execution of the
+  body to the destination atom, which must contain a collection.  If
+  logger-id is not a class, it is converted via str."
+  [logger-id destination & body]
+  ;; Specify the root logger via org.slf4j.Logger/ROOT_LOGGER_NAME.
+  `(let [logger-id# ~logger-id
+         logger-id# (if (class? logger-id#) logger-id# (str logger-id#))
+         logger# (.getLogger (LoggerFactory/getILoggerFactory) logger-id#)
+         appender# (doto (create-log-appender-to-atom ~destination) .start)]
+     (.addAppender logger# appender#)
+     (try
+       (do ~@body)
+       (finally (.detachAppender logger# appender#)))))

--- a/test/puppetlabs/puppetdb/testutils/log.clj
+++ b/test/puppetlabs/puppetdb/testutils/log.clj
@@ -1,8 +1,35 @@
 (ns puppetlabs.puppetdb.testutils.log
-  (:require [puppetlabs.kitchensink.core :as kitchensink])
-  (:import [ch.qos.logback.core spi.LifeCycle Appender]
-           [ch.qos.logback.classic Level Logger]
-           [org.slf4j LoggerFactory]))
+  (:require
+   [puppetlabs.kitchensink.core :as kitchensink]
+   [puppetlabs.puppetdb.testutils :refer [temp-file]]
+   [me.raynes.fs :as fs])
+  (:import
+   [ch.qos.logback.core Appender FileAppender]
+   [ch.qos.logback.core.spi LifeCycle]
+   [ch.qos.logback.classic Level Logger]
+   [ch.qos.logback.classic.encoder PatternLayoutEncoder]
+   [org.slf4j LoggerFactory]))
+
+(defmacro with-started
+  "Ensures that if a given name's init form executes without throwing
+  an exception, (.stop name) will be called before returning from
+  with-started.  It is the responsibility of the init form to make
+  sure the object has been started.  This macro behaves like
+  with-open, but with respect to .stop instead of .close."
+  [[name init & bindings] & body]
+  (if-let [s (seq bindings)]
+    `(let [~name ~init]
+       (try
+         (with-started ~bindings ~@body)
+         (finally (.stop ~name))))
+    `(let [~name ~init]
+       (try
+         ~@body
+         (finally (.stop ~name))))))
+
+(defn- find-logger [id]
+  (.getLogger (LoggerFactory/getILoggerFactory)
+              (if (class? id) id (str id))))
 
 (defmacro with-log-level
   "Sets the (logback) log level for the logger specified by logger-id
@@ -10,34 +37,84 @@
   converted via str, and the level must be a clojure.tools.logging
   key, i.e. :info, :error, etc."
   [logger-id level & body]
+  ;; Specify the root logger via org.slf4j.Logger/ROOT_LOGGER_NAME.
   ;; Assumes use of logback (i.e. logger supports Levels).
-  `(let [logger-id# ~logger-id
-         logger-id# (if (class? logger-id#) logger-id# (str logger-id#))
-         logger# (.getLogger (LoggerFactory/getILoggerFactory) logger-id#)
+  `(let [logger# (#'puppetlabs.puppetdb.testutils.log/find-logger ~logger-id)
          original-level# (.getLevel logger#)]
-     (.setLevel logger# (case ~level
-                          :trace Level/TRACE
-                          :debug Level/DEBUG
-                          :info Level/INFO
-                          :warn Level/WARN
-                          :error Level/ERROR
-                          :fatal Level/ERROR))
      (try
+       (.setLevel logger# (case ~level
+                            :trace Level/TRACE
+                            :debug Level/DEBUG
+                            :info Level/INFO
+                            :warn Level/WARN
+                            :error Level/ERROR
+                            :fatal Level/ERROR))
        (do ~@body)
        (finally (.setLevel logger# original-level#)))))
 
-(defn create-log-appender-to-atom
-  [destination-atom]
+(defn- log-event-listener
+  "Returns a log Appender that will call (listen event) for each log event."
+  [listen]
   ;; No clue yet if we're supposed to start with a default name.
-  (let [name (atom (str "log-appender-to-atom-" (kitchensink/uuid)))]
+  (let [name (atom (str "log-listener-" (kitchensink/uuid)))]
     (reify
       Appender
-      (doAppend [this event] (swap! destination-atom conj event))
+      (doAppend [this event] (listen event))
       (getName [this] @name)
       (setName [this x] (reset! name x))
       LifeCycle
       (start [this] true)
       (stop [this] true))))
+
+(defn- call-with-additional-log-appenders [logger-id appenders body]
+  (let [logger (find-logger logger-id)]
+    (try
+      (doseq [appender appenders]
+        (.addAppender logger appender))
+      (body)
+      (finally
+        (doseq [appender appenders]
+          (.detachAppender logger appender))))))
+
+(defmacro with-additional-log-appenders
+  "Runs body with the appenders temporarily added to the logger
+  specified by logger-id.  If logger-id is not a class, it is
+  converted via str."
+  [logger-id appenders & body]
+  `(#'puppetlabs.puppetdb.testutils.log/call-with-additional-log-appenders
+     ~logger-id ~appenders (fn [] ~@body)))
+
+(defn- call-with-log-appenders [logger-id appenders body]
+  (let [logger (find-logger logger-id)
+        original-appenders (iterator-seq (.iteratorForAppenders logger))]
+    (try
+      (doseq [appender original-appenders]
+        (.detachAppender logger appender))
+      (call-with-additional-log-appenders logger-id appenders body)
+      (finally
+        (doseq [appender original-appenders]
+          (.addAppender logger appender))))))
+
+(defmacro with-log-appenders
+  "Runs body with the current appenders of the logger specified by
+  logger-id replaced by the specified appenders.  If logger-id is not
+  a class, it is converted via str."
+  [logger-id appenders & body]
+  `(#'puppetlabs.puppetdb.testutils.log/call-with-log-appenders
+     ~logger-id ~appenders (fn [] ~@body)))
+
+(defmacro with-log-event-listener
+  "Calls (listen event) for each logger-id event produced during the
+  execution of the body.  If logger-id is not a class, it is converted
+  via str."
+  [logger-id listen & body]
+  ;; Specify the root logger via org.slf4j.Logger/ROOT_LOGGER_NAME.
+  `(with-started [listener#
+                  (doto (#'puppetlabs.puppetdb.testutils.log/log-event-listener
+                         ~listen)
+                    .start)]
+     (with-additional-log-appenders ~logger-id [listener#]
+       (do ~@body))))
 
 (defmacro with-logging-to-atom
   "Conjoins all logger-id events produced during the execution of the
@@ -45,11 +122,62 @@
   logger-id is not a class, it is converted via str."
   [logger-id destination & body]
   ;; Specify the root logger via org.slf4j.Logger/ROOT_LOGGER_NAME.
-  `(let [logger-id# ~logger-id
-         logger-id# (if (class? logger-id#) logger-id# (str logger-id#))
-         logger# (.getLogger (LoggerFactory/getILoggerFactory) logger-id#)
-         appender# (doto (create-log-appender-to-atom ~destination) .start)]
-     (.addAppender logger# appender#)
-     (try
-       (do ~@body)
-       (finally (.detachAppender logger# appender#)))))
+  `(with-log-event-listener
+     ~logger-id
+     (fn [event#] (swap! ~destination conj event#))
+     ~@body))
+
+(defn- suppressing-file-appender
+  [log-path]
+  (let [pattern "%-4relative [%thread] %-5level %logger{35} - %msg%n"
+        context (LoggerFactory/getILoggerFactory)]
+    (doto (FileAppender.)
+      (.setFile log-path)
+      (.setAppend true)
+      (.setEncoder (doto (PatternLayoutEncoder.)
+                     (.setPattern pattern)
+                     (.setContext context)
+                     (.start)))
+      (.setContext context)
+      (.start))))
+
+(def ^:private annoying-peer-error-rx #"peer.*vm://localhost.*stopped")
+
+(defn notable-pdb-event? [event]
+  (and (.isGreaterOrEqual (.getLevel event) Level/ERROR)
+       (not (and (-> (.getFormattedMessage event)
+                     (.contains "queue connection error"))
+                 (when-let [cause (.getThrowableProxy event)]
+                   (re-find annoying-peer-error-rx (.getMessage cause)))))))
+
+(defn- call-with-log-suppressed-unless-notable [notable-event? f]
+  (let [problem (atom false)
+        log-path (fs/absolute-path (temp-file "pdb-suppressed" ".log"))]
+    (try
+      (with-started
+        [appender (suppressing-file-appender log-path)
+         detector (doto (#'puppetlabs.puppetdb.testutils.log/log-event-listener
+                         (fn [event]
+                           (when (notable-event? event)
+                             (reset! problem true))))
+                    .start)]
+        (with-log-appenders org.slf4j.Logger/ROOT_LOGGER_NAME
+          [appender detector]
+          (f)))
+      (finally
+        (when @problem
+          (binding [*out* *err*]
+            (print (slurp log-path))
+            (println "From error log:" log-path)))
+        (when-not @problem (fs/delete log-path))))))
+
+(defmacro with-log-suppressed-unless-notable
+  "Executes the body with all logging suppressed.  If a notable error
+  is logged, dumps the full log to *err* along with its path.  Assumes
+  that the logging level is already set as desired.  This may not work
+  correctly if the system logback config is altered during the
+  execution of the body."
+  [notable-event? & body]
+  `(#'puppetlabs.puppetdb.testutils.log/call-with-log-suppressed-unless-notable
+    ~notable-event?
+    (fn [] ~@body)))

--- a/test/puppetlabs/puppetdb/testutils/log_test.clj
+++ b/test/puppetlabs/puppetdb/testutils/log_test.clj
@@ -1,6 +1,8 @@
 (ns puppetlabs.puppetdb.testutils.log-test
   (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
+            [puppetlabs.kitchensink.core :as kitchensink]
+            [puppetlabs.puppetdb.testutils :refer [temp-file]]
             [puppetlabs.puppetdb.testutils.log :as tgt])
   (:import [org.slf4j Logger LoggerFactory]))
 
@@ -21,3 +23,71 @@
         (log/info "wlta-test"))
       (is (some #(= {:level "INFO" :message "wlta-test"} %)
                 (map event->map @log))))))
+
+(def find-logger #'puppetlabs.puppetdb.testutils.log/find-logger)
+
+(defn get-appenders [logger]
+  (iterator-seq (.iteratorForAppenders logger)))
+
+(deftest with-additional-log-appenders
+  (let [log (atom [])
+        logger (find-logger org.slf4j.Logger/ROOT_LOGGER_NAME)
+        uuid (kitchensink/uuid)
+        original-appenders (get-appenders logger)
+        new-appender (#'puppetlabs.puppetdb.testutils.log/log-event-listener
+                      (fn [event] (swap! log conj event)))]
+    (tgt/with-additional-log-appenders org.slf4j.Logger/ROOT_LOGGER_NAME
+      [new-appender]
+      (is (= (set (cons new-appender original-appenders))
+             (set (get-appenders logger))))
+      (log/error uuid))
+    (is (= (set original-appenders)
+           (set (get-appenders logger))))
+    (is (some #(= {:level "ERROR" :message uuid} %)
+              (map event->map @log)))))
+
+(deftest with-log-appenders
+  (let [log (atom [])
+        logger (find-logger org.slf4j.Logger/ROOT_LOGGER_NAME)
+        uuid (kitchensink/uuid)
+        original-appenders (get-appenders logger)
+        new-appender (#'puppetlabs.puppetdb.testutils.log/log-event-listener
+                      (fn [event] (swap! log conj event)))]
+    (tgt/with-log-appenders org.slf4j.Logger/ROOT_LOGGER_NAME
+      [new-appender]
+      (is (= [new-appender] (get-appenders logger)))
+      (log/error uuid))
+    (is (= (set original-appenders)
+           (set (get-appenders logger))))
+    (is (some #(= {:level "ERROR" :message uuid} %)
+              (map event->map @log)))))
+
+(deftest with-log-listener
+  (let [log (atom [])
+        uuid (kitchensink/uuid)]
+    (tgt/with-log-level Logger/ROOT_LOGGER_NAME :info
+      (tgt/with-log-event-listener Logger/ROOT_LOGGER_NAME
+        (fn [event] (swap! log conj event))
+        (log/info uuid))
+      (is (is (some #(= {:level "INFO" :message uuid} %)
+                    (map event->map @log)))))))
+
+(deftest suppressing-log-unless-error
+  (tgt/with-log-suppressed-unless-notable tgt/notable-pdb-event?
+   (log/info "shouldn't see this"))
+  (let [uuid (kitchensink/uuid)
+        expected (format "shouldn't see this %s" uuid)]
+    (is (not (re-matches (re-pattern (str expected ".*"))
+                         (with-out-str
+                           (binding [*err* *out*]
+                             (tgt/with-log-suppressed-unless-notable
+                               tgt/notable-pdb-event?
+                               (log/info expected))))))))
+  (let [uuid (kitchensink/uuid)
+        expected (format "not really an error, but should be shown %s" uuid)]
+    (is (re-find (re-pattern expected)
+                 (with-out-str
+                   (binding [*err* *out*]
+                     (tgt/with-log-suppressed-unless-notable
+                       tgt/notable-pdb-event?
+                       (log/error expected))))))))

--- a/test/puppetlabs/puppetdb/testutils/log_test.clj
+++ b/test/puppetlabs/puppetdb/testutils/log_test.clj
@@ -1,7 +1,7 @@
-(ns puppetlabs.puppetdb.testutils.services-test
+(ns puppetlabs.puppetdb.testutils.log-test
   (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
-            [puppetlabs.puppetdb.testutils.services :as tgt])
+            [puppetlabs.puppetdb.testutils.log :as tgt])
   (:import [org.slf4j Logger LoggerFactory]))
 
 (defn- event->map [event]

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -3,6 +3,8 @@
             [clj-time.coerce :as time-coerce]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.testutils :refer [temp-dir temp-file]]
+            [puppetlabs.puppetdb.testutils.log
+             :refer [notable-pdb-event? with-log-suppressed-unless-notable]]
             [puppetlabs.puppetdb.fixtures :as fixt]
             [puppetlabs.trapperkeeper.app :refer [get-service]]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tkbs]
@@ -31,34 +33,6 @@
 ;; See utils.clj for more information about base-urls.
 (def ^:dynamic *base-url* nil) ; Will not have a :version.
 
-;; Some useful knobs to control logging in your tests
-(def ^:dynamic *log-level* "ERROR")
-(def ^:dynamic *pdb-log-level* "ERROR")
-(def ^:dynamic *log-levels* {}) ; a map like {"puppetlabs.puppetdb.command" "ERROR"}
-(def ^:dynamic *extra-log-config* nil)
-(def ^:dynamic *extra-appender-config* nil)
-
-(defn log-config
-  "Returns a logback.xml string with the specified `log-file` `log-level`."
-  [log-file]
-  (-> [:configuration
-       [:appender {:name "FILE" :class "ch.qos.logback.core.FileAppender"}
-        [:file log-file]
-        [:append true]
-        [:encoder
-         [:pattern "%-4relative [%thread] %-5level %logger{35} - %msg%n"]]
-        *extra-appender-config*]
-
-       (map (fn [[k v]] [:logger {:name k :level (name v)}])
-            *log-levels*)
-       [:logger {:name "puppetlabs.puppetdb" :level *pdb-log-level*}]
-       *extra-log-config*
-
-       [:root {:level *log-level*}
-        [:appender-ref {:ref "FILE"}]]]
-      xml/sexp-as-element
-      xml/emit-str))
-
 (defn create-config
   "Creates a default config, populated with a temporary vardir and
   a fresh hypersql instance"
@@ -68,15 +42,6 @@
    :jetty {:port 0}
    :database (fixt/create-db-map)
    :command-processing {}})
-
-(defn assoc-logging-config
-  "Adds a dynamically created logback.xml with a test log. The
-  generated log file name is returned for printing to the console."
-  [config]
-  (let [logback-file (fs/absolute-path (temp-file "logback" ".xml"))
-        log-file (fs/absolute-path (temp-file "jett-test" ".log"))]
-    (spit logback-file (log-config log-file))
-    [log-file (assoc-in config [:global :logging-config] logback-file)]))
 
 (defn open-port-num
   "Returns a currently open port number"
@@ -94,24 +59,23 @@
 
 (def ^:dynamic *server*)
 
-(defn puppetdb-instance
+(defn call-with-puppetdb-instance
   "Stands up a puppetdb instance with `config`, tears down once `f` returns.
   `services` is a seq of additional services that should be started in
   addition to the core PuppetDB services. Binds *server* and
   *base-url* to refer to the instance. `attempts` indicates how many
   failed attempts should be made to bind to an HTTP port before giving
-  up, defaults to 10"
-  ([f] (puppetdb-instance (create-config) f))
-  ([config f] (puppetdb-instance config [] f))
+  up, defaults to 10."
+  ([f] (call-with-puppetdb-instance (create-config) f))
+  ([config f] (call-with-puppetdb-instance config [] f))
   ([config services f]
-   (puppetdb-instance config services 10 f))
+   (call-with-puppetdb-instance config services 10 f))
   ([config services attempts f]
    (when (zero? attempts)
      (throw (RuntimeException. "Repeated attempts to bind port failed, giving up")))
-   (let [[log-file config] (-> config
-                               conf/adjust-and-validate-tk-config
-                               assoc-open-port
-                               assoc-logging-config)
+   (let [config (-> config
+                    conf/adjust-and-validate-tk-config
+                    assoc-open-port)
          port (or (get-in config [:jetty :port])
                   (get-in config [:jetty :ssl-port]))
          is-ssl (boolean (get-in config [:jetty :ssl-port]))
@@ -140,21 +104,29 @@
            (f)))
        (catch java.net.BindException e
          (log/errorf e "Error occured when Jetty tried to bind to port %s, attempt #%s" port attempts)
-         (puppetdb-instance config services (dec attempts) f))
-       (finally
-         (let [log-contents (slurp log-file)]
-           (when-not (str/blank? log-contents)
-             (utils/println-err
-               "-------Begin PuppetDB Instance Log--------------------\n"
-               log-contents
-               "\n-------End PuppetDB Instance Log----------------------"))))))))
+         (call-with-puppetdb-instance config services (dec attempts) f))))))
 
 (defmacro with-puppetdb-instance
   "Convenience macro to launch a puppetdb instance"
   [& body]
-  `(puppetdb-instance
+  `(call-with-puppetdb-instance
     (fn []
       ~@body)))
+
+(defn call-with-single-quiet-pdb-instance
+  "Calls the call-with-puppetdb-instance with args after suppressing
+  all log events.  If there's an error or worse, prints the log to
+  *err*.  Should not be nested, nor nested with calls to
+  with-log-suppressed-unless-notable."
+  [& args]
+  (with-log-suppressed-unless-notable notable-pdb-event?
+    (apply call-with-puppetdb-instance args)))
+
+(defmacro with-single-quiet-pdb-instance
+  "Convenience macro for call-with-single-quiet-pdb-instance."
+  [& body]
+  `(call-with-single-quiet-pdb-instance
+    (fn [] ~@body)))
 
 (def max-attempts 50)
 
@@ -205,8 +177,8 @@
             (recur (inc attempts)))))))
 
 (defn queue-metadata
-  "Return command queue metadata (from the `puppetdb-instance` launched PuppetDB)
-   as a map:
+  "Return command queue metadata from the current PuppetDB instance as
+  a map:
 
   EnqueueCount - total number of messages sent to the queue since startup
   DequeueCount - total number of messages dequeued (ack'd by consumer) since startup
@@ -216,23 +188,23 @@
 
   http://activemq.apache.org/how-do-i-find-the-size-of-a-queue.html"
   []
-  ;; When starting up a `puppetdb-instance` there seems to be a brief
-  ;; period of time that the server is up, the broker has been
-  ;; started, but the JMX beans have not been initialized, so querying
-  ;; for queue metrics fails, this check ensures it's started
+  ;; When starting up an instance via call-with-puppetdb-instance
+  ;; there seems to be a brief period of time that the server is up,
+  ;; the broker has been started, but the JMX beans have not been
+  ;; initialized, so querying for queue metrics fails.  This check
+  ;; ensures it has started.
   (-> (mbeans-url-str *base-url* (command-mbean-name (:host *base-url*)))
       (client/get {:as :json})
       :body))
 
 (defn current-queue-depth
-  "Return the queue depth currently running PuppetDB instance
-   (see `puppetdb-instance` for launching PuppetDB)"
+  "Returns current PuppetDB instance's queue depth."
   []
   (:QueueSize (queue-metadata)))
 
 (defn discard-count
-  "Return the number of discarded messages from the command queue for the current
-   running `puppetdb-instance`"
+  "Returns the number of messages discarded from the command queue by
+  the current PuppetDB instance."
   []
   (-> (mbeans-url-str *base-url* "puppetlabs.puppetdb.command:type=global,name=discarded")
       (client/get {:as :json})
@@ -294,8 +266,7 @@
         result)))))
 
 (defn dispatch-count
-  "Return the queue depth currently running PuppetDB instance
-   (see `puppetdb-instance` for launching PuppetDB)"
+  "Returns the dispatch count for the currently running PuppetDB instance."
   [dest-name]
   (-> (mbeans-url-str *base-url* (command-mbean-name (:host *base-url*)))
       (client/get {:as :json})


### PR DESCRIPTION
 (PDB-1845) Treat the log config as global resource

Previously pdb-instance invocations would pass a custom config to
trapperkeeper.  Although it probably intended for the changes to be
per-instance, the logging configuration is global, and so whatever
changes were made would apply to everyone, and the original
configuration would never be restored.

As an alternative, add a new with-log-suppressed-unless-notable macro
that can wrap the dynamic lifetime of any number of pdb-instances.  It
will suppress all logging unless an event matches its notable-event?
predicate, and if a notable event is encountered, it will dump the log
to *err* and provide a path to the temporary log file.

Include notable-pdb-event?, which ignores the same spurious errors
previously ignored by modifications introduced via the
removed *extra-appender-config*.

To support of the changes, add with-additional-log-appenders and
with-log-appenders (and because it was trivial and seems useful,
with-log-event-listener).

Finally, rework the existing operations to use the new ones when
appropriate.  Rename puppetdb-instance to call-with-puppetdb-instance to
reflect the way it works, and add two new operations:
call-with-lone-log-suppressed-puppetdb-instance and
with-lone-log-suppressed-puppetdb-instance.  They wrap the previous
operations in with-log-suppressed-unless-notable and allow make it
possible to update the previous call sites without additional
wrapping/indentation.
