### PR TITLE
(maint) Use latest ruby for beaker & net-ssh 2.10.0

### DIFF
--- a/ext/jenkins/beaker-tests-source.sh
+++ b/ext/jenkins/beaker-tests-source.sh
@@ -10,7 +10,7 @@ echo "**********************************************"
 
 # Setup RVM and gemset
 [[ -s "/usr/local/rvm/scripts/rvm" ]] && source /usr/local/rvm/scripts/rvm
-rvm use ruby-1.9.3-p484
+rvm use ruby-2.0.0-p481
 
 set -e # Fail if we receive non-zero exit code
 set -x # Start tracing

--- a/ext/jenkins/beaker-tests.sh
+++ b/ext/jenkins/beaker-tests.sh
@@ -27,7 +27,7 @@ export PUPPETDB_PACKAGE_BUILD_VERSION=$PACKAGE_BUILD_VERSION
 
 # Setup RVM and gemset
 [[ -s "/usr/local/rvm/scripts/rvm" ]] && source /usr/local/rvm/scripts/rvm
-rvm use ruby-1.9.3-p484
+rvm use ruby-2.0.0-p481
 
 # Remove old vendor directory to ensure we have a clean slate
 if [ -d "vendor" ];


### PR DESCRIPTION
net-ssh 2.10.0 was released with only Ruby 2 support, this patch bumps our
testing/ci scripts to use Ruby 2 instead.

Signed-off-by: Ken Barber <ken@bob.sh>