### PR TITLE
(PDB-1784) Target PC1 repos in ezbake config

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -102,7 +102,8 @@
   :lein-ezbake {:vars {:user "puppetdb"
                        :group "puppetdb"
                        :build-type "foss"
-                       :main-namespace "puppetlabs.puppetdb.main"}
+                       :main-namespace "puppetlabs.puppetdb.main"
+                       :repo-target "PC1"}
                 :config-dir "ext/config/foss"
                 }
 


### PR DESCRIPTION
This commit saves release from having to type an extra flag when pushing
the PuppetDB packages up for a release.