### PR TITLE
(PDB-1879) to-timestamp: always return Timestamp

### DIFF
--- a/src/puppetlabs/puppetdb/time.clj
+++ b/src/puppetlabs/puppetdb/time.clj
@@ -235,5 +235,6 @@
   [ts]
   (tc/to-timestamp
    (if (string? ts)
-     (from-string ts)
+     (when-let [dt (from-string ts)]
+       (java.sql.Timestamp. (.getMillis dt)))
      ts)))


### PR DESCRIPTION
The "timestamp" in clj-time.coerce/to-timestamp refers to
java.sql.Timestamp, which it always returns.  Do the same from
PuppetDB's to-timestamp (which wraps it).

Note that this change, by itself, should not be able to cause any (new)
potential timestamp truncation issues because from-string returns a
DateTime (millisecond resolution) and Timestamp is more
accurate (nanosecond resolution).