### PR TITLE
(PDB-1653) Add basic test for rendering of the dashboard page

### DIFF
--- a/test/puppetlabs/puppetdb/dashboard_test.clj
+++ b/test/puppetlabs/puppetdb/dashboard_test.clj
@@ -4,7 +4,10 @@
             [clojure.test :refer :all]
             [ring.mock.request :refer :all]
             [puppetlabs.puppetdb.testutils.services :as svc-utils]
-            [clojure.java.io :refer [file]]))
+            [clojure.java.io :refer [file]]
+            [clj-http.client :as client]
+            [puppetlabs.puppetdb.testutils.services :as svc-utils]
+            [puppetlabs.puppetdb.testutils :as tu]))
 
 (deftest dashboard-resource-requests
   (testing "serving the dashboard works correctly"
@@ -18,3 +21,29 @@
     (let [{:keys [status headers]} (dashboard/dashboard-redirect (request :get "/"))]
       (is (= status 302))
       (is (= "/pdb/dashboard/index.html" (get headers "Location"))))))
+
+(defn base-url->str'
+  "Similar to puppetlabs.puppetdb.utils/base-url->str but doesn't
+  include a version as the dashboard page does not include a version"
+  [{:keys [protocol host port prefix] :as base-url}]
+  (-> (java.net.URL. protocol host port prefix)
+      .toURI .toASCIIString))
+
+(defn dashboard-page? [{:keys [body] :as req}]
+  (.contains body "<title>PuppetDB: Dashboard</title>"))
+
+(deftest dashboard-routing
+  (svc-utils/puppetdb-instance
+   (fn []
+     (let [pdb-resp (client/get (base-url->str' (assoc svc-utils/*base-url*
+                                                  :prefix "/pdb")))
+           root-resp (client/get (base-url->str' (assoc svc-utils/*base-url*
+                                                   :prefix "/")))]
+       (tu/assert-success! pdb-resp)
+       (tu/assert-success! root-resp)
+
+       (is (dashboard-page? pdb-resp))
+       (is (dashboard-page? root-resp))
+
+       (is (= (:body pdb-resp)
+              (:body root-resp)))))))

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -21,7 +21,8 @@
             [me.raynes.fs :as fs]
             [slingshot.slingshot :refer [throw+]]
             [clojure.tools.logging :as log]
-            [clojure.data.xml :as xml])
+            [clojure.data.xml :as xml]
+            [puppetlabs.puppetdb.dashboard :refer [dashboard-service dashboard-redirect-service]])
   (:import [ch.qos.logback.core Appender spi.LifeCycle]
            [ch.qos.logback.classic Level Logger]
            [org.slf4j LoggerFactory]))
@@ -173,7 +174,9 @@
                   metrics/metrics-service
                   admin/admin-service
                   puppetdb-command-service
-                  metadata-service]
+                  metadata-service
+                  dashboard-service
+                  dashboard-redirect-service]
                  services)
          config
          (binding [*server* server


### PR DESCRIPTION
Added a test that just issues a GET request on the two dashboard
URLs, / and /pdb, and verifies that the dashboard page is
returned. Issues the request from outside of PuppetDB to ensure proper
web routing config.