### PR TITLE
(maint) stop reusing import-export-test functions

### DIFF
--- a/test/puppetlabs/puppetdb/admin_test.clj
+++ b/test/puppetlabs/puppetdb/admin_test.clj
@@ -1,13 +1,14 @@
 (ns puppetlabs.puppetdb.admin-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.puppetdb.cli.import-export-roundtrip-test :as roundtrip]
             [puppetlabs.puppetdb.cli.services :refer :all]
             [puppetlabs.puppetdb.http.command :refer :all]
             [puppetlabs.puppetdb.cli.export :as export]
             [puppetlabs.puppetdb.cli.import :as import]
             [puppetlabs.puppetdb.admin :as admin]
             [puppetlabs.trapperkeeper.app :as tk-app]
-            [puppetlabs.puppetdb.testutils :as testutils]
+            [puppetlabs.puppetdb.testutils :as tu]
+            [puppetlabs.puppetdb.testutils.tar :as tar]
+            [puppetlabs.puppetdb.testutils.catalogs :as tuc]
             [puppetlabs.puppetdb.fixtures :as fixt]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.examples :as examples]
@@ -28,7 +29,7 @@
                         :baz "the baz"
                         :biz {:a [3.14 2.71] :b "the b" :c [1 2 3] :d {:e nil}}}
                :producer_timestamp (time-coerce/to-string (time/now))}
-        export-out-file (testutils/temp-file "export-test" ".tar.gz")
+        export-out-file (tu/temp-file "export-test" ".tar.gz")
         catalog (-> (get-in examples/wire-catalogs [6 :empty])
                     (assoc :certname certname
                            :producer_timestamp (time/now)))
@@ -41,25 +42,32 @@
              submit-command-fn (partial submit-command (tk-app/get-service svc-utils/*server* :PuppetDBCommand))]
          (is (empty? (query-fn :nodes admin/query-api-version nil nil doall)))
 
-         (svc-utils/sync-command-post (roundtrip/command-base-url svc-utils/*base-url*) "replace catalog" 6 catalog)
-         (svc-utils/sync-command-post (roundtrip/command-base-url svc-utils/*base-url*) "store report" 5
-                                      (tur/munge-example-report-for-storage report))
-         (svc-utils/sync-command-post (roundtrip/command-base-url svc-utils/*base-url*) "replace facts" 4 facts)
+         (svc-utils/sync-command-post
+           (tu/command-base-url svc-utils/*base-url*)
+           "replace catalog" 6 catalog)
+         (svc-utils/sync-command-post
+           (tu/command-base-url svc-utils/*base-url*)
+           "store report" 5
+           (tur/munge-example-report-for-storage report))
+         (svc-utils/sync-command-post
+           (tu/command-base-url svc-utils/*base-url*)
+           "replace facts" 4 facts)
 
-         (is (testutils/=-after? roundtrip/munge-catalog
-                                 catalog
-                                 (->> certname
-                                      (export/catalogs-for-node query-fn)
-                                      roundtrip/parse-tar-entry-contents)))
+         (is (tu/=-after? tuc/munge-catalog
+                          catalog
+                          (->> certname
+                               (export/catalogs-for-node query-fn)
+                               tar/parse-tar-entry-contents)))
 
-         (is (testutils/=-after? roundtrip/munge-report
-                                 report
-                                 (->> certname
-                                      (export/reports-for-node query-fn)
-                                      roundtrip/parse-tar-entry-contents)))
+         (is (tu/=-after? tur/munge-report
+                          report
+                          (->> certname
+                               (export/reports-for-node query-fn)
+                               tar/parse-tar-entry-contents)))
+
          (is (= facts (->> certname
                            (export/facts-for-node query-fn)
-                           roundtrip/parse-tar-entry-contents)))
+                           tar/parse-tar-entry-contents)))
 
          (admin/export-app export-out-file query-fn))))
 
@@ -80,23 +88,23 @@
          ;; for querying. Maybe this is a race condition in our tests?
          ;; The next two lines ensure that the message is not only
          ;; consumed but present in the DB before proceeding
-         @(roundtrip/block-until-results 100 (export/catalogs-for-node query-fn certname))
-         @(roundtrip/block-until-results 100 (export/facts-for-node query-fn certname))
-         @(roundtrip/block-until-results 100 (export/reports-for-node query-fn certname))
+         @(tu/block-until-results 100 (export/catalogs-for-node query-fn certname))
+         @(tu/block-until-results 100 (export/facts-for-node query-fn certname))
+         @(tu/block-until-results 100 (export/reports-for-node query-fn certname))
 
-         (is (testutils/=-after? roundtrip/munge-catalog
-                                 catalog
-                                 (->> certname
-                                      (export/catalogs-for-node query-fn)
-                                      roundtrip/parse-tar-entry-contents)))
+         (is (tu/=-after? tuc/munge-catalog
+                          catalog
+                          (->> certname
+                               (export/catalogs-for-node query-fn)
+                               tar/parse-tar-entry-contents)))
 
 
          (is (= facts (->> certname
                            (export/facts-for-node query-fn)
-                           roundtrip/parse-tar-entry-contents)))
+                           tar/parse-tar-entry-contents)))
 
-         (is (testutils/=-after? roundtrip/munge-report
-                                 report
-                                 (->> certname
-                                      (export/reports-for-node query-fn)
-                                      roundtrip/parse-tar-entry-contents))))))))
+         (is (tu/=-after? tur/munge-report
+                          report
+                          (->> certname
+                               (export/reports-for-node query-fn)
+                               tar/parse-tar-entry-contents))))))))

--- a/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
+++ b/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
@@ -2,10 +2,11 @@
   (:require [puppetlabs.puppetdb.cli.export :as export]
             [puppetlabs.puppetdb.cli.import :as import]
             [puppetlabs.puppetdb.cli.anonymize :as anonymize]
+            [puppetlabs.puppetdb.testutils.tar :as tar]
             [puppetlabs.puppetdb.cli.services :refer :all]
             [puppetlabs.puppetdb.http.command :refer :all]
             [clojure.test :refer :all]
-            [puppetlabs.puppetdb.testutils :as testutils]
+            [puppetlabs.puppetdb.testutils :as tu]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.puppetdb.fixtures :as fixt]
             [puppetlabs.puppetdb.cheshire :as json]
@@ -25,24 +26,6 @@
 
 (use-fixtures :each fixt/with-test-logging-silenced)
 
-(defn munge-report
-  "Munges a catalog of list of reports for comparision.
-  Returns a list of reports."
-  [report-or-reports]
-  (->> report-or-reports
-       utils/vector-maybe
-       (map (comp tur/munge-report-for-comparison
-                  tur/munge-example-report-for-storage))))
-
-(defn munge-catalog
-  "Munges a catalog or list of catalogs for comparison.
-  Returns a list of catalogs."
-  [catalog-or-catalogs]
-  (->> catalog-or-catalogs
-       utils/vector-maybe
-       (map (comp (partial tuc/munge-catalog-for-comparison :v6)
-                  #(dissoc % :hash)))))
-
 (defn block-until-queue-empty
   "Blocks the current thread until all messages from the queue have been processed."
   []
@@ -50,54 +33,6 @@
     (when (< 0 depth)
       (Thread/sleep 10)
       (recur (svc-utils/current-queue-depth)))))
-
-(defn block-until-results-fn
-  "Executes `f`, if results are found, return them, otherwise
-  wait and try again. Will throw an exception if results aren't found
-  after 100 tries"
-  [n f]
-  (loop [count 0
-         results (f)]
-    (cond
-     (seq results)
-     results
-
-     (< n count)
-     (throw+ (format "Results not found after %d iterations, giving up" n))
-
-     :else
-     (do
-       (Thread/sleep 100)
-       (recur (inc count) (f))))))
-
-(defmacro block-until-results
-  "Body is some expression that will be executed in a future. All
-  errors from the body of the macro are ignored. Will block until
-  results are returned from the body of the macro"
-  [n & body]
-  `(future
-     (block-until-results-fn
-      ~n
-      (fn []
-        (try
-          (do ~@body)
-          (catch Exception e#
-            ;; Ignore
-            ))))))
-
-(defn parse-tar-entry-contents
-  "Parses the first of a list of tar-entries :contents"
-  [tar-entries]
-  (-> tar-entries
-      first
-      :contents
-      (json/parse-string true)))
-
-(defn command-base-url
-  [base-url]
-  (assoc base-url
-         :prefix "/pdb/cmd"
-         :version :v1))
 
 (deftest test-basic-roundtrip
   (let [certname "foo.local"
@@ -108,7 +43,7 @@
                         :baz "the baz"
                         :biz {:a [3.14 2.71] :b "the b" :c [1 2 3] :d {:e nil}}}
                :producer_timestamp (to-string (now))}
-        export-out-dir (testutils/temp-dir "export-test")
+        export-out-dir (tu/temp-dir "export-test")
         export-out-file-path (str (.getPath export-out-dir) "/outfile.tar.gz")
         catalog (-> (get-in wire-catalogs [6 :empty])
                     (assoc :certname certname
@@ -122,21 +57,32 @@
              submit-command-fn (partial submit-command (tk-app/get-service svc-utils/*server* :PuppetDBCommand))]
          (is (empty? (query-fn :nodes admin/query-api-version nil nil doall)))
 
-         (svc-utils/sync-command-post (command-base-url svc-utils/*base-url*) "replace catalog" 6 catalog)
-         (svc-utils/sync-command-post (command-base-url svc-utils/*base-url*) "store report" 5
-                                      (tur/munge-example-report-for-storage report))
-         (svc-utils/sync-command-post (command-base-url svc-utils/*base-url*) "replace facts" 4 facts)
+         (svc-utils/sync-command-post
+           (tu/command-base-url svc-utils/*base-url*)
+           "replace catalog" 6 catalog)
 
-         (is (testutils/=-after? munge-catalog catalog (->> certname
-                                                            (export/catalogs-for-node query-fn)
-                                                            parse-tar-entry-contents)))
+         (svc-utils/sync-command-post
+           (tu/command-base-url svc-utils/*base-url*)
+           "store report" 5
+           (tur/munge-example-report-for-storage report))
 
-         (is (testutils/=-after? munge-report report (->> certname
-                                                          (export/reports-for-node query-fn)
-                                                          parse-tar-entry-contents)))
+         (svc-utils/sync-command-post
+           (tu/command-base-url svc-utils/*base-url*)
+           "replace facts" 4 facts)
+
+         (is (tu/=-after? tuc/munge-catalog catalog
+                          (->> certname
+                               (export/catalogs-for-node query-fn)
+                               tar/parse-tar-entry-contents)))
+
+         (is (tu/=-after? tur/munge-report report
+                          (->> certname
+                               (export/reports-for-node query-fn)
+                               tar/parse-tar-entry-contents)))
+
          (is (= facts (->> certname
                            (export/facts-for-node query-fn)
-                           parse-tar-entry-contents)))
+                           tar/parse-tar-entry-contents)))
 
          (#'export/-main "--outfile" export-out-file-path
                          "--host" (:host svc-utils/*base-url*)
@@ -160,20 +106,23 @@
          ;; for querying. Maybe this is a race condition in our tests?
          ;; The next two lines ensure that the message is not only
          ;; consumed but present in the DB before proceeding
-         @(block-until-results 100 (export/catalogs-for-node query-fn certname))
-         @(block-until-results 100 (export/facts-for-node query-fn certname))
-         @(block-until-results 100 (export/reports-for-node query-fn certname))
+         @(tu/block-until-results 100 (export/catalogs-for-node query-fn certname))
+         @(tu/block-until-results 100 (export/facts-for-node query-fn certname))
+         @(tu/block-until-results 100 (export/reports-for-node query-fn certname))
 
-         (is (testutils/=-after? munge-catalog catalog (->> certname
-                                                            (export/catalogs-for-node query-fn)
-                                                            parse-tar-entry-contents)))
+         (is (tu/=-after? tuc/munge-catalog catalog
+                          (->> certname
+                               (export/catalogs-for-node query-fn)
+                               tar/parse-tar-entry-contents)))
+
          (is (= facts (->> certname
                            (export/facts-for-node query-fn)
-                           parse-tar-entry-contents)))
+                           tar/parse-tar-entry-contents)))
 
-         (is (testutils/=-after? munge-report report (->> certname
-                                                          (export/reports-for-node query-fn)
-                                                          parse-tar-entry-contents))))))))
+         (is (tu/=-after? tur/munge-report report
+                          (->> certname
+                               (export/reports-for-node query-fn)
+                               tar/parse-tar-entry-contents))))))))
 
 (deftest test-max-frame-size
   (let [certname "foo.local"
@@ -184,8 +133,11 @@
      (fn []
        (let [query-fn (partial query (tk-app/get-service svc-utils/*server* :PuppetDBServer))]
          (is (empty? (query-fn :nodes admin/query-api-version nil nil doall)))
-         (pdb-client/submit-command-via-http! (command-base-url svc-utils/*base-url*) "replace catalog" 6 catalog)
+         (pdb-client/submit-command-via-http!
+           (tu/command-base-url svc-utils/*base-url*)
+           "replace catalog" 6 catalog)
          (is (thrown-with-msg?
               java.util.concurrent.ExecutionException #"Results not found"
-              @(block-until-results 5 (first
-                                       (export/catalogs-for-node query-fn certname))))))))))
+               @(tu/block-until-results
+                  5 (first
+                      (export/catalogs-for-node query-fn certname))))))))))

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -11,7 +11,7 @@
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.testutils.services :as svc-utils :refer [*base-url*]]
             [puppetlabs.trapperkeeper.app :refer [get-service]]
-            [puppetlabs.puppetdb.cli.import-export-roundtrip-test :refer [block-until-results]]
+            [puppetlabs.puppetdb.testutils :refer [block-until-results]]
             [clj-time.coerce :refer [to-string]]
             [clj-time.core :refer [now]]
             [puppetlabs.puppetdb.cli.export :as export]))

--- a/test/puppetlabs/puppetdb/testutils/catalogs.clj
+++ b/test/puppetlabs/puppetdb/testutils/catalogs.clj
@@ -7,6 +7,7 @@
             [clj-time.coerce :refer [to-string]]
             [schema.core :as s]
             [puppetlabs.puppetdb.fixtures :refer [*db*]]
+            [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.command.constants :refer [command-names]]
             [puppetlabs.puppetdb.catalogs :refer [catalog-version]]))
 
@@ -110,3 +111,12 @@
                   :received (now)}
     :version     catalog-version}
    {:db          *db*}))
+
+(defn munge-catalog
+  "Munges a catalog or list of catalogs for comparison.
+   Returns a list of catalogs."
+  [catalog-or-catalogs]
+  (->> catalog-or-catalogs
+       utils/vector-maybe
+       (map (comp (partial munge-catalog-for-comparison :v6)
+                  #(dissoc % :hash)))))

--- a/test/puppetlabs/puppetdb/testutils/reports.clj
+++ b/test/puppetlabs/puppetdb/testutils/reports.clj
@@ -4,6 +4,7 @@
             [puppetlabs.puppetdb.reports :as report]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.query-eng :as eng]
+            [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.fixtures :as fixt]
             [clj-time.coerce :as time-coerce]
             [puppetlabs.puppetdb.testutils.events :refer [munge-example-event-for-storage]]
@@ -123,3 +124,12 @@
   (into (omap/ordered-map)
         (for [ev (:resource_events example-report)]
           [(:test_id ev) ev])))
+
+(defn munge-report
+  "Munges a catalog of list of reports for comparision.
+  Returns a list of reports."
+  [report-or-reports]
+  (->> report-or-reports
+       utils/vector-maybe
+       (map (comp munge-report-for-comparison
+                  munge-example-report-for-storage))))

--- a/test/puppetlabs/puppetdb/testutils/tar.clj
+++ b/test/puppetlabs/puppetdb/testutils/tar.clj
@@ -59,3 +59,10 @@
                         (json/parse-string (archive/read-entry-content tar))))
             {} (archive/all-entries tar))))
 
+(defn parse-tar-entry-contents
+  "Parses the first of a list of tar-entries :contents"
+  [tar-entries]
+  (-> tar-entries
+      first
+      :contents
+      (json/parse-string true)))


### PR DESCRIPTION
Before this patch, we had some functions in our import-export-roundtrip test
that were used in other test namespaces.  This prevented us from using our
fixtures namespace in any of the http tests due to a cyclic dependency, which
I need for PDB-1737. This will break sync testing, but the fix will be
straightforward.