### PR TITLE
(PDB-1653) Refactor to a one top level web route for /pdb

### DIFF
--- a/resources/puppetlabs/puppetdb/bootstrap.cfg
+++ b/resources/puppetlabs/puppetdb/bootstrap.cfg
@@ -13,11 +13,8 @@ puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-servi
 puppetlabs.puppetdb.cli.services/puppetdb-service
 puppetlabs.puppetdb.http.command/puppetdb-command-service
 puppetlabs.puppetdb.metrics/metrics-service
-puppetlabs.puppetdb.dashboard/dashboard-service
-puppetlabs.puppetdb.admin/admin-service
 puppetlabs.puppetdb.mq-listener/message-listener-service
 puppetlabs.puppetdb.command/command-service
-puppetlabs.puppetdb.meta/metadata-service
 
 # NREPL
 puppetlabs.trapperkeeper.services.nrepl.nrepl-service/nrepl-service

--- a/resources/puppetlabs/puppetdb/bootstrap.cfg
+++ b/resources/puppetlabs/puppetdb/bootstrap.cfg
@@ -15,6 +15,8 @@ puppetlabs.puppetdb.http.command/puppetdb-command-service
 puppetlabs.puppetdb.metrics/metrics-service
 puppetlabs.puppetdb.mq-listener/message-listener-service
 puppetlabs.puppetdb.command/command-service
+puppetlabs.puppetdb.pdb-routing/maint-mode-service
+puppetlabs.puppetdb.pdb-routing/pdb-routing-service
 
 # NREPL
 puppetlabs.trapperkeeper.services.nrepl.nrepl-service/nrepl-service

--- a/src/puppetlabs/puppetdb/admin.clj
+++ b/src/puppetlabs/puppetdb/admin.clj
@@ -31,7 +31,7 @@
                        (mapcat (partial export/get-node-data query-fn)))))
 
 (defn build-app
-  [submit-command-fn query-fn {:keys [authorizer]}]
+  [get-authorizer submit-command-fn query-fn]
   (-> (compojure/routes
        (mp/wrap-multipart-params
         (compojure/POST "/v1/archive" request
@@ -44,4 +44,4 @@
                       (http/streamed-tar-response #(export-app % query-fn)
                                                   (format "puppetdb-export-%s.tgz" (now))))
        (route/not-found "Not Found"))
-      (mid/wrap-with-puppetdb-middleware authorizer)))
+      (mid/wrap-with-puppetdb-middleware get-authorizer)))

--- a/src/puppetlabs/puppetdb/admin.clj
+++ b/src/puppetlabs/puppetdb/admin.clj
@@ -45,14 +45,3 @@
                                                   (format "puppetdb-export-%s.tgz" (now))))
        (route/not-found "Not Found"))
       (mid/wrap-with-puppetdb-middleware authorizer)))
-
-(trapperkeeper/defservice admin-service
-  [[:PuppetDBServer shared-globals query]
-   [:PuppetDBCommand submit-command]
-   [:WebroutingService add-ring-handler get-route]]
-
-  (start [this context]
-         (->> (build-app submit-command query (shared-globals))
-              (compojure/context (get-route this) [])
-              (add-ring-handler this))
-         context))

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -274,7 +274,7 @@
         ;;is also sensitive to startup order. get-registered-endpoints
         ;;only has one item in the map at that point (metrics gets
         ;;added later
-        url-prefix (ffirst (get-registered-endpoints))
+        url-prefix (str (ffirst (get-registered-endpoints)) "/query")
 
         write-db (pl-jdbc/pooled-datasource database)
         read-db (pl-jdbc/pooled-datasource (assoc read-database :read-only? true))

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -314,8 +314,6 @@
       (when-not disable-update-checking
         (maybe-check-for-updates product-name update-server read-db))
 
-      (log/info "Starting query server")
-
       ;; Pretty much this helper just knows our job-pool and gc-interval
       (let [job-pool (mk-pool)
             gc-interval-millis (to-millis gc-interval)
@@ -364,7 +362,10 @@
   (set-url-prefix [this url-prefix]
                   (let [old-url-prefix (:url-prefix (service-context this))]
                     (when-not (compare-and-set! old-url-prefix nil url-prefix)
-                      (throw (RuntimeException. (format "Attempt to set url-prefix to %s when it's already been set to %s" url-prefix @old-url-prefix))))))
+                      (throw+ {:url-prefix old-url-prefix
+                               :new-url-prefix url-prefix
+                               :type ::url-prefix-already-set}
+                              (format "Attempt to set url-prefix to %s when it's already been set to %s" url-prefix @old-url-prefix)))))
   (shared-globals [this]
                   (:shared-globals (service-context this)))
   (query [this query-obj version query-expr paging-options row-callback-fn]

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -371,7 +371,7 @@
   [[:PuppetDBServer shared-globals]
    [:MessageListenerService register-listener]]
   (init [this context]
-    (let [response-chan (async/chan)
+    (let [response-chan (async/chan 1000)
           response-mult (async/mult response-chan)
           response-chan-for-pub (async/chan)]
       (async/tap response-mult response-chan-for-pub)

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -335,13 +335,8 @@
 
 (defn add-web-routing-service-config
   [config-data]
-  (let [default-web-router-service
-        {:puppetlabs.puppetdb.cli.services/puppetdb-service "/pdb/query"
-         :puppetlabs.puppetdb.http.command/puppetdb-command-service "/pdb/cmd"
-         :puppetlabs.puppetdb.meta/metadata-service "/pdb/meta"
-         :puppetlabs.puppetdb.admin/admin-service "/pdb/admin"
-         :puppetlabs.puppetdb.dashboard/dashboard-service "/pdb"
-         :puppetlabs.puppetdb.metrics/metrics-service "/metrics"}
+  (let [default-web-router-service {:puppetlabs.puppetdb.metrics/metrics-service "/metrics"
+                                    :puppetlabs.puppetdb.pdb-routing/pdb-routing-service "/pdb"}
         bootstrap-cfg (-> (find-bootstrap-config config-data)
                           slurp
                           str/split-lines)

--- a/src/puppetlabs/puppetdb/dashboard.clj
+++ b/src/puppetlabs/puppetdb/dashboard.clj
@@ -1,33 +1,8 @@
 (ns puppetlabs.puppetdb.dashboard
   (:require [clojure.tools.logging :as log]
             [net.cgrand.moustache :refer [app]]
-            [puppetlabs.puppetdb.middleware :refer [wrap-with-puppetdb-middleware]]
             [puppetlabs.trapperkeeper.core :refer [defservice]]
-            [ring.middleware.resource :refer [wrap-resource]]
-            [ring.util.request :as rreq]
-            [ring.util.response :as rr]
-            [compojure.core :as compojure]))
-
-(def dashboard
-  (let [index-handler #(->> %
-                            rreq/request-url
-                            (format "%s/dashboard/index.html")
-                            rr/redirect)]
-    (-> (app [""] {:get index-handler})
-        (wrap-resource "public"))))
-
-(defservice dashboard-service
-  [[:PuppetDBServer shared-globals]
-   [:WebroutingService add-ring-handler get-route]]
-
-  (start [this context]
-         (let [app (-> dashboard
-                       (wrap-with-puppetdb-middleware (:authorizer (shared-globals))))]
-           (log/info "Starting dashboard service")
-           (->> app
-                (compojure/context (get-route this) [])
-                (add-ring-handler this))
-           context)))
+            [ring.util.response :as rr]))
 
 (def dashboard-redirect
   (app ["" &] {:get (fn [req] (rr/redirect "/pdb/dashboard/index.html"))}))
@@ -38,6 +13,5 @@
 
   (start [this context]
          (log/info "Redirecting / to the PuppetDB dashboard")
-         (->> dashboard-redirect
-              (add-ring-handler this))
+         (add-ring-handler this dashboard-redirect)
          context))

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -124,16 +124,23 @@
       (mid/wrap-with-globals get-shared-globals)))
 
 (defprotocol PuppetDBCommand
-  (submit-command [this command version payload]))
+  (submit-command
+    [this command version payload]
+    [this command version payload uuid]))
 
 (defservice puppetdb-command-service
   PuppetDBCommand
   [[:PuppetDBServer shared-globals]
    [:PuppetDBCommandDispatcher enqueue-command]]
+
   (start [this context]
          (log/info "Starting command service")
          context)
+
   (submit-command [this command version payload]
+    (submit-command this command version payload nil))
+
+  (submit-command [this command version payload uuid]
     (let [{{:keys [connection endpoint]} :command-mq} (shared-globals)]
       (enqueue-command connection endpoint
-                       (command-names command) version payload))))
+                       (command-names command) version payload uuid))))

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -133,18 +133,10 @@
 (defservice puppetdb-command-service
   PuppetDBCommand
   [[:PuppetDBServer shared-globals]
-   [:WebroutingService add-ring-handler get-route]
-   [:PuppetDBCommandDispatcher enqueue-command enqueue-raw-command response-pub]]
-
+   [:PuppetDBCommandDispatcher enqueue-command]]
   (start [this context]
-         (let [globals (shared-globals)
-               url-prefix (get-route this)]
-           (log/info "Starting command service")
-           (->> (command-app globals enqueue-raw-command (response-pub))
-                (compojure/context url-prefix [])
-                (add-ring-handler this))
-           context))
-
+         (log/info "Starting command service")
+         context)
   (submit-command [this command version payload]
     (let [{{:keys [connection endpoint]} :command-mq} (shared-globals)]
       (enqueue-command connection endpoint

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -88,20 +88,20 @@
 
 (defn enqueue-command-handler
   "Enqueues the command in request and returns a UUID"
-  [enqueue-fn connection endpoint response-pub]
+  [get-command-mq enqueue-fn get-response-pub]
   (fn [{:keys [body-string params] :as request}]
     (let [uuid (kitchensink/uuid)
           completion-timeout-ms (some-> params
                                         (get "secondsToWaitForCompletion")
                                         Double/parseDouble
                                         (* 1000))
+          {:keys [connection endpoint]} (get-command-mq)
           do-submit #(enqueue-fn connection endpoint body-string uuid)]
       (if (some-> completion-timeout-ms pos?)
-        (blocking-submit-command do-submit response-pub uuid completion-timeout-ms)
+        (blocking-submit-command do-submit (get-response-pub) uuid completion-timeout-ms)
         (do
           (do-submit)
           (http/json-response {:uuid uuid}))))))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
@@ -110,22 +110,18 @@
 ;; return functions that accept a ring request map
 
 (defn command-app
-  [{:keys [command-mq authorizer] :as globals} enqueue-fn response-pub]
-  (let [{:keys [connection endpoint]} command-mq
-        app (moustache/app
-             ["v1" &] {:any (enqueue-command-handler enqueue-fn
-                                                     connection endpoint
-                                                     response-pub)})]
-    (-> app
-        validate-command-version
-        mid/verify-accepts-json
-        mid/verify-checksum
-        (mid/validate-query-params {:optional ["checksum" "secondsToWaitForCompletion"]})
-        mid/payload-to-body-string
-        (mid/verify-content-type ["application/json"])
-        (mid/wrap-with-puppetdb-middleware authorizer)
-        (mid/wrap-with-metrics (atom {}) http/leading-uris)
-        (mid/wrap-with-globals globals))))
+  [get-authorizer get-command-mq get-shared-globals enqueue-fn get-response-pub]
+  (-> (moustache/app
+       ["v1" &] {:any (enqueue-command-handler get-command-mq enqueue-fn get-response-pub)})
+      validate-command-version
+      mid/verify-accepts-json
+      mid/verify-checksum
+      (mid/validate-query-params {:optional ["checksum" "secondsToWaitForCompletion"]})
+      mid/payload-to-body-string
+      (mid/verify-content-type ["application/json"])
+      (mid/wrap-with-puppetdb-middleware get-authorizer)
+      (mid/wrap-with-metrics (atom {}) http/leading-uris)
+      (mid/wrap-with-globals get-shared-globals)))
 
 (defprotocol PuppetDBCommand
   (submit-command [this command version payload]))

--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -38,16 +38,14 @@
    ["v3" &] {:any (refuse-retired-api "v3")}))
 
 (defn build-app
-  "Generate a Ring application that handles PuppetDB requests
-
-  `globals` is a map containing global state useful
-   to request handlers which may contain the following:
-
-  * `authorizer` - a function that takes a request and returns a
-    :authorized if the request is authorized, or a user-visible reason if not.
-    If not supplied, we default to authorizing all requests."
-  [{:keys [authorizer] :as globals}]
+  "Generates a Ring application that handles PuppetDB requests.
+  If get-authorizer is nil or false, all requests will be accepted.
+  Otherwise it must accept no arguments and return an authorize
+  function that accepts a request.  The request will be allowed only
+  if authorize returns :authorized.  Otherwise, the return value
+  should be a message describing the reason that access was denied."
+  [get-authorizer get-shared-globals]
   (-> routes
-      (wrap-with-puppetdb-middleware authorizer)
+      (wrap-with-puppetdb-middleware get-authorizer)
       (wrap-with-metrics (atom {}) http/leading-uris)
-      (wrap-with-globals globals)))
+      (wrap-with-globals get-shared-globals)))

--- a/src/puppetlabs/puppetdb/meta.clj
+++ b/src/puppetlabs/puppetdb/meta.clj
@@ -26,47 +26,46 @@
    object containing a `version` key with the version, as well as a `newer` key
    which is a boolean specifying whether the latest version is newer
    than the current version."
-  [{:keys [update-server product-name scf-read-db]}]
-  {:pre [(and update-server product-name scf-read-db)]}
+  [get-shared-globals]
   (fn [_]
-    (try
-      ;; if we get one of these requests from
-      ;; pe-puppetdb, we always want to
-      ;; return 'newer->false' so that the
-      ;; dashboard will never try to
-      ;; display info about a newer version
-      ;; being available
-      (if (= product-name "pe-puppetdb")
-        (http/json-response {:newer false
-                             :version (v/version)
-                             :link nil})
-        (try+
-         (http/json-response (v/update-info update-server scf-read-db))
-         (catch map? {m :message}
-           (log/debug m (format "Could not retrieve update information (%s)" update-server))
-           (http/error-response "Could not find version" 404))))
+    (let [{:keys [update-server product-name scf-read-db]}
+          (get-shared-globals)]
+      (try
+        ;; If we get one of these requests from pe-puppetdb, we always want to
+        ;; return 'newer->false' so that the dashboard will never try
+        ;; to display info about a newer version being available.
+        (if (= product-name "pe-puppetdb")
+          (http/json-response {:newer false
+                               :version (v/version)
+                               :link nil})
+          (try+
+           (http/json-response (v/update-info update-server scf-read-db))
+           (catch map? {m :message}
+             (log/debug m (format "Could not retrieve update information (%s)"
+                                  update-server))
+             (http/error-response "Could not find version" 404))))
 
-      (catch java.io.IOException e
-        (log/debugf "Error when checking for latest version: %s" e)
-        (http/error-response
-          (format "Error when checking for latest version: %s" e))))))
+        (catch java.io.IOException e
+          (log/debugf "Error when checking for latest version: %s" e)
+          (http/error-response
+           (format "Error when checking for latest version: %s" e)))))))
 
 (defn version-routes
-  [globals]
+  [get-shared-globals]
   (moustache/app [""] {:get (current-version-fn (v/version))}
-                 ["latest"] {:get (latest-version-fn globals)}))
+                 ["latest"] {:get (latest-version-fn get-shared-globals)}))
 
 (def server-time-routes
   (moustache/app [""] {:get (fn [_] (http/json-response {:server_time (now)}))}))
 
 (defn routes
-  [globals]
-  (moustache/app ["v1" "version" &] {:any (version-routes globals)}
+  [get-shared-globals]
+  (moustache/app ["v1" "version" &] {:any (version-routes get-shared-globals)}
                  ["v1" "server-time" &] {:any server-time-routes}))
 
 (defn build-app
-  [{:keys [authorizer] :as globals}]
-  (-> (routes globals)
+  [get-authorizer get-shared-globals]
+  (-> (routes get-shared-globals)
       verify-accepts-json
       validate-no-query-params
-      (wrap-with-puppetdb-middleware authorizer)))
+      (wrap-with-puppetdb-middleware get-authorizer)))

--- a/src/puppetlabs/puppetdb/meta.clj
+++ b/src/puppetlabs/puppetdb/meta.clj
@@ -70,14 +70,3 @@
       verify-accepts-json
       validate-no-query-params
       (wrap-with-puppetdb-middleware authorizer)))
-
-(defservice metadata-service
-  [[:PuppetDBServer shared-globals]
-   [:WebroutingService add-ring-handler get-route]]
-
-  (start [this context]
-         (log/info "Starting metadata service")
-         (->> (build-app (shared-globals))
-              (compojure/context (get-route this) [])
-              (add-ring-handler this))
-         context))

--- a/src/puppetlabs/puppetdb/metrics.clj
+++ b/src/puppetlabs/puppetdb/metrics.clj
@@ -9,7 +9,7 @@
    [:WebroutingService add-ring-handler get-route]]
 
   (start [this context]
-         (let [app (->> (server/build-app (shared-globals))
+         (let [app (->> (server/build-app #(:authorizer (shared-globals)))
                         (compojure/context (get-route this) []))]
            (log/info "Starting metrics server")
            (add-ring-handler this app)

--- a/src/puppetlabs/puppetdb/metrics/server.clj
+++ b/src/puppetlabs/puppetdb/metrics/server.clj
@@ -17,13 +17,12 @@
    {:any v1-app}))
 
 (defn build-app
-  "Generate a Ring application that handles metrics requests
-
-   Takes an `options` map which may contain the following keys:
-
-  * `authorizer` - a function that takes a request and returns a
-    :authorized if the request is authorized, or a user-visible reason if not.
-    If not supplied, we default to authorizing all requests."
-  [{:keys [authorizer]}]
+  "Generates a Ring application that handles metrics requests.
+  If get-authorizer is nil or false, all requests will be accepted.
+  Otherwise it must accept no arguments and return an authorize
+  function that accepts a request.  The request will be allowed only
+  if authorize returns :authorized.  Otherwise, the return value
+  should be a message describing the reason that access was denied."
+  [get-authorizer]
   (-> routes
-      (wrap-with-puppetdb-middleware authorizer)))
+      (wrap-with-puppetdb-middleware get-authorizer)))

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -10,11 +10,19 @@
             [puppetlabs.puppetdb.admin :as admin]
             [puppetlabs.puppetdb.http.command :as cmd]
             [puppetlabs.puppetdb.cli.services :as query]
-            [puppetlabs.puppetdb.http.server :as server]))
+            [puppetlabs.puppetdb.http.server :as server]
+            [clojure.tools.logging :as log]))
 
 
 (defn resource-request-handler [req]
   (resource-request req "public"))
+
+(defn maint-mode-handler [maint-mode-fn]
+  (fn [req]
+    (when (maint-mode-fn)
+      (log/info "HTTP request received while in maintenance mode")
+      {:status 503
+       :body "PuppetDB is currently down. Try again later."})))
 
 (defn pdb-core-routes [get-shared-globals submit-command-fn query-fn enqueue-raw-command-fn response-pub]
   (let [auth #(:authorizer (get-shared-globals))
@@ -34,8 +42,9 @@
            "/query" (server/build-app auth get-shared-globals)
            "/admin" (admin/build-app auth submit-command-fn query-fn)]))))
 
-(defn pdb-app [root app-routes]
+(defn pdb-app [root maint-mode-fn app-routes]
   (compojure/context root []
+                     (maint-mode-handler maint-mode-fn)
                      resource-request-handler
                      (compojure/GET "/" req
                                     (->> req
@@ -44,18 +53,41 @@
                                          rr/redirect))
                      (apply compojure/routes app-routes)))
 
+(defprotocol MaintenanceMode
+  (enable-maint-mode [this])
+  (disable-maint-mode [this])
+  (maint-mode? [this]))
+
 (tk/defservice pdb-routing-service
+  MaintenanceMode
   [[:WebroutingService add-ring-handler get-route]
    [:PuppetDBServer shared-globals query]
    [:PuppetDBCommand submit-command]
    [:PuppetDBCommandDispatcher enqueue-command enqueue-raw-command response-pub]]
   (init [this context]
         (add-ring-handler this (pdb-app (get-route this)
+                                        #(maint-mode? this)
                                         (pdb-core-routes shared-globals
                                                          submit-command
                                                          query
                                                          enqueue-raw-command
                                                          response-pub)))
-        context)
+        (assoc context ::maint-mode? (atom true)))
   (start [this context]
-         context))
+         (disable-maint-mode this)
+         context)
+  (enable-maint-mode [this]
+                     (let [ctx (tksvc/service-context this)]
+                       (update ctx ::maint-mode? reset! true)))
+  (disable-maint-mode [this]
+                      (let [ctx (tksvc/service-context this)]
+                        (update ctx ::maint-mode? reset! false)))
+  (maint-mode? [this]
+               (let [maint-mode-atom (::maint-mode? (tksvc/service-context this) ::not-found)]
+                 ;;There's a small gap in time after the routes have
+                 ;;been added but before the TK service context gets
+                 ;;updated. This handles that and counts it as the app
+                 ;;being in maintenance mode
+                 (if (= ::not-found maint-mode-atom)
+                   true
+                   @maint-mode-atom))))

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -16,13 +16,23 @@
 (defn resource-request-handler [req]
   (resource-request req "public"))
 
-(defn pdb-core-routes [shared-globals submit-command-fn query-fn enqueue-raw-command-fn response-pub]
-  (map (fn [[uri route]]
-         (compojure/context uri [] route))
-       (partition 2 ["/meta" (meta/build-app shared-globals)
-                     "/cmd" (cmd/command-app shared-globals enqueue-raw-command-fn (response-pub))
-                     "/query" (server/build-app shared-globals)
-                     "/admin" (admin/build-app submit-command-fn query-fn shared-globals)])))
+(defn pdb-core-routes [get-shared-globals submit-command-fn query-fn enqueue-raw-command-fn response-pub]
+  (let [auth #(:authorizer (get-shared-globals))
+        cmd-mq #(:command-mq (get-shared-globals))
+        meta-cfg #(select-keys (get-shared-globals) [:update-server
+                                                     :product-name
+                                                     :scf-read-db])
+        get-response-pub #(response-pub)]
+    (map (fn [[uri route]]
+           (compojure/context uri [] route))
+         (partition
+          2
+          ;; The remaining get-shared-globals args are for wrap-with-globals.
+          ["/meta" (meta/build-app auth meta-cfg)
+           "/cmd" (cmd/command-app auth cmd-mq get-shared-globals
+                                   enqueue-raw-command-fn get-response-pub)
+           "/query" (server/build-app auth get-shared-globals)
+           "/admin" (admin/build-app auth submit-command-fn query-fn)]))))
 
 (defn pdb-app [root app-routes]
   (compojure/context root []
@@ -40,8 +50,12 @@
    [:PuppetDBCommand submit-command]
    [:PuppetDBCommandDispatcher enqueue-command enqueue-raw-command response-pub]]
   (init [this context]
+        (add-ring-handler this (pdb-app (get-route this)
+                                        (pdb-core-routes shared-globals
+                                                         submit-command
+                                                         query
+                                                         enqueue-raw-command
+                                                         response-pub)))
         (assoc context ::pdb-routing (atom {})))
   (start [this context]
-         (add-ring-handler this (pdb-app (get-route this)
-                                         (pdb-core-routes (shared-globals) submit-command query enqueue-raw-command response-pub)))
          context))

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -56,6 +56,6 @@
                                                          query
                                                          enqueue-raw-command
                                                          response-pub)))
-        (assoc context ::pdb-routing (atom {})))
+        context)
   (start [this context]
          context))

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -1,15 +1,13 @@
 (ns puppetlabs.puppetdb.pdb-routing
   (:require [puppetlabs.trapperkeeper.core :as tk]
-            [clout.core :as cc]
             [compojure.core :as compojure]
             [puppetlabs.trapperkeeper.services :as tksvc]
-            [ring.middleware.resource :refer [wrap-resource resource-request]]
+            [ring.middleware.resource :refer [resource-request]]
             [ring.util.request :as rreq]
             [ring.util.response :as rr]
             [puppetlabs.puppetdb.meta :as meta]
             [puppetlabs.puppetdb.admin :as admin]
             [puppetlabs.puppetdb.http.command :as cmd]
-            [puppetlabs.puppetdb.cli.services :as query]
             [puppetlabs.puppetdb.http.server :as server]
             [clojure.tools.logging :as log]))
 
@@ -92,6 +90,7 @@
               query-prefix (str context-root "/query")
               shared-with-prefix #(assoc (shared-globals) :url-prefix query-prefix)]
           (set-url-prefix query-prefix)
+          (log/info "Starting PuppetDB, entering maintenance mode")
           (add-ring-handler this (pdb-app context-root
                                           maint-mode?
                                           (pdb-core-routes shared-with-prefix
@@ -102,5 +101,6 @@
         (enable-maint-mode)
         context)
   (start [this context]
+         (log/info "PuppetDB finished starting, disabling maintenance mode")
          (disable-maint-mode)
          context))

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -88,10 +88,11 @@
    [:PuppetDBCommandDispatcher enqueue-command enqueue-raw-command response-pub]
    [:MaintenanceMode enable-maint-mode maint-mode? disable-maint-mode]]
   (init [this context]
-        (let [url-prefix (get-route this)
-              shared-with-prefix #(assoc-in (shared-globals) [:globals :url-prefix] url-prefix)]
-          (set-url-prefix url-prefix)
-          (add-ring-handler this (pdb-app url-prefix
+        (let [context-root (get-route this)
+              query-prefix (str context-root "/query")
+              shared-with-prefix #(assoc (shared-globals) :url-prefix query-prefix)]
+          (set-url-prefix query-prefix)
+          (add-ring-handler this (pdb-app context-root
                                           maint-mode?
                                           (pdb-core-routes shared-with-prefix
                                                            submit-command

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -1,0 +1,47 @@
+(ns puppetlabs.puppetdb.pdb-routing
+  (:require [puppetlabs.trapperkeeper.core :as tk]
+            [clout.core :as cc]
+            [compojure.core :as compojure]
+            [puppetlabs.trapperkeeper.services :as tksvc]
+            [ring.middleware.resource :refer [wrap-resource resource-request]]
+            [ring.util.request :as rreq]
+            [ring.util.response :as rr]
+            [puppetlabs.puppetdb.meta :as meta]
+            [puppetlabs.puppetdb.admin :as admin]
+            [puppetlabs.puppetdb.http.command :as cmd]
+            [puppetlabs.puppetdb.cli.services :as query]
+            [puppetlabs.puppetdb.http.server :as server]))
+
+
+(defn resource-request-handler [req]
+  (resource-request req "public"))
+
+(defn pdb-core-routes [shared-globals submit-command-fn query-fn enqueue-raw-command-fn response-pub]
+  (map (fn [[uri route]]
+         (compojure/context uri [] route))
+       (partition 2 ["/meta" (meta/build-app shared-globals)
+                     "/cmd" (cmd/command-app shared-globals enqueue-raw-command-fn (response-pub))
+                     "/query" (server/build-app shared-globals)
+                     "/admin" (admin/build-app submit-command-fn query-fn shared-globals)])))
+
+(defn pdb-app [root app-routes]
+  (compojure/context root []
+                     resource-request-handler
+                     (compojure/GET "/" req
+                                    (->> req
+                                         rreq/request-url
+                                         (format "%s/dashboard/index.html")
+                                         rr/redirect))
+                     (apply compojure/routes app-routes)))
+
+(tk/defservice pdb-routing-service
+  [[:WebroutingService add-ring-handler get-route]
+   [:PuppetDBServer shared-globals query]
+   [:PuppetDBCommand submit-command]
+   [:PuppetDBCommandDispatcher enqueue-command enqueue-raw-command response-pub]]
+  (init [this context]
+        (assoc context ::pdb-routing (atom {})))
+  (start [this context]
+         (add-ring-handler this (pdb-app (get-route this)
+                                         (pdb-core-routes (shared-globals) submit-command query enqueue-raw-command response-pub)))
+         context))

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -237,6 +237,14 @@
    :prefix "/pdb/cmd"
    :version (or version :v1)})
 
+(defn pdb-meta-base-url
+  [host port & [version]]
+  {:protocol "http"
+   :host host
+   :port port
+   :prefix "/pdb/meta"
+   :version (or version :v1)})
+
 (defn assoc-if-exists
   "Assoc only if the key is already present"
   [m & ks]

--- a/test/puppetlabs/puppetdb/fixtures.clj
+++ b/test/puppetlabs/puppetdb/fixtures.clj
@@ -77,9 +77,11 @@
   `with-test-mq`."
   ([f]
    (binding [*command-app* (command/command-app
-                            {:command-mq *mq*}
+                            nil
+                            (fn [] *mq*)
+                            (fn [] {})
                             #'dispatch/do-enqueue-raw-command
-                            nil)]
+                            (fn [] nil))]
      (f))))
 
 (defn with-http-app
@@ -88,17 +90,16 @@
   are available. Note this means this fixture should be nested _within_
   `with-test-db` or `with-test-mq`."
   ([f]
-     (with-http-app {} f))
+   (with-http-app {} f))
   ([globals-overrides f]
-     (binding [*app* (server/build-app
-                       (merge
-                         {:scf-read-db          *db*
-                          :scf-write-db         *db*
-                          :command-mq           *mq*
-                          :product-name         "puppetdb"
-                          :url-prefix           ""}
-                         globals-overrides))]
-       (f))))
+   (binding [*app* (server/build-app nil
+                                     #(merge {:scf-read-db *db*
+                                              :scf-write-db *db*
+                                              :command-mq *mq*
+                                              :product-name "puppetdb"
+                                              :url-prefix ""}
+                                             globals-overrides))]
+     (f))))
 
 (defn defaulted-write-db-config
   "Defaults and converts `db-config` from the write database INI format to the internal

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -441,11 +441,10 @@
   ([read-write-db]
    (test-app read-write-db read-write-db))
   ([read-db write-db]
-   (server/build-app
-     {:scf-read-db          read-db
-      :scf-write-db         write-db
-      :command-mq           *mq*
-      :product-name         "puppetdb"})))
+   (server/build-app nil #(hash-map :scf-read-db read-db
+                                    :scf-write-db write-db
+                                    :command-mq *mq*
+                                    :product-name "puppetdb"))))
 
 (defn with-shutdown-after [dbs f]
   (f)

--- a/test/puppetlabs/puppetdb/meta_test.clj
+++ b/test/puppetlabs/puppetdb/meta_test.clj
@@ -21,10 +21,9 @@
 
 (defn with-meta-app
   [request & [overrides]]
-  (let [app (-> (merge {:product-name "puppetdb"
-                        :update-server "FOO"}
-                       overrides)
-                meta/build-app)]
+  (let [app (meta/build-app nil #(merge {:product-name "puppetdb"
+                                         :update-server "FOO"}
+                                        overrides))]
     (app request)))
 
 (deftestseq test-latest-version

--- a/test/puppetlabs/puppetdb/metrics/core_test.clj
+++ b/test/puppetlabs/puppetdb/metrics/core_test.clj
@@ -36,7 +36,7 @@
 (deftestseq metrics-set-handler
   [version api-versions]
 
-  (let [app (server/build-app {})
+  (let [app (server/build-app nil)
         mbeans-endpoint (str version "/mbeans")]
     (testing "Remote metrics endpoint"
       (testing "should return a http/status-not-found for an unknown metric"

--- a/test/puppetlabs/puppetdb/middleware_test.clj
+++ b/test/puppetlabs/puppetdb/middleware_test.clj
@@ -52,7 +52,7 @@
                                     (rr/status http/status-ok)))
           message     "Only odd numbers are allowed!"
           authorizer  #(if (odd? %) :authorized message)
-          app         (wrap-with-authorization handler authorizer)]
+          app (wrap-with-authorization handler (fn [] authorizer))]
       ;; Even numbers should trigger an unauthorized response
       (is (= http/status-forbidden (:status (app 0))))
       ;; The failure reason should be shown to the user

--- a/test/puppetlabs/puppetdb/pdb_routing_test.clj
+++ b/test/puppetlabs/puppetdb/pdb_routing_test.clj
@@ -1,4 +1,4 @@
-(ns puppetlabs.puppetdb.pdb-routing
+(ns puppetlabs.puppetdb.pdb-routing-test
   (:require [clojure.test :refer :all]
             [clj-http.client :as client]
             [puppetlabs.puppetdb.testutils.services :as svc-utils]
@@ -14,11 +14,8 @@
             [puppetlabs.puppetdb.pdb-routing :refer :all]
             [puppetlabs.trapperkeeper.app :as tk-app]))
 
-(defn command-base-url
-  [base-url]
-  (assoc base-url
-         :prefix "/pdb/cmd"
-         :version :v1))
+(defn command-base-url [{:keys [host port]}]
+  (utils/pdb-cmd-base-url host port :v1))
 
 (defn pdb-get [base-url url-suffix]
   (let [resp (client/get (str (utils/base-url->str base-url)
@@ -29,29 +26,21 @@
       resp)))
 
 (defn submit-facts [base-url facts]
-  (svc-utils/sync-command-post (assoc base-url
-                                 :prefix "/pdb/cmd"
-                                 :version :v1)
+  (svc-utils/sync-command-post (command-base-url base-url)
                                "replace facts"
                                4
                                facts))
 
-(defn query-fact-names [base-url]
-  (pdb-get (assoc svc-utils/*base-url*
-             :prefix "/pdb/query"
-             :version :v4)
+(defn query-fact-names [{:keys [host port]}]
+  (pdb-get (utils/pdb-query-base-url host port :v4)
            "/fact-names"))
 
-(defn export [base-url]
-  (pdb-get (assoc base-url
-             :prefix "/pdb/admin"
-             :version :v1)
+(defn export [{:keys [host port]}]
+  (pdb-get (utils/pdb-admin-base-url host port :v1)
            "/archive"))
 
-(defn query-server-time [base-url]
-  (pdb-get (assoc svc-utils/*base-url*
-             :prefix "/pdb/meta"
-             :version :v1)
+(defn query-server-time [{:keys [host port]}]
+  (pdb-get (utils/pdb-meta-base-url host port :v1)
            "/server-time"))
 
 (def test-facts {:certname "foo.com"

--- a/test/puppetlabs/puppetdb/pdb_routing_test.clj
+++ b/test/puppetlabs/puppetdb/pdb_routing_test.clj
@@ -1,0 +1,81 @@
+(ns puppetlabs.puppetdb.pdb-routing
+  (:require [clojure.test :refer :all]
+            [clj-http.client :as client]
+            [puppetlabs.puppetdb.testutils.services :as svc-utils]
+            [puppetlabs.puppetdb.testutils :as tu]
+            [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.time :as time]
+            [puppetlabs.puppetdb.client :as pdb-client]
+            [clj-time.coerce :refer [to-string]]
+            [clj-time.core :refer [now]]
+            [puppetlabs.puppetdb.testutils.dashboard :as dtu]
+            [puppetlabs.puppetdb.utils :as utils]))
+
+(defn command-base-url
+  [base-url]
+  (assoc base-url
+         :prefix "/pdb/cmd"
+         :version :v1))
+
+(defn pdb-get [base-url url-suffix]
+  (let [resp (client/get (str (utils/base-url->str base-url)
+                              url-suffix))]
+    (if (tu/json-content-type? resp)
+      (update resp :body #(json/parse-string % true))
+      resp)))
+
+(defn submit-facts [base-url facts]
+  (svc-utils/sync-command-post (assoc base-url
+                                 :prefix "/pdb/cmd"
+                                 :version :v1)
+                               "replace facts"
+                               4
+                               facts))
+
+(defn query-fact-names [base-url]
+  (pdb-get (assoc svc-utils/*base-url*
+             :prefix "/pdb/query"
+             :version :v4)
+           "/fact-names"))
+
+(defn export [base-url]
+  (pdb-get (assoc base-url
+             :prefix "/pdb/admin"
+             :version :v1)
+           "/archive"))
+
+(defn query-server-time [base-url]
+  (pdb-get (assoc svc-utils/*base-url*
+             :prefix "/pdb/meta"
+             :version :v1)
+           "/server-time"))
+
+(deftest top-level-routes
+  (svc-utils/call-with-puppetdb-instance
+   (fn []
+     (let [pdb-resp (client/get (dtu/dashboard-base-url->str (assoc svc-utils/*base-url*
+                                                               :prefix "/pdb")))
+           test-facts {:certname "foo.com"
+                       :environment "DEV"
+                       :producer_timestamp (to-string (now))
+                       :values {:foo 1
+                                :bar "2"
+                                :baz 3}}]
+       (tu/assert-success! pdb-resp)
+       (is (dtu/dashboard-page? pdb-resp))
+
+       (is (-> (query-server-time svc-utils/*base-url*)
+               (get-in [:body :server_time])
+               time/from-string))
+
+       (is (= 200 (:status (submit-facts svc-utils/*base-url* test-facts))))
+
+       (is (= #{"foo" "bar" "baz"}
+              (-> (query-fact-names svc-utils/*base-url*)
+                  :body
+                  set)))
+
+       (let [resp (export svc-utils/*base-url*)]
+         (tu/assert-success! resp)
+         (is (.contains (get-in resp [:headers "Content-Disposition"]) "puppetdb-export"))
+         (is (:body resp)))))))

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -161,6 +161,9 @@
   `(let [fixture-fn# (join-fixtures (:clojure.test/each-fixtures (meta ~*ns*)))]
      (fixture-fn# (fn [] ~@body))))
 
+(defn json-content-type? [response]
+  (= http/json-response-content-type (get-in response [:headers "Content-Type"])))
+
 (defn response-equal?
   "Test if the HTTP request is a success, and if the result is equal
   to the result of the form supplied to this method.  Arguments:
@@ -179,7 +182,7 @@
      (response-equal? response expected identity))
   ([response expected body-munge-fn]
      (is (= http/status-ok (:status response)))
-     (is (= http/json-response-content-type (get-in response [:headers "Content-Type"])))
+     (is (json-content-type? response))
      (let [actual (when (:body response)
                     (-> (:body response)
                         (json/parse-string true)

--- a/test/puppetlabs/puppetdb/testutils/dashboard.clj
+++ b/test/puppetlabs/puppetdb/testutils/dashboard.clj
@@ -1,0 +1,11 @@
+(ns puppetlabs.puppetdb.testutils.dashboard)
+
+(defn dashboard-base-url->str
+  "Similar to puppetlabs.puppetdb.utils/base-url->str but doesn't
+  include a version as the dashboard page does not include a version"
+  [{:keys [protocol host port prefix] :as base-url}]
+  (-> (java.net.URL. protocol host port prefix)
+      .toURI .toASCIIString))
+
+(defn dashboard-page? [{:keys [body] :as req}]
+  (.contains body "<title>PuppetDB: Dashboard</title>"))

--- a/test/puppetlabs/puppetdb/testutils/http.clj
+++ b/test/puppetlabs/puppetdb/testutils/http.clj
@@ -1,0 +1,17 @@
+(ns puppetlabs.puppetdb.testutils.http
+  (:require [clj-http.client :as client]
+            [puppetlabs.puppetdb.testutils :as tu]
+            [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.cheshire :as json]))
+
+(defn pdb-get
+  "Makes a GET reqeust using to the PuppetDB instance at `base-url`
+  with `url-suffix`. Will parse the body of the response if it has a
+  json content type."
+  [base-url url-suffix]
+  (let [resp (client/get (str (utils/base-url->str base-url)
+                              url-suffix)
+                         {:throw-exceptions false})]
+    (if (tu/json-content-type? resp)
+      (update resp :body #(json/parse-string % true))
+      resp)))

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -59,6 +59,18 @@
 
 (def ^:dynamic *server*)
 
+(def default-services
+  [#'jetty9-service
+   #'webrouting-service
+   #'svcs/puppetdb-service
+   #'message-listener-service
+   #'command-service
+   #'metrics/metrics-service
+   #'puppetdb-command-service
+   #'dashboard-redirect-service
+   #'pdb-routing-service
+   #'maint-mode-service])
+
 (defn call-with-puppetdb-instance
   "Stands up a puppetdb instance with `config`, tears down once `f` returns.
   `services` is a seq of additional services that should be started in
@@ -67,7 +79,7 @@
   failed attempts should be made to bind to an HTTP port before giving
   up, defaults to 10."
   ([f] (call-with-puppetdb-instance (create-config) f))
-  ([config f] (call-with-puppetdb-instance config [] f))
+  ([config f] (call-with-puppetdb-instance config default-services f))
   ([config services f]
    (call-with-puppetdb-instance config services 10 f))
   ([config services attempts f]
@@ -86,17 +98,7 @@
                    :version :v4}]
      (try
        (tkbs/with-app-with-config server
-         (concat [jetty9-service
-                  webrouting-service
-                  svcs/puppetdb-service
-                  message-listener-service
-                  command-service
-                  metrics/metrics-service
-                  puppetdb-command-service
-                  dashboard-redirect-service
-                  pdb-routing-service
-                  maint-mode-service]
-                 services)
+         (map var-get services)
          config
          (binding [*server* server
                    *base-url* base-url]

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -18,7 +18,6 @@
             [puppetlabs.puppetdb.mq-listener :refer [message-listener-service]]
             [puppetlabs.puppetdb.command :refer [command-service] :as dispatch]
             [puppetlabs.puppetdb.http.command :refer [puppetdb-command-service]]
-            [puppetlabs.puppetdb.meta :refer [metadata-service]]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.config :as conf]
             [clj-http.util :refer [url-encode]]
@@ -28,8 +27,8 @@
             [slingshot.slingshot :refer [throw+]]
             [clojure.tools.logging :as log]
             [clojure.data.xml :as xml]
-            [puppetlabs.puppetdb.dashboard
-             :refer [dashboard-service dashboard-redirect-service]]))
+            [puppetlabs.puppetdb.dashboard :refer [dashboard-redirect-service]]
+            [puppetlabs.puppetdb.pdb-routing :refer [pdb-routing-service]]))
 
 ;; See utils.clj for more information about base-urls.
 (def ^:dynamic *base-url* nil) ; Will not have a :version.
@@ -93,11 +92,9 @@
                   message-listener-service
                   command-service
                   metrics/metrics-service
-                  admin/admin-service
                   puppetdb-command-service
-                  metadata-service
-                  dashboard-service
-                  dashboard-redirect-service]
+                  dashboard-redirect-service
+                  pdb-routing-service]
                  services)
          config
          (binding [*server* server

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -28,7 +28,7 @@
             [clojure.tools.logging :as log]
             [clojure.data.xml :as xml]
             [puppetlabs.puppetdb.dashboard :refer [dashboard-redirect-service]]
-            [puppetlabs.puppetdb.pdb-routing :refer [pdb-routing-service]]))
+            [puppetlabs.puppetdb.pdb-routing :refer [pdb-routing-service maint-mode-service]]))
 
 ;; See utils.clj for more information about base-urls.
 (def ^:dynamic *base-url* nil) ; Will not have a :version.
@@ -94,7 +94,8 @@
                   metrics/metrics-service
                   puppetdb-command-service
                   dashboard-redirect-service
-                  pdb-routing-service]
+                  pdb-routing-service
+                  maint-mode-service]
                  services)
          config
          (binding [*server* server

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -278,7 +278,10 @@
    off the queue."
   [base-url cmd version payload]
   (let [timeout-seconds 10]
-    (pdb-client/submit-command-via-http! base-url cmd version payload timeout-seconds)))
+    (let [response (pdb-client/submit-command-via-http! base-url cmd version payload timeout-seconds)]
+      (if (>= (:status response) 400)
+        (throw (ex-info "Command processing failed" {:response response}))
+        response))))
 
 (defn wait-for-server-processing
   "Returns a truthy value indicating whether the wait was


### PR DESCRIPTION
This commit moves the configuration of the ring routes to a single namespace (pdb-routing). Previously several components (dashboard, meta, admin) existed solely to attach a new top level pdb
route (i.e. /pdb/meta). This refactor sets us up to better accommodate global (from a PuppetDB perspective) functionality like setting PuppetDB in "maintenance mode" while starting.