### PR TITLE
(maint) Remove unnecessary tools.nrepl dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,6 @@
                  [org.clojure/math.combinatorics "0.0.4"]
                  [org.clojure/math.numeric-tower "0.0.4"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [org.clojure/tools.nrepl "0.2.10"]
                  [puppetlabs/tools.namespace "0.2.4.1"]
                  [clj-stacktrace "0.2.8"]
                  [metrics-clojure "0.7.0" :exclusions [org.clojure/clojure org.slf4j/slf4j-api]]


### PR DESCRIPTION
This commit removes an unnecessary tools.nrepl dependency from the
PuppetDB project.clj which was causing conflicts when using ezbake
commands. The ezbake commands in question were in our Jenkins job
configs and although they were improper commands, they would not have
caused an issue if we didn't explicitly list `tools.nrepl` as a
dependency.