### PR TITLE
(PDB-1737) use memoized function get-db-metadata for db metadata functions

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -56,6 +56,7 @@
             [puppetlabs.puppetdb.http.server :as server]
             [puppetlabs.puppetdb.jdbc :as pl-jdbc :refer [with-transacted-connection]]
             [puppetlabs.puppetdb.meta.version :as version]
+            [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.mq :as mq]
             [puppetlabs.puppetdb.query-eng :as qeng]
             [puppetlabs.puppetdb.query.population :as pop]
@@ -226,6 +227,7 @@
   [db-conn-pool product-name]
   (sql/with-connection db-conn-pool
     (scf-store/validate-database-version #(System/exit 1))
+    @sutils/db-metadata
     (migrate! db-conn-pool)
     (indexes! product-name)))
 

--- a/src/puppetlabs/puppetdb/meta/version.clj
+++ b/src/puppetlabs/puppetdb/meta/version.clj
@@ -26,8 +26,8 @@
   (sql/with-connection db
     {:product-name {:group-id "puppetlabs"
                     :artifact-id "puppetdb"}
-     :database-name (sutils/sql-current-connection-database-name)
-     :database-version (string/join "." (sutils/sql-current-connection-database-version))}))
+     :database-name (:database @sutils/db-metadata)
+     :database-version (string/join "." (:version @sutils/db-metadata))}))
 
 (def pdb-version-check-values
   (memoize pdb-version-check-values*))

--- a/src/puppetlabs/puppetdb/scf/hash_debug.clj
+++ b/src/puppetlabs/puppetdb/scf/hash_debug.clj
@@ -86,8 +86,8 @@
                     (-> {"new catalog hash" new-hash
                          "old catalog hash" (-> old-catalog json/generate-string kitchensink/utf8-string->sha1)
                          "java version" kitchensink/java-version
-                         "database name" (sutils/sql-current-connection-database-name)
-                         "database version" (sutils/sql-current-connection-database-version)}
+                         "database name" (:database @sutils/db-metadata)
+                         "database version" (:version @sutils/db-metadata)}
                         (output-clj-catalog "old catalog path - edn" (file-path-fn "catalog-old.edn") old-catalog)
                         (output-clj-catalog "new catalog path - edn" (file-path-fn "catalog-new.edn") new-catalog)
                         (output-json-catalog "old catalog path - json" (file-path-fn "catalog-old.json") old-catalog)

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -344,12 +344,12 @@
   encountered some version strings that are longer than 40 chars."
   []
   (sql/do-commands
-   (condp = (sutils/sql-current-connection-database-name)
+   (condp = (:database @sutils/db-metadata)
      "PostgreSQL" "ALTER TABLE reports ALTER puppet_version TYPE VARCHAR(255)"
      "HSQL Database Engine" "ALTER TABLE reports ALTER puppet_version VARCHAR(255)"
      (throw (IllegalArgumentException.
              (format "Unsupported database engine '%s'"
-                     (sutils/sql-current-connection-database-name)))))))
+                     (:database @sutils/db-metadata)))))))
 
 (defn burgundy-schema-changes
   "Schema changes for the initial release of Burgundy. These include:

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -7,6 +7,7 @@
             [puppetlabs.puppetdb.cli.services :refer :all]
             [puppetlabs.puppetdb.http.command :refer :all]
             [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.meta.version :as version]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.testutils.services :as svc-utils :refer [*base-url*]]

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -3,6 +3,7 @@
             [puppetlabs.puppetdb.scf.migrate :as migrate]
             [puppetlabs.puppetdb.scf.migration-legacy :as legacy]
             [puppetlabs.puppetdb.scf.storage :as store]
+            [puppetlabs.puppetdb.fixtures :refer [with-db-metadata *db*]]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils
              :refer [db-serialize postgres?]]
             [cheshire.core :as json]
@@ -17,7 +18,7 @@
   (:import [java.sql SQLIntegrityConstraintViolationException]
            [org.postgresql.util PSQLException]))
 
-(def db (test-db))
+(use-fixtures :each with-db-metadata)
 
 (defn apply-migration-for-testing!
   [i]
@@ -34,19 +35,19 @@
 
 (deftest migration
   (testing "pending migrations"
-    (testing "should return every migration if the db isn't migrated"
-      (sql/with-connection db
+    (testing "should return every migration if the *db* isn't migrated"
+      (sql/with-connection *db*
         (clear-db-for-testing!)
         (is (= (pending-migrations) migrations))))
 
-    (testing "should return nothing if the db is completely migrated"
-      (sql/with-connection db
+    (testing "should return nothing if the *db* is completely migrated"
+      (sql/with-connection *db*
         (clear-db-for-testing!)
-        (migrate! db)
+        (migrate! *db*)
         (is (empty? (pending-migrations)))))
 
-    (testing "should return missing migrations if the db is partially migrated"
-      (sql/with-connection db
+    (testing "should return missing migrations if the *db* is partially migrated"
+      (sql/with-connection *db*
         (clear-db-for-testing!)
         (let [applied '(1 2 4)]
           (doseq [m applied]
@@ -57,15 +58,15 @@
 
   (testing "applying the migrations"
     (let [expected-migrations (apply sorted-set (keys migrations))]
-      (sql/with-connection db
+      (sql/with-connection *db*
         (clear-db-for-testing!)
         (is (= (applied-migrations) #{}))
         (testing "should migrate the database"
-          (migrate! db)
+          (migrate! *db*)
           (is (= (applied-migrations) expected-migrations)))
 
         (testing "should not do anything the second time"
-          (migrate! db)
+          (migrate! *db*)
           (is (= (applied-migrations) expected-migrations)))
 
         (testing "should attempt a partial migration if there are migrations missing"
@@ -75,19 +76,19 @@
           (doseq [m (filter (fn [[i migration]] (not= i 27)) (pending-migrations))]
             (apply-migration-for-testing! (first m)))
           (is (= (keys (pending-migrations)) '(27)))
-          (migrate! db)
+          (migrate! *db*)
           (is (= (applied-migrations) expected-migrations))))))
 
-  (testing "should throw error if db is at a higher schema rev than we support"
-    (with-transacted-connection db
-      (migrate! db)
+  (testing "should throw error if *db* is at a higher schema rev than we support"
+    (with-transacted-connection *db*
+      (migrate! *db*)
       (sql/insert-record :schema_migrations
                          {:version (inc migrate/desired-schema-version) :time (to-timestamp (now))})
-      (is (thrown? IllegalStateException (migrate! db))))))
+      (is (thrown? IllegalStateException (migrate! *db*))))))
 
 (deftest migration-14
   (testing "building parameter cache"
-    (sql/with-connection db
+    (sql/with-connection *db*
       (clear-db-for-testing!)
       ;; Migrate to prior to the cache table
       (fast-forward-to-migration! 13)
@@ -126,7 +127,7 @@
 
 (deftest migration-25
   (testing "should contain same facts before and after migration"
-    (sql/with-connection db
+    (sql/with-connection *db*
       (clear-db-for-testing!)
       (fast-forward-to-migration! 24)
       (let [current-time (to-timestamp (now))
@@ -182,11 +183,11 @@
                    :timestamp (to-timestamp current-time) :value_string "false"}])))))))
 
 (deftest migration-28
-  (sql/with-connection db
+  (sql/with-connection *db*
     (clear-db-for-testing!)
     (fast-forward-to-migration! 27)
-    (letfn [(one-row [db]
-              (first (query-to-vec (format "SELECT * FROM %s LIMIT 1" db))))
+    (letfn [(one-row [*db*]
+              (first (query-to-vec (format "SELECT * FROM %s LIMIT 1" *db*))))
             (facts-now [c v]
               {:certname c :values v
                :environment nil :timestamp (now) :producer_timestamp nil})
@@ -278,7 +279,7 @@
 
 (deftest migration-29
   (testing "should contain same reports before and after migration"
-    (sql/with-connection db
+    (sql/with-connection *db*
       (clear-db-for-testing!)
       (fast-forward-to-migration! 28)
 
@@ -349,7 +350,7 @@
             (is (= [id1 id2] latest-ids))))))))
 
 (deftest migration-29-producer-timestamp-not-null
-  (sql/with-connection db
+  (sql/with-connection *db*
     (clear-db-for-testing!)
     (fast-forward-to-migration! 28)
 
@@ -382,7 +383,7 @@
         (is (= factsets-response [{:producer_timestamp current-time}]))))))
 
 (deftest migration-in-different-schema
-  (sql/with-connection db
+  (sql/with-connection *db*
     (clear-db-for-testing!)
     (sql/do-commands
      ;; Cleaned up in clear-db-for-testing!
@@ -394,10 +395,10 @@
     (let [tables (sutils/sql-current-connection-table-names)]
       ;; Currently sql-current-connection-table-names only looks in public.
       (is (empty? (sutils/sql-current-connection-table-names)))
-      (migrate! db))))
+      (migrate! *db*))))
 
 (deftest test-coalesce-fact-values
-  (sql/with-connection db
+  (sql/with-connection *db*
     (clear-db-for-testing!)
     (fast-forward-to-migration! 30)
     (sql/insert-records :fact_values

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1398,8 +1398,8 @@
         (is (= expected actual))))))
 
 (defn with-db-version [db version f]
-  (with-redefs-fn {#'sutils/sql-current-connection-database-name (constantly db)
-                   #'sutils/sql-current-connection-database-version (constantly version)}
+  (with-redefs [sutils/db-metadata (delay {:database db
+                                           :version version})]
     f))
 
 (deftest test-db-unsupported-msg

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -6,6 +6,7 @@
             [puppetlabs.puppetdb.testutils.log
              :refer [notable-pdb-event? with-log-suppressed-unless-notable]]
             [puppetlabs.puppetdb.fixtures :as fixt]
+            [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.trapperkeeper.app :refer [get-service]]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tkbs]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
@@ -109,9 +110,11 @@
 (defmacro with-puppetdb-instance
   "Convenience macro to launch a puppetdb instance"
   [& body]
-  `(call-with-puppetdb-instance
-    (fn []
-      ~@body)))
+  `(with-redefs [sutils/db-metadata (delay {:database "HSQL Database Engine"
+                                            :version [2 2]})]
+     (call-with-puppetdb-instance
+       (fn []
+         ~@body))))
 
 (defn call-with-single-quiet-pdb-instance
   "Calls the call-with-puppetdb-instance with args after suppressing


### PR DESCRIPTION
Previously we required a database connection to determine the database and
version we were connected to. This patch stashes that data in a dynamic var
on startup.