### PR TITLE
(PDB-1855) Add flag for filtering unchanged resources in the terminus

### DIFF
--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -76,9 +76,8 @@ Puppet::Reports.register_report(:puppetdb) do
   def build_resources_list
     profile("Build resources list (count: #{resource_statuses.count})",
             [:puppetdb, :resources_list, :build]) do
-      include_unchanged_resources = false
       resources = resource_statuses.values.map { |resource| resource_status_to_hash(resource) }
-      if ! include_unchanged_resources
+      if ! config.include_unchanged_resources?
         resources.select{ |resource| (! resource["events"].empty?) or resource["skipped"] }
       else
         resources

--- a/puppet/lib/puppet/util/puppetdb/config.rb
+++ b/puppet/lib/puppet/util/puppetdb/config.rb
@@ -12,7 +12,8 @@ module Puppet::Util::Puppetdb
         :server                    => "puppetdb",
         :port                      => 8081,
         :soft_write_failure        => false,
-        :server_url_timeout        => 30
+        :server_url_timeout        => 30,
+        :include_unchanged_resources => false,
       }
 
       config_file ||= File.join(Puppet[:confdir], "puppetdb.conf")
@@ -55,6 +56,7 @@ module Puppet::Util::Puppetdb
         !([:server,
            :port,
            :ignore_blacklisted_events,
+           :include_unchanged_resources,
            :soft_write_failure,
            :server_urls,
            :server_url_timeout].include?(k))
@@ -70,6 +72,7 @@ module Puppet::Util::Puppetdb
       config_hash[:server_urls] = convert_and_validate_urls(config_hash[:server_urls])
 
       config_hash[:server_url_timeout] = config_hash[:server_url_timeout].to_i
+      config_hash[:include_unchanged_resources] = Puppet::Util::Puppetdb.to_bool(config_hash[:include_unchanged_resources])
       config_hash[:soft_write_failure] = Puppet::Util::Puppetdb.to_bool(config_hash[:soft_write_failure])
 
       self.new(config_hash, uses_server_urls)
@@ -104,6 +107,10 @@ module Puppet::Util::Puppetdb
 
     def server_url_timeout
       config[:server_url_timeout]
+    end
+
+    def include_unchanged_resources?
+      config[:include_unchanged_resources]
     end
 
     def soft_write_failure


### PR DESCRIPTION
Previously we had now way of sending unchanged resources in the
terminus. This commit adds a boolean flag to the terminus config file,
`include_unchanged_resources=<boolean>`, which will _not_ filter
unchanged resources from a report when set to `true`.

As a side note PuppetDB cannot actually handle storing these unchanged resources if you turn them on, that will be handled by a subsequent storage related change.