### PR TITLE
(maint) Relay errors for blocking commands

### DIFF
--- a/documentation/api/command/v1/commands.markdown
+++ b/documentation/api/command/v1/commands.markdown
@@ -58,16 +58,15 @@ The PuppetDB termini for puppet masters use this command API to update facts, ca
 When submitting a command, you may specify the "secondsToWaitForCompletion"
 query parameter. If you do, PuppetDB will block the request until the command
 has been processed, or until the specified timeout has passed, whichever comes
-first. The response will indicate which happened:
+first. The response will contain the following additional keys:
 
-* When a command has timed out, the response code will be 503 and the response
-  body JSON will contain a "processed" key with the value false. This does not
-  mean that the command succeeded or failed; it simply means that the specified
-  timeout passed.
+* `timed_out`: true when your timeout was hit before the command finished processing.
 
-* When a command completes within the timeout, the response code with be 200 and
-  "processed" will be true. It does not indicate success or failure, just that
-  it has been processed.
+* `processed`: true when the command has been processed, successfully or not.
+  Will be set to false if the timeout was hit first.
+
+* `error`, `exception`: If the command was processed but an error occurred,
+  these two fields provide the specifics of what went wrong.
 
 Note: This is an /EXPERIMENTAL/ feature, and it may be changed or removed at any
 time. Although convenient, it should be used with caution. Always prefer


### PR DESCRIPTION
When submitting a command in blocking mode, relay any errors that occur
before the timeout in the http response.