### PR TITLE
(PDB-1797) enable test cells for debian jessie

### DIFF
--- a/acceptance/config/ec2-west-debian8-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-debian8-64mda-64a.cfg
@@ -1,0 +1,28 @@
+HOSTS:
+  debian8-64-1:
+    roles:
+      - master
+      - database
+      - dashboard
+      - agent
+    vmname: debian-8-amd64-west
+    platform: debian-8-amd64
+    amisize: c3.large
+    hypervisor: ec2
+    snapshot: foss
+  debian7-64-2:
+    roles:
+      - agent
+    vmname: debian-8-amd64-west
+    platform: debian-8-amd64
+    amisize: c3.large
+    hypervisor: ec2
+    snapshot: foss
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  vpc_id: vpc-cc4aeda9
+  subnet_ids:
+    - subnet-4a74d73d
+    - subnet-6169e404
+    - subnet-5870b101

--- a/config/image_templates/ec2.yaml
+++ b/config/image_templates/ec2.yaml
@@ -29,6 +29,12 @@ AMI:
       :foss: ami-52ea6262
     :region: us-west-2
 
+  debian-8-amd64-west:
+    :image:
+      :pe: ami-17120727
+      :foss: ami-17120727
+    :region: us-west-2
+
   debian-7-amd64-west:
     :image:
       :pe: ami-99e0ada9


### PR DESCRIPTION
This adds config for the new Debian 8 AMI. After this is merged we can hook it
up.