### PR TITLE
(PDB-1852) Add migration and storage for JSONB columns for Unchanged Resources

### DIFF
--- a/documentation/api/wire_format/report_format_v6.markdown
+++ b/documentation/api/wire_format/report_format_v6.markdown
@@ -164,6 +164,10 @@ that represents the containment hierarchy of the resource within the catalog. Th
 `"events"` is a collection of objects where each is a Puppet event corresponding
 to the resource. This array may be empty.
 
+`"file"` is the manifest in which the resource is defined. This field may be `null`.
+
+`"line"` is the line number (within `"file"`) where the resource is defined. This field may be `null`.
+
 ### Data type: `<event>`
 
 A JSON Object of the following form:
@@ -175,9 +179,7 @@ A JSON Object of the following form:
      "status": <string>,
      "old_value": <string>,
      "new_value": <string>,
-     "message": <string>,
-     "file": <string>,
-     "line: <integer>
+     "message": <string>
     }
 
 All keys are required.
@@ -194,6 +196,3 @@ to the event.
 `"message"` is a descriptive message providing extra information about the event.
 This should be `null` if `status` is `success`.
 
-`"file"` is the manifest in which the resource is defined. This field may be `null`.
-
-`"line"` is the line number (within `"file"`) where the resource is defined. This field may be `null`.

--- a/src/puppetlabs/puppetdb/anonymizer.clj
+++ b/src/puppetlabs/puppetdb/anonymizer.clj
@@ -21,7 +21,7 @@
 (def resource-event-schema-str (utils/str-schema reports/resource-event-v5-wireformat-schema))
 (def metric-schema-str (utils/str-schema reports/metric-wireformat-schema))
 (def log-schema-str (utils/str-schema reports/log-wireformat-schema))
-(def report-schema-str (utils/str-schema (assoc reports/report-wireformat-schema
+(def report-schema-str (utils/str-schema (assoc reports/report-v5-wireformat-schema
                                            :resource_events [resource-event-schema-str]
                                            :metrics (s/maybe [metric-schema-str])
                                            :logs (s/maybe [log-schema-str]))))

--- a/src/puppetlabs/puppetdb/anonymizer.clj
+++ b/src/puppetlabs/puppetdb/anonymizer.clj
@@ -18,9 +18,9 @@
    (contains? edge "target")
    (contains? edge "relationship")))
 
-(def resource-event-schema-str (utils/str-schema reports/resource-event-wireformat-schema))
-(def metric-schema-str (utils/str-schema reports/metric-schema))
-(def log-schema-str (utils/str-schema reports/log-schema))
+(def resource-event-schema-str (utils/str-schema reports/resource-event-v5-wireformat-schema))
+(def metric-schema-str (utils/str-schema reports/metric-wireformat-schema))
+(def log-schema-str (utils/str-schema reports/log-wireformat-schema))
 (def report-schema-str (utils/str-schema (assoc reports/report-wireformat-schema
                                            :resource_events [resource-event-schema-str]
                                            :metrics (s/maybe [metric-schema-str])

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -283,45 +283,26 @@
                id (command-names :store-report)
                puppet_version certname)))
 
-(defn- resource->skipped-resource-events
-  "Fabricate a skipped resource-event"
-  [resource]
-  (-> resource
-      ;; We also need to grab the timestamp when the resource is `skipped'
-      (select-keys [:resource_type :resource_title :file :line :containment_path :timestamp])
-      (merge {:status "skipped" :property nil :old_value nil :new_value nil :message nil})
-      vector))
-
-(defn- resource->resource-events
-  [{:keys [skipped] :as resource}]
-  (if (= skipped true)
-    (resource->skipped-resource-events resource)
-    (let [resource-metadata (select-keys resource [:resource_type :resource_title :file :line :containment_path])]
-      (map (partial merge resource-metadata) (:events resource)))))
-
-(defn- resources->resource-events
-  [report]
-  (-> report
-      (update :resources (partial mapcat resource->resource-events))
-      (clojure.set/rename-keys {:resources :resource_events})))
-
 (defmethod process-command! [(command-names :store-report) 3]
-  [{:keys [version] :as command} {:keys [db]}]
-  (store-report* 5 db (-> command
-                          (update :payload report/wire-v3->wire-v5 (get-in command [:annotations :received])))))
+  [command {:keys [db]}]
+  (store-report* 6 db
+                 (let [received-time (get-in command [:annotations :received])]
+                   (update command :payload report/wire-v3->wire-v6 received-time))))
 
 (defmethod process-command! [(command-names :store-report) 4]
-  [{:keys [version] :as command} {:keys [db]}]
-  (store-report* 5 db (-> command
-                          (update :payload report/wire-v4->wire-v5 (get-in command [:annotations :received])))))
+  [command {:keys [db]}]
+  (store-report* 6 db
+                 (let [received-time (get-in command [:annotations :received])]
+                   (update command :payload report/wire-v4->wire-v6 received-time))))
 
 (defmethod process-command! [(command-names :store-report) 5]
-  [{:keys [version] :as command} {:keys [db]}]
-  (store-report* 5 db command))
+  [command {:keys [db]}]
+  (store-report* 6 db
+                 (update command :payload report/wire-v5->wire-v6)))
 
 (defmethod process-command! [(command-names :store-report) 6]
-  [{:keys [version] :as command} {:keys [db]}]
-  (store-report* 6 db (update command :payload resources->resource-events)))
+  [command {:keys [db]}]
+  (store-report* 6 db command))
 
 (def supported-command?
   (comp (kitchensink/valset command-names) :command))

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -270,8 +270,7 @@
 
 (defn store-report*
   [version db {:keys [payload annotations]}]
-  (let [id (:id annotations)
-        received-timestamp (:received annotations)
+  (let [{id :id received-timestamp :received} annotations
         {:keys [certname puppet_version] :as report}
         (->> payload
              (s/validate report/report-wireformat-schema)

--- a/src/puppetlabs/puppetdb/reports.clj
+++ b/src/puppetlabs/puppetdb/reports.clj
@@ -10,28 +10,30 @@
 
 ;; SCHEMA
 
-(def resource-event-wireformat-schema
-  {:status             s/Str
-   :timestamp          pls/Timestamp
-   :resource_type      s/Str
-   :resource_title     s/Str
-   :property           (s/maybe s/Str)
-   :new_value          (s/maybe pls/JSONable)
-   :old_value          (s/maybe pls/JSONable)
-   :message            (s/maybe s/Str)
-   :file               (s/maybe s/Str)
-   :line               (s/maybe s/Int)
-   :containment_path   [s/Str]})
+(def event-wireformat-schema
+  {:status s/Str
+   :timestamp pls/Timestamp
+   :property (s/maybe s/Str)
+   :new_value (s/maybe pls/JSONable)
+   :old_value (s/maybe pls/JSONable)
+   :message (s/maybe s/Str)})
 
-(def resource-event-v4-wireformat-schema
-  (utils/underscore->dash-keys resource-event-wireformat-schema))
+(def resource-wireformat-schema
+  {:skipped s/Bool
+   :timestamp pls/Timestamp
+   :resource_type s/Str
+   :resource_title s/Str
+   :file (s/maybe s/Str)
+   :line (s/maybe s/Int)
+   :containment_path [s/Str]
+   :events [event-wireformat-schema]})
 
-(def metric-schema
+(def metric-wireformat-schema
   {:category s/Str
    :name s/Str
    :value s/Num})
 
-(def log-schema
+(def log-wireformat-schema
   {:file (s/maybe s/Str)
    :line (s/maybe s/Int)
    :level s/Str
@@ -41,23 +43,36 @@
    :time pls/Timestamp})
 
 (def report-wireformat-schema
-  {:certname                 s/Str
-   :puppet_version           s/Str
-   :report_format            s/Int
-   :configuration_version    s/Str
-   :start_time               pls/Timestamp
-   :end_time                 pls/Timestamp
-   :producer_timestamp       pls/Timestamp
-   :resource_events          [resource-event-wireformat-schema]
-   :noop                     (s/maybe s/Bool)
-   :transaction_uuid         (s/maybe s/Str)
-   :metrics                  (s/maybe [metric-schema])
-   :logs                     (s/maybe [log-schema])
-   :environment              s/Str
-   :status                   (s/maybe s/Str)})
+  {:certname s/Str
+   :puppet_version s/Str
+   :report_format s/Int
+   :configuration_version s/Str
+   :start_time pls/Timestamp
+   :end_time pls/Timestamp
+   :producer_timestamp pls/Timestamp
+   :resources [resource-wireformat-schema]
+   :noop (s/maybe s/Bool)
+   :transaction_uuid (s/maybe s/Str)
+   :metrics (s/maybe [metric-wireformat-schema])
+   :logs (s/maybe [log-wireformat-schema])
+   :environment s/Str
+   :status (s/maybe s/Str)})
+
+(def resource-event-v5-wireformat-schema
+  (-> resource-wireformat-schema
+      (dissoc :skipped :events)
+      (merge event-wireformat-schema)))
+
+(def report-v5-wireformat-schema
+  (-> report-wireformat-schema
+      (dissoc :resources)
+      (assoc :resource_events [resource-event-v5-wireformat-schema])))
+
+(def resource-event-v4-wireformat-schema
+  (utils/underscore->dash-keys resource-event-v5-wireformat-schema))
 
 (def report-v4-wireformat-schema
-  (-> report-wireformat-schema
+  (-> report-v5-wireformat-schema
       utils/underscore->dash-keys
       (assoc :resource-events [resource-event-v4-wireformat-schema])
       (dissoc :logs :metrics :noop :producer-timestamp)))
@@ -65,19 +80,19 @@
 (def report-v3-wireformat-schema
   (dissoc report-v4-wireformat-schema :status))
 
-(pls/defn-validated sanitize-events :- [resource-event-wireformat-schema]
+(pls/defn-validated sanitize-v5-resource-events :- [resource-event-v5-wireformat-schema]
   "This function takes an array of events and santizes them, ensuring only
    valid keys are returned."
-  [events :- (s/pred coll? 'coll?)]
-  (for [event events]
-    (pls/strip-unknown-keys resource-event-wireformat-schema event)))
+  [resource-events :- (s/pred coll? 'coll?)]
+  (for [resource-event resource-events]
+    (pls/strip-unknown-keys resource-event-v5-wireformat-schema resource-event)))
 
-(pls/defn-validated sanitize-report :- report-wireformat-schema
+(pls/defn-validated sanitize-report :- report-v5-wireformat-schema
   "This function takes a report and sanitizes it, ensuring only valid data
    is left over."
   [payload :- (s/pred map? 'map?)]
-  (-> (pls/strip-unknown-keys report-wireformat-schema payload)
-      (update-in [:resource_events] sanitize-events)))
+  (-> (pls/strip-unknown-keys report-v5-wireformat-schema payload)
+      (update :resource_events sanitize-v5-resource-events)))
 
 (def resource-event-query-schema
   {(s/optional-key :certname) s/Str
@@ -106,11 +121,11 @@
 
 (def metrics-expanded-query-schema
   {:href s/Str
-   (s/optional-key :data) [metric-schema]})
+   (s/optional-key :data) [metric-wireformat-schema]})
 
 (def logs-expanded-query-schema
   {:href s/Str
-   (s/optional-key :data) [log-schema]})
+   (s/optional-key :data) [log-wireformat-schema]})
 
 (def report-query-schema
   {(s/optional-key :hash) s/Str
@@ -133,57 +148,102 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Reports Query -> Wire format conversions
 
-(pls/defn-validated event-query->wire-v5 :- resource-event-wireformat-schema
-  [event :- resource-event-query-schema]
-  (-> event
-      (dissoc :report :certname :containing_class :configuration_version
-              :run_start_time :run_end_time :report_receive_time :environment)))
-
-(pls/defn-validated events-expanded->wire-v5 :- [resource-event-wireformat-schema]
+(pls/defn-validated resource-events-query->wire-v5 :- [resource-event-v5-wireformat-schema]
   [events :- resource-events-expanded-query-schema]
   (sort-by
    #(mapv % [:timestamp :resource_type :resource_title :property])
-   (map event-query->wire-v5
-        (:data events))))
+   (map
+    #(dissoc % :report :certname :containing_class :configuration_version
+             :run_start_time :run_end_time :report_receive_time :environment)
+    (:data events))))
 
-(pls/defn-validated logs-query->wire-v5 :- [log-schema]
+(pls/defn-validated logs-query->wire-v5 :- [log-wireformat-schema]
   [logs :- logs-expanded-query-schema]
   (:data logs))
 
-(pls/defn-validated metrics-query->wire-v5 :- [metric-schema]
+(pls/defn-validated metrics-query->wire-v5 :- [metric-wireformat-schema]
   [metrics :- metrics-expanded-query-schema]
   (:data metrics))
 
-(pls/defn-validated report-query->wire-v5 :- report-wireformat-schema
+(pls/defn-validated report-query->wire-v5 :- report-v5-wireformat-schema
   [report :- report-query-schema]
   (-> report
       (dissoc :hash :receive_time)
-      (update-in [:resource_events] events-expanded->wire-v5)
-      (update-in [:metrics] metrics-query->wire-v5)
-      (update-in [:logs] logs-query->wire-v5)))
+      (update :resource_events resource-events-query->wire-v5)
+      (update :metrics metrics-query->wire-v5)
+      (update :logs logs-query->wire-v5)))
 
-(pls/defn-validated reports-query->wire-v5
+(pls/defn-validated reports-query->wire-v5 :- [report-v5-wireformat-schema]
   [reports :- [report-query-schema]]
-  (map report-query->wire-v5
-       reports))
+  (map report-query->wire-v5 reports))
 
-(defn dash->underscore-report-keys [report]
-  (->> report
+(defn dash->underscore-report-keys [v5-report-or-older]
+  (->> v5-report-or-older
        utils/dash->underscore-keys
        (sp/transform [:resource_events sp/ALL sp/ALL]
                      #(update % 0 utils/dashes->underscores))))
 
-(pls/defn-validated wire-v4->wire-v5
+(defn- resource-event-v5->resource
+  [resource-event]
+  (-> resource-event
+      (select-keys [:file :line :timestamp :resource_type :resource_title :containment_path])
+      (assoc :skipped (= "skipped" (:status resource-event)))))
+
+(defn resource-events-v5->resources
+  [resource-events]
+  (vec
+   (for [[resource resource-events] (group-by resource-event-v5->resource resource-events)
+         :let [events (mapv #(dissoc % :file :line :resource_type :resource_title :containment_path) resource-events)]]
+     (assoc resource :events events))))
+
+(defn wire-v5->wire-v6
+  [report]
+  (-> report
+      (update :resource_events resource-events-v5->resources)
+      (clojure.set/rename-keys {:resource_events :resources})))
+
+(defn wire-v4->wire-v6
   [report received-time]
   (-> report
       dash->underscore-report-keys
       (assoc :metrics nil
              :logs nil
              :noop nil
-             :producer_timestamp received-time)))
+             :producer_timestamp received-time)
+      wire-v5->wire-v6))
 
-(pls/defn-validated wire-v3->wire-v5
+
+(defn wire-v3->wire-v6
   [report received-time]
   (-> report
       (assoc :status nil)
-      (wire-v4->wire-v5 received-time)))
+      (wire-v4->wire-v6 received-time)))
+
+(defn- resource->skipped-resource-events
+  "Fabricate a skipped resource-event"
+  [resource]
+  (-> resource
+      ;; We also need to grab the timestamp when the resource is `skipped'
+      (select-keys [:resource_type :resource_title :file :line :containment_path :timestamp])
+      (merge {:status "skipped" :property nil :old_value nil :new_value nil :message nil})
+      vector))
+
+(defn- resource->resource-events
+  [{:keys [skipped] :as resource}]
+  (cond
+    (= skipped true)
+    (resource->skipped-resource-events resource)
+
+    ;; If we get an unchanged resource, disregard it
+    (empty? (:events resource))
+    []
+
+    :else
+    (let [resource-metadata (select-keys resource [:resource_type :resource_title :file :line :containment_path])]
+      (map (partial merge resource-metadata) (:events resource)))))
+
+(defn resources->resource-events
+  [resources]
+  (->> resources
+       (mapcat resource->resource-events)
+       vec))

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1425,6 +1425,75 @@
       "ALTER TABLE environments RENAME COLUMN name TO environment"
       "ALTER TABLE environments ALTER COLUMN name RENAME TO environment")))
 
+(defn move-to-jsonb-for-metrics-logs-resources
+  []
+  (let [hash-type (if (sutils/postgres?) "bytea" "varchar(40)")
+        uuid-type (if (sutils/postgres?) "uuid" "varchar(255)")
+        jsonb-type (if (sutils/postgres?) "jsonb" "text")]
+    (sql/create-table :reports_transform
+                      ["id"                    "bigint NOT NULL DEFAULT nextval('reports_id_seq')"]
+                      ["hash"                  hash-type "NOT NULL"]
+                      ["transaction_uuid"      uuid-type]
+                      ["certname"              "text NOT NULL"]
+                      ["puppet_version"        "varchar(255) NOT NULL"]
+                      ["report_format"         "smallint NOT NULL"]
+                      ["configuration_version" "varchar(255) NOT NULL"]
+                      ["start_time"            "timestamp with time zone NOT NULL"]
+                      ["end_time"              "timestamp with time zone NOT NULL"]
+                      ["receive_time"          "timestamp with time zone NOT NULL"]
+                      ["producer_timestamp"    "timestamp with time zone NOT NULL"]
+                      ["noop"                  "boolean"]
+                      ["environment_id"        "bigint"]
+                      ["status_id"             "bigint"]
+                      ;; Add a `resources' column and change from "json" to
+                      ;; "jsonb" for the `logs' and `metrics' columns.
+                      ["resources" jsonb-type]
+                      ["metrics" jsonb-type]
+                      ["logs" jsonb-type])
+
+    (sql/do-commands
+     (let [cast-to-jsonb (if (= jsonb-type "text") "" "::jsonb")]
+       (format
+        "INSERT INTO reports_transform (id, hash, certname, puppet_version,
+        report_format, configuration_version, start_time, end_time,
+        receive_time, producer_timestamp, transaction_uuid, environment_id,
+        status_id, metrics, logs)
+       SELECT id, hash, certname, puppet_version, report_format,
+        configuration_version, start_time, end_time, receive_time,
+        producer_timestamp, transaction_uuid, environment_id, status_id,
+        metrics%s, logs%s
+       FROM reports"
+        cast-to-jsonb cast-to-jsonb)))
+
+    (when (sutils/postgres?)
+      (sql/do-commands
+       "ALTER TABLE certnames DROP CONSTRAINT certnames_reports_id_fkey"))
+    (sql/do-commands
+     "ALTER TABLE resource_events DROP CONSTRAINT resource_events_report_id_fkey"
+     "DROP TABLE reports")
+
+    (sql/do-commands "ALTER TABLE reports_transform RENAME to reports")
+
+    (sql/do-commands
+     "ALTER TABLE reports ADD CONSTRAINT reports_pkey PRIMARY KEY (id)"
+     "CREATE INDEX reports_certname_idx ON reports(certname)"
+     "CREATE INDEX reports_end_time_idx ON reports(end_time)"
+     "CREATE INDEX reports_environment_id_idx ON reports(environment_id)"
+     "CREATE INDEX reports_status_id_idx ON reports(status_id)"
+     "CREATE INDEX reports_transaction_uuid_idx ON reports(transaction_uuid)"
+     ;; Foreign contraints from reports
+     "ALTER TABLE reports ADD CONSTRAINT reports_env_fkey FOREIGN KEY (environment_id) REFERENCES environments(id) ON DELETE CASCADE"
+     "ALTER TABLE reports ADD CONSTRAINT reports_status_fkey FOREIGN KEY (status_id) REFERENCES report_statuses(id) ON DELETE CASCADE"
+     "ALTER TABLE reports ADD CONSTRAINT reports_certname_fkey FOREIGN KEY (certname) REFERENCES certnames(certname) ON DELETE CASCADE"
+     "ALTER TABLE reports ADD CONSTRAINT reports_hash_key UNIQUE (hash)"
+     ;; Foreign constraints into reports
+     "ALTER TABLE resource_events ADD CONSTRAINT resource_events_report_id_fkey FOREIGN KEY (report_id) REFERENCES reports(id) ON DELETE CASCADE"
+     ))
+
+    (when (sutils/postgres?)
+      (sql/do-commands
+       "ALTER TABLE certnames ADD CONSTRAINT certnames_reports_id_fkey FOREIGN KEY (latest_report_id) REFERENCES reports(id) ON DELETE SET NULL")))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {1 initialize-store
@@ -1465,7 +1534,9 @@
    ;; date when the "vacuum analyze" code was added to migrate! will
    ;; still analyze their existing databases.
    35 (fn [] true)
-   36 rename-environments-name-to-environment})
+   36 rename-environments-name-to-environment
+   37 move-to-jsonb-for-metrics-logs-resources
+   })
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1102,6 +1102,13 @@
       #(not (or (empty? %) (kitchensink/string-contains? "[" %)))
       (reverse containment-path)))))
 
+(def store-resources-column? (atom false))
+(defn maybe-resources
+  [row-map]
+  (if @store-resources-column?
+    row-map
+    (dissoc row-map :resources)))
+
 (defn maybe-environment
   "This fn is most to help in testing, instead of persisting a value of
   nil, just omit it from the row map. For tests that are running older versions
@@ -1149,22 +1156,23 @@
              (let [certname-id (certname-id certname)
                    {:keys [id]} (sql/insert-record :reports
                                  (maybe-environment
+                                  (maybe-resources
                                    {:hash                   (sutils/munge-hash-for-storage report-hash)
-                                    :transaction_uuid       (sutils/munge-uuid-for-storage transaction_uuid)
-                                    :metrics (sutils/munge-jsonb-for-storage metrics)
-                                    :logs (sutils/munge-jsonb-for-storage logs)
-                                    :resources (sutils/munge-jsonb-for-storage resources)
-                                    :noop                   noop
-                                    :puppet_version         puppet_version
-                                    :certname               certname
-                                    :report_format          report_format
-                                    :configuration_version  configuration_version
-                                    :producer_timestamp     producer_timestamp
-                                    :start_time             start_time
-                                    :end_time               end_time
-                                    :receive_time           (to-timestamp received-timestamp)
-                                    :environment_id         (ensure-environment environment)
-                                    :status_id              (ensure-status status)}))
+                                     :transaction_uuid       (sutils/munge-uuid-for-storage transaction_uuid)
+                                     :metrics (sutils/munge-jsonb-for-storage metrics)
+                                     :logs (sutils/munge-jsonb-for-storage logs)
+                                     :resources (sutils/munge-jsonb-for-storage resources)
+                                     :noop                   noop
+                                     :puppet_version         puppet_version
+                                     :certname               certname
+                                     :report_format          report_format
+                                     :configuration_version  configuration_version
+                                     :producer_timestamp     producer_timestamp
+                                     :start_time             start_time
+                                     :end_time               end_time
+                                     :receive_time           (to-timestamp received-timestamp)
+                                     :environment_id         (ensure-environment environment)
+                                     :status_id              (ensure-status status)})))
                    assoc-ids #(assoc %
                                      :report_id id
                                      :certname_id certname-id)]

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1156,8 +1156,8 @@
                                  (maybe-environment
                                    {:hash                   (sutils/munge-hash-for-storage report-hash)
                                     :transaction_uuid       (sutils/munge-uuid-for-storage transaction_uuid)
-                                    :metrics                (sutils/munge-json-for-storage metrics)
-                                    :logs                   (sutils/munge-json-for-storage logs)
+                                    :metrics                (sutils/munge-jsonb-for-storage metrics)
+                                    :logs                   (sutils/munge-jsonb-for-storage logs)
                                     :noop                   noop
                                     :puppet_version         puppet_version
                                     :certname               certname

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -335,3 +335,11 @@ must be supplied as the value to be matched."
       (str->pgobject "json" json-str)
       json-str)))
 
+(defn munge-jsonb-for-storage
+  "Prepare a clojure object for storage depending on db type."
+  [value]
+  (let [json-str (json/generate-string value)]
+    (if (postgres?)
+      (str->pgobject "jsonb" json-str)
+      json-str)))
+

--- a/test/puppetlabs/puppetdb/examples/reports.clj
+++ b/test/puppetlabs/puppetdb/examples/reports.clj
@@ -37,14 +37,12 @@
                               :name  "failed_to_restart"
                               :value  0}]
     :resource_events
-    ;; NOTE: this is a bit wonky because resource events should *not* contain
-    ;;  a certname or containment-class on input, but they will have one on output
-    ;;  To make it easier to test output, we're included them here.  We also include
-    ;;  a `:test_id` field to make it easier to reference individual events during
-    ;;  testing.  All of these are munged out by the testutils `store-example-report!`
-    ;;  function before the report is submitted to the test database.
-    [{:test_id          1
-      :certname         "foo.local"
+    ;; NOTE: this is a bit wonky because resource events should *not* contain a
+    ;;  certname or containment-class on input, but they will have one on output
+    ;;  To make it easier to test output, we're included them here. All of these
+    ;;  are munged out by the testutils `store-example-report!` function before
+    ;;  the report is submitted to the test database.
+    [{:certname         "foo.local"
       :status           "success"
       :timestamp        "2011-01-01T12:00:01-03:00"
       :resource_type    "Notify"
@@ -58,8 +56,7 @@
       :line             1
       :containment_path nil
       :containing_class nil}
-     {:test_id          2
-      :certname         "foo.local"
+     {:certname         "foo.local"
       :status           "success"
       :timestamp        "2011-01-01T12:00:03-03:00"
       :resource_type    "Notify"
@@ -73,8 +70,7 @@
       :line             nil
       :containment_path []
       :containing_class nil}
-     {:test_id          3
-      :certname         "foo.local"
+     {:certname         "foo.local"
       :status           "skipped"
       :timestamp        "2011-01-01T12:00:02-03:00"
       :environment      "DEV"
@@ -125,14 +121,7 @@
                               :name  "failed_to_restart"
                               :value  0}]
     :resource_events
-    ;; NOTE: this is a bit wonky because resource events should *not* contain
-    ;;  a certname on input, but they will have one on output.  To make it
-    ;;  easier to test output, we're included them here.  We also include a
-    ;;  `:test_id` field to make it easier to reference individual events during
-    ;;  testing.  Both of this are munged out by the testutils `store-example-report!`
-    ;;  function before the report is submitted to the test database.
-    [{:test_id          4
-      :certname         "foo.local"
+    [{:certname         "foo.local"
       :status           "success"
       :timestamp        "2013-08-28T19:36:34.000Z"
       :resource_type    "Notify"
@@ -145,8 +134,7 @@
       :line             8
       :containment_path nil
       :containing_class nil}
-     {:test_id          5
-      :certname         "foo.local"
+     {:certname         "foo.local"
       :status           "success"
       :timestamp        "2013-08-28T17:55:45.000Z"
       :resource_type    "File"
@@ -159,8 +147,7 @@
       :line             17
       :containment_path []
       :containing_class nil}
-     {:test_id          6
-      :certname         "foo.local"
+     {:certname         "foo.local"
       :status           "success"
       :timestamp        "2013-08-28T17:55:45.000Z"
       :resource_type    "File"
@@ -210,14 +197,7 @@
                               :name  "failed_to_restart"
                               :value  0}]
     :resource_events
-    ;; NOTE: this is a bit wonky because resource events should *not* contain
-    ;;  a certname or containment-class on input, but they will have one on output
-    ;;  To make it easier to test output, we're included them here.  We also include
-    ;;  a `:test_id` field to make it easier to reference individual events during
-    ;;  testing.  All of these are munged out by the testutils `store-example-report!`
-    ;;  function before the report is submitted to the test database.
-    [{:test_id          7
-      :certname         "foo.local"
+    [{:certname         "foo.local"
       :status           "success"
       :timestamp        "2011-01-03T12:00:00-03:00"
       :resource_type    "Notify"
@@ -230,8 +210,7 @@
       :line             1
       :containment_path nil
       :containing_class nil}
-     {:test_id          8
-      :certname         "foo.local"
+     {:certname         "foo.local"
       :status           "failure"
       :timestamp        "2011-01-03T12:00:00-03:00"
       :resource_type    "Notify"
@@ -244,8 +223,7 @@
       :line             nil
       :containment_path []
       :containing_class nil}
-     {:test_id          9
-      :certname         "foo.local"
+     {:certname         "foo.local"
       :status           "skipped"
       :timestamp        "2011-01-03T12:00:00-03:00"
       :resource_type    "Notify"
@@ -295,14 +273,7 @@
                               :name  "failed_to_restart"
                               :value  0}]
     :resource_events
-    ;; NOTE: this is a bit wonky because resource events should *not* contain
-    ;;  a certname or containment-class on input, but they will have one on output
-    ;;  To make it easier to test output, we're included them here.  We also include
-    ;;  a `:test_id` field to make it easier to reference individual events during
-    ;;  testing.  All of these are munged out by the testutils `store-example-report!`
-    ;;  function before the report is submitted to the test database.
-    [{:test_id          10
-      :certname         "foo.local"
+    [{:certname         "foo.local"
       :status           "success"
       :timestamp        "2011-01-03T12:00:00-03:00"
       :resource_type    "Notify"
@@ -315,8 +286,7 @@
       :line             1
       :containment_path nil
       :containing_class nil}
-     {:test_id          11
-      :certname         "foo.local"
+     {:certname         "foo.local"
       :status           "success"
       :timestamp        "2012-01-03T12:00:00-03:00"
       :resource_type    "Notify"
@@ -329,8 +299,7 @@
       :line             2
       :containment_path []
       :containing_class nil}
-     {:test_id          12
-      :certname         "foo.local"
+     {:certname         "foo.local"
       :status           "skipped"
       :timestamp        "2013-01-03T12:00:00-03:00"
       :resource_type    "Notify"

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1311,7 +1311,10 @@
              (query-to-vec ["SELECT certname FROM reports"])))
 
       (is (= [{:hash report-hash}]
-             (query-to-vec [(format "SELECT %s AS hash FROM reports" (sutils/sql-hash-as-str "hash"))]))))
+             (query-to-vec [(format "SELECT %s AS hash FROM reports" (sutils/sql-hash-as-str "hash"))])))
+
+      (testing "foss doesn't store in the resources column"
+        (is (nil? (:resources (first (query-to-vec ["SELECT resources FROM reports"])))))))
 
     (testing "should store report with long puppet version string"
       (store-example-report!

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.puppetdb.scf.storage-test
   (:require [clojure.java.jdbc.deprecated :as sql]
             [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.reports :as report]
             [puppetlabs.puppetdb.scf.hash :as shash]
             [puppetlabs.puppetdb.facts :as facts
              :refer [path->pathmap string-to-factpath value->valuemap]]
@@ -1295,25 +1296,27 @@
              (fn [events]
                (map #(assoc % :timestamp new-timestamp) events))))
 
-(let [timestamp     (now)
-      report        (:basic reports)
-      report-hash   (shash/report-identity-hash (normalize-report report))
-      certname      (:certname report)]
+(let [timestamp (now)
+      {:keys [certname] :as report} (:basic reports)
+      report-hash (-> report
+                      report/wire-v5->wire-v6
+                      normalize-report
+                      shash/report-identity-hash)]
 
   (deftest report-storage
     (testing "should store reports"
       (store-example-report! report timestamp)
 
-      (is (= (query-to-vec ["SELECT certname FROM reports"])
-             [{:certname (:certname report)}]))
+      (is (= [{:certname certname}]
+             (query-to-vec ["SELECT certname FROM reports"])))
 
-      (is (= (query-to-vec [(format "SELECT %s AS hash FROM reports" (sutils/sql-hash-as-str "hash"))])
-             [{:hash report-hash}])))
+      (is (= [{:hash report-hash}]
+             (query-to-vec [(format "SELECT %s AS hash FROM reports" (sutils/sql-hash-as-str "hash"))]))))
 
     (testing "should store report with long puppet version string"
       (store-example-report!
        (assoc report
-         :puppet_version "3.2.1 (Puppet Enterprise 3.0.0-preview0-168-g32c839e)") timestamp)))
+              :puppet_version "3.2.1 (Puppet Enterprise 3.0.0-preview0-168-g32c839e)") timestamp)))
 
   (deftest report-with-event-timestamp
     (let [z-report (update-event-timestamps report "2011-01-01T12:00:01Z")

--- a/test/puppetlabs/puppetdb/testutils/events.clj
+++ b/test/puppetlabs/puppetdb/testutils/events.clj
@@ -18,7 +18,7 @@
   ;; Because we want to compare 'certname' in the output of event queries, the
   ;; example data includes it... but it is not a legal key for an event during
   ;; report submission.
-  (dissoc example-event :certname :test_id :containing_class :environment))
+  (dissoc example-event :certname :containing_class :environment))
 
 (defn environment [resource-event report version]
   (if (= :v4 version)
@@ -40,8 +40,7 @@
       ;; we need to convert the datetime fields from the examples to timestamp objects
       ;; in order to compare them.
       (update :timestamp to-timestamp)
-      (environment report version)
-      (dissoc :test_id)))
+      (environment report version)))
 
 (defn raw-expected-resource-events
   "Given a sequence of resource events from the example data, plus a report,

--- a/test/puppetlabs/puppetdb/testutils/nodes.clj
+++ b/test/puppetlabs/puppetdb/testutils/nodes.clj
@@ -4,6 +4,7 @@
             [puppetlabs.puppetdb.examples :refer :all]
             [puppetlabs.puppetdb.zip :as zip]
             [puppetlabs.puppetdb.testutils.reports :as tur]
+            [puppetlabs.puppetdb.reports :as report]
             [clj-time.core :refer [now plus seconds]]))
 
 (defn change-certname
@@ -21,7 +22,8 @@
   (-> (:basic reports)
       (change-certname node-name)
       tur/munge-example-report-for-storage
-      (assoc :end_time (now))))
+      (assoc :end_time (now))
+      report/wire-v5->wire-v6))
 
 (defn store-example-nodes
   []


### PR DESCRIPTION
This commit moves to using JSONB columns for metrics, logs, and the new
column resources in the reports table. The resources column will be used
by unchanged resources for storing "resource" jsonb blobs. The old
metrics and logs json columns have been moved to deprecated_metrics and
deprecated_logs (coalesced with the jsonb columns in the query-eng to
preserve querying for the old data).

This commit also changes PuppetDB's report storage to expect the v6
wire-format with the resources (instead of resource_events) field and
stores the resources document as a JSONB column in reports that was
created in a previous commit's migration addition. This commit updates
the tests to be more compatible with the new version, removing
unnecessary fields in the example reports' `resource_events` fields.