### PR TITLE
(PDB-1921) Swallow exceptions during the `check-for-update!` on startup

### DIFF
--- a/src/puppetlabs/puppetdb/meta/version.clj
+++ b/src/puppetlabs/puppetdb/meta/version.clj
@@ -43,4 +43,6 @@
 
 (defn check-for-updates!
   [update-server db]
-  (version-check/check-for-updates! (pdb-version-check-values db) update-server))
+  (try
+    (version-check/check-for-updates! (pdb-version-check-values db) update-server)
+    (catch Exception e)))

--- a/test/puppetlabs/puppetdb/meta/version_test.clj
+++ b/test/puppetlabs/puppetdb/meta/version_test.clj
@@ -1,0 +1,13 @@
+(ns puppetlabs.puppetdb.meta.version-test
+  (:require [puppetlabs.puppetdb.meta.version :refer :all]
+            [clojure.test :refer :all]
+            [puppetlabs.puppetdb.fixtures :refer [with-test-db *db*]]))
+
+(deftest check-for-updates!-test
+  (testing "check-for-updates! swallows exceptions"
+    (testing "can't connect to server"
+      (with-test-db
+        (fn []
+          (is (nil? (check-for-updates! "http://updates.foo.com" *db*))))))
+    (testing "can't connect to database"
+      (is (nil? (check-for-updates! "http://updates.puppetlabs.com" {:invalid :connection}))))))


### PR DESCRIPTION
This commit fixes a regression with our check-for-update! function in
which the new shared library we upgraded to does not swallow exceptions
like our previous code. Since the library will log exceptions and
rethrow them, we just need to be sure to swallow the exception in our
wrappers for the library. This commit swallows exceptions for the
version-check library on startup.