### PR TITLE
(MAINT) Refactor puppetdb-middleware to central location

### DIFF
--- a/src/puppetlabs/puppetdb/admin.clj
+++ b/src/puppetlabs/puppetdb/admin.clj
@@ -31,7 +31,7 @@
                        (mapcat (partial export/get-node-data query-fn)))))
 
 (defn build-app
-  [get-authorizer submit-command-fn query-fn]
+  [submit-command-fn query-fn]
   (-> (compojure/routes
        (mp/wrap-multipart-params
         (compojure/POST "/v1/archive" request
@@ -43,5 +43,4 @@
        (compojure/GET "/v1/archive" []
                       (http/streamed-tar-response #(export-app % query-fn)
                                                   (format "puppetdb-export-%s.tgz" (now))))
-       (route/not-found "Not Found"))
-      (mid/wrap-with-puppetdb-middleware get-authorizer)))
+       (route/not-found "Not Found"))))

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -110,7 +110,7 @@
 ;; return functions that accept a ring request map
 
 (defn command-app
-  [get-authorizer get-command-mq get-shared-globals enqueue-fn get-response-pub]
+  [get-command-mq get-shared-globals enqueue-fn get-response-pub]
   (-> (moustache/app
        ["v1" &] {:any (enqueue-command-handler get-command-mq enqueue-fn get-response-pub)})
       validate-command-version
@@ -119,7 +119,6 @@
       (mid/validate-query-params {:optional ["checksum" "secondsToWaitForCompletion"]})
       mid/payload-to-body-string
       (mid/verify-content-type ["application/json"])
-      (mid/wrap-with-puppetdb-middleware get-authorizer)
       (mid/wrap-with-metrics (atom {}) http/leading-uris)
       (mid/wrap-with-globals get-shared-globals)))
 

--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -44,8 +44,7 @@
   function that accepts a request.  The request will be allowed only
   if authorize returns :authorized.  Otherwise, the return value
   should be a message describing the reason that access was denied."
-  [get-authorizer get-shared-globals]
+  [get-shared-globals]
   (-> routes
-      (wrap-with-puppetdb-middleware get-authorizer)
       (wrap-with-metrics (atom {}) http/leading-uris)
       (wrap-with-globals get-shared-globals)))

--- a/src/puppetlabs/puppetdb/meta.clj
+++ b/src/puppetlabs/puppetdb/meta.clj
@@ -64,8 +64,7 @@
                  ["v1" "server-time" &] {:any server-time-routes}))
 
 (defn build-app
-  [get-authorizer get-shared-globals]
+  [get-shared-globals]
   (-> (routes get-shared-globals)
       verify-accepts-json
-      validate-no-query-params
-      (wrap-with-puppetdb-middleware get-authorizer)))
+      validate-no-query-params))

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -20,7 +20,8 @@
                                                    deftestseq
                                                    parse-result]]
             [puppetlabs.puppetdb.utils :as utils]
-            [puppetlabs.kitchensink.core :as ks]))
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.puppetdb.middleware :as mid]))
 
 (def v4-facts-endpoint "/v4/facts")
 (def v4-facts-environment "/v4/environments/DEV/facts")
@@ -441,10 +442,12 @@
   ([read-write-db]
    (test-app read-write-db read-write-db))
   ([read-db write-db]
-   (server/build-app nil #(hash-map :scf-read-db read-db
-                                    :scf-write-db write-db
-                                    :command-mq *mq*
-                                    :product-name "puppetdb"))))
+   (mid/wrap-with-puppetdb-middleware
+    (server/build-app #(hash-map :scf-read-db read-db
+                                 :scf-write-db write-db
+                                 :command-mq *mq*
+                                 :product-name "puppetdb"))
+    nil)))
 
 (defn with-shutdown-after [dbs f]
   (f)

--- a/test/puppetlabs/puppetdb/meta_test.clj
+++ b/test/puppetlabs/puppetdb/meta_test.clj
@@ -8,7 +8,8 @@
             [puppetlabs.puppetdb.meta :as meta]
             [puppetlabs.puppetdb.fixtures :as fixt]
             [puppetlabs.puppetdb.meta.version :as version]
-            [puppetlabs.trapperkeeper.testutils.logging :refer [with-log-output]]))
+            [puppetlabs.trapperkeeper.testutils.logging :refer [with-log-output]]
+            [puppetlabs.puppetdb.middleware :as mid]))
 
 (use-fixtures :each fixt/with-test-db)
 
@@ -21,9 +22,11 @@
 
 (defn with-meta-app
   [request & [overrides]]
-  (let [app (meta/build-app nil #(merge {:product-name "puppetdb"
-                                         :update-server "FOO"}
-                                        overrides))]
+  (let [app (mid/wrap-with-puppetdb-middleware
+             (meta/build-app #(merge {:product-name "puppetdb"
+                                      :update-server "FOO"}
+                                     overrides))
+             nil)]
     (app request)))
 
 (deftestseq test-latest-version


### PR DESCRIPTION
Prior to this change, each route (i.e. meta, admin, query etc) included
an explicit wrap of puppetdb-middleware. This pulls that wrapping up to
the top level (where the /pdb route is being defined). This reduces
duplication and centralizes that code to pdb-routing.