### PR TITLE
(maint) install debian-archive-keyring in repo setup

### DIFF
--- a/acceptance/setup/pre_suite/15_setup_repos.rb
+++ b/acceptance/setup/pre_suite/15_setup_repos.rb
@@ -8,6 +8,7 @@ def initialize_repo_on_host(host, os)
       on host, "curl -O http://apt.puppetlabs.com/puppetlabs-release-$(lsb_release -sc).deb"
       on host, "dpkg -i puppetlabs-release-$(lsb_release -sc).deb"
     end
+      on host, "apt-get install debian-archive-keyring"
       on host, "apt-get update"
   when :redhat
     if options[:type] == 'aio' then


### PR DESCRIPTION
This should correct test failures on debian 7 due to missing keys.