### PR TITLE
(PDB-1902) Create a defaulted config service

### DIFF
--- a/resources/puppetlabs/puppetdb/bootstrap.cfg
+++ b/resources/puppetlabs/puppetdb/bootstrap.cfg
@@ -17,6 +17,7 @@ puppetlabs.puppetdb.mq-listener/message-listener-service
 puppetlabs.puppetdb.command/command-service
 puppetlabs.puppetdb.pdb-routing/maint-mode-service
 puppetlabs.puppetdb.pdb-routing/pdb-routing-service
+puppetlabs.puppetdb.config/config-service
 
 # NREPL
 puppetlabs.trapperkeeper.services.nrepl.nrepl-service/nrepl-service

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -16,7 +16,9 @@
             [schema.core :as s]
             [slingshot.slingshot :refer [throw+]]
             [puppetlabs.puppetdb.schema :as pls]
-            [puppetlabs.puppetdb.utils :as utils]))
+            [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.trapperkeeper.core :refer [defservice] :as tk]
+            [puppetlabs.trapperkeeper.services :refer [service-id service-context]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
@@ -375,3 +377,24 @@
       validate-vardir
       convert-config
       configure-catalog-debugging))
+
+
+(defprotocol DefaultedConfig
+  (get-config [this])
+  (get-in-config [this ks] [this ks default]))
+
+(defn create-defaulted-config-service [config-transform-fn]
+  (tk/service
+   DefaultedConfig
+   [[:ConfigService get-config]]
+   (init [this context]
+         (assoc context :config (config-transform-fn (get-config))))
+   (get-config [this]
+               (:config (service-context this)))
+   (get-in-config [this ks]
+                  (get-in (service-context this) ks))
+   (get-in-config [this ks default]
+                  (get-in (service-context this) ks default))))
+
+(def config-service
+  (create-defaulted-config-service process-config!))

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -17,7 +17,7 @@
             [slingshot.slingshot :refer [throw+]]
             [puppetlabs.puppetdb.schema :as pls]
             [puppetlabs.puppetdb.utils :as utils]
-            [puppetlabs.trapperkeeper.core :refer [defservice] :as tk]
+            [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.services :refer [service-id service-context]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -378,10 +378,9 @@
       convert-config
       configure-catalog-debugging))
 
-
 (defprotocol DefaultedConfig
   (get-config [this])
-  (get-in-config [this ks] [this ks default]))
+  (get-in-config [this ks]))
 
 (defn create-defaulted-config-service [config-transform-fn]
   (tk/service
@@ -392,9 +391,7 @@
    (get-config [this]
                (:config (service-context this)))
    (get-in-config [this ks]
-                  (get-in (service-context this) ks))
-   (get-in-config [this ks default]
-                  (get-in (service-context this) ks default))))
+                  (get-in (service-context this) ks))))
 
 (def config-service
   (create-defaulted-config-service process-config!))

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -378,6 +378,15 @@
       convert-config
       configure-catalog-debugging))
 
+(defn foss? [config]
+  (= "puppetdb" (get-in config [:global :product-name])))
+
+(defn pe? [config]
+  (= "pe-puppetdb" (get-in config [:global :product-name])))
+
+(defn update-server [config]
+  (get-in config [:global :update-server]))
+
 (defprotocol DefaultedConfig
   (get-config [this])
   (get-in-config [this ks]))

--- a/src/puppetlabs/puppetdb/http/aggregate_event_counts.clj
+++ b/src/puppetlabs/puppetdb/http/aggregate_event_counts.clj
@@ -6,14 +6,15 @@
             [puppetlabs.puppetdb.query-eng :refer [produce-streaming-body]]
             [puppetlabs.puppetdb.middleware :refer [verify-accepts-json validate-query-params]]
             [clojure.tools.logging :as log]
-            [net.cgrand.moustache :refer [app]]))
+            [net.cgrand.moustache :refer [app]]
+            [puppetlabs.puppetdb.config :as conf]))
 
 (defn routes
-  [version]
+  [version config]
   (app
     [""]
     {:get (fn [{:keys [params globals]}]
-            (when (= "puppetdb" (:product-name globals))
+            (when (conf/foss? config)
               (log/warn "The aggregate-event-counts endpoint is experimental"
                         " and may be altered or removed in the future."))
             (if (utils/hsql? (:scf-read-db globals))
@@ -40,8 +41,8 @@
 
 (defn aggregate-event-counts-app
   "Ring app for querying for aggregated summary information about resource events."
-  [version]
-  (-> (routes version)
+  [version config]
+  (-> (routes version config)
       verify-accepts-json
       (validate-query-params {:required ["summarize_by"]
                               :optional ["query"

--- a/src/puppetlabs/puppetdb/http/event_counts.clj
+++ b/src/puppetlabs/puppetdb/http/event_counts.clj
@@ -6,14 +6,15 @@
             [puppetlabs.puppetdb.middleware :refer [verify-accepts-json validate-query-params
                                                     wrap-with-paging-options]]
             [clojure.tools.logging :as log]
-            [net.cgrand.moustache :refer [app]]))
+            [net.cgrand.moustache :refer [app]]
+            [puppetlabs.puppetdb.config :as conf]))
 
 (defn routes
-  [version]
+  [version config]
   (app
    [""]
    {:get (fn [{:keys [params globals paging-options]}]
-           (when (= "puppetdb" (:product-name globals))
+           (when (conf/foss? config)
              (log/warn "The event-counts endpoint is experimental"
                        " and may be altered or removed in the future."))
            (let [{:strs [query summarize_by counts_filter count_by] :as query-params} params
@@ -32,8 +33,8 @@
 
 (defn event-counts-app
   "Ring app for querying for summary information about resource events."
-  [version]
-  (-> (routes version)
+  [version config]
+  (-> (routes version config)
       verify-accepts-json
       (validate-query-params {:required ["summarize_by"]
                               :optional (concat ["query"

--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -30,9 +30,9 @@
     (format "The %s API has been retired; please use v4" version)
     404)))
 
-(def routes
+(defn routes [config]
   (app
-   ["v4" &] {:any v4-app}
+   ["v4" &] {:any (v4-app config)}
    ["v1" &] {:any (refuse-retired-api "v1")}
    ["v2" &] {:any (refuse-retired-api "v2")}
    ["v3" &] {:any (refuse-retired-api "v3")}))
@@ -44,7 +44,7 @@
   function that accepts a request.  The request will be allowed only
   if authorize returns :authorized.  Otherwise, the return value
   should be a message describing the reason that access was denied."
-  [get-shared-globals]
-  (-> routes
+  [get-shared-globals config]
+  (-> (routes config)
       (wrap-with-metrics (atom {}) http/leading-uris)
       (wrap-with-globals get-shared-globals)))

--- a/src/puppetlabs/puppetdb/http/v4.clj
+++ b/src/puppetlabs/puppetdb/http/v4.clj
@@ -17,7 +17,7 @@
 
 (def version :v4)
 
-(def v4-app
+(defn v4-app [config]
   (moustache/app
    ["facts" &]
    {:any (facts/facts-app version)}
@@ -53,10 +53,10 @@
    {:any (events/events-app version)}
 
    ["event-counts" &]
-   {:any (ec/event-counts-app version)}
+   {:any (ec/event-counts-app version config)}
 
    ["aggregate-event-counts" &]
-   {:any (aec/aggregate-event-counts-app version)}
+   {:any (aec/aggregate-event-counts-app version config)}
 
    ["reports" &]
    {:any (reports/reports-app version)}))

--- a/src/puppetlabs/puppetdb/metrics.clj
+++ b/src/puppetlabs/puppetdb/metrics.clj
@@ -5,11 +5,11 @@
             [compojure.core :as compojure]))
 
 (defservice metrics-service
-  [[:PuppetDBServer shared-globals]
+  [[:DefaultedConfig get-in-config]
    [:WebroutingService add-ring-handler get-route]]
 
   (start [this context]
-         (let [app (->> (server/build-app #(:authorizer (shared-globals)))
+         (let [app (->> (server/build-app (get-in-config [:puppetdb :certificate-whitelist]))
                         (compojure/context (get-route this) []))]
            (log/info "Starting metrics server")
            (add-ring-handler this app)

--- a/src/puppetlabs/puppetdb/metrics/server.clj
+++ b/src/puppetlabs/puppetdb/metrics/server.clj
@@ -23,6 +23,6 @@
   function that accepts a request.  The request will be allowed only
   if authorize returns :authorized.  Otherwise, the return value
   should be a message describing the reason that access was denied."
-  [get-authorizer]
+  [cert-whitelist]
   (-> routes
-      (wrap-with-puppetdb-middleware get-authorizer)))
+      (wrap-with-puppetdb-middleware cert-whitelist)))

--- a/src/puppetlabs/puppetdb/mq_listener.clj
+++ b/src/puppetlabs/puppetdb/mq_listener.clj
@@ -353,8 +353,7 @@
 
 (defservice message-listener-service
   MessageListenerService
-  [[:PuppetDBServer shared-globals]
-   [:ConfigService get-config]]
+  [[:PuppetDBServer shared-globals]]
 
   (init [this context]
         (assoc context :listeners (atom [])))

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -29,20 +29,16 @@
 
 (defn pdb-core-routes [defaulted-config get-shared-globals submit-command-fn query-fn enqueue-raw-command-fn response-pub]
   (let [cmd-mq #(:command-mq (get-shared-globals))
-        meta-cfg #(merge
-                   (select-keys (:globals defaulted-config)
-                                [:update-server :product-name])
-                   (select-keys (get-shared-globals)
-                                [:scf-read-db]))
+        meta-cfg #(select-keys (get-shared-globals) [:scf-read-db])
         get-response-pub #(response-pub)]
     (map #(apply wrap-with-context %)
          (partition
           2
           ;; The remaining get-shared-globals args are for wrap-with-globals.
-          ["/meta" (meta/build-app meta-cfg)
+          ["/meta" (meta/build-app meta-cfg defaulted-config)
            "/cmd" (cmd/command-app cmd-mq get-shared-globals
                                    enqueue-raw-command-fn get-response-pub)
-           "/query" (server/build-app get-shared-globals)
+           "/query" (server/build-app get-shared-globals defaulted-config)
            "/admin" (admin/build-app submit-command-fn query-fn)]))))
 
 (defn pdb-app [root defaulted-config maint-mode-fn app-routes]

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -57,7 +57,8 @@
             [clojure.set :refer :all]
             [puppetlabs.puppetdb.time :refer [to-timestamp]]
             [clj-time.core :refer [now]]
-            [puppetlabs.puppetdb.jdbc :as jdbc :refer [query-to-vec]]))
+            [puppetlabs.puppetdb.jdbc :as jdbc :refer [query-to-vec]]
+            [puppetlabs.puppetdb.config :as conf]))
 
 (defn- drop-constraints
   "Drop all constraints of given `constraint-type` on `table`."
@@ -1635,7 +1636,7 @@
 
 (defn indexes!
   "Create missing indexes for applicable database platforms."
-  [product-name]
+  [config]
   (if (and (sutils/postgres?)
            (sutils/db-version-newer-than? [9 2]))
     (sql/transaction
@@ -1649,7 +1650,7 @@
          "    CREATE EXTENSION pg_trgm;\n\n"
          "as the database super user on the PuppetDB database to correct\n"
          "this, then restart PuppetDB.\n"))))
-    (when (= product-name "puppetdb")
+    (when (conf/foss? config)
       (log/warn
        (str
         "Unable to install optimal indexing\n\n"

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -123,16 +123,6 @@
         (testing (format "%s requests are refused" (name v)))
         (is (retirement-response? v (ping v)))))))
 
-(deftest whitelist-middleware
-  (testing "should log on reject"
-    (let [wl (temp-file "whitelist-log-reject")]
-      (spit wl "foobar")
-      (let [authorizer-fn (build-whitelist-authorizer (fs/absolute-path wl))]
-        (is (= :authorized (authorizer-fn {:ssl-client-cn "foobar"})))
-        (with-log-output logz
-          (is (string? (authorizer-fn {:ssl-client-cn "badguy"})))
-          (is (= 1 (count (logs-matching #"^badguy rejected by certificate whitelist " @logz)))))))))
-
 (defn make-https-request-with-whitelisted-host [whitelisted-host]
   (let [whitelist-file (temp-file "whitelist-log-reject")
         cert-config {:ssl-cert "test-resources/localhost.pem"

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -19,14 +19,17 @@
             [puppetlabs.puppetdb.cli.export :as export]))
 
 (deftest update-checking
-  (testing "should check for updates if running as puppetdb"
-    (with-redefs [version/check-for-updates! (constantly "Checked for updates!")]
-      (is (= (maybe-check-for-updates "puppetdb" "update-server!" {}) "Checked for updates!"))))
+  (let [config-map {:global {:product-name "puppetdb"
+                              :update-server "update-server!"}}]
 
-  (testing "should skip the update check if running as pe-puppetdb"
-    (with-log-output log-output
-      (maybe-check-for-updates "pe-puppetdb" "update-server!" {})
-      (is (= 1 (count (logs-matching #"Skipping update check on Puppet Enterprise" @log-output)))))))
+    (testing "should check for updates if running as puppetdb"
+      (with-redefs [version/check-for-updates! (constantly "Checked for updates!")]
+        (is (= (maybe-check-for-updates config-map {}) "Checked for updates!"))))
+
+    (testing "should skip the update check if running as pe-puppetdb"
+      (with-log-output log-output
+        (maybe-check-for-updates (assoc-in config-map [:global :product-name] "pe-puppetdb") {})
+        (is (= 1 (count (logs-matching #"Skipping update check on Puppet Enterprise" @log-output))))))))
 
 (defn- check-service-query
   [endpoint version q pagination check-result]

--- a/test/puppetlabs/puppetdb/fixtures.clj
+++ b/test/puppetlabs/puppetdb/fixtures.clj
@@ -91,11 +91,10 @@
    (let [get-shared-globals #(merge {:scf-read-db *db*
                                      :scf-write-db *db*
                                      :command-mq *mq*
-                                     :product-name "puppetdb"
                                      :url-prefix ""}
                                     globals-overrides)]
      (binding [*app* (mid/wrap-with-puppetdb-middleware
-                      (server/build-app get-shared-globals)
+                      (server/build-app get-shared-globals {:global {:product-name "puppetdb"}})
                       nil)]
        (f)))))
 

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -70,7 +70,8 @@
    #'puppetdb-command-service
    #'dashboard-redirect-service
    #'pdb-routing-service
-   #'maint-mode-service])
+   #'maint-mode-service
+   #'config-service])
 
 (defn call-with-puppetdb-instance
   "Stands up a puppetdb instance with `config`, tears down once `f` returns.

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -28,7 +28,8 @@
             [clojure.tools.logging :as log]
             [clojure.data.xml :as xml]
             [puppetlabs.puppetdb.dashboard :refer [dashboard-redirect-service]]
-            [puppetlabs.puppetdb.pdb-routing :refer [pdb-routing-service maint-mode-service]]))
+            [puppetlabs.puppetdb.pdb-routing :refer [pdb-routing-service maint-mode-service]]
+            [puppetlabs.puppetdb.config :refer [config-service]]))
 
 ;; See utils.clj for more information about base-urls.
 (def ^:dynamic *base-url* nil) ; Will not have a :version.


### PR DESCRIPTION
Currently configuration is retrieved from the TK config service,
defaulted and consumed by other componentes via shared-globals. This
commit creates a new DefaultedConfig service that has a similar API as
the config service, but applies our validation and defaulting logic
first. This will allow a large amount of shared-globals to be removed
and instead just use the defaulted values from this new service.

This also starts the process of removing things from shared-globals (specifically removing the authorizer). MQ related config probably makes the most sense to work on next (this will be handled in a separate ticket).