### PR TITLE
(PDB-1738) (PDB-1739) Drop jdbc.deprecated

### DIFF
--- a/src/puppetlabs/puppetdb/meta/version.clj
+++ b/src/puppetlabs/puppetdb/meta/version.clj
@@ -3,11 +3,11 @@
 
    This namespace contains some utility functions relating to checking version
    numbers of various fun things."
-  (:require [clojure.java.jdbc.deprecated :as sql]
-            [clojure.string :as string]
+  (:require [clojure.string :as string]
             [clj-http.client :as client]
             [ring.util.codec :as ring-codec]
             [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.dujour.version-check :as version-check]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]))
 
@@ -23,7 +23,7 @@
 
 (defn pdb-version-check-values*
   [db]
-  (sql/with-connection db
+  (jdbc/with-db-connection db
     {:product-name {:group-id "puppetlabs"
                     :artifact-id "puppetdb"}
      :database-name (:database @sutils/db-metadata)

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.puppetdb.query-eng
-  (:require [clojure.java.jdbc.deprecated :as sql]
+  (:require [clojure.java.jdbc :as sql]
             [clojure.tools.logging :as log]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.query.paging :as paging]
@@ -197,6 +197,5 @@
                               INNER JOIN factsets
                               ON factsets.certname = certnames.certname
                               WHERE certnames.certname=?")]
-    (sql/with-query-results result-set
-      [check-sql id]
-      (pos? (count result-set)))))
+    (jdbc/query-with-resultset [check-sql id]
+                               (comp boolean seq sql/result-set-seq))))

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -2,7 +2,7 @@
   (:require [cheshire.core :as json]
             [clj-time.coerce :refer [to-timestamp to-string]]
             [clj-time.core :refer [now]]
-            [clojure.java.jdbc.deprecated :as sql]
+            [clojure.java.jdbc :as sql]
             [clojure.java.io :as io]
             [clojure.test :refer :all]
             [flatland.ordered.map :as omap]
@@ -13,7 +13,7 @@
             [puppetlabs.puppetdb.fixtures :refer :all]
             [puppetlabs.puppetdb.http :as http]
             [puppetlabs.puppetdb.http.server :as server]
-            [puppetlabs.puppetdb.jdbc :refer [with-transacted-connection]]
+            [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.puppetdb.testutils :refer [get-request
                                                    assert-success!
                                                    paged-results
@@ -452,19 +452,12 @@
                                  :product-name "puppetdb"))
     nil)))
 
-(defn with-shutdown-after [dbs f]
-  (f)
-  (doseq [db dbs]
-    (sql/with-connection db
-      (sql/do-commands "SHUTDOWN"))
-    (.close (:datasource db))))
-
 (defmacro with-shutdown-after
   [dbs & body]
   `(do ~@body)
   `(doseq [db# ~dbs]
-     (sql/with-connection db#
-       (sql/do-commands "SHUTDOWN"))
+     (jdbc/with-db-connection db#
+       (jdbc/do-commands "SHUTDOWN"))
      (.close (:datasource db#))))
 
 (deftestseq fact-queries
@@ -492,7 +485,7 @@
                 "kernel" "Linux"
                 "operatingsystem" "RedHat"
                 "uptime_seconds" 6000}]
-    (with-transacted-connection *db*
+    (jdbc/with-transacted-connection *db*
       (scf-store/add-certname! "foo1")
       (scf-store/add-certname! "foo2")
       (scf-store/add-certname! "foo3")
@@ -622,7 +615,7 @@
                           "some_version" "1.3.7+build.11.e0f985a"
                           "uptime_seconds" "4000"}]
 
-              (with-transacted-connection write-db
+              (jdbc/with-transacted-connection write-db
                 (scf-store/add-certname! "foo1")
                 (scf-store/add-facts! {:certname "foo1"
                                        :values facts1
@@ -682,7 +675,7 @@
                 "kernel" "Linux"
                 "operatingsystem" "RedHat"
                 "uptime_seconds" "6000"}]
-    (with-transacted-connection *db*
+    (jdbc/with-transacted-connection *db*
       (scf-store/add-certname! "foo1")
       (scf-store/add-certname! "foo2")
       (scf-store/add-facts! {:certname "foo1"
@@ -969,7 +962,7 @@
                   "kernel" "Linux"
                   "operatingsystem" "RedHat"
                   "uptime_seconds" "6000"}]
-      (with-transacted-connection *db*
+      (jdbc/with-transacted-connection *db*
         (scf-store/add-certname! "foo1")
         (scf-store/add-certname! "foo2")
         (scf-store/add-certname! "foo3")
@@ -1043,7 +1036,7 @@
                 "domain" "testing.com"
                 "hostname" "foo4"
                 "uptime_seconds" "6000"}]
-    (with-transacted-connection *db*
+    (jdbc/with-transacted-connection *db*
       (scf-store/add-certname! "foo1")
       (scf-store/add-certname! "foo2")
       (scf-store/add-certname! "foo3")
@@ -1541,7 +1534,7 @@
                 "domain" "testing.com"
                 "hostname" "foo4"
                 "uptime_seconds" 6000}]
-    (with-transacted-connection *db*
+    (jdbc/with-transacted-connection *db*
       (scf-store/add-certname! "foo1")
       (scf-store/add-certname! "foo2")
       (scf-store/add-certname! "foo3")

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -7,13 +7,13 @@
             [puppetlabs.puppetdb.scf.storage-utils :as sutils
              :refer [db-serialize postgres?]]
             [cheshire.core :as json]
-            [clojure.java.jdbc.deprecated :as sql]
+            [clojure.java.jdbc :as sql]
             [puppetlabs.puppetdb.scf.migrate :refer :all]
             [clj-time.coerce :refer [to-timestamp]]
             [clj-time.core :refer [now ago days]]
             [clojure.test :refer :all]
             [clojure.set :refer :all]
-            [puppetlabs.puppetdb.jdbc :refer [query-to-vec with-transacted-connection]]
+            [puppetlabs.puppetdb.jdbc :as jdbc :refer [query-to-vec]]
             [puppetlabs.puppetdb.testutils :refer [clear-db-for-testing! test-db]])
   (:import [java.sql SQLIntegrityConstraintViolationException]
            [org.postgresql.util PSQLException]))
@@ -36,18 +36,18 @@
 (deftest migration
   (testing "pending migrations"
     (testing "should return every migration if the *db* isn't migrated"
-      (sql/with-connection *db*
+      (jdbc/with-db-connection *db*
         (clear-db-for-testing!)
         (is (= (pending-migrations) migrations))))
 
     (testing "should return nothing if the *db* is completely migrated"
-      (sql/with-connection *db*
+      (jdbc/with-db-connection *db*
         (clear-db-for-testing!)
         (migrate! *db*)
         (is (empty? (pending-migrations)))))
 
     (testing "should return missing migrations if the *db* is partially migrated"
-      (sql/with-connection *db*
+      (jdbc/with-db-connection *db*
         (clear-db-for-testing!)
         (let [applied '(1 2 4)]
           (doseq [m applied]
@@ -58,7 +58,7 @@
 
   (testing "applying the migrations"
     (let [expected-migrations (apply sorted-set (keys migrations))]
-      (sql/with-connection *db*
+      (jdbc/with-db-connection *db*
         (clear-db-for-testing!)
         (is (= (applied-migrations) #{}))
         (testing "should migrate the database"
@@ -80,32 +80,35 @@
           (is (= (applied-migrations) expected-migrations))))))
 
   (testing "should throw error if *db* is at a higher schema rev than we support"
-    (with-transacted-connection *db*
+    (jdbc/with-transacted-connection *db*
       (migrate! *db*)
-      (sql/insert-record :schema_migrations
-                         {:version (inc migrate/desired-schema-version) :time (to-timestamp (now))})
+      (jdbc/insert! :schema_migrations
+                    {:version (inc migrate/desired-schema-version)
+                     :time (to-timestamp (now))})
       (is (thrown? IllegalStateException (migrate! *db*))))))
 
 (deftest migration-14
   (testing "building parameter cache"
-    (sql/with-connection *db*
+    (jdbc/with-db-connection *db*
       (clear-db-for-testing!)
       ;; Migrate to prior to the cache table
       (fast-forward-to-migration! 13)
 
       ;; Now add some resource parameters
-      (sql/insert-records
+      (jdbc/insert!
        :resource_params
-       {:resource "1" :name "ensure"  :value (db-serialize "file")}
-       {:resource "1" :name "owner"   :value (db-serialize "root")}
-       {:resource "1" :name "group"   :value (db-serialize "root")}
-       {:resource "2" :name "random"  :value (db-serialize "true")}
+       {:resource "1" :name "ensure" :value (db-serialize "file")}
+       {:resource "1" :name "owner" :value (db-serialize "root")}
+       {:resource "1" :name "group" :value (db-serialize "root")}
+       {:resource "2" :name "random" :value (db-serialize "true")}
        ;; resource 3 deliberately left blank
-       {:resource "4" :name "ensure"  :value (db-serialize "present")}
-       {:resource "4" :name "content" :value (db-serialize "#!/usr/bin/make\nall:\n\techo done\n")}
-       {:resource "5" :name "random"  :value (db-serialize "false")}
-       {:resource "6" :name "multi"   :value (db-serialize ["one" "two" "three"])}
-       {:resource "7" :name "hash"    :value (db-serialize (sorted-map  "foo" 5 "bar" 10))})
+       {:resource "4" :name "ensure" :value (db-serialize "present")}
+       {:resource "4" :name "content"
+        :value (db-serialize "#!/usr/bin/make\nall:\n\techo done\n")}
+       {:resource "5" :name "random" :value (db-serialize "false")}
+       {:resource "6" :name "multi" :value (db-serialize ["one" "two" "three"])}
+       {:resource "7" :name "hash" :value (db-serialize
+                                           (sorted-map "foo" 5 "bar" 10))})
 
       ;; Now add the parameter cache
       (apply-migration-for-testing! 14)
@@ -127,40 +130,41 @@
 
 (deftest migration-25
   (testing "should contain same facts before and after migration"
-    (sql/with-connection *db*
+    (jdbc/with-db-connection *db*
       (clear-db-for-testing!)
       (fast-forward-to-migration! 24)
       (let [current-time (to-timestamp (now))
             yesterday (to-timestamp (-> 1 days ago))]
-        (sql/insert-records
-          :certnames
-          {:name "testing1" :deactivated nil}
-          {:name "testing2" :deactivated nil}
-          {:name "testing3" :deactivated current-time}
-          {:name "testing4" :deactivated nil}
-          {:name "testing5" :deactivated current-time})
-        (sql/insert-records
-          :environments
-          {:id 1 :name "test_env_1"}
-          {:id 2 :name "test_env_2"}
-          {:id 3 :name "test_env_3"}
-          {:id 4 :name "test_env_4"}
-          {:id 5 :name "test_env_5"})
-        (sql/insert-records
-          :certname_facts_metadata
-          {:certname "testing1" :timestamp current-time :environment_id 1}
-          {:certname "testing2" :timestamp current-time :environment_id 2}
-          ;; deactivated node with facts
-          {:certname "testing3" :timestamp current-time :environment_id 3}
-          ;; active node with no facts
-          {:certname "testing4" :timestamp yesterday :environment_id 4}
-          ;; deactivated node with no facts
-          {:certname "testing5" :timestamp yesterday :environment_id 5})
-        (sql/insert-records
-          :certname_facts
-          {:certname "testing1" :name "foo"  :value  "1"}
-          {:certname "testing2" :name "bar"  :value "true"}
-          {:certname "testing3" :name "baz"  :value "false"})
+        (jdbc/insert! :certnames
+                      {:name "testing1" :deactivated nil}
+                      {:name "testing2" :deactivated nil}
+                      {:name "testing3" :deactivated current-time}
+                      {:name "testing4" :deactivated nil}
+                      {:name "testing5" :deactivated current-time})
+        (jdbc/insert! :environments
+                      {:id 1 :name "test_env_1"}
+                      {:id 2 :name "test_env_2"}
+                      {:id 3 :name "test_env_3"}
+                      {:id 4 :name "test_env_4"}
+                      {:id 5 :name "test_env_5"})
+        (jdbc/insert! :certname_facts_metadata
+                      {:certname "testing1" :timestamp current-time
+                       :environment_id 1}
+                      {:certname "testing2" :timestamp current-time
+                       :environment_id 2}
+                      ;; deactivated node with facts
+                      {:certname "testing3" :timestamp current-time
+                       :environment_id 3}
+                      ;; active node with no facts
+                      {:certname "testing4" :timestamp yesterday
+                       :environment_id 4}
+                      ;; deactivated node with no facts
+                      {:certname "testing5" :timestamp yesterday
+                       :environment_id 5})
+        (jdbc/insert! :certname_facts
+                      {:certname "testing1" :name "foo" :value  "1"}
+                      {:certname "testing2" :name "bar" :value "true"}
+                      {:certname "testing3" :name "baz" :value "false"})
 
         (apply-migration-for-testing! 25)
 
@@ -183,7 +187,7 @@
                    :timestamp (to-timestamp current-time) :value_string "false"}])))))))
 
 (deftest migration-28
-  (sql/with-connection *db*
+  (jdbc/with-db-connection *db*
     (clear-db-for-testing!)
     (fast-forward-to-migration! 27)
     (letfn [(one-row [*db*]
@@ -217,22 +221,21 @@
                                                        "foo-2" "bar"}))
 
       ;; Add two facts with the same :path, but different values.
-      (let [[p1 p2] (map :id (sql/insert-records
-                              :fact_paths
-                              {:value_type_id 0
-                               :path "orphan" :name "orphan" :depth 0}
-                              {:value_type_id 1
-                               :path "orphan" :name "orphan" :depth 0}))]
-        (sql/insert-records
-         :fact_values
-         {:path_id p1
-          :value_type_id 0
-          :value_hash (hash/generic-identity-hash "1")
-          :value_string "1"}
-         {:path_id p2
-          :value_type_id 1
-          :value_hash (hash/generic-identity-hash 1)
-          :value_integer 1}))
+      (let [[p1 p2]
+            (map :id (jdbc/insert! :fact_paths
+                                   {:value_type_id 0
+                                    :path "orphan" :name "orphan" :depth 0}
+                                   {:value_type_id 1
+                                    :path "orphan" :name "orphan" :depth 0}))]
+        (jdbc/insert! :fact_values
+                      {:path_id p1
+                       :value_type_id 0
+                       :value_hash (hash/generic-identity-hash "1")
+                       :value_string "1"}
+                      {:path_id p2
+                       :value_type_id 1
+                       :value_hash (hash/generic-identity-hash 1)
+                       :value_integer 1}))
 
       (testing "different paths produce different values"
         (is (= 2
@@ -255,77 +258,67 @@
       (testing "fact_paths enforces path uniqueness"
         (if (postgres?)
           (is (thrown? PSQLException
-                       (sql/insert-records
-                        :fact_paths {:path "foo-1" :name "foo-1" :depth 0})))
+                       (jdbc/insert! :fact_paths
+                                     {:path "foo-1" :name "foo-1" :depth 0})))
           (is (thrown? SQLIntegrityConstraintViolationException
-                       (sql/insert-records
-                        :fact_paths {:path "foo-1" :name "foo-1" :depth 0})))))
+                       (jdbc/insert! :fact_paths
+                                     {:path "foo-1" :name "foo-1" :depth 0})))))
       (testing "fact_values enforces value_hash uniqueness"
         (if (postgres?)
           (is (thrown?
                PSQLException
-               (sql/insert-records
-                :fact_values
-                {:value_type_id 0
-                 :value_hash (hash/generic-identity-hash "bar")
-                 :value_string "bar"})))
+               (jdbc/insert! :fact_values
+                             {:value_type_id 0
+                              :value_hash (hash/generic-identity-hash "bar")
+                              :value_string "bar"})))
           (is (thrown?
                SQLIntegrityConstraintViolationException
-               (sql/insert-records
-                :fact_values
-                {:value_type_id 0
-                 :value_hash (hash/generic-identity-hash "bar")
-                 :value_string "bar"}))))))))
+               (jdbc/insert! :fact_values
+                             {:value_type_id 0
+                              :value_hash (hash/generic-identity-hash "bar")
+                              :value_string "bar"}))))))))
 
 (deftest migration-29
   (testing "should contain same reports before and after migration"
-    (sql/with-connection *db*
+    (jdbc/with-db-connection *db*
       (clear-db-for-testing!)
       (fast-forward-to-migration! 28)
 
       (let [current-time (to-timestamp (now))]
-        (sql/insert-records
-          :report_statuses
-          {:status "testing1" :id 1})
-        (sql/insert-records
-          :environments
-          {:id 1 :name "testing1"})
-        (sql/insert-records
-          :certnames
-          {:name "testing1" :deactivated nil}
-          {:name "testing2" :deactivated nil})
+        (jdbc/insert! :report_statuses
+                      {:status "testing1" :id 1})
+        (jdbc/insert! :environments
+                      {:id 1 :name "testing1"})
+        (jdbc/insert! :certnames
+                      {:name "testing1" :deactivated nil}
+                      {:name "testing2" :deactivated nil})
+        (jdbc/insert! :reports
+                      {:hash "01"
+                       :configuration_version  "thisisacoolconfigversion"
+                       :transaction_uuid "bbbbbbbb-2222-bbbb-bbbb-222222222222"
+                       :certname "testing1"
+                       :puppet_version "0.0.0"
+                       :report_format 1
+                       :start_time current-time
+                       :end_time current-time
+                       :receive_time current-time
+                       :environment_id 1
+                       :status_id 1}
+                      {:hash "0000"
+                       :transaction_uuid "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"
+                       :configuration_version "blahblahblah"
+                       :certname "testing2"
+                       :puppet_version "911"
+                       :report_format 1
+                       :start_time current-time
+                       :end_time current-time
+                       :receive_time current-time
+                       :environment_id 1
+                       :status_id 1})
 
-        (sql/insert-records
-          :reports
-          {:hash                   "01"
-           :configuration_version  "thisisacoolconfigversion"
-           :transaction_uuid "bbbbbbbb-2222-bbbb-bbbb-222222222222"
-           :certname               "testing1"
-           :puppet_version         "0.0.0"
-           :report_format          1
-           :start_time             current-time
-           :end_time               current-time
-           :receive_time           current-time
-           :environment_id         1
-           :status_id              1}
-          {:hash "0000"
-           :transaction_uuid "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"
-           :configuration_version "blahblahblah"
-           :certname "testing2"
-           :puppet_version "911"
-           :report_format 1
-           :start_time current-time
-           :end_time current-time
-           :receive_time current-time
-           :environment_id 1
-           :status_id 1})
-
-        (sql/insert-records
-          :latest_reports
-          {:report                 "01"
-           :certname               "testing1"}
-          {:report                 "0000"
-           :certname               "testing2"})
+        (jdbc/insert! :latest_reports
+                      {:report "01" :certname "testing1"}
+                      {:report "0000" :certname "testing2"})
 
         (apply-migration-for-testing! 29)
 
@@ -351,55 +344,56 @@
 
 (deftest migration-37
   (testing "should contain same reports before and after migration"
-    (sql/with-connection *db*
+    (jdbc/with-db-connection *db*
       (clear-db-for-testing!)
       (fast-forward-to-migration! 36)
 
       (let [current-time (to-timestamp (now))]
-        (sql/insert-records
-          :report_statuses
-          {:status "testing1" :id 1})
-        (sql/insert-records
-          :environments
-          {:id 1 :environment "testing1"})
-        (sql/insert-records
-          :certnames
-          {:certname "testing1" :deactivated nil}
-          {:certname "testing2" :deactivated nil})
+        (jdbc/insert! :report_statuses
+                      {:status "testing1" :id 1})
+        (jdbc/insert! :environments
+                      {:id 1 :environment "testing1"})
+        (jdbc/insert! :certnames
+                      {:certname "testing1" :deactivated nil}
+                      {:certname "testing2" :deactivated nil})
+        (jdbc/insert! :reports
+                      {:hash (sutils/munge-hash-for-storage "01")
+                       :transaction_uuid (sutils/munge-uuid-for-storage
+                                          "bbbbbbbb-2222-bbbb-bbbb-222222222222")
+                       :configuration_version "thisisacoolconfigversion"
+                       :certname "testing1"
+                       :puppet_version "0.0.0"
+                       :report_format 1
+                       :start_time current-time
+                       :end_time current-time
+                       :receive_time current-time
+                       :producer_timestamp current-time
+                       :environment_id 1
+                       :status_id 1
+                       :metrics (sutils/munge-json-for-storage [{:foo "bar"}])
+                       :logs (sutils/munge-json-for-storage [{:bar "baz"}])}
+                      {:hash (sutils/munge-hash-for-storage "0000")
+                       :transaction_uuid (sutils/munge-uuid-for-storage
+                                          "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa")
+                       :configuration_version "blahblahblah"
+                       :certname "testing2"
+                       :puppet_version "911"
+                       :report_format 1
+                       :start_time current-time
+                       :end_time current-time
+                       :receive_time current-time
+                       :producer_timestamp current-time
+                       :environment_id 1
+                       :status_id 1
+                       :metrics (sutils/munge-json-for-storage [{:foo "bar"}])
+                       :logs (sutils/munge-json-for-storage [{:bar "baz"}])})
 
-        (sql/insert-records
-          :reports
-          {:hash (sutils/munge-hash-for-storage "01")
-           :transaction_uuid (sutils/munge-uuid-for-storage "bbbbbbbb-2222-bbbb-bbbb-222222222222")
-           :configuration_version "thisisacoolconfigversion"
-           :certname "testing1"
-           :puppet_version "0.0.0"
-           :report_format 1
-           :start_time current-time
-           :end_time current-time
-           :receive_time current-time
-           :producer_timestamp current-time
-           :environment_id 1
-           :status_id 1
-           :metrics (sutils/munge-json-for-storage [{:foo "bar"}])
-           :logs (sutils/munge-json-for-storage [{:bar "baz"}])}
-          {:hash (sutils/munge-hash-for-storage "0000")
-           :transaction_uuid (sutils/munge-uuid-for-storage "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa")
-           :configuration_version "blahblahblah"
-           :certname "testing2"
-           :puppet_version "911"
-           :report_format 1
-           :start_time current-time
-           :end_time current-time
-           :receive_time current-time
-           :producer_timestamp current-time
-           :environment_id 1
-           :status_id 1
-           :metrics (sutils/munge-json-for-storage [{:foo "bar"}])
-           :logs (sutils/munge-json-for-storage [{:bar "baz"}])})
-
-        (sql/update-values :certnames ["certname = ?" "testing1"] {:latest_report_id (if (postgres?) 1 0)})
-        (sql/update-values :certnames ["certname = ?" "testing2"] {:latest_report_id (if (postgres?) 2 1)})
+        (jdbc/update! :certnames
+                      {:latest_report_id (if (postgres?) 1 0)}
+                      ["certname = ?" "testing1"])
+        (jdbc/update! :certnames
+                      {:latest_report_id (if (postgres?) 2 1)}
+                      ["certname = ?" "testing2"])
 
         (apply-migration-for-testing! 37)
 
@@ -427,30 +421,29 @@
             (is (= [id1 id2] latest-ids))))))))
 
 (deftest migration-29-producer-timestamp-not-null
-  (sql/with-connection *db*
+  (jdbc/with-db-connection *db*
     (clear-db-for-testing!)
     (fast-forward-to-migration! 28)
 
     (let [current-time (to-timestamp (now))]
-      (sql/insert-record :environments
-                         {:id 1
-                          :name "test env"})
-      (sql/insert-record :certnames
-                         {:name "foo.local"})
-      (sql/insert-record :catalogs
-                         {:hash "18440af604d18536b1c77fd688dff8f0f9689d90"
-                          :api_version 1
-                          :catalog_version 1
-                          :transaction_uuid "95d132b3-cb21-4e0a-976d-9a65567696ba"
-                          :timestamp current-time
-                          :certname "foo.local"
-                          :environment_id 1
-                          :producer_timestamp nil})
-      (sql/insert-record :factsets
-                         {:timestamp current-time
-                          :certname "foo.local"
-                          :environment_id 1
-                          :producer_timestamp nil})
+      (jdbc/insert! :environments
+                    {:id 1 :name "test env"})
+      (jdbc/insert! :certnames
+                   {:name "foo.local"})
+      (jdbc/insert! :catalogs
+                    {:hash "18440af604d18536b1c77fd688dff8f0f9689d90"
+                     :api_version 1
+                     :catalog_version 1
+                     :transaction_uuid "95d132b3-cb21-4e0a-976d-9a65567696ba"
+                     :timestamp current-time
+                     :certname "foo.local"
+                     :environment_id 1
+                     :producer_timestamp nil})
+      (jdbc/insert! :factsets
+                    {:timestamp current-time
+                     :certname "foo.local"
+                     :environment_id 1
+                     :producer_timestamp nil})
 
       (apply-migration-for-testing! 29)
 
@@ -460,13 +453,12 @@
         (is (= factsets-response [{:producer_timestamp current-time}]))))))
 
 (deftest migration-in-different-schema
-  (sql/with-connection *db*
+  (jdbc/with-db-connection *db*
     (clear-db-for-testing!)
-    (sql/do-commands
+    (jdbc/do-commands
      ;; Cleaned up in clear-db-for-testing!
      "CREATE SCHEMA pdbtestschema"
-     (format "SET SCHEMA %s"
-             (if (postgres?) "'pdbtestschema'" "pdbtestschema")))
+     (format "SET SCHEMA %s" (if (postgres?) "'pdbtestschema'" "pdbtestschema")))
     ((migrations 1))
     (record-migration! 1)
     (let [tables (sutils/sql-current-connection-table-names)]
@@ -475,19 +467,19 @@
       (migrate! *db*))))
 
 (deftest test-coalesce-fact-values
-  (sql/with-connection *db*
+  (jdbc/with-db-connection *db*
     (clear-db-for-testing!)
     (fast-forward-to-migration! 30)
-    (sql/insert-records :fact_values
-                        {:value_type_id 0
-                         :value_hash (sutils/munge-hash-for-storage "aaaa")
-                         :value_string "foobar"}
-                        {:value_type_id 5
-                         :value_hash (sutils/munge-hash-for-storage "bbbb")
-                         :value_json (json/generate-string {:foo "bar"})}
-                        {:value_type_id 1
-                         :value_hash (sutils/munge-hash-for-storage "cccc")
-                         :value_integer 1})
+    (jdbc/insert! :fact_values
+                  {:value_type_id 0
+                   :value_hash (sutils/munge-hash-for-storage "aaaa")
+                   :value_string "foobar"}
+                  {:value_type_id 5
+                   :value_hash (sutils/munge-hash-for-storage "bbbb")
+                   :value_json (json/generate-string {:foo "bar"})}
+                  {:value_type_id 1
+                   :value_hash (sutils/munge-hash-for-storage "cccc")
+                   :value_integer 1})
     (let [pre-migration-values (query-to-vec "SELECT * FROM fact_values")
           value-keys [:value_string :value_integer]]
       (apply-migration-for-testing! 31)

--- a/test/puppetlabs/puppetdb/scf/storage_utils_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_utils_test.clj
@@ -1,9 +1,10 @@
 (ns puppetlabs.puppetdb.scf.storage-utils-test
-  (:require [clojure.java.jdbc.deprecated :as sql]
+  (:require [clojure.java.jdbc :as sql]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.scf.storage-utils :refer :all]
             [cheshire.core :as json]
-            [puppetlabs.puppetdb.fixtures :refer [with-test-db]]))
+            [puppetlabs.puppetdb.fixtures :refer [with-test-db]]
+            [puppetlabs.puppetdb.jdbc :as jdbc]))
 
 (use-fixtures :each with-test-db)
 
@@ -39,7 +40,7 @@
   (testing "test to see if an index doesn't exists"
     (is (false? (index-exists? "somerandomname"))))
   (testing "test to see if an index does exist"
-    (sql/do-commands "CREATE INDEX foobar ON fact_values(value_float)")
+    (jdbc/do-commands "CREATE INDEX foobar ON fact_values(value_float)")
     (is (true? (index-exists? "foobar")))))
 
 (deftest ^{:postgres false} test-postgres?-hsql

--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -1,6 +1,9 @@
 (ns puppetlabs.puppetdb.testutils.db
-  (:require [clojure.java.jdbc.deprecated :as sql]
+  (:require [clojure.java.jdbc :as sql]
+            [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.puppetdb.testutils :refer [clear-db-for-testing! test-db]]))
+
+(def ^:dynamic *db-spec* nil)
 
 (def antonym-data {"absence"    "presence"
                    "abundant"   "scarce"
@@ -20,20 +23,19 @@
                    "blandness"  "zest"
                    "lethargy"   "zest"})
 
-(def ^:dynamic *db-spec* nil)
-
 (defn insert-map [data]
-  (apply (partial sql/insert-values :test [:key :value]) data))
+  (apply (partial jdbc/insert! :test [:key :value]) data))
 
 (defn with-antonym-test-database
   [function]
-  (sql/with-connection (test-db)
-    (clear-db-for-testing!))
-  (binding [*db-spec* (test-db)]
-    (sql/with-connection *db-spec*
-      (sql/transaction
-       (sql/create-table :test
-                         [:key   "VARCHAR(256)" "PRIMARY KEY"]
-                         [:value "VARCHAR(256)" "NOT NULL"])
-       (insert-map antonym-data))
-      (function))))
+  (let [db (test-db)]
+    (binding [*db-spec* db]
+      (jdbc/with-db-connection db
+        (clear-db-for-testing!)
+        (jdbc/with-db-transaction []
+          (jdbc/do-commands
+           (sql/create-table-ddl :test
+                                 [:key "VARCHAR(256)" "PRIMARY KEY"]
+                                 [:value "VARCHAR(256)" "NOT NULL"]))
+          (insert-map antonym-data))
+        (function)))))


### PR DESCRIPTION
 ```
(PDB-1738) (PDB-1739) Drop jdbc.deprecated

Migrate all code to the newer clojure.jdbc API.

Note that the newer jdbc API handles some database operations like
transactions by storing bookkeeping information in nested database
references.  For example, (with-db-transaction ...) creates a new
database connection map with an incremented level, and the library uses
that level to determine where the "top" is, i.e. to decide when to
commit.

To accommodate that approach (without threading a db argument through
all of the existing code), add a jdbc/*db* variable to refer to the
"current" database, and make sure to bind appropriately it in
puppetdb.jdbc wrappers for the relevant clojure.jdbc calls.

Use (jdbc/db) to refer to *db* when invoking the new jdbc API's
functions.

Use jdbc/ consistently to refer to puppetdb.jdbc in altered files.

While updating migrations, combine adjacent db-do-commands into one
broader do-commands.
```