### PR TITLE
(PDB-1932) deprecate catalog-hash-debug

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -172,6 +172,9 @@ and override this setting to point to your proxy server.
 
 ### `catalog-hash-conflict-debugging`
 
+**NOTE** This setting is deprecated and will be retired in the next major
+release.
+
 When this is set to true, debugging information will be written to `<vardir>/debug/catalog-hashes` every time a catalog is received with a hash that is different than the previously received catalog for that host. Note that this should only be enabled when troubleshooting performance related issues with PuppetDB and the database server. This will output many files and could potentially slow down a production PuppetDB instance. See the [Troubleshooting Low Catalog Duplication guide][low_catalog_dupe] for more information on the outputted files and debugging this problem.
 
 `[puppetdb]` Settings

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -300,6 +300,8 @@
                      "This is intended to troubleshoot catalog duplication issues and "
                      "not for enabling in production long term.  See the PuppetDB docs "
                      "for more information on this setting."))
+      (log/warn (str "The config item 'catalog-hash-conflict-debugging' is "
+                     "deprecated and will be retired in a future release."))
       (assoc-in config [:global :catalog-hash-debug-dir] debug-dir))
     config))
 


### PR DESCRIPTION
This documents the deprecation of catalog-hash-debugging.