### PR TITLE
(PDB-1924) Implicit subqueries

### DIFF
--- a/documentation/api/query/v4/catalogs.markdown
+++ b/documentation/api/query/v4/catalogs.markdown
@@ -9,7 +9,10 @@ canonical: "/puppetdb/latest/api/query/v4/catalogs.html"
 [edges]: ./edges.html
 [paging]: ./paging.html
 [query]: ./query.html
+[subqueries]: ./operators.html#subquery-operators
+[edges]: ./edges.html
 [resources]: ./resources.html
+
 
 You can query catalogs by making an HTTP request to the
 `/catalogs` endpoint.
@@ -37,6 +40,16 @@ See [the Operators page.](./operators.html)
   recent catalog
 * `producer_timestamp` (string): a string representing the time at which the
   `replace_catalog` command for a given catalog was submitted from the master.
+
+### Subquery Relationships
+
+Here is a list of relationships that can be queried using implicit subqueries. For
+more information consult the documentation for [subqueries].
+
+Direct relationships:
+
+* [`edges`][edges]: Resource edges received with this catalog.
+* [`resources`][resources]: Resources received with this catalog.
 
 ### Response Format
 

--- a/documentation/api/query/v4/environments.markdown
+++ b/documentation/api/query/v4/environments.markdown
@@ -6,11 +6,17 @@ canonical: "/puppetdb/latest/api/query/v4/environments.html"
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
 [paging]: ./paging.html
-[events]: ./events.html
-[reports]: ./reports.html
-[resources]: ./resources.html
-[facts]: ./facts.html
 [query]: ./query.html
+[subqueries]: ./operators.html#subquery-operators
+[factsets]: ./factsets.html
+[reports]: ./reports.html
+[catalogs]: ./catalogs.html
+[facts]: ./facts.html
+[fact-contents]: ./fact_contents.html
+[events]: ./events.html
+[edges]: ./edges.html
+[resources]: ./resources.html
+
 
 Environments are semi-isolated groups of nodes managed by Puppet. Nodes are assigned to environments by their own configuration, or by the puppet master's external node classifier.
 
@@ -34,6 +40,24 @@ See [the Operators page](./operators.html)
 ### Query Fields
 
 * `"name"` (string): the name of an environment
+
+### Subquery Relationships
+
+Here is a list of relationships that can be queried using implicit subqueries. For
+more information consult the documentation for [subqueries].
+
+Direct relationships:
+
+* [`factsets`][factsets]: Factsets received from this environment.
+* [`reports`][reports]: Reports received from this environment.
+* [`catalogs`][catalogs]: Catalogs received for this this environment.
+
+Transitive relationships:
+
+* [`facts`][facts]: Fact names and values received from this environment.
+* [`fact_contents`][fact-contents]: Factset paths and values received from this environment.
+* [`events`][events]: Report events triggered from this environment.
+* [`resources`][resources]: Catalog resources received for this environment.
 
 ### Response format
 

--- a/documentation/api/query/v4/fact-paths.markdown
+++ b/documentation/api/query/v4/fact-paths.markdown
@@ -8,6 +8,9 @@ canonical: "/puppetdb/latest/api/query/v4/fact-paths.html"
 [paging]: ./paging.html
 [query]: ./query.html
 [fact-names]: ./query/v4/fact-names.html
+[subqueries]: ./operators.html#subquery-operators
+[facts]: ./facts.html
+[fact-contents]: ./fact_contents.html
 
 The `/fact-paths` endpoint retrieves the set of all known fact paths for all
 known nodes, and is intended as a counterpart to the [fact-names][fact-names]
@@ -33,6 +36,16 @@ See [the Operators page.](./operators.html)
 
 * `path` (path): the path associated with a fact node
 * `type` (string): the type of the value a the fact node
+
+### Subquery Relationships
+
+Here is a list of relationships that can be queried using implicit subqueries. For
+more information consult the documentation for [subqueries].
+
+Direct relationships:
+
+* [`facts`][facts]: All facts from all nodes using the fact path.
+* [`fact-contents`][fact-contents]: All factset paths and values using the fact path.
 
 ## Response Format
 

--- a/documentation/api/query/v4/facts.markdown
+++ b/documentation/api/query/v4/facts.markdown
@@ -7,6 +7,8 @@ canonical: "/puppetdb/latest/api/query/v4/facts.html"
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
 [paging]: ./paging.html
 [query]: ./query.html
+[subqueries]: ./operators.html#subquery-operators
+[fact-contents]: ./fact_contents.html
 
 You can query facts by making an HTTP request to the `/facts` endpoint.
 
@@ -34,6 +36,15 @@ See [the Operators page.](./operators.html)
 * `value` (string, numeric, boolean): the value of the fact
 * `certname` (string): the node associated with the fact
 * `environment` (string): the environment associated with the fact
+
+### Subquery Relationships
+
+Here is a list of relationships that can be queried using implicit subqueries. For
+more information consult the documentation for [subqueries].
+
+Direct relationships:
+
+* [`fact-contents`][fact-contents]: Expanded fact paths and values for this fact.
 
 ### Response Format
 

--- a/documentation/api/query/v4/factsets.markdown
+++ b/documentation/api/query/v4/factsets.markdown
@@ -8,6 +8,9 @@ canonical: "/puppetdb/latest/api/query/v4/factsets.html"
 [facts]: ./facts.html
 [paging]: ./paging.html
 [query]: ./query.html
+[subqueries]: ./operators.html#subquery-operators
+[facts]: ./facts.html
+[fact-contents]: ./fact_contents.html
 
 You can query factsets by making an HTTP request to the `/factsets` endpoint.
 
@@ -37,6 +40,17 @@ See [the Operators page.](./operators.html)
   the relevant certname from the master.
 * `hash` (string): a hash of the factset's certname, environment,
   timestamp, facts, and producer_timestamp.
+
+### Subquery Relationships
+
+Here is a list of relationships that can be queried using implicit subqueries. For
+more information consult the documentation for [subqueries].
+
+Direct relationships:
+
+* [`facts`][facts]: Fact names and values received from this factset.
+* [`fact_contents`][fact-contents]: Factset paths and values received from this factset.
+
 
 ### Response Format
 

--- a/documentation/api/query/v4/nodes.markdown
+++ b/documentation/api/query/v4/nodes.markdown
@@ -10,6 +10,15 @@ canonical: "/puppetdb/latest/api/query/v4/nodes.html"
 [paging]: ./paging.html
 [query]: ./query.html
 [8601]: http://en.wikipedia.org/wiki/ISO_8601
+[subqueries]: ./operators.html#subquery-operators
+[factsets]: ./factsets.html
+[reports]: ./reports.html
+[catalogs]: ./catalogs.html
+[facts]: ./facts.html
+[fact-contents]: ./fact_contents.html
+[events]: ./events.html
+[edges]: ./edges.html
+[resources]: ./resources.html
 
 Nodes can be queried by making an HTTP request to the `/nodes` endpoint.
 
@@ -59,6 +68,24 @@ The below fields are allowed as filter criteria and are returned in all response
     Note that nodes which are missing a fact referenced by a `not` query will match
     the query.
 
+### Subquery Relationships
+
+Here is a list of relationships that can be queried using implicit subqueries. For
+more information consult the documentation for [subqueries].
+
+Direct relationships:
+
+* [`factsets`][factsets]: Factsets received from this node.
+* [`reports`][reports]: Reports received from this node.
+* [`catalogs`][catalogs]: Catalogs received for this node.
+
+Transitive relationships:
+
+* [`facts`][facts]: Fact names and values received from this node.
+* [`fact_contents`][fact-contents]: Factset paths and values received from this node.
+* [`events`][events]: Report events triggered from this node.
+* [`edges`][edges]: Catalog edges received for this node.
+* [`resources`][resources]: Catalog resources received for this node.
 
 ### Response format
 

--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -224,8 +224,9 @@ with `web1`:
     ["and",
       ["~", "certname", "^web1"],
       ["subquery", "resources",
-        ["=", "type", "Package"],
-        ["=", "title", "Tomcat"]]]
+        ["and",
+          ["=", "type", "Package"],
+          ["=", "title", "Tomcat"]]]]
 
 If you wanted to display the entire `networking` fact, if the hosts interfaces uses a certain mac address
 you can do the following on the [facts][`facts`] endpoint:
@@ -233,8 +234,9 @@ you can do the following on the [facts][`facts`] endpoint:
     ["and",
       ["=", "name", "networking"],
       ["subquery", "fact_contents",
-        ["~>", "path", ["networking", ".*", "macaddresses", ".*"]],
-        ["=", "value", "aa:bb:cc:dd:ee:00"]]]
+        ["and",
+          ["~>", "path", ["networking", ".*", "macaddresses", ".*"]],
+          ["=", "value", "aa:bb:cc:dd:ee:00"]]]]
 
 ### Explicit Subqueries
 

--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -11,6 +11,8 @@ canonical: "/puppetdb/latest/api/query/v4/reports.html"
 [statuses]: /puppet/latest/reference/format_report.html#puppettransactionreport
 [query]: ./query.html
 [8601]: http://en.wikipedia.org/wiki/ISO_8601
+[subqueries]: ./operators.html#subquery-operators
+[events]: ./events.html
 
 Puppet agent nodes submit reports after their runs, and the puppet master forwards these to PuppetDB. Each report includes:
 
@@ -68,6 +70,15 @@ The below fields are allowed as filter criteria and are returned in all response
 
 * `latest_report?` (boolean): return only reports associated with the most recent puppet run for each node.
   NOTE: this field does not appear in the response.
+
+### Subquery Relationships
+
+Here is a list of relationships that can be queried using implicit subqueries. For
+more information consult the documentation for [subqueries].
+
+Direct relationships:
+
+* [`events`][events]: Events received in this report.
 
 ### Response format
 

--- a/test/puppetlabs/puppetdb/http/catalogs_test.clj
+++ b/test/puppetlabs/puppetdb/http/catalogs_test.clj
@@ -154,6 +154,11 @@
       (is (= (query-result method endpoint query {} strip-hash)
              expected))
 
+    ;;;;;;;;;;
+    ;; Resources subquery
+    ;;;;;;;;;;
+
+    ;; In syntax
     ["extract" "certname"
      ["in" "certname"
       ["extract" "certname"
@@ -162,6 +167,7 @@
     #{{:certname "myhost.localdomain"}
       {:certname "host2.localdomain"}}
 
+    ;; Implicit subquery syntax
     ["extract" "certname"
      ["subquery" "resources"
       ["=" "type" "Apt::Pin"]]]
@@ -203,8 +209,24 @@
     #{{:certname "host2.localdomain"}
       {:certname "myhost.localdomain"}}
 
+    ;; Implicit query
     ["extract" "certname"
      ["subquery" "edges"
+      ["=" "target_type" "File"]]]
+    #{{:certname "host2.localdomain"}
+      {:certname "myhost.localdomain"}}
+
+    ;; Explicit without columns identifier
+    ;; TODO: determine if this syntax is okay
+    ["extract" "certname"
+     ["subquery" "edges" "certname"
+      ["=" "target_type" "File"]]]
+    #{{:certname "host2.localdomain"}
+      {:certname "myhost.localdomain"}}
+
+    ;; Explicit but with columns bit, only 1 column
+    ["extract" "certname"
+     ["subquery" "edges" ["columns" "certname"]
       ["=" "target_type" "File"]]]
     #{{:certname "host2.localdomain"}
       {:certname "myhost.localdomain"}}))

--- a/test/puppetlabs/puppetdb/http/catalogs_test.clj
+++ b/test/puppetlabs/puppetdb/http/catalogs_test.clj
@@ -8,7 +8,9 @@
             [puppetlabs.puppetdb.http :as http]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.testutils :refer [get-request deftestseq strip-hash]]
-            [puppetlabs.puppetdb.testutils.http :refer [query-response vector-param]]
+            [puppetlabs.puppetdb.testutils.http :refer [query-response
+                                                        query-result
+                                                        vector-param]]
             [puppetlabs.puppetdb.testutils.catalogs :as testcat]))
 
 (def endpoints [[:v4 "/v4/catalogs"]])
@@ -140,6 +142,72 @@
     (let [{:keys [body]} (query-response method (str endpoint "/myhost.localdomain"))
           response-body  (json/parse-string body true)]
       (is (= "myhost.localdomain" (:certname response-body))))))
+
+(deftestseq catalog-subqueries
+  [[version endpoint] endpoints
+   method [:get :post]]
+
+  (testcat/replace-catalog (json/generate-string catalog1))
+  (testcat/replace-catalog (json/generate-string catalog2))
+
+  (are [query expected]
+      (is (= (query-result method endpoint query {} strip-hash)
+             expected))
+
+    ["extract" "certname"
+     ["in" "certname"
+      ["extract" "certname"
+       ["select_resources"
+        ["=" "type" "Apt::Pin"]]]]]
+    #{{:certname "myhost.localdomain"}
+      {:certname "host2.localdomain"}}
+
+    ["extract" "certname"
+     ["subquery" "resources"
+      ["=" "type" "Apt::Pin"]]]
+    #{{:certname "myhost.localdomain"}
+      {:certname "host2.localdomain"}}
+
+    ;; Explicit subquery syntax
+    ;; TODO: determine if this format is going to be used
+    ["extract" "certname"
+     ["subquery" "resources" "certname"
+      ["=" "type" "Apt::Pin"]]]
+    #{{:certname "myhost.localdomain"}
+      {:certname "host2.localdomain"}}
+
+    ;; Explicit with columns specified
+    ["extract" "certname"
+     ["subquery" "resources" ["columns" "certname"]
+      ["=" "type" "Apt::Pin"]]]
+    #{{:certname "myhost.localdomain"}
+      {:certname "host2.localdomain"}}
+
+    ;; Explicit but with inside and outside columns specified
+    ["extract" "certname"
+     ["subquery" "resources" ["columns" ["certname"] ["certname"]]
+      ["=" "type" "Apt::Pin"]]]
+    #{{:certname "myhost.localdomain"}
+      {:certname "host2.localdomain"}}
+
+    ;;;;;;;;;
+    ;; Edges subqueries
+    ;;;;;;;;;
+
+    ;; In operator
+    ["extract" "certname"
+     ["in" "certname"
+      ["extract" "certname"
+       ["select_edges"
+        ["=" "target_type" "File"]]]]]
+    #{{:certname "host2.localdomain"}
+      {:certname "myhost.localdomain"}}
+
+    ["extract" "certname"
+     ["subquery" "edges"
+      ["=" "target_type" "File"]]]
+    #{{:certname "host2.localdomain"}
+      {:certname "myhost.localdomain"}}))
 
 (def no-parent-endpoints [[:v4 "/v4/catalogs/foo/edges"]
                           [:v4 "/v4/catalogs/foo/resources"]])

--- a/test/puppetlabs/puppetdb/http/environments_test.clj
+++ b/test/puppetlabs/puppetdb/http/environments_test.clj
@@ -86,6 +86,11 @@
            {:name "bar"}
            {:name "baz"}}
 
+         ;;;;;;;;;;;;
+         ;; Basic facts subquery examples
+         ;;;;;;;;;;;;
+
+         ;; In syntax
          ["in" "name"
           ["extract" "environment"
            ["select_facts"
@@ -94,12 +99,26 @@
              ["=" "value" "Debian"]]]]]
          #{{:name "DEV"}}
 
+         ;; Implicit subquery syntax
          ["subquery" "facts"
           ["and"
            ["=" "name" "operatingsystem"]
            ["=" "value" "Debian"]]]
          #{{:name "DEV"}}
 
+         ;; Explicit subquery syntax
+         ["subquery" "facts"
+          ["columns" "name" "environment"]
+          ["and"
+           ["=" "name" "operatingsystem"]
+           ["=" "value" "Debian"]]]
+         #{{:name "DEV"}}
+
+         ;;;;;;;;;;;;;
+         ;; Not-wrapped subquery syntax
+         ;;;;;;;;;;;;;
+
+         ;; In syntax
          ["not"
           ["in" "name"
            ["extract" "environment"
@@ -111,6 +130,7 @@
            {:name "bar"}
            {:name "baz"}}
 
+         ;; Implict subquery syntax
          ["not"
           ["subquery" "facts"
           ["and"
@@ -120,6 +140,22 @@
           {:name "bar"}
           {:name "baz"}}
 
+         ;; Explicit subquery syntax with column definitions
+         ["not"
+          ["subquery" "facts"
+           ["columns" "name" "environment"]
+          ["and"
+           ["=" "name" "operatingsystem"]
+           ["=" "value" "Debian"]]]]
+         #{{:name "foo"}
+          {:name "bar"}
+          {:name "baz"}}
+
+         ;;;;;;;;
+         ;; Complex subquery example
+         ;;;;;;;;
+
+         ;; In syntax
          ["in" "name"
           ["extract" "environment"
            ["select_facts"
@@ -128,8 +164,20 @@
              ["in" "value"
               ["extract" "title"
                ["select_resources"
-                ["and"
-                 ["=" "type" "Class"]]]]]]]]]
+                ["=" "type" "Class"]]]]]]]]
+         #{{:name "DEV"}}
+
+         ;; Note: fact/resource comparison isn't a natural
+         ;; join, so there is no implicit syntax here.
+
+         ;; Complex Explicit subquery syntax
+         ["subquery" "facts"
+          ["columns" "name" "environment"]
+          ["and"
+           ["=" "name" "hostname"]
+           ["subquery" "resources"
+            ["columns" "value" "title"]
+            ["=" "type" "Class"]]]]
          #{{:name "DEV"}}))
 
   (testing "failed comparison"

--- a/test/puppetlabs/puppetdb/http/environments_test.clj
+++ b/test/puppetlabs/puppetdb/http/environments_test.clj
@@ -94,6 +94,12 @@
              ["=" "value" "Debian"]]]]]
          #{{:name "DEV"}}
 
+         ["subquery" "facts"
+          ["and"
+           ["=" "name" "operatingsystem"]
+           ["=" "value" "Debian"]]]
+         #{{:name "DEV"}}
+
          ["not"
           ["in" "name"
            ["extract" "environment"
@@ -104,6 +110,15 @@
          #{{:name "foo"}
            {:name "bar"}
            {:name "baz"}}
+
+         ["not"
+          ["subquery" "facts"
+          ["and"
+           ["=" "name" "operatingsystem"]
+           ["=" "value" "Debian"]]]]
+         #{{:name "foo"}
+          {:name "bar"}
+          {:name "baz"}}
 
          ["in" "name"
           ["extract" "environment"
@@ -119,14 +134,14 @@
 
   (testing "failed comparison"
     (are [query]
-         (let [{:keys [status body]} (query-response method endpoint query)]
-           (re-find
+          (let [{:keys [status body]} (query-response method endpoint query)]
+            (re-find
              #"Query operators >,>=,<,<= are not allowed on field name" body))
 
-         ["<=" "name" "foo"]
-         [">=" "name" "foo"]
-         ["<" "name" "foo"]
-         [">" "name" "foo"])))
+      ["<=" "name" "foo"]
+      [">=" "name" "foo"]
+      ["<" "name" "foo"]
+      [">" "name" "foo"])))
 
 (def no-parent-endpoints [[:v4 "/v4/environments/foo/events"]
                           [:v4 "/v4/environments/foo/facts"]

--- a/test/puppetlabs/puppetdb/http/fact_names_test.clj
+++ b/test/puppetlabs/puppetdb/http/fact_names_test.clj
@@ -8,6 +8,7 @@
             [puppetlabs.puppetdb.testutils :refer [paged-results deftestseq
                                                    parse-result]]
             [puppetlabs.puppetdb.testutils.http :refer [query-response
+                                                        query-result
                                                         vector-param]]
             [puppetlabs.puppetdb.jdbc :refer [with-transacted-connection]]))
 
@@ -202,9 +203,25 @@
                 {:path ["kernel"], :type "string"}
                 {:path ["hostname"], :type "string"}
                 {:path ["domain"], :type "string"}]))))
+
     (testing "invalid query throws an error"
       (let [{:keys [status body]} (query-response
                                     method endpoint ["=" "myfield" "myval"])
             result (parse-result body)]
         (is (= status http/status-bad-request))
-        (is (re-find #"is not a queryable object" result))))))
+        (is (re-find #"is not a queryable object" result))))
+
+    (testing "subqueries"
+      (are [query expected]
+          (is (= expected
+                 (query-result method endpoint query)))
+
+        ["in" "path"
+         ["extract" "path"
+          ["select_fact_contents"
+           ["=" "path" ["kernel"]]]]]
+        #{{:path ["kernel"] :type "string"}}
+
+        ["subquery" "fact_contents"
+         ["=" "path" ["kernel"]]]
+        #{{:path ["kernel"] :type "string"}}))))

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -22,6 +22,7 @@
                                                    create-hsqldb-map
                                                    parse-result]]
             [puppetlabs.puppetdb.testutils.http :refer [query-response
+                                                        query-result
                                                         vector-param]]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.testutils.services :as svc-utils]
@@ -168,6 +169,7 @@
                                                                                       [">" "value" 10000]]]]]]]]]]
 
    #{{:certname "foo" :name "ipaddress" :value "192.168.1.100" :environment "DEV"}}
+
    ;; Multiple fact subqueries
    ["and"
     ["=" "name" "ipaddress"]
@@ -180,7 +182,25 @@
                                              ["=" "name" "uptime_seconds"]
                                              [">" "value" 10000]]]]]]
 
-   #{{:certname "foo" :name "ipaddress" :value "192.168.1.100" :environment "DEV"}}))
+   #{{:certname "foo" :name "ipaddress" :value "192.168.1.100" :environment "DEV"}}
+
+   ;; Fact-contents subquery
+   ["in" ["certname" "name"]
+    ["extract" ["certname" "name"]
+     ["select_fact_contents"
+      ["and"
+       ["=" "path" ["osfamily"]]
+       ["=" "value" "Debian"]]]]]
+
+   #{{:certname "bar" :environment "DEV" :name "osfamily" :value "Debian"}
+     {:certname "foo" :environment "DEV" :name "osfamily" :value "Debian"}}
+
+   ["subquery" "fact_contents"
+    ["and"
+     ["=" "path" ["osfamily"]]
+     ["=" "value" "Debian"]]]
+   #{{:certname "bar" :environment "DEV" :name "osfamily" :value "Debian"}
+     {:certname "foo" :environment "DEV" :name "osfamily" :value "Debian"}}))
 
 (def versioned-subqueries
   (omap/ordered-map
@@ -1363,6 +1383,48 @@
       (is (= (into [] (nth responses 4))
              [{"certname" "foo1"
                "hash" "b966980c39a141ab3c82b51951bb51a2e3787ac7"}])))))
+
+(deftestseq factset-subqueries
+  [[version endpoint] factsets-endpoints
+   method [:get :post]]
+
+  (populate-for-structured-tests reference-time)
+
+  (are [query expected]
+      (is (= expected
+             (query-result method endpoint query)))
+
+    ["extract" "certname"
+     ["in" "certname"
+      ["extract" "certname"
+       ["select_facts"
+        ["and"
+         ["=" "name" "uptime_seconds"]
+         ["=" "value" "4000"]]]]]]
+    #{{:certname "foo1"}}
+
+    ["extract" "certname"
+     ["subquery" "facts"
+      ["and"
+       ["=" "name" "uptime_seconds"]
+       ["=" "value" "4000"]]]]
+    #{{:certname "foo1"}}
+
+    ["extract" "certname"
+     ["in" "certname"
+      ["extract" "certname"
+       ["select_fact_contents"
+        ["and"
+         ["=" "name" "uptime_seconds"]
+         ["=" "value" "4000"]]]]]]
+    #{{:certname "foo1"}}
+
+    ["extract" "certname"
+     ["subquery" "fact_contents"
+      ["and"
+       ["=" "name" "uptime_seconds"]
+       ["=" "value" "4000"]]]]
+    #{{:certname "foo1"}}))
 
 (deftestseq factset-single-response
   [[version endpoint] factsets-endpoints

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -184,18 +184,42 @@
 
    #{{:certname "foo" :name "ipaddress" :value "192.168.1.100" :environment "DEV"}}
 
-   ;; Fact-contents subquery
+   ;;;;;;;;;
+   ;; Fact-contents subqueries
+   ;;;;;;;;;
+
+   ;; In syntax
    ["in" ["certname" "name"]
     ["extract" ["certname" "name"]
      ["select_fact_contents"
       ["and"
        ["=" "path" ["osfamily"]]
        ["=" "value" "Debian"]]]]]
-
    #{{:certname "bar" :environment "DEV" :name "osfamily" :value "Debian"}
      {:certname "foo" :environment "DEV" :name "osfamily" :value "Debian"}}
 
+   ;; Implicit subquery
    ["subquery" "fact_contents"
+    ["and"
+     ["=" "path" ["osfamily"]]
+     ["=" "value" "Debian"]]]
+   #{{:certname "bar" :environment "DEV" :name "osfamily" :value "Debian"}
+     {:certname "foo" :environment "DEV" :name "osfamily" :value "Debian"}}
+
+   ;; Explicit new subquery, with columns specified
+   ["subquery" "fact_contents"
+    ["columns" ["certname" "name"]]
+    ["and"
+     ["=" "path" ["osfamily"]]
+     ["=" "value" "Debian"]]]
+   #{{:certname "bar" :environment "DEV" :name "osfamily" :value "Debian"}
+     {:certname "foo" :environment "DEV" :name "osfamily" :value "Debian"}}
+
+   ;; Explicit new subquery, with inner & outer columns specified
+   ["subquery" "fact_contents"
+    ["columns"
+     ["certname" "name"]
+     ["certname" "name"]]
     ["and"
      ["=" "path" ["osfamily"]]
      ["=" "value" "Debian"]]]
@@ -1394,6 +1418,11 @@
       (is (= expected
              (query-result method endpoint query)))
 
+    ;;;;;;;;;;;;;;
+    ;; Facts subqueries
+    ;;;;;;;;;;;;;;
+
+    ;; In format
     ["extract" "certname"
      ["in" "certname"
       ["extract" "certname"
@@ -1403,6 +1432,7 @@
          ["=" "value" "4000"]]]]]]
     #{{:certname "foo1"}}
 
+    ;; Implicit subquery
     ["extract" "certname"
      ["subquery" "facts"
       ["and"
@@ -1410,6 +1440,19 @@
        ["=" "value" "4000"]]]]
     #{{:certname "foo1"}}
 
+    ;; Explicit subquery
+    ["extract" "certname"
+     ["subquery" "facts" ["columns" "certname"]
+      ["and"
+       ["=" "name" "uptime_seconds"]
+       ["=" "value" "4000"]]]]
+    #{{:certname "foo1"}}
+
+    ;;;;;;;;;;;;;
+    ;; Fact content subqueries
+    ;;;;;;;;;;;;;
+
+    ;; In format
     ["extract" "certname"
      ["in" "certname"
       ["extract" "certname"
@@ -1419,8 +1462,17 @@
          ["=" "value" "4000"]]]]]]
     #{{:certname "foo1"}}
 
+    ;; Implicit subqueries
     ["extract" "certname"
      ["subquery" "fact_contents"
+      ["and"
+       ["=" "name" "uptime_seconds"]
+       ["=" "value" "4000"]]]]
+    #{{:certname "foo1"}}
+
+    ;; Explicit subqueries
+    ["extract" "certname"
+     ["subquery" "fact_contents" ["columns" "certname"]
       ["and"
        ["=" "name" "uptime_seconds"]
        ["=" "value" "4000"]]]]

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -139,7 +139,11 @@
     (are [query expected]
         (is-query-result method endpoint query expected)
 
-      ;; Basic sub-query for fact operatingsystem
+      ;;;;;;;;;;;;
+      ;; Fact subqueries
+      ;;;;;;;;;;;;
+
+      ;; In format
       ["in" "certname"
        ["extract" "certname"
         ["select_facts"
@@ -148,13 +152,26 @@
           ["=" "value" "Debian"]]]]]
       [db web1 web2]
 
+      ;; Implicit subquery
       ["subquery" "facts"
        ["and"
         ["=" "name" "operatingsystem"]
         ["=" "value" "Debian"]]]
       [db web1 web2]
 
-      ;; Fact_contents subquery
+      ;; Explicit subquery
+      ["subquery" "facts"
+       ["columns" "certname"]
+       ["and"
+        ["=" "name" "operatingsystem"]
+        ["=" "value" "Debian"]]]
+      [db web1 web2]
+
+      ;;;;;;;;;;;
+      ;; Fact_contents subqueries
+      ;;;;;;;;;;;
+
+      ;; In format
       ["in" "certname"
        ["extract" "certname"
         ["select_fact_contents"
@@ -163,13 +180,26 @@
           ["=" "value" "Debian"]]]]]
       [db web1 web2]
 
+      ;; Implicit subquery
       ["subquery" "fact_contents"
        ["and"
         ["=" "name" "operatingsystem"]
         ["=" "value" "Debian"]]]
       [db web1 web2]
 
+      ;; Explicit subquery
+      ["subquery" "fact_contents"
+       ["columns" "certname"]
+       ["and"
+        ["=" "name" "operatingsystem"]
+        ["=" "value" "Debian"]]]
+      [db web1 web2]
+
+      ;;;;;;;;;;;;;
       ;; Nodes with a class matching their hostname
+      ;;;;;;;;;;;;;
+
+      ;; In format
       ["in" "certname"
        ["extract" "certname"
         ["select_facts"
@@ -182,6 +212,7 @@
               ["=" "type" "Class"]]]]]]]]]
       [web1]
 
+      ;; Implicit subquery
       ["subquery" "facts"
        ["and"
         ["=" "name" "hostname"]
@@ -192,7 +223,21 @@
             ["=" "type" "Class"]]]]]]]
       [web1]
 
+      ;; Explicit subquery
+      ["subquery" "facts"
+       ["columns" "certname"]
+       ["and"
+        ["=" "name" "hostname"]
+        ["subquery" "resources"
+         ["columns" "value" "title"]
+         ["=" "type" "Class"]]]]
+      [web1]
+
+      ;;;;;;;;;;;;
       ;; Nodes with matching select-resources for file/line
+      ;;;;;;;;;;;;
+
+      ;; In format
       ["in" "certname"
        ["extract" "certname"
         ["select_resources"
@@ -201,64 +246,128 @@
           ["=" "line" 1]]]]]
       [db puppet web1]
 
+      ;; Implicit subquery
       ["subquery" "resources"
        ["and"
         ["=" "file" "/etc/puppet/modules/settings/manifests/init.pp"]
         ["=" "line" 1]]]
       [db puppet web1]
 
+      ;; Explicit subquery
+      ["subquery" "resources"
+       ["columns" "certname"]
+       ["and"
+        ["=" "file" "/etc/puppet/modules/settings/manifests/init.pp"]
+        ["=" "line" 1]]]
+      [db puppet web1]
+
+      ;;;;;;;;;;;;
       ;; Reports subquery
+      ;;;;;;;;;;;;
+
+      ;; In format
       ["in" "certname"
        ["extract" "certname"
         ["select_reports"
          ["=" "certname" db]]]]
       [db]
 
+      ;; Implicit subquery
       ["subquery" "reports"
        ["=" "certname" db]]
       [db]
 
+      ;; Explicit subquery
+      ["subquery" "reports"
+       ["columns" "certname"]
+       ["=" "certname" db]]
+      [db]
+
+      ;;;;;;;;;;;;;;
       ;; Catalogs subquery
+      ;;;;;;;;;;;;;;
+
+      ;; In format
       ["in" "certname"
        ["extract" "certname"
         ["select_catalogs"
          ["=" "certname" web1]]]]
       [web1]
 
+      ;; Implicit subquery
       ["subquery" "catalogs"
        ["=" "certname" web1]]
       [web1]
 
+      ;; Explicit subquery
+      ["subquery" "catalogs"
+       ["columns" "certname"]
+       ["=" "certname" web1]]
+      [web1]
+
+      ;;;;;;;;;;;;;;
       ;; Factsets subquery
+      ;;;;;;;;;;;;;;
+
+      ;; In format
       ["in" "certname"
        ["extract" "certname"
         ["select_factsets"
          ["=" "certname" web2]]]]
       [web2]
 
+      ;; Implict subquery
       ["subquery" "factsets"
        ["=" "certname" web2]]
       [web2]
 
+      ;; Explicit subquery
+      ["subquery" "factsets"
+       ["columns" "certname"]
+       ["=" "certname" web2]]
+      [web2]
+
+      ;;;;;;;;;;;;;
       ;; Events subquery
+      ;;;;;;;;;;;;;
+
+      ;; In format
       ["in" "certname"
        ["extract" "certname"
         ["select_events"
          ["=" "certname" db]]]]
       [db]
 
+      ;; Implicit subquery
       ["subquery" "events"
        ["=" "certname" db]]
       [db]
 
+      ;; Explicit subquery
+      ["subquery" "events"
+       ["columns" "certname"]
+       ["=" "certname" db]]
+      [db]
+
+      ;;;;;;;;;;;;;
       ;; Resource subquery
+      ;;;;;;;;;;;;;
+
+      ;; In format
       ["in" "certname"
        ["extract" "certname"
         ["select_resources"
          ["=" "certname" web1]]]]
       [web1]
 
+      ;; Implicit subquery
       ["subquery" "resources"
+       ["=" "certname" web1]]
+      [web1]
+
+      ;; Explicit subquery
+      ["subquery" "resources"
+       ["columns" "certname"]
        ["=" "certname" web1]]
       [web1]))
 

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -574,6 +574,30 @@
     (is (= 1 (count basic-result)))
     (is (= basic-result (munge-reports-for-comparison [basic])))))
 
+(deftestseq report-subqueries
+  [[version endpoint] endpoints
+   method [:get :post]]
+
+  (store-example-report! (:basic reports) (now))
+  (store-example-report! (:basic2 reports) (now))
+  (store-example-report! (:basic3 reports) (now))
+
+  (are [query expected]
+      (is (= expected
+             (query-result method endpoint query)))
+
+    ["extract" "certname"
+     ["in" "hash"
+      ["extract" "report"
+       ["select_events"
+        ["=" "file" "bar"]]]]]
+    #{{:certname "foo.local"}}
+
+    ["extract" "certname"
+     ["subquery" "events"
+      ["=" "file" "bar"]]]
+    #{{:certname "foo.local"}}))
+
 (def invalid-projection-queries
   (omap/ordered-map
     ;; Top level extract using invalid fields should throw an error

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -586,6 +586,11 @@
       (is (= expected
              (query-result method endpoint query)))
 
+    ;;;;;;;;;;;;;;;
+    ;; Event subqueries
+    ;;;;;;;;;;;;;;;
+
+    ;; In format
     ["extract" "certname"
      ["in" "hash"
       ["extract" "report"
@@ -593,8 +598,16 @@
         ["=" "file" "bar"]]]]]
     #{{:certname "foo.local"}}
 
+    ;; Implicit subqueries
     ["extract" "certname"
      ["subquery" "events"
+      ["=" "file" "bar"]]]
+    #{{:certname "foo.local"}}
+
+    ;; Explicit subqueries
+    ["extract" "certname"
+     ["subquery" "events"
+      ["columns" "hash" "report"]
       ["=" "file" "bar"]]]
     #{{:certname "foo.local"}}))
 


### PR DESCRIPTION
This patch adds the new functionality for implicit subqueries, rather subqueries
that require no explicit column names to be specified.

Signed-off-by: Ken Barber <ken@bob.sh>