### PR TITLE
(maint) Bump oldes support puppet version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 puppet_branch = ENV['PUPPET_VERSION'] || "latest"
-oldest_supported_puppet = "3.5.1"
+oldest_supported_puppet = "3.8.1"
 beaker_version = ENV['BEAKER_VERSION']
 
 def location_for(place, fake_version = nil)


### PR DESCRIPTION
Packaging currently requires at least Puppet 3.8.1, but the Gemfile is
out of date and lists the olds supported Puppet as 3.5.1. Bumping the
Gemfile to match packaging.