### PR TITLE
(maint) Change char encoding context test to > 1.8.7

### DIFF
--- a/puppet/spec/unit/util/puppetdb/char_encoding_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/char_encoding_spec.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-# encoding: UTF-8
+# encoding: utf-8
 
 require 'spec_helper'
 
@@ -145,4 +145,28 @@ describe Puppet::Util::Puppetdb::CharEncoding do
     end
   end
 
+  describe "on ruby > 1.8", :if => RUBY_VERSION !~ /^1.8/ do
+    describe "#all_indexes_of_char" do
+      described_class.all_indexes_of_char("a\u2192b\u2192c\u2192d\u2192", "\u2192").should == [1, 3, 5, 7]
+      described_class.all_indexes_of_char("abcd", "\u2192").should == []
+    end
+
+    describe "#collapse_ranges" do
+      described_class.collapse_ranges((1..5).to_a).should == [1..5]
+      described_class.collapse_ranges([]).should == []
+      described_class.collapse_ranges([1,2,3,5,7,8,9]).should == [1..3, 5..5, 7..9]
+    end
+
+    describe "#error_char_context" do
+      described_class.error_char_context("abc\ufffddef", [3]).should ==
+        ["'abc' followed by 1 invalid/undefined bytes then 'def'"]
+
+      described_class.error_char_context("abc\ufffd\ufffd\ufffd\ufffddef", [3,4,5,6]).should ==
+        ["'abc' followed by 4 invalid/undefined bytes then 'def'"]
+
+      described_class.error_char_context("abc\ufffddef\ufffdg", [3, 7]).should ==
+        ["'abc' followed by 1 invalid/undefined bytes then 'def'",
+         "'def' followed by 1 invalid/undefined bytes then 'g'"]
+    end
+  end
 end


### PR DESCRIPTION
The code doesn't work on 1.8.7. The main code paths guard against that,
but the tests did not. This puts that guard around the tests