### PR TITLE
(maint) Change char encoding context test to > 1.8.7

### DIFF
--- a/puppet/spec/unit/util/puppetdb/char_encoding_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/char_encoding_spec.rb
@@ -185,30 +185,28 @@ describe Puppet::Util::Puppetdb::CharEncoding do
     end
   end
 
-  describe "#all_indexes_of_char" do
-    described_class.all_indexes_of_char("a\u2192b\u2192c\u2192d\u2192", "\u2192").should == [1, 3, 5, 7]
-    described_class.all_indexes_of_char("abcd", "\u2192").should == []
-  end
+  describe "on ruby > 1.8", :if => RUBY_VERSION !~ /^1.8/ do
+    it "finds all index of a given character" do
+      described_class.all_indexes_of_char("a\u2192b\u2192c\u2192d\u2192", "\u2192").should == [1, 3, 5, 7]
+      described_class.all_indexes_of_char("abcd", "\u2192").should == []
+    end
 
-  describe "#collapse_ranges" do
-    described_class.collapse_ranges((1..5).to_a).should == [1..5]
-    described_class.collapse_ranges([]).should == []
-    described_class.collapse_ranges([1,2,3,5,7,8,9]).should == [1..3, 5..5, 7..9]
-  end
+    it "should collapse consecutive integers into ranges" do
+      described_class.collapse_ranges((1..5).to_a).should == [1..5]
+      described_class.collapse_ranges([]).should == []
+      described_class.collapse_ranges([1,2,3,5,7,8,9]).should == [1..3, 5..5, 7..9]
+    end
 
-  describe "#error_char_context" do
-    described_class.error_char_context("abc\ufffddef", [3]).should ==
-      ["'abc' followed by 1 invalid/undefined bytes then 'def'"]
+    it "gives error context around each bad character" do
+      described_class.error_char_context("abc\ufffddef", [3]).should ==
+        ["'abc' followed by 1 invalid/undefined bytes then 'def'"]
 
-    described_class.error_char_context("abc\ufffd\ufffd\ufffd\ufffddef", [3,4,5,6]).should ==
-      ["'abc' followed by 4 invalid/undefined bytes then 'def'"]
+      described_class.error_char_context("abc\ufffd\ufffd\ufffd\ufffddef", [3,4,5,6]).should ==
+        ["'abc' followed by 4 invalid/undefined bytes then 'def'"]
 
-    described_class.error_char_context("abc\ufffddef\ufffdg", [3, 7]).should ==
-      ["'abc' followed by 1 invalid/undefined bytes then 'def'",
-       "'def' followed by 1 invalid/undefined bytes then 'g'"]
-  end
-
-  describe "#warn_if_invalid_chars" do
-
+      described_class.error_char_context("abc\ufffddef\ufffdg", [3, 7]).should ==
+        ["'abc' followed by 1 invalid/undefined bytes then 'def'",
+         "'def' followed by 1 invalid/undefined bytes then 'g'"]
+    end
   end
 end

--- a/puppet/spec/unit/util/puppetdb/command_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/command_spec.rb
@@ -62,34 +62,37 @@ describe Puppet::Util::Puppetdb::Command do
     cmd.payload.include?("\u2192").should be_true
   end
 
-  it "should warn when a command payload includes non-ascii UTF-8 characters" do
-    Puppet.expects(:warning).with {|msg| msg =~ /Error encoding a 'command-1' command for host 'foo.localdomain' ignoring invalid UTF-8 byte sequences/}
-    cmd = described_class.new("command-1", 1, "foo.localdomain", {"foo" => [192].pack('c*')})
-    cmd.payload.include?("\ufffd").should be_true
-  end
-
-  describe "Debug log testing of bad data" do
-    let!(:existing_log_level){ Puppet[:log_level]}
-
-    before :each do
-      Puppet[:log_level] = "debug"
-    end
-
-    after :each do
-      Puppet[:log_level] = "notice"
-    end
+  describe "on ruby > 1.8", :if => RUBY_VERSION !~ /^1.8/ do
 
     it "should warn when a command payload includes non-ascii UTF-8 characters" do
-      Puppet.expects(:warning).with do |msg|
-        msg =~ /Error encoding a 'command-1' command for host 'foo.localdomain' ignoring invalid UTF-8 byte sequences/
-      end
-      Puppet.expects(:debug).with do |msg|
-        msg =~ /Error encoding a 'command-1' command for host 'foo.localdomain'/ &&
-        msg =~ Regexp.new(Regexp.quote('"command":"command-1","version":1,"payload":{"foo"')) &&
-        msg =~ /1 invalid\/undefined/
-      end
+      Puppet.expects(:warning).with {|msg| msg =~ /Error encoding a 'command-1' command for host 'foo.localdomain' ignoring invalid UTF-8 byte sequences/}
       cmd = described_class.new("command-1", 1, "foo.localdomain", {"foo" => [192].pack('c*')})
       cmd.payload.include?("\ufffd").should be_true
+    end
+
+    describe "Debug log testing of bad data" do
+      let!(:existing_log_level){ Puppet[:log_level]}
+
+      before :each do
+        Puppet[:log_level] = "debug"
+      end
+
+      after :each do
+        Puppet[:log_level] = "notice"
+      end
+
+      it "should warn when a command payload includes non-ascii UTF-8 characters" do
+        Puppet.expects(:warning).with do |msg|
+          msg =~ /Error encoding a 'command-1' command for host 'foo.localdomain' ignoring invalid UTF-8 byte sequences/
+        end
+        Puppet.expects(:debug).with do |msg|
+          msg =~ /Error encoding a 'command-1' command for host 'foo.localdomain'/ &&
+            msg =~ Regexp.new(Regexp.quote('"command":"command-1","version":1,"payload":{"foo"')) &&
+            msg =~ /1 invalid\/undefined/
+        end
+        cmd = described_class.new("command-1", 1, "foo.localdomain", {"foo" => [192].pack('c*')})
+        cmd.payload.include?("\ufffd").should be_true
+      end
     end
   end
 end


### PR DESCRIPTION
The code doesn't work on 1.8.7. The main code paths guard against that,
but the tests did not. This puts that guard around the tests