### PR TITLE
(PDB-1951) remove static items from shared globals

### DIFF
--- a/resources/puppetlabs/puppetdb/bootstrap.cfg
+++ b/resources/puppetlabs/puppetdb/bootstrap.cfg
@@ -11,7 +11,6 @@ puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-servi
 
 # PuppetDB Services
 puppetlabs.puppetdb.cli.services/puppetdb-service
-puppetlabs.puppetdb.http.command/puppetdb-command-service
 puppetlabs.puppetdb.metrics/metrics-service
 puppetlabs.puppetdb.mq-listener/message-listener-service
 puppetlabs.puppetdb.command/command-service

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -233,7 +233,7 @@
         {:keys [vardir catalog-hash-debug-dir]} global
         {:keys [gc-interval dlo-compression-interval node-ttl
                 node-purge-ttl report-ttl]} database
-        {:keys [dlo-compression-threshold threads]} command-processing
+        {:keys [dlo-compression-threshold]} command-processing
         {:keys [disable-update-checking]} puppetdb
 
         write-db (jdbc/pooled-datasource database)
@@ -269,7 +269,6 @@
           globals {:scf-read-db read-db
                    :scf-write-db write-db
                    :discard-dir (.getAbsolutePath discard-dir)
-                   :mq-threads threads
                    :catalog-hash-debug-dir catalog-hash-debug-dir
                    :command-mq {:connection mq-connection}}]
       (transfer-old-messages! mq-connection (conf/mq-endpoint config))

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -311,6 +311,8 @@
     "Submits the raw-command to the endpoint of the connection and
     returns the command's unique id.")
 
+  (submit-raw-command [this raw-command uuid])
+  
   (submit-command
     [this command version payload]
     [this command version payload uuid])
@@ -402,6 +404,12 @@
       ;; Obviously assumes that if do-* doesn't throw, msg is in
       (swap! (:stats (service-context this)) update :received-commands inc)
       result))
+
+  (submit-raw-command [this raw-command uuid]
+    (enqueue-raw-command this
+                         (get-in (shared-globals) [:command-mq :connection])
+                         (conf/mq-endpoint (get-config))
+                         raw-command uuid))
 
   (submit-command [this command version payload]
     (submit-command this command version payload nil))

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -425,8 +425,7 @@
   (str (io/file (mq-dir config) "discard")))
 
 (defprotocol DefaultedConfig
-  (get-config [this])
-  (get-in-config [this ks]))
+  (get-config [this]))
 
 (defn create-defaulted-config-service [config-transform-fn]
   (tk/service
@@ -435,9 +434,7 @@
    (init [this context]
          (assoc context :config (config-transform-fn (get-config))))
    (get-config [this]
-               (:config (service-context this)))
-   (get-in-config [this ks]
-                  (get-in (service-context this) ks))))
+               (:config (service-context this)))))
 
 (def config-service
   (create-defaulted-config-service process-config!))

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -358,6 +358,12 @@
             (when dashboard-redirect?
               {:puppetlabs.puppetdb.dashboard/dashboard-redirect-service "/"}))))
 
+(defn- add-mq-defaults
+  [config-data]
+  (update-in config-data
+             [:command-processing :mq :address]
+             #(or % "vm://localhost?jms.prefetchPolicy.all=1&create=false")))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
@@ -381,7 +387,8 @@
       configure-globals
       validate-vardir
       convert-config
-      configure-catalog-debugging))
+      configure-catalog-debugging
+      add-mq-defaults))
 
 (defn foss? [config]
   (= "puppetdb" (get-in config [:global :product-name])))
@@ -391,6 +398,13 @@
 
 (defn update-server [config]
   (get-in config [:global :update-server]))
+
+(defn mq-broker-url
+  "Returns an appropriate ActiveMQ broker URL."
+  [config]
+  (format "%s&wireFormat.maxFrameSize=%s&marshal=true"
+          (get-in config [:command-processing :mq :address])
+          (get-in config [:command-processing :max-frame-size])))
 
 (defprotocol DefaultedConfig
   (get-config [this])

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -413,6 +413,11 @@
           (get-in config [:command-processing :mq :address])
           (get-in config [:command-processing :max-frame-size])))
 
+(defn mq-thread-count
+  "Returns the desired number of MQ listener threads."
+  [config]
+  (get-in config [:command-processing :threads]))
+
 (defprotocol DefaultedConfig
   (get-config [this])
   (get-in-config [this ks]))

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -418,6 +418,12 @@
   [config]
   (get-in config [:command-processing :threads]))
 
+(defn mq-dir [config]
+  (str (io/file (get-in config [:global :vardir]) "mq")))
+
+(defn mq-discard-dir [config]
+  (str (io/file (mq-dir config) "discard")))
+
 (defprotocol DefaultedConfig
   (get-config [this])
   (get-in-config [this ks]))

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -20,6 +20,8 @@
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.services :refer [service-id service-context]]))
 
+(def default-mq-endpoint "puppetlabs.puppetdb.commands")
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
 
@@ -360,9 +362,11 @@
 
 (defn- add-mq-defaults
   [config-data]
-  (update-in config-data
-             [:command-processing :mq :address]
-             #(or % "vm://localhost?jms.prefetchPolicy.all=1&create=false")))
+  (-> config-data
+      (update-in [:command-processing :mq :address]
+                 #(or % "vm://localhost?jms.prefetchPolicy.all=1&create=false"))
+      (update-in [:command-processing :mq :endpoint]
+                 #(or % default-mq-endpoint))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
@@ -398,6 +402,9 @@
 
 (defn update-server [config]
   (get-in config [:global :update-server]))
+
+(defn mq-endpoint [config]
+  (get-in config [:command-processing :mq :endpoint]))
 
 (defn mq-broker-url
   "Returns an appropriate ActiveMQ broker URL."

--- a/src/puppetlabs/puppetdb/dashboard.clj
+++ b/src/puppetlabs/puppetdb/dashboard.clj
@@ -8,8 +8,7 @@
   (app ["" &] {:get (fn [req] (rr/redirect "/pdb/dashboard/index.html"))}))
 
 (defservice dashboard-redirect-service
-  [[:PuppetDBServer shared-globals]
-   [:WebroutingService add-ring-handler get-route]]
+  [[:WebroutingService add-ring-handler get-route]]
 
   (start [this context]
          (log/info "Redirecting / to the PuppetDB dashboard")

--- a/src/puppetlabs/puppetdb/metrics.clj
+++ b/src/puppetlabs/puppetdb/metrics.clj
@@ -5,11 +5,12 @@
             [compojure.core :as compojure]))
 
 (defservice metrics-service
-  [[:DefaultedConfig get-in-config]
+  [[:DefaultedConfig get-config]
    [:WebroutingService add-ring-handler get-route]]
 
   (start [this context]
-         (let [app (->> (server/build-app (get-in-config [:puppetdb :certificate-whitelist]))
+         (let [app (->> (get-in (get-config) [:puppetdb :certificate-whitelist])
+                        server/build-app
                         (compojure/context (get-route this) []))]
            (log/info "Starting metrics server")
            (add-ring-handler this app)

--- a/src/puppetlabs/puppetdb/mq_listener.clj
+++ b/src/puppetlabs/puppetdb/mq_listener.clj
@@ -355,7 +355,7 @@
 (defservice message-listener-service
   MessageListenerService
   [[:DefaultedConfig get-config]
-   [:PuppetDBServer shared-globals]]
+   [:PuppetDBServer]] ; MessageListenerService depends on the broker
 
   (init [this context]
         (assoc context :listeners (atom [])))

--- a/src/puppetlabs/puppetdb/mq_listener.clj
+++ b/src/puppetlabs/puppetdb/mq_listener.clj
@@ -361,15 +361,15 @@
         (assoc context :listeners (atom [])))
 
   (start [this context]
-    (let [{:keys [discard-dir]} (shared-globals)
-          config (get-config)
+    (let [config (get-config)
+          discard-dir (conf/mq-discard-dir config)
           factory (mq/activemq-connection-factory (conf/mq-broker-url config))
-          mq-endpoint (conf/mq-endpoint config)
+          endpoint (conf/mq-endpoint config)
           connection (.createConnection factory)
           process-msg #(process-message this %)
           receivers (doall (repeatedly (conf/mq-thread-count config)
                                        #(start-receiver connection
-                                                        mq-endpoint
+                                                        endpoint
                                                         discard-dir
                                                         process-msg)))]
       (.setExceptionListener

--- a/src/puppetlabs/puppetdb/mq_listener.clj
+++ b/src/puppetlabs/puppetdb/mq_listener.clj
@@ -361,13 +361,13 @@
         (assoc context :listeners (atom [])))
 
   (start [this context]
-    (let [{:keys [discard-dir mq-threads]} (shared-globals)
-          factory (mq/activemq-connection-factory
-                   (conf/mq-broker-url (get-config)))
-          mq-endpoint (conf/mq-endpoint (get-config))
+    (let [{:keys [discard-dir]} (shared-globals)
+          config (get-config)
+          factory (mq/activemq-connection-factory (conf/mq-broker-url config))
+          mq-endpoint (conf/mq-endpoint config)
           connection (.createConnection factory)
           process-msg #(process-message this %)
-          receivers (doall (repeatedly mq-threads
+          receivers (doall (repeatedly (conf/mq-thread-count config)
                                        #(start-receiver connection
                                                         mq-endpoint
                                                         discard-dir

--- a/src/puppetlabs/puppetdb/mq_listener.clj
+++ b/src/puppetlabs/puppetdb/mq_listener.clj
@@ -361,14 +361,15 @@
         (assoc context :listeners (atom [])))
 
   (start [this context]
-    (let [{:keys [mq-dest discard-dir mq-threads]} (shared-globals)
+    (let [{:keys [discard-dir mq-threads]} (shared-globals)
           factory (mq/activemq-connection-factory
                    (conf/mq-broker-url (get-config)))
+          mq-endpoint (conf/mq-endpoint (get-config))
           connection (.createConnection factory)
           process-msg #(process-message this %)
           receivers (doall (repeatedly mq-threads
                                        #(start-receiver connection
-                                                        mq-dest
+                                                        mq-endpoint
                                                         discard-dir
                                                         process-msg)))]
       (.setExceptionListener

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -86,8 +86,8 @@
 (tk/defservice pdb-routing-service
   [[:WebroutingService add-ring-handler get-route]
    [:PuppetDBServer shared-globals query set-url-prefix]
-   [:PuppetDBCommand submit-command]
-   [:PuppetDBCommandDispatcher enqueue-command enqueue-raw-command response-pub]
+   [:PuppetDBCommandDispatcher
+    enqueue-command enqueue-raw-command response-pub submit-command]
    [:MaintenanceMode enable-maint-mode maint-mode? disable-maint-mode]
    [:DefaultedConfig get-config]]
   (init [this context]

--- a/test/puppetlabs/puppetdb/admin_test.clj
+++ b/test/puppetlabs/puppetdb/admin_test.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.puppetdb.admin-test
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetdb.cli.services :refer :all]
-            [puppetlabs.puppetdb.command :refer [submit-command]]
+            [puppetlabs.puppetdb.command :refer [enqueue-command]]
             [puppetlabs.puppetdb.export :as export]
             [puppetlabs.puppetdb.import :as import]
             [puppetlabs.puppetdb.cli.import :as cli-import]
@@ -43,7 +43,7 @@
 
        (let [dispatcher (tk-app/get-service svc-utils/*server*
                                             :PuppetDBCommandDispatcher)
-             submit-command-fn (partial submit-command dispatcher)
+             submit-command-fn (partial enqueue-command dispatcher)
              command-versions (:command_versions (cli-import/parse-metadata
                                                   export-out-file))]
          (import/import! export-out-file command-versions submit-command-fn))

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -1307,9 +1307,7 @@
                         (deliver received-cmd? true)
                         @go-ahead-and-execute
                         (apply real-replace! args))]
-          (enqueue-command connection
-                           (conf/mq-endpoint (get-config))
-                           (command-names :replace-facts) 4
+          (enqueue-command (command-names :replace-facts) 4
                            {:environment "DEV" :certname "foo.local"
                             :values {:foo "foo"}
                             :producer_timestamp (to-string (now))})
@@ -1333,9 +1331,7 @@
           ;; enqueue, a DateTime wasn't a problem.
           input-stamp (java.util.Date. deactivate-ms)
           expected-stamp (DateTime. deactivate-ms DateTimeZone/UTC)]
-      (enqueue-command connection
-                       (conf/mq-endpoint (get-config))
-                       (command-names :deactivate-node) 3
+      (enqueue-command (command-names :deactivate-node) 3
                        {:certname "foo.local" :producer_timestamp input-stamp})
       (is (svc-utils/wait-for-server-processing svc-utils/*server* 5000))
       ;; While we're here, check the value in the database too...
@@ -1370,9 +1366,7 @@
           response-chan (async/chan)
           command-uuid (ks/uuid)]
       (async/tap response-mult response-chan)
-      (enqueue-command connection
-                       (conf/mq-endpoint (get-config))
-                       (command-names :deactivate-node) 3
+      (enqueue-command (command-names :deactivate-node) 3
                        {:certname "foo.local" :producer_timestamp (java.util.Date.)}
                        command-uuid)
       (let [received-uuid (async/alt!! response-chan ([msg] (:id msg))

--- a/test/puppetlabs/puppetdb/fixtures.clj
+++ b/test/puppetlabs/puppetdb/fixtures.clj
@@ -72,10 +72,10 @@
   ([f]
    (binding [*command-app* (mid/wrap-with-puppetdb-middleware
                             (command/command-app
-                             (fn [] (:connection *mq*))
-                             conf/default-mq-endpoint
                              (fn [] {})
-                             #'dispatch/do-enqueue-raw-command
+                             (partial #'dispatch/do-enqueue-raw-command
+                                      (:connection *mq*)
+                                      conf/default-mq-endpoint)
                              (fn [] nil))
                             nil)]
      (f))))

--- a/test/puppetlabs/puppetdb/fixtures.clj
+++ b/test/puppetlabs/puppetdb/fixtures.clj
@@ -6,7 +6,7 @@
             [puppetlabs.puppetdb.http.command :as command]
             [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.puppetdb.schema :as pls]
-            [puppetlabs.puppetdb.config :as cfg]
+            [puppetlabs.puppetdb.config :as conf]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
             [clojure.tools.macro :as tmacro]
@@ -61,8 +61,7 @@
   [f]
   (without-jmx
    (with-test-broker "test" connection
-     (binding [*mq* {:connection connection
-                     :endpoint "puppetlabs.puppetdb.commands"}]
+     (binding [*mq* {:connection connection}]
        (f)))))
 
 (defn with-command-app
@@ -73,7 +72,8 @@
   ([f]
    (binding [*command-app* (mid/wrap-with-puppetdb-middleware
                             (command/command-app
-                             (fn [] *mq*)
+                             (fn [] (:connection *mq*))
+                             conf/default-mq-endpoint
                              (fn [] {})
                              #'dispatch/do-enqueue-raw-command
                              (fn [] nil))
@@ -99,16 +99,18 @@
        (f)))))
 
 (defn defaulted-write-db-config
-  "Defaults and converts `db-config` from the write database INI format to the internal
-   write database format"
+  "Defaults and converts `db-config` from the write database INI
+  format to the internal write database format"
   [db-config]
-  (pls/transform-data cfg/write-database-config-in cfg/write-database-config-out db-config))
+  (pls/transform-data conf/write-database-config-in
+                      conf/write-database-config-out db-config))
 
 (defn defaulted-read-db-config
-  "Defaults and converts `db-config` from the read-database INI format to the internal
-   read database format"
+  "Defaults and converts `db-config` from the read-database INI format
+  to the internal read database format"
   [db-config]
-  (pls/transform-data cfg/database-config-in cfg/database-config-out db-config))
+  (pls/transform-data conf/database-config-in
+                      conf/database-config-out db-config))
 
 (defn with-test-logging-silenced
   "A fixture to temporarily redirect all logging output to an atom, rather than

--- a/test/puppetlabs/puppetdb/fixtures.clj
+++ b/test/puppetlabs/puppetdb/fixtures.clj
@@ -90,7 +90,6 @@
   ([globals-overrides f]
    (let [get-shared-globals #(merge {:scf-read-db *db*
                                      :scf-write-db *db*
-                                     :command-mq *mq*
                                      :url-prefix ""}
                                     globals-overrides)]
      (binding [*app* (mid/wrap-with-puppetdb-middleware
@@ -138,7 +137,6 @@
       :globals (merge {:update-server "FOO"
                        :scf-read-db          *db*
                        :scf-write-db         *db*
-                       :command-mq           *mq*
                        :product-name         "puppetdb"}
                       global-overrides)}))
 
@@ -155,7 +153,6 @@
       :globals {:update-server "FOO"
                 :scf-read-db          *db*
                 :scf-write-db         *db*
-                :command-mq           *mq*
                 :product-name         "puppetdb"}
       :body (ByteArrayInputStream. (.getBytes body "utf8"))}))
 

--- a/test/puppetlabs/puppetdb/http/command_test.clj
+++ b/test/puppetlabs/puppetdb/http/command_test.clj
@@ -9,6 +9,7 @@
                                                    content-type uuid-in-response?
                                                    assert-success! deftestseq]]
             [puppetlabs.kitchensink.core :as kitchensink]
+            [puppetlabs.puppetdb.config :as conf]
             [puppetlabs.puppetdb.http :as http]
             [puppetlabs.puppetdb.mq :as mq]
             [clj-time.format :as time]))
@@ -129,7 +130,7 @@
 
     (let [[good-msg] (mq/bounded-drain-into-vec!
                        (:connection fixt/*mq*)
-                       "puppetlabs.puppetdb.commands"
+                       conf/default-mq-endpoint
                        1)
           good-command (json/parse-string (:body good-msg) true)]
       (testing "should be timestamped when parseable"

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -448,7 +448,6 @@
    (mid/wrap-with-puppetdb-middleware
     (server/build-app #(hash-map :scf-read-db read-db
                                  :scf-write-db write-db
-                                 :command-mq *mq*
                                  :product-name "puppetdb"))
     nil)))
 

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -17,7 +17,6 @@
             [puppetlabs.puppetdb.admin :as admin]
             [puppetlabs.puppetdb.mq-listener :refer [message-listener-service]]
             [puppetlabs.puppetdb.command :refer [command-service] :as dispatch]
-            [puppetlabs.puppetdb.http.command :refer [puppetdb-command-service]]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.config :as conf]
             [puppetlabs.puppetdb.cheshire :as json]
@@ -69,7 +68,6 @@
    #'message-listener-service
    #'command-service
    #'metrics/metrics-service
-   #'puppetdb-command-service
    #'dashboard-redirect-service
    #'pdb-routing-service
    #'maint-mode-service

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -167,7 +167,7 @@
   [host]
   (str "org.apache.activemq:type=Broker,brokerName=" (url-encode host)
        ",destinationType=Queue"
-       ",destinationName=" svcs/mq-endpoint))
+       ",destinationName=" conf/default-mq-endpoint))
 
 (defn mq-mbeans-found?
   "Returns true if the ActiveMQ mbeans and the discarded command


### PR DESCRIPTION
Migrate the MQ endpoint, connection, threads, and discard-dir values from shared-globals to the DefaultedConfigService.

Move all command submission to PuppetDBCommandDispatcher and remove the PuppetDBCommand service.

Have PuppetDBCommandDispatcher manage its own AMQP connection.