### PR TITLE
(maint) Store reports without resources again

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1189,10 +1189,11 @@
                    assoc-ids #(assoc %
                                      :report_id report-id
                                      :certname_id certname-id)]
-               (->> resource_events
-                    (sp/transform [sp/ALL :containment_path] #(some-> % sutils/to-jdbc-varchar-array))
-                    (map assoc-ids)
-                    (apply jdbc/insert! :resource_events))
+               (when-not (empty? resource_events)
+                 (->> resource_events
+                      (sp/transform [sp/ALL :containment_path] #(some-> % sutils/to-jdbc-varchar-array))
+                      (map assoc-ids)
+                      (apply jdbc/insert! :resource_events)))
                (when update-latest-report?
                  (update-latest-report! certname)))))))
 

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1354,6 +1354,17 @@
            [{:certname (:certname report)
              :status_id (status-id "unchanged")}])))
 
+  (deftest report-storage-without-resources
+    (testing "should store reports"
+      (let [env-id (ensure-environment "DEV")]
+
+        (store-example-report! (assoc report :resource_events []) timestamp)
+
+        (is (= (query-to-vec ["SELECT certname FROM reports"])
+               [{:certname (:certname report)}]))
+        (is (= (query-to-vec ["SELECT COUNT(1) as num_resource_events FROM resource_events"])
+               [{:num_resource_events 0}])))))
+
   (deftest report-storage-with-existing-environment
     (testing "should store reports"
       (let [env-id (ensure-environment "DEV")]


### PR DESCRIPTION
This commit fixes a bug with the jdbc upgrade where reports without
resources/resource-events would throw and exception while trying to call
`jdbc/insert!`.