### PR TITLE
(PDB-1848) make max-frame-size tunable

### DIFF
--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -126,14 +126,14 @@
     {:dlo-compression-threshold (pls/defaulted-maybe String "1d")
      :threads (pls/defaulted-maybe s/Int half-the-cores)
      :store-usage s/Int
-     :max-frame-size (pls/defaulted-maybe String "209715200")
+     :max-frame-size (pls/defaulted-maybe s/Int 209715200)
      :temp-usage s/Int}))
 
 (def command-processing-out
   "Schema for parsed/processed command processing config - currently incomplete"
   {:dlo-compression-threshold Period
    :threads s/Int
-   :max-frame-size s/Str
+   :max-frame-size s/Int
    (s/optional-key :store-usage) s/Int
    (s/optional-key :temp-usage) s/Int})
 

--- a/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
+++ b/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
@@ -129,7 +129,7 @@
         catalog (-> (get-in wire-catalogs [6 :empty])
                     (assoc :certname certname))]
     (svc-utils/call-with-single-quiet-pdb-instance
-     (assoc-in (svc-utils/create-config) [:command-processing :max-frame-size] "1024")
+     (assoc-in (svc-utils/create-config) [:command-processing :max-frame-size] 1024)
      (fn []
        (let [query-fn (partial query (tk-app/get-service svc-utils/*server* :PuppetDBServer))]
          (is (empty? (query-fn :nodes admin/query-api-version nil nil doall)))


### PR DESCRIPTION
previously we had a schema that was attempting to validate this as a string,
when it should have been an int.