### PR TITLE
(maint) change migrate trgm message to refer to 9.4

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1583,5 +1583,5 @@
        (str
         "Unable to install optimal indexing\n\n"
         "We are unable to create optimal indexes for your database.\n"
-        "For maximum index performance, we recommend using PostgreSQL 9.3 or\n"
+        "For maximum index performance, we require PostgreSQL 9.4 or\n"
         "greater.\n")))))


### PR DESCRIPTION
Previously this gave the impression that 9.3 was allowed.