### PR TITLE
(PDB-1984) Migrate CLI tools to wireformat v6 of reports

### DIFF
--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-304bebf8e5fc109ced84e8b086f9bcf8324f3d78.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-304bebf8e5fc109ced84e8b086f9bcf8324f3d78.json
@@ -1,191 +1,260 @@
 {
-  "transaction_uuid" : "6906e9f2-d15a-414d-928c-ec1eac4b5e92",
-  "puppet_version" : "3.7.4",
-  "noop" : true,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 0.29 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:22:54.288+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "defined 'message' as 'foo'",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
-    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:22:54.117+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "notice",
-    "message" : "foo",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:22:54.116+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423833741'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:22:54.054+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for pg1.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:22:53.904+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:22:51.695+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:22:51.23+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:22:51.192+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:22:51.075Z",
-  "end_time" : "2015-02-13T13:22:52.014Z",
-  "resource_events" : [ {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 3,
-    "resource_type" : "Notify",
-    "status" : "success",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:22:54.116Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
-    "message" : "defined 'message' as 'foo'"
-  } ],
-  "status" : "changed",
-  "configuration_version" : "1423833741",
-  "environment" : "production",
-  "certname" : "pg1.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 4.93414E-4,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.800477095,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.013962715,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.02031697,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 8.1892E-5,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.009883399,
-    "name" : "gnupg_key"
-  }, {
-    "category" : "time",
-    "value" : 3.83931E-4,
-    "name" : "ini_setting"
-  }, {
-    "category" : "time",
-    "value" : 0.001923986,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.018245457000000003,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 5.32156E-4,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.071825341,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 0.938319936,
-    "name" : "total"
-  }, {
-    "category" : "time",
-    "value" : 1.9358E-4,
-    "name" : "vcsrepo"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 47,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 1,
-    "name" : "total"
-  } ]
+    "certname": "pg1.vm",
+    "configuration_version": "1423833741",
+    "end_time": "2015-02-13T13:22:52.014Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 0.29 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:22:54.288+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 3,
+            "message": "defined 'message' as 'foo'",
+            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
+            "tags": [
+                "notice",
+                "notify",
+                "foo",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:22:54.117+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "foo",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:22:54.116+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423833741'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:22:54.054+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for pg1.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:22:53.904+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:22:51.695+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:22:51.23+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:22:51.192+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.000493414
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 0.800477095
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.013962715
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.02031697
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 8.1892e-05
+        },
+        {
+            "category": "time",
+            "name": "gnupg_key",
+            "value": 0.009883399
+        },
+        {
+            "category": "time",
+            "name": "ini_setting",
+            "value": 0.000383931
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.001923986
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.018245457000000003
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.000532156
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.071825341
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 0.938319936
+        },
+        {
+            "category": "time",
+            "name": "vcsrepo",
+            "value": 0.00019358
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 47
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 1
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 1
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 1
+        }
+    ],
+    "noop": true,
+    "puppet_version": "3.7.4",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "defined 'message' as 'foo'",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:22:54.116Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 3,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:22:54.116Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:22:51.075Z",
+    "status": "changed",
+    "transaction_uuid": "6906e9f2-d15a-414d-928c-ec1eac4b5e92"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-327147ee71a6e67db76112add34d49c674f97b4f.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-327147ee71a6e67db76112add34d49c674f97b4f.json
@@ -1,335 +1,559 @@
 {
-  "transaction_uuid" : "d00ab23c-bd14-42a5-b5ef-855ceede8a40",
-  "puppet_version" : "3.7.4",
-  "noop" : true,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 0.35 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:21:06.7+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 2 events",
-    "source" : "Stage[main]",
-    "tags" : [ "notice", "completed_stage", "main" ],
-    "time" : "2015-02-13T13:21:06.647+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 4 events",
-    "source" : "Class[Loadtest]",
-    "tags" : [ "notice", "completed_class", "loadtest" ],
-    "time" : "2015-02-13T13:21:06.64+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Concat::Fragment[tmpfile]",
-    "tags" : [ "notice", "completed_concat::fragment", "completed_concat", "fragment", "tmpfile" ],
-    "time" : "2015-02-13T13:21:06.613+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Concat[/tmp/file]",
-    "tags" : [ "notice", "completed_concat" ],
-    "time" : "2015-02-13T13:21:06.612+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 2 events",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-    "tags" : [ "notice", "exec", "concat", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:06.608+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-    "tags" : [ "info", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:06.589+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
-    "tags" : [ "notice", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:06.589+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "\n--- /var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile\t2015-02-13 13:05:05.021459942 +0000\n+++ /tmp/puppet-file20150213-9820-1huuxni\t2015-02-13 13:21:06.573472904 +0000\n@@ -1 +1 @@\n-test contents\n\\ No newline at end of file\n+test contents foo\n\\ No newline at end of file\n",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
-    "tags" : [ "notice", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm", "content" ],
-    "time" : "2015-02-13T13:21:06.588+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Concat::Fragment[tmpfile2]",
-    "tags" : [ "notice", "completed_concat::fragment", "completed_concat", "fragment", "tmpfile2" ],
-    "time" : "2015-02-13T13:21:06.577+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-    "tags" : [ "info", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:06.576+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be file (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
-    "tags" : [ "notice", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:06.575+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be foo (noop)",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
-    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:06.489+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Motd]",
-    "tags" : [ "notice", "completed_class", "motd" ],
-    "time" : "2015-02-13T13:21:06.445+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}a3bfa10444570ab20a2f7d563592294d (noop)",
-    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
-    "tags" : [ "notice", "file", "class", "motd", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:06.444+00:00",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "line" : 33
-  }, {
-    "level" : "notice",
-    "message" : "\n--- /etc/motd\t2015-02-13 13:06:12.997460859 +0000\n+++ /tmp/puppet-file20150213-9820-vsqcg9\t2015-02-13 13:21:06.425472902 +0000\n@@ -1 +1,3 @@\n-Welcome to my test host!\n\\ No newline at end of file\n+The operating system is Debian\n+The free memory is 203.97 MB\n+The domain is vm\n",
-    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
-    "tags" : [ "notice", "file", "class", "motd", "loadtest", "node", "pg1.vm", "content" ],
-    "time" : "2015-02-13T13:21:06.443+00:00",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "line" : 33
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423833650'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:06.412+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for pg1.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:06.268+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:03.917+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:03.481+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:03.442+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:21:03.326Z",
-  "end_time" : "2015-02-13T13:21:04.382Z",
-  "resource_events" : [ {
-    "new_value" : "{md5}a3bfa10444570ab20a2f7d563592294d",
-    "property" : "content",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "old_value" : "{md5}a3f731187a6aaaa23d4a7b244f223f33",
-    "line" : 33,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/etc/motd",
-    "timestamp" : "2015-02-13T13:21:06.444Z",
-    "containment_path" : [ "Stage[main]", "Motd", "File[/etc/motd]" ],
-    "message" : "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}a3bfa10444570ab20a2f7d563592294d (noop)"
-  }, {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 3,
-    "resource_type" : "Notify",
-    "status" : "noop",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:21:06.488Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
-    "message" : "current_value absent, should be foo (noop)"
-  }, {
-    "new_value" : "file",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "old_value" : "absent",
-    "line" : 113,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
-    "timestamp" : "2015-02-13T13:21:06.575Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat::Fragment[tmpfile2]", "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]" ],
-    "message" : "current_value absent, should be file (noop)"
-  }, {
-    "new_value" : "{md5}3a010064e9f94f26236ba1167c7ee125",
-    "property" : "content",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "old_value" : "{md5}df14e44b311152c34358a675ae34afe0",
-    "line" : 113,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
-    "timestamp" : "2015-02-13T13:21:06.589Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat::Fragment[tmpfile]", "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]" ],
-    "message" : "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)"
-  } ],
-  "status" : "unchanged",
-  "configuration_version" : "1423833650",
-  "environment" : "production",
-  "certname" : "pg1.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 5.503540000000001E-4,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.882534088,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.016960151,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.043997192,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 9.3244E-5,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.011448235,
-    "name" : "gnupg_key"
-  }, {
-    "category" : "time",
-    "value" : 3.85746E-4,
-    "name" : "ini_setting"
-  }, {
-    "category" : "time",
-    "value" : 0.00134731,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.019649724000000004,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 5.75223E-4,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.078253771,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 1.056010572,
-    "name" : "total"
-  }, {
-    "category" : "time",
-    "value" : 2.15534E-4,
-    "name" : "vcsrepo"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 4,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 47,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 4,
-    "name" : "noop"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 4,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 0,
-    "name" : "total"
-  } ]
+    "certname": "pg1.vm",
+    "configuration_version": "1423833650",
+    "end_time": "2015-02-13T13:21:04.382Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 0.35 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:21:06.7+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 2 events",
+            "source": "Stage[main]",
+            "tags": [
+                "notice",
+                "completed_stage",
+                "main"
+            ],
+            "time": "2015-02-13T13:21:06.647+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 4 events",
+            "source": "Class[Loadtest]",
+            "tags": [
+                "notice",
+                "completed_class",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:21:06.64+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Concat::Fragment[tmpfile]",
+            "tags": [
+                "notice",
+                "completed_concat::fragment",
+                "completed_concat",
+                "fragment",
+                "tmpfile"
+            ],
+            "time": "2015-02-13T13:21:06.613+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Concat[/tmp/file]",
+            "tags": [
+                "notice",
+                "completed_concat"
+            ],
+            "time": "2015-02-13T13:21:06.612+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 187,
+            "message": "Would have triggered 'refresh' from 2 events",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+            "tags": [
+                "notice",
+                "exec",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:06.608+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "info",
+            "line": 113,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+            "tags": [
+                "info",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:06.589+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "notice",
+            "line": 113,
+            "message": "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
+            "tags": [
+                "notice",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:06.589+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "notice",
+            "line": 113,
+            "message": "\n--- /var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile\t2015-02-13 13:05:05.021459942 +0000\n+++ /tmp/puppet-file20150213-9820-1huuxni\t2015-02-13 13:21:06.573472904 +0000\n@@ -1 +1 @@\n-test contents\n\\ No newline at end of file\n+test contents foo\n\\ No newline at end of file\n",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
+            "tags": [
+                "notice",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "content"
+            ],
+            "time": "2015-02-13T13:21:06.588+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Concat::Fragment[tmpfile2]",
+            "tags": [
+                "notice",
+                "completed_concat::fragment",
+                "completed_concat",
+                "fragment",
+                "tmpfile2"
+            ],
+            "time": "2015-02-13T13:21:06.577+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "info",
+            "line": 113,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+            "tags": [
+                "info",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile2",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:06.576+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "notice",
+            "line": 113,
+            "message": "current_value absent, should be file (noop)",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
+            "tags": [
+                "notice",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile2",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:06.575+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 3,
+            "message": "current_value absent, should be foo (noop)",
+            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
+            "tags": [
+                "notice",
+                "notify",
+                "foo",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:06.489+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Motd]",
+            "tags": [
+                "notice",
+                "completed_class",
+                "motd"
+            ],
+            "time": "2015-02-13T13:21:06.445+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "level": "notice",
+            "line": 33,
+            "message": "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}a3bfa10444570ab20a2f7d563592294d (noop)",
+            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
+            "tags": [
+                "notice",
+                "file",
+                "class",
+                "motd",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:06.444+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "level": "notice",
+            "line": 33,
+            "message": "\n--- /etc/motd\t2015-02-13 13:06:12.997460859 +0000\n+++ /tmp/puppet-file20150213-9820-vsqcg9\t2015-02-13 13:21:06.425472902 +0000\n@@ -1 +1,3 @@\n-Welcome to my test host!\n\\ No newline at end of file\n+The operating system is Debian\n+The free memory is 203.97 MB\n+The domain is vm\n",
+            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
+            "tags": [
+                "notice",
+                "file",
+                "class",
+                "motd",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "content"
+            ],
+            "time": "2015-02-13T13:21:06.443+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423833650'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:06.412+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for pg1.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:06.268+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:03.917+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:03.481+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:03.442+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.0005503540000000001
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 0.882534088
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.016960151
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.043997192
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 9.3244e-05
+        },
+        {
+            "category": "time",
+            "name": "gnupg_key",
+            "value": 0.011448235
+        },
+        {
+            "category": "time",
+            "name": "ini_setting",
+            "value": 0.000385746
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.00134731
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.019649724000000004
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.000575223
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.078253771
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 1.056010572
+        },
+        {
+            "category": "time",
+            "name": "vcsrepo",
+            "value": 0.000215534
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 4
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 47
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "noop",
+            "value": 4
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 4
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 0
+        }
+    ],
+    "noop": true,
+    "puppet_version": "3.7.4",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Motd",
+                "File[/etc/motd]"
+            ],
+            "events": [
+                {
+                    "message": "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}a3bfa10444570ab20a2f7d563592294d (noop)",
+                    "new_value": "{md5}a3bfa10444570ab20a2f7d563592294d",
+                    "old_value": "{md5}a3f731187a6aaaa23d4a7b244f223f33",
+                    "property": "content",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:21:06.444Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "line": 33,
+            "resource_title": "/etc/motd",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:21:06.444Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be foo (noop)",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:21:06.488Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 3,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:21:06.488Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat::Fragment[tmpfile2]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be file (noop)",
+                    "new_value": "file",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:21:06.575Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "line": 113,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:21:06.575Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat::Fragment[tmpfile]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]"
+            ],
+            "events": [
+                {
+                    "message": "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)",
+                    "new_value": "{md5}3a010064e9f94f26236ba1167c7ee125",
+                    "old_value": "{md5}df14e44b311152c34358a675ae34afe0",
+                    "property": "content",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:21:06.589Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "line": 113,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:21:06.589Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:21:03.326Z",
+    "status": "unchanged",
+    "transaction_uuid": "d00ab23c-bd14-42a5-b5ef-855ceede8a40"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-339914cdb0a7a9a7ca4c9c310ab96ba20649376f.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-339914cdb0a7a9a7ca4c9c310ab96ba20649376f.json
@@ -1,1623 +1,2759 @@
 {
-  "transaction_uuid" : "ac63fb6f-d191-4d8a-94af-995ccaadb7dd",
-  "puppet_version" : "3.7.4",
-  "noop" : true,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 0.39 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:21:16.622+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Stored state in 0.04 seconds",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.622+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Storing state",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.578+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Finishing transaction 10519500",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.578+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 2 events",
-    "source" : "Stage[main]",
-    "tags" : [ "notice", "completed_stage", "main" ],
-    "time" : "2015-02-13T13:21:16.577+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Nothing to manage: no ensure and the resource doesn't exist",
-    "source" : "/Package[gunicorn]",
-    "tags" : [ "debug", "package", "gunicorn", "class", "python::install", "python", "install", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.572+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 71
-  }, {
-    "level" : "debug",
-    "message" : "The container Stage[main] will propagate my refresh event",
-    "source" : "Class[Loadtest]",
-    "tags" : [ "debug", "completed_class", "loadtest" ],
-    "time" : "2015-02-13T13:21:16.57+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 4 events",
-    "source" : "Class[Loadtest]",
-    "tags" : [ "notice", "completed_class", "loadtest" ],
-    "time" : "2015-02-13T13:21:16.569+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Executing '/etc/init.d/snmpd status'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.547+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "The container Class[Loadtest] will propagate my refresh event",
-    "source" : "Concat::Fragment[tmpfile]",
-    "tags" : [ "debug", "completed_concat::fragment", "completed_concat", "fragment", "tmpfile" ],
-    "time" : "2015-02-13T13:21:16.545+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Concat::Fragment[tmpfile]",
-    "tags" : [ "notice", "completed_concat::fragment", "completed_concat", "fragment", "tmpfile" ],
-    "time" : "2015-02-13T13:21:16.544+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "The container Class[Loadtest] will propagate my refresh event",
-    "source" : "Concat[/tmp/file]",
-    "tags" : [ "debug", "completed_concat" ],
-    "time" : "2015-02-13T13:21:16.544+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Concat[/tmp/file]",
-    "tags" : [ "notice", "completed_concat" ],
-    "time" : "2015-02-13T13:21:16.543+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "The container Concat[/tmp/file] will propagate my refresh event",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.541+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 2 events",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-    "tags" : [ "notice", "exec", "concat", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.54+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "debug",
-    "message" : "Executing '/var/lib/puppet/concat/bin/concatfragments.sh -o \"/var/lib/puppet/concat/_tmp_file/fragments.concat.out\" -d \"/var/lib/puppet/concat/_tmp_file\" -t'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.526+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Executing check '/var/lib/puppet/concat/bin/concatfragments.sh -o \"/var/lib/puppet/concat/_tmp_file/fragments.concat.out\" -d \"/var/lib/puppet/concat/_tmp_file\" -t'",
-    "source" : "Exec[concat_/tmp/file](provider=posix)",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.525+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "The container Concat::Fragment[tmpfile] will propagate my refresh event",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-    "tags" : [ "debug", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.524+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-    "tags" : [ "info", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.523+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
-    "tags" : [ "notice", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.523+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "\n--- /var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile\t2015-02-13 13:05:05.021459942 +0000\n+++ /tmp/puppet-file20150213-10108-1ebmfcz\t2015-02-13 13:21:16.509473038 +0000\n@@ -1 +1 @@\n-test contents\n\\ No newline at end of file\n+test contents foo\n\\ No newline at end of file\n",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
-    "tags" : [ "notice", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm", "content" ],
-    "time" : "2015-02-13T13:21:16.522+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "debug",
-    "message" : "Executing 'diff -u /var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile /tmp/puppet-file20150213-10108-1ebmfcz'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.513+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "The container Class[Loadtest] will propagate my refresh event",
-    "source" : "Concat::Fragment[tmpfile2]",
-    "tags" : [ "debug", "completed_concat::fragment", "completed_concat", "fragment", "tmpfile2" ],
-    "time" : "2015-02-13T13:21:16.511+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Concat::Fragment[tmpfile2]",
-    "tags" : [ "notice", "completed_concat::fragment", "completed_concat", "fragment", "tmpfile2" ],
-    "time" : "2015-02-13T13:21:16.511+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "The container Concat::Fragment[tmpfile2] will propagate my refresh event",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-    "tags" : [ "debug", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.51+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-    "tags" : [ "info", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.509+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be file (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
-    "tags" : [ "notice", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.508+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "debug",
-    "message" : "Executing 'gpg --list-keys --with-colons 20BC0A86'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.47+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Executing '/etc/init.d/ntp status'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.433+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Executing '/etc/init.d/cron status'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.395+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "The container Class[Loadtest] will propagate my refresh event",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]",
-    "tags" : [ "debug", "notify", "foo", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.394+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be foo (noop)",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
-    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.393+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "debug",
-    "message" : "Executing '/usr/bin/apt-cache policy etckeeper'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.375+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Executing '/usr/bin/dpkg-query -W --showformat '${Status} ${Package} ${Version}\\n''",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.352+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Prefetching apt resources for package",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.351+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "The container Stage[main] will propagate my refresh event",
-    "source" : "Class[Motd]",
-    "tags" : [ "debug", "completed_class", "motd" ],
-    "time" : "2015-02-13T13:21:16.35+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Motd]",
-    "tags" : [ "notice", "completed_class", "motd" ],
-    "time" : "2015-02-13T13:21:16.349+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "The container Class[Motd] will propagate my refresh event",
-    "source" : "/Stage[main]/Motd/File[/etc/motd]",
-    "tags" : [ "debug", "file", "class", "motd", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.349+00:00",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "line" : 33
-  }, {
-    "level" : "notice",
-    "message" : "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}6e10c92cc7cd37f8033108d9555eb33a (noop)",
-    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
-    "tags" : [ "notice", "file", "class", "motd", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.348+00:00",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "line" : 33
-  }, {
-    "level" : "notice",
-    "message" : "\n--- /etc/motd\t2015-02-13 13:06:12.997460859 +0000\n+++ /tmp/puppet-file20150213-10108-1epr0sd\t2015-02-13 13:21:16.333473035 +0000\n@@ -1 +1,3 @@\n-Welcome to my test host!\n\\ No newline at end of file\n+The operating system is Debian\n+The free memory is 204.09 MB\n+The domain is vm\n",
-    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
-    "tags" : [ "notice", "file", "class", "motd", "loadtest", "node", "pg1.vm", "content" ],
-    "time" : "2015-02-13T13:21:16.347+00:00",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "line" : 33
-  }, {
-    "level" : "debug",
-    "message" : "Executing 'diff -u /etc/motd /tmp/puppet-file20150213-10108-1epr0sd'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.338+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Caching connection for https://puppet:8140",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.335+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Using cached connection for https://puppet:8140",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.327+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "file_metadata supports formats: pson b64_zlib_yaml yaml raw",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.327+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Network::Format[msgpack]: feature msgpack is missing",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.326+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Failed to load library 'msgpack' for feature 'msgpack'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.325+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423833650'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:16.316+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Autorequiring File[/var/lib/puppet/concat/_tmp_file/fragments]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-    "tags" : [ "debug", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.305+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "debug",
-    "message" : "Autorequiring File[/var/lib/puppet/concat/_tmp_file/fragments]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-    "tags" : [ "debug", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.304+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "debug",
-    "message" : "Autorequiring File[/var/lib/puppet/concat/bin/concatfragments.sh]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.304+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "debug",
-    "message" : "Autorequiring File[/var/lib/puppet/concat/_tmp_file]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]",
-    "tags" : [ "debug", "file", "concat", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.303+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 164
-  }, {
-    "level" : "debug",
-    "message" : "Autorequiring File[/var/lib/puppet/concat/_tmp_file]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]",
-    "tags" : [ "debug", "file", "concat", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.302+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 159
-  }, {
-    "level" : "debug",
-    "message" : "Autorequiring File[/var/lib/puppet/concat/_tmp_file]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
-    "tags" : [ "debug", "file", "concat", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.301+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 149
-  }, {
-    "level" : "debug",
-    "message" : "Autorequiring File[/var/lib/puppet/concat]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
-    "tags" : [ "debug", "file", "concat", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.3+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 144
-  }, {
-    "level" : "debug",
-    "message" : "Autorequiring File[/var/lib/puppet/concat]",
-    "source" : "/Stage[main]/Concat::Setup/File[/var/lib/puppet/concat/bin]",
-    "tags" : [ "debug", "file", "class", "concat::setup", "concat", "setup", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.3+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/setup.pp",
-    "line" : 60
-  }, {
-    "level" : "debug",
-    "message" : "Autorequiring File[/var/lib/puppet/concat/bin]",
-    "source" : "/Stage[main]/Concat::Setup/File[/var/lib/puppet/concat/bin/concatfragments.sh]",
-    "tags" : [ "debug", "file", "class", "concat::setup", "concat", "setup", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.299+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/setup.pp",
-    "line" : 53
-  }, {
-    "level" : "debug",
-    "message" : "Autorequiring Package[gnupg]",
-    "source" : "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]",
-    "tags" : [ "debug", "gnupg_key", "hkp_server_20bc0a86", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.298+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 69
-  }, {
-    "level" : "debug",
-    "message" : "Autorequiring Package[git]",
-    "source" : "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
-    "tags" : [ "debug", "vcsrepo", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.295+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 11
-  }, {
-    "level" : "debug",
-    "message" : "subscribes to Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/notify",
-    "tags" : [ "debug", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm", "notify" ],
-    "time" : "2015-02-13T13:21:16.294+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "debug",
-    "message" : "subscribes to Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/notify",
-    "tags" : [ "debug", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm", "notify" ],
-    "time" : "2015-02-13T13:21:16.293+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "debug",
-    "message" : "subscribes to File[/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/notify",
-    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm", "notify" ],
-    "time" : "2015-02-13T13:21:16.292+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "debug",
-    "message" : "subscribes to File[/var/lib/puppet/concat/_tmp_file]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/subscribe",
-    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm", "subscribe" ],
-    "time" : "2015-02-13T13:21:16.291+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "debug",
-    "message" : "requires File[/var/lib/puppet/concat/_tmp_file/fragments.concat]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/require",
-    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm", "require" ],
-    "time" : "2015-02-13T13:21:16.29+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "debug",
-    "message" : "requires File[/var/lib/puppet/concat/_tmp_file/fragments]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/require",
-    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm", "require" ],
-    "time" : "2015-02-13T13:21:16.29+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "debug",
-    "message" : "requires File[/var/lib/puppet/concat/_tmp_file]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/require",
-    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm", "require" ],
-    "time" : "2015-02-13T13:21:16.289+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "debug",
-    "message" : "subscribes to Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/notify",
-    "tags" : [ "debug", "file", "concat", "class", "loadtest", "node", "pg1.vm", "notify" ],
-    "time" : "2015-02-13T13:21:16.289+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 149
-  }, {
-    "level" : "debug",
-    "message" : "requires Anchor[python::end]",
-    "source" : "/Stage[main]/Python::Config/before",
-    "tags" : [ "debug", "class", "python::config", "python", "config", "loadtest", "node", "pg1.vm", "before" ],
-    "time" : "2015-02-13T13:21:16.288+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/init.pp",
-    "line" : 92
-  }, {
-    "level" : "debug",
-    "message" : "requires Class[Python::Config]",
-    "source" : "/Stage[main]/Python::Install/before",
-    "tags" : [ "debug", "class", "python::install", "python", "install", "loadtest", "node", "pg1.vm", "before" ],
-    "time" : "2015-02-13T13:21:16.287+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/init.pp",
-    "line" : 91
-  }, {
-    "level" : "debug",
-    "message" : "requires Class[Python::Install]",
-    "source" : "/Stage[main]/Python/Anchor[python::begin]/before",
-    "tags" : [ "debug", "anchor", "python::begin", "python", "begin", "class", "loadtest", "node", "pg1.vm", "before" ],
-    "time" : "2015-02-13T13:21:16.286+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/init.pp",
-    "line" : 90
-  }, {
-    "level" : "debug",
-    "message" : "requires File[var-net-snmp]",
-    "source" : "/Stage[main]/Snmp/Service[snmpd]/require",
-    "tags" : [ "debug", "service", "snmpd", "class", "snmp", "loadtest", "node", "pg1.vm", "require" ],
-    "time" : "2015-02-13T13:21:16.286+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 517
-  }, {
-    "level" : "debug",
-    "message" : "requires Package[snmpd]",
-    "source" : "/Stage[main]/Snmp/Service[snmpd]/require",
-    "tags" : [ "debug", "service", "snmpd", "class", "snmp", "loadtest", "node", "pg1.vm", "require" ],
-    "time" : "2015-02-13T13:21:16.285+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 517
-  }, {
-    "level" : "debug",
-    "message" : "subscribes to Service[snmpd]",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]/notify",
-    "tags" : [ "debug", "file", "snmptrapd.conf", "class", "snmp", "loadtest", "node", "pg1.vm", "notify" ],
-    "time" : "2015-02-13T13:21:16.284+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 453
-  }, {
-    "level" : "debug",
-    "message" : "requires Package[snmpd]",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]/require",
-    "tags" : [ "debug", "file", "snmptrapd.conf", "class", "snmp", "loadtest", "node", "pg1.vm", "require" ],
-    "time" : "2015-02-13T13:21:16.283+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 453
-  }, {
-    "level" : "debug",
-    "message" : "subscribes to Service[snmpd]",
-    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]/notify",
-    "tags" : [ "debug", "file", "snmpd.sysconfig", "class", "snmp", "loadtest", "node", "pg1.vm", "notify" ],
-    "time" : "2015-02-13T13:21:16.282+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 441
-  }, {
-    "level" : "debug",
-    "message" : "requires Package[snmpd]",
-    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]/require",
-    "tags" : [ "debug", "file", "snmpd.sysconfig", "class", "snmp", "loadtest", "node", "pg1.vm", "require" ],
-    "time" : "2015-02-13T13:21:16.282+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 441
-  }, {
-    "level" : "debug",
-    "message" : "subscribes to Service[snmpd]",
-    "source" : "/Stage[main]/Snmp/File[snmpd.conf]/notify",
-    "tags" : [ "debug", "file", "snmpd.conf", "class", "snmp", "loadtest", "node", "pg1.vm", "notify" ],
-    "time" : "2015-02-13T13:21:16.281+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 429
-  }, {
-    "level" : "debug",
-    "message" : "requires Package[snmpd]",
-    "source" : "/Stage[main]/Snmp/File[snmpd.conf]/require",
-    "tags" : [ "debug", "file", "snmpd.conf", "class", "snmp", "loadtest", "node", "pg1.vm", "require" ],
-    "time" : "2015-02-13T13:21:16.28+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 429
-  }, {
-    "level" : "debug",
-    "message" : "requires Package[snmpd]",
-    "source" : "/Stage[main]/Snmp/File[var-net-snmp]/require",
-    "tags" : [ "debug", "file", "var-net-snmp", "class", "snmp", "loadtest", "node", "pg1.vm", "require" ],
-    "time" : "2015-02-13T13:21:16.279+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 410
-  }, {
-    "level" : "debug",
-    "message" : "requires Package[snmp-client]",
-    "source" : "/Stage[main]/Snmp::Client/File[snmp.conf]/require",
-    "tags" : [ "debug", "file", "snmp.conf", "class", "snmp::client", "snmp", "client", "loadtest", "node", "pg1.vm", "require" ],
-    "time" : "2015-02-13T13:21:16.279+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "line" : 85
-  }, {
-    "level" : "debug",
-    "message" : "requires Anchor[ntp::end]",
-    "source" : "/Stage[main]/Ntp::Service/before",
-    "tags" : [ "debug", "class", "ntp::service", "ntp", "service", "loadtest", "node", "pg1.vm", "before" ],
-    "time" : "2015-02-13T13:21:16.278+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/init.pp",
-    "line" : 61
-  }, {
-    "level" : "debug",
-    "message" : "subscribes to Class[Ntp::Service]",
-    "source" : "/Stage[main]/Ntp::Config/notify",
-    "tags" : [ "debug", "class", "ntp::config", "ntp", "config", "loadtest", "node", "pg1.vm", "notify" ],
-    "time" : "2015-02-13T13:21:16.277+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/init.pp",
-    "line" : 60
-  }, {
-    "level" : "debug",
-    "message" : "requires Class[Ntp::Config]",
-    "source" : "/Stage[main]/Ntp::Install/before",
-    "tags" : [ "debug", "class", "ntp::install", "ntp", "install", "loadtest", "node", "pg1.vm", "before" ],
-    "time" : "2015-02-13T13:21:16.276+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/init.pp",
-    "line" : 59
-  }, {
-    "level" : "debug",
-    "message" : "requires Class[Ntp::Install]",
-    "source" : "/Stage[main]/Ntp/Anchor[ntp::begin]/before",
-    "tags" : [ "debug", "anchor", "ntp::begin", "ntp", "begin", "class", "loadtest", "node", "pg1.vm", "before" ],
-    "time" : "2015-02-13T13:21:16.271+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/init.pp",
-    "line" : 58
-  }, {
-    "level" : "debug",
-    "message" : "Loaded state in 0.04 seconds",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.269+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Creating default schedules",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.207+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[gnupg]",
-    "tags" : [ "debug", "package", "gnupg", "class", "gnupg::install", "install", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.19+00:00",
-    "file" : "/etc/puppet/modules/gnupg/manifests/install.pp",
-    "line" : 4
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[gunicorn]",
-    "tags" : [ "debug", "package", "gunicorn", "class", "python::install", "python", "install", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.187+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 71
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[python]",
-    "tags" : [ "debug", "package", "python", "class", "python::install", "install", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.186+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 62
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[python-dev]",
-    "tags" : [ "debug", "package", "python-dev", "class", "python::install", "python", "install", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.185+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 61
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[python-pip]",
-    "tags" : [ "debug", "package", "python-pip", "class", "python::install", "python", "install", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.184+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 60
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[python-virtualenv]",
-    "tags" : [ "debug", "package", "python-virtualenv", "class", "python::install", "python", "install", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.183+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 59
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[snmpd]",
-    "tags" : [ "debug", "package", "snmpd", "class", "snmp", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.177+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 405
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[snmp-client]",
-    "tags" : [ "debug", "package", "snmp-client", "class", "snmp::client", "snmp", "client", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.175+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "line" : 76
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[git]",
-    "tags" : [ "debug", "package", "git", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.172+00:00",
-    "file" : "/etc/puppet/modules/git/manifests/init.pp",
-    "line" : 12
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[etckeeper]",
-    "tags" : [ "debug", "package", "etckeeper", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.17+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 41
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Vcsrepo::ProviderCvs: file cvs does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.165+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Vcsrepo::ProviderHg: file hg does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.164+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Vcsrepo::ProviderSvn: file svn does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.163+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Vcsrepo::ProviderBzr: file bzr does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.163+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[ntp]",
-    "tags" : [ "debug", "package", "ntp", "class", "ntp::install", "install", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:16.159+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/install.pp",
-    "line" : 4
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Service::ProviderRunit: file /usr/bin/sv does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.155+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Service::ProviderGentoo: file /sbin/rc-update does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.155+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Service::ProviderLaunchd: file /bin/launchctl does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.154+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Service::ProviderUpstart: 0 confines (of 2) were true",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.154+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Service::ProviderOpenrc: file /bin/rc-status does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.153+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Service::ProviderDaemontools: file /usr/bin/svc does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.153+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Service::ProviderRedhat: file /sbin/chkconfig does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.152+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Service::ProviderSystemd: file systemctl does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:16.152+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for pg1.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:16.135+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Caching connection for https://puppet:8140",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:15.783+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Using cached connection for https://puppet:8140",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:15.35+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "catalog supports formats: pson b64_zlib_yaml yaml dot raw",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:15.349+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Network::Format[msgpack]: feature msgpack is missing",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:15.349+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Failed to load library 'msgpack' for feature 'msgpack'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:15.348+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Executing '/usr/bin/dpkg-query -W --showformat '${Status} ${Package} ${Version}\\n' python'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:15.302+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[python]",
-    "tags" : [ "debug", "package", "python" ],
-    "time" : "2015-02-13T13:21:14.371+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[python-pip]",
-    "tags" : [ "debug", "package", "python-pip" ],
-    "time" : "2015-02-13T13:21:14.369+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-    "source" : "/Package[virtualenv]",
-    "tags" : [ "debug", "package", "virtualenv" ],
-    "time" : "2015-02-13T13:21:14.368+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderPacman: file /usr/bin/pacman does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.367+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderPkg: file /usr/bin/pkg does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.366+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderZypper: file /usr/bin/zypper does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.366+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderAptrpm: file rpm does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.365+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderSunfreeware: file pkg-get does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.365+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderHpux: file /usr/sbin/swinstall does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.364+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderNim: file /usr/sbin/nimclient does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.364+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderUrpmi: file urpmi does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.363+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderUp2date: file /usr/sbin/up2date-nox does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.362+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderRug: file /usr/bin/rug does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.362+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderPortupgrade: file /usr/local/sbin/portupgrade does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.362+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderYum: file yum does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.361+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderRpm: file rpm does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.361+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderFink: file /sw/bin/fink does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.36+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderPorts: file /usr/local/sbin/portupgrade does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.359+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderFreebsd: file /usr/sbin/pkg_info does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.359+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderOpenbsd: file pkg_info does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.358+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderOpkg: file opkg does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.358+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderPkgin: file pkgin does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.357+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderSun: file /usr/bin/pkginfo does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.357+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderPortage: file /usr/bin/emerge does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.356+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Type::Package::ProviderAix: file /usr/bin/lslpp does not exist",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:14.355+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/puppet_vardir.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.849+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/root_home.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.849+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/ip6tables_version.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.849+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/git_version.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.848+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/facter_dot_d.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.848+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/iptables_version.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.847+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/python_version.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.847+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/git_exec_path.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.846+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/apt_package_updates.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.846+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/git_html_path.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.846+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/pip_version.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.845+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/virtualenv_version.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.845+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/concat_basedir.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.844+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/apt_security_updates.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.844+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/apt_updates.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.843+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/pe_version.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.843+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading facts from /var/lib/puppet/lib/facter/iptables_persistent_version.rb",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.842+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:13.842+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Loading external facts from /var/lib/puppet/facts.d",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.841+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Finishing transaction 11350920",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.82+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Caching connection for https://puppet:8140",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.6+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Using cached connection for https://puppet:8140",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.56+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "file_metadata supports formats: pson b64_zlib_yaml yaml raw",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.559+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Network::Format[msgpack]: feature msgpack is missing",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.559+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Failed to load library 'msgpack' for feature 'msgpack'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.558+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:13.401+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Finishing transaction 21451200",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.4+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Caching connection for https://puppet:8140",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.398+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Using cached connection for https://puppet:8140",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.39+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "file_metadata supports formats: pson b64_zlib_yaml yaml raw",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.389+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Network::Format[msgpack]: feature msgpack is missing",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.389+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Failed to load library 'msgpack' for feature 'msgpack'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.388+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:13.365+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Caching connection for https://puppet:8140",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.35+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Starting connection for https://puppet:8140",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.305+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Using cached certificate_revocation_list for ca",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.305+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Creating new connection for https://puppet:8140",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.304+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Using cached certificate for pg1.vm",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.304+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Using cached certificate for ca",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.303+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "node supports formats: pson b64_zlib_yaml yaml raw",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.302+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Puppet::Network::Format[msgpack]: feature msgpack is missing",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.301+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "debug",
-    "message" : "Failed to load library 'msgpack' for feature 'msgpack'",
-    "source" : "Puppet",
-    "tags" : [ "debug" ],
-    "time" : "2015-02-13T13:21:13.301+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:21:13.238Z",
-  "end_time" : "2015-02-13T13:21:14.240Z",
-  "resource_events" : [ {
-    "new_value" : "{md5}6e10c92cc7cd37f8033108d9555eb33a",
-    "property" : "content",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "old_value" : "{md5}a3f731187a6aaaa23d4a7b244f223f33",
-    "line" : 33,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/etc/motd",
-    "timestamp" : "2015-02-13T13:21:16.348Z",
-    "containment_path" : [ "Stage[main]", "Motd", "File[/etc/motd]" ],
-    "message" : "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}6e10c92cc7cd37f8033108d9555eb33a (noop)"
-  }, {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 3,
-    "resource_type" : "Notify",
-    "status" : "noop",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:21:16.393Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
-    "message" : "current_value absent, should be foo (noop)"
-  }, {
-    "new_value" : "file",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "old_value" : "absent",
-    "line" : 113,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
-    "timestamp" : "2015-02-13T13:21:16.508Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat::Fragment[tmpfile2]", "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]" ],
-    "message" : "current_value absent, should be file (noop)"
-  }, {
-    "new_value" : "{md5}3a010064e9f94f26236ba1167c7ee125",
-    "property" : "content",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "old_value" : "{md5}df14e44b311152c34358a675ae34afe0",
-    "line" : 113,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
-    "timestamp" : "2015-02-13T13:21:16.523Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat::Fragment[tmpfile]", "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]" ],
-    "message" : "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)"
-  } ],
-  "status" : "unchanged",
-  "configuration_version" : "1423833650",
-  "environment" : "production",
-  "certname" : "pg1.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 5.24479E-4,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.809646404,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.015701975,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.04500305600000001,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 1.15401E-4,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.0245873,
-    "name" : "gnupg_key"
-  }, {
-    "category" : "time",
-    "value" : 3.74412E-4,
-    "name" : "ini_setting"
-  }, {
-    "category" : "time",
-    "value" : 0.00119644,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.018980525999999994,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 5.5239E-4,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.085381164,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 1.0023958039999998,
-    "name" : "total"
-  }, {
-    "category" : "time",
-    "value" : 3.32257E-4,
-    "name" : "vcsrepo"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 4,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 47,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 4,
-    "name" : "noop"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 4,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 0,
-    "name" : "total"
-  } ]
+    "certname": "pg1.vm",
+    "configuration_version": "1423833650",
+    "end_time": "2015-02-13T13:21:14.240Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 0.39 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:21:16.622+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Stored state in 0.04 seconds",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.622+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Storing state",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.578+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Finishing transaction 10519500",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.578+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 2 events",
+            "source": "Stage[main]",
+            "tags": [
+                "notice",
+                "completed_stage",
+                "main"
+            ],
+            "time": "2015-02-13T13:21:16.577+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "debug",
+            "line": 71,
+            "message": "Nothing to manage: no ensure and the resource doesn't exist",
+            "source": "/Package[gunicorn]",
+            "tags": [
+                "debug",
+                "package",
+                "gunicorn",
+                "class",
+                "python::install",
+                "python",
+                "install",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.572+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "The container Stage[main] will propagate my refresh event",
+            "source": "Class[Loadtest]",
+            "tags": [
+                "debug",
+                "completed_class",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:21:16.57+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 4 events",
+            "source": "Class[Loadtest]",
+            "tags": [
+                "notice",
+                "completed_class",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:21:16.569+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Executing '/etc/init.d/snmpd status'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.547+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "The container Class[Loadtest] will propagate my refresh event",
+            "source": "Concat::Fragment[tmpfile]",
+            "tags": [
+                "debug",
+                "completed_concat::fragment",
+                "completed_concat",
+                "fragment",
+                "tmpfile"
+            ],
+            "time": "2015-02-13T13:21:16.545+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Concat::Fragment[tmpfile]",
+            "tags": [
+                "notice",
+                "completed_concat::fragment",
+                "completed_concat",
+                "fragment",
+                "tmpfile"
+            ],
+            "time": "2015-02-13T13:21:16.544+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "The container Class[Loadtest] will propagate my refresh event",
+            "source": "Concat[/tmp/file]",
+            "tags": [
+                "debug",
+                "completed_concat"
+            ],
+            "time": "2015-02-13T13:21:16.544+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Concat[/tmp/file]",
+            "tags": [
+                "notice",
+                "completed_concat"
+            ],
+            "time": "2015-02-13T13:21:16.543+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "debug",
+            "line": 187,
+            "message": "The container Concat[/tmp/file] will propagate my refresh event",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+            "tags": [
+                "debug",
+                "exec",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.541+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 187,
+            "message": "Would have triggered 'refresh' from 2 events",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+            "tags": [
+                "notice",
+                "exec",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.54+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Executing '/var/lib/puppet/concat/bin/concatfragments.sh -o \"/var/lib/puppet/concat/_tmp_file/fragments.concat.out\" -d \"/var/lib/puppet/concat/_tmp_file\" -t'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.526+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Executing check '/var/lib/puppet/concat/bin/concatfragments.sh -o \"/var/lib/puppet/concat/_tmp_file/fragments.concat.out\" -d \"/var/lib/puppet/concat/_tmp_file\" -t'",
+            "source": "Exec[concat_/tmp/file](provider=posix)",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.525+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "debug",
+            "line": 113,
+            "message": "The container Concat::Fragment[tmpfile] will propagate my refresh event",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+            "tags": [
+                "debug",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.524+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "info",
+            "line": 113,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+            "tags": [
+                "info",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.523+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "notice",
+            "line": 113,
+            "message": "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
+            "tags": [
+                "notice",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.523+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "notice",
+            "line": 113,
+            "message": "\n--- /var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile\t2015-02-13 13:05:05.021459942 +0000\n+++ /tmp/puppet-file20150213-10108-1ebmfcz\t2015-02-13 13:21:16.509473038 +0000\n@@ -1 +1 @@\n-test contents\n\\ No newline at end of file\n+test contents foo\n\\ No newline at end of file\n",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
+            "tags": [
+                "notice",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "content"
+            ],
+            "time": "2015-02-13T13:21:16.522+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Executing 'diff -u /var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile /tmp/puppet-file20150213-10108-1ebmfcz'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.513+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "The container Class[Loadtest] will propagate my refresh event",
+            "source": "Concat::Fragment[tmpfile2]",
+            "tags": [
+                "debug",
+                "completed_concat::fragment",
+                "completed_concat",
+                "fragment",
+                "tmpfile2"
+            ],
+            "time": "2015-02-13T13:21:16.511+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Concat::Fragment[tmpfile2]",
+            "tags": [
+                "notice",
+                "completed_concat::fragment",
+                "completed_concat",
+                "fragment",
+                "tmpfile2"
+            ],
+            "time": "2015-02-13T13:21:16.511+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "debug",
+            "line": 113,
+            "message": "The container Concat::Fragment[tmpfile2] will propagate my refresh event",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+            "tags": [
+                "debug",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile2",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.51+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "info",
+            "line": 113,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+            "tags": [
+                "info",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile2",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.509+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "notice",
+            "line": 113,
+            "message": "current_value absent, should be file (noop)",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
+            "tags": [
+                "notice",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile2",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.508+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Executing 'gpg --list-keys --with-colons 20BC0A86'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.47+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Executing '/etc/init.d/ntp status'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.433+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Executing '/etc/init.d/cron status'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.395+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "debug",
+            "line": 3,
+            "message": "The container Class[Loadtest] will propagate my refresh event",
+            "source": "/Stage[main]/Loadtest/Notify[foo]",
+            "tags": [
+                "debug",
+                "notify",
+                "foo",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.394+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 3,
+            "message": "current_value absent, should be foo (noop)",
+            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
+            "tags": [
+                "notice",
+                "notify",
+                "foo",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.393+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Executing '/usr/bin/apt-cache policy etckeeper'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.375+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Executing '/usr/bin/dpkg-query -W --showformat '${Status} ${Package} ${Version}\\n''",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.352+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Prefetching apt resources for package",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.351+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "The container Stage[main] will propagate my refresh event",
+            "source": "Class[Motd]",
+            "tags": [
+                "debug",
+                "completed_class",
+                "motd"
+            ],
+            "time": "2015-02-13T13:21:16.35+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Motd]",
+            "tags": [
+                "notice",
+                "completed_class",
+                "motd"
+            ],
+            "time": "2015-02-13T13:21:16.349+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "level": "debug",
+            "line": 33,
+            "message": "The container Class[Motd] will propagate my refresh event",
+            "source": "/Stage[main]/Motd/File[/etc/motd]",
+            "tags": [
+                "debug",
+                "file",
+                "class",
+                "motd",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.349+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "level": "notice",
+            "line": 33,
+            "message": "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}6e10c92cc7cd37f8033108d9555eb33a (noop)",
+            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
+            "tags": [
+                "notice",
+                "file",
+                "class",
+                "motd",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.348+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "level": "notice",
+            "line": 33,
+            "message": "\n--- /etc/motd\t2015-02-13 13:06:12.997460859 +0000\n+++ /tmp/puppet-file20150213-10108-1epr0sd\t2015-02-13 13:21:16.333473035 +0000\n@@ -1 +1,3 @@\n-Welcome to my test host!\n\\ No newline at end of file\n+The operating system is Debian\n+The free memory is 204.09 MB\n+The domain is vm\n",
+            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
+            "tags": [
+                "notice",
+                "file",
+                "class",
+                "motd",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "content"
+            ],
+            "time": "2015-02-13T13:21:16.347+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Executing 'diff -u /etc/motd /tmp/puppet-file20150213-10108-1epr0sd'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.338+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Caching connection for https://puppet:8140",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.335+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Using cached connection for https://puppet:8140",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.327+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "file_metadata supports formats: pson b64_zlib_yaml yaml raw",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.327+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Network::Format[msgpack]: feature msgpack is missing",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.326+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Failed to load library 'msgpack' for feature 'msgpack'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.325+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423833650'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:16.316+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "debug",
+            "line": 113,
+            "message": "Autorequiring File[/var/lib/puppet/concat/_tmp_file/fragments]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+            "tags": [
+                "debug",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile2",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.305+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "debug",
+            "line": 113,
+            "message": "Autorequiring File[/var/lib/puppet/concat/_tmp_file/fragments]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+            "tags": [
+                "debug",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.304+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "debug",
+            "line": 187,
+            "message": "Autorequiring File[/var/lib/puppet/concat/bin/concatfragments.sh]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+            "tags": [
+                "debug",
+                "exec",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.304+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "debug",
+            "line": 164,
+            "message": "Autorequiring File[/var/lib/puppet/concat/_tmp_file]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]",
+            "tags": [
+                "debug",
+                "file",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.303+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "debug",
+            "line": 159,
+            "message": "Autorequiring File[/var/lib/puppet/concat/_tmp_file]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]",
+            "tags": [
+                "debug",
+                "file",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.302+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "debug",
+            "line": 149,
+            "message": "Autorequiring File[/var/lib/puppet/concat/_tmp_file]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
+            "tags": [
+                "debug",
+                "file",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.301+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "debug",
+            "line": 144,
+            "message": "Autorequiring File[/var/lib/puppet/concat]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
+            "tags": [
+                "debug",
+                "file",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.3+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/setup.pp",
+            "level": "debug",
+            "line": 60,
+            "message": "Autorequiring File[/var/lib/puppet/concat]",
+            "source": "/Stage[main]/Concat::Setup/File[/var/lib/puppet/concat/bin]",
+            "tags": [
+                "debug",
+                "file",
+                "class",
+                "concat::setup",
+                "concat",
+                "setup",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.3+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/setup.pp",
+            "level": "debug",
+            "line": 53,
+            "message": "Autorequiring File[/var/lib/puppet/concat/bin]",
+            "source": "/Stage[main]/Concat::Setup/File[/var/lib/puppet/concat/bin/concatfragments.sh]",
+            "tags": [
+                "debug",
+                "file",
+                "class",
+                "concat::setup",
+                "concat",
+                "setup",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.299+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "debug",
+            "line": 69,
+            "message": "Autorequiring Package[gnupg]",
+            "source": "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]",
+            "tags": [
+                "debug",
+                "gnupg_key",
+                "hkp_server_20bc0a86",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.298+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "debug",
+            "line": 11,
+            "message": "Autorequiring Package[git]",
+            "source": "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
+            "tags": [
+                "debug",
+                "vcsrepo",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.295+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "debug",
+            "line": 113,
+            "message": "subscribes to Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/notify",
+            "tags": [
+                "debug",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile2",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "notify"
+            ],
+            "time": "2015-02-13T13:21:16.294+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "debug",
+            "line": 113,
+            "message": "subscribes to Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/notify",
+            "tags": [
+                "debug",
+                "file",
+                "concat::fragment",
+                "concat",
+                "fragment",
+                "tmpfile",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "notify"
+            ],
+            "time": "2015-02-13T13:21:16.293+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "debug",
+            "line": 187,
+            "message": "subscribes to File[/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/notify",
+            "tags": [
+                "debug",
+                "exec",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "notify"
+            ],
+            "time": "2015-02-13T13:21:16.292+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "debug",
+            "line": 187,
+            "message": "subscribes to File[/var/lib/puppet/concat/_tmp_file]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/subscribe",
+            "tags": [
+                "debug",
+                "exec",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "subscribe"
+            ],
+            "time": "2015-02-13T13:21:16.291+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "debug",
+            "line": 187,
+            "message": "requires File[/var/lib/puppet/concat/_tmp_file/fragments.concat]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/require",
+            "tags": [
+                "debug",
+                "exec",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "require"
+            ],
+            "time": "2015-02-13T13:21:16.29+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "debug",
+            "line": 187,
+            "message": "requires File[/var/lib/puppet/concat/_tmp_file/fragments]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/require",
+            "tags": [
+                "debug",
+                "exec",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "require"
+            ],
+            "time": "2015-02-13T13:21:16.29+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "debug",
+            "line": 187,
+            "message": "requires File[/var/lib/puppet/concat/_tmp_file]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/require",
+            "tags": [
+                "debug",
+                "exec",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "require"
+            ],
+            "time": "2015-02-13T13:21:16.289+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "debug",
+            "line": 149,
+            "message": "subscribes to Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/notify",
+            "tags": [
+                "debug",
+                "file",
+                "concat",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "notify"
+            ],
+            "time": "2015-02-13T13:21:16.289+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/init.pp",
+            "level": "debug",
+            "line": 92,
+            "message": "requires Anchor[python::end]",
+            "source": "/Stage[main]/Python::Config/before",
+            "tags": [
+                "debug",
+                "class",
+                "python::config",
+                "python",
+                "config",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "before"
+            ],
+            "time": "2015-02-13T13:21:16.288+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/init.pp",
+            "level": "debug",
+            "line": 91,
+            "message": "requires Class[Python::Config]",
+            "source": "/Stage[main]/Python::Install/before",
+            "tags": [
+                "debug",
+                "class",
+                "python::install",
+                "python",
+                "install",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "before"
+            ],
+            "time": "2015-02-13T13:21:16.287+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/init.pp",
+            "level": "debug",
+            "line": 90,
+            "message": "requires Class[Python::Install]",
+            "source": "/Stage[main]/Python/Anchor[python::begin]/before",
+            "tags": [
+                "debug",
+                "anchor",
+                "python::begin",
+                "python",
+                "begin",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "before"
+            ],
+            "time": "2015-02-13T13:21:16.286+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "debug",
+            "line": 517,
+            "message": "requires File[var-net-snmp]",
+            "source": "/Stage[main]/Snmp/Service[snmpd]/require",
+            "tags": [
+                "debug",
+                "service",
+                "snmpd",
+                "class",
+                "snmp",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "require"
+            ],
+            "time": "2015-02-13T13:21:16.286+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "debug",
+            "line": 517,
+            "message": "requires Package[snmpd]",
+            "source": "/Stage[main]/Snmp/Service[snmpd]/require",
+            "tags": [
+                "debug",
+                "service",
+                "snmpd",
+                "class",
+                "snmp",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "require"
+            ],
+            "time": "2015-02-13T13:21:16.285+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "debug",
+            "line": 453,
+            "message": "subscribes to Service[snmpd]",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]/notify",
+            "tags": [
+                "debug",
+                "file",
+                "snmptrapd.conf",
+                "class",
+                "snmp",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "notify"
+            ],
+            "time": "2015-02-13T13:21:16.284+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "debug",
+            "line": 453,
+            "message": "requires Package[snmpd]",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]/require",
+            "tags": [
+                "debug",
+                "file",
+                "snmptrapd.conf",
+                "class",
+                "snmp",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "require"
+            ],
+            "time": "2015-02-13T13:21:16.283+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "debug",
+            "line": 441,
+            "message": "subscribes to Service[snmpd]",
+            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]/notify",
+            "tags": [
+                "debug",
+                "file",
+                "snmpd.sysconfig",
+                "class",
+                "snmp",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "notify"
+            ],
+            "time": "2015-02-13T13:21:16.282+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "debug",
+            "line": 441,
+            "message": "requires Package[snmpd]",
+            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]/require",
+            "tags": [
+                "debug",
+                "file",
+                "snmpd.sysconfig",
+                "class",
+                "snmp",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "require"
+            ],
+            "time": "2015-02-13T13:21:16.282+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "debug",
+            "line": 429,
+            "message": "subscribes to Service[snmpd]",
+            "source": "/Stage[main]/Snmp/File[snmpd.conf]/notify",
+            "tags": [
+                "debug",
+                "file",
+                "snmpd.conf",
+                "class",
+                "snmp",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "notify"
+            ],
+            "time": "2015-02-13T13:21:16.281+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "debug",
+            "line": 429,
+            "message": "requires Package[snmpd]",
+            "source": "/Stage[main]/Snmp/File[snmpd.conf]/require",
+            "tags": [
+                "debug",
+                "file",
+                "snmpd.conf",
+                "class",
+                "snmp",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "require"
+            ],
+            "time": "2015-02-13T13:21:16.28+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "debug",
+            "line": 410,
+            "message": "requires Package[snmpd]",
+            "source": "/Stage[main]/Snmp/File[var-net-snmp]/require",
+            "tags": [
+                "debug",
+                "file",
+                "var-net-snmp",
+                "class",
+                "snmp",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "require"
+            ],
+            "time": "2015-02-13T13:21:16.279+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "level": "debug",
+            "line": 85,
+            "message": "requires Package[snmp-client]",
+            "source": "/Stage[main]/Snmp::Client/File[snmp.conf]/require",
+            "tags": [
+                "debug",
+                "file",
+                "snmp.conf",
+                "class",
+                "snmp::client",
+                "snmp",
+                "client",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "require"
+            ],
+            "time": "2015-02-13T13:21:16.279+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/init.pp",
+            "level": "debug",
+            "line": 61,
+            "message": "requires Anchor[ntp::end]",
+            "source": "/Stage[main]/Ntp::Service/before",
+            "tags": [
+                "debug",
+                "class",
+                "ntp::service",
+                "ntp",
+                "service",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "before"
+            ],
+            "time": "2015-02-13T13:21:16.278+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/init.pp",
+            "level": "debug",
+            "line": 60,
+            "message": "subscribes to Class[Ntp::Service]",
+            "source": "/Stage[main]/Ntp::Config/notify",
+            "tags": [
+                "debug",
+                "class",
+                "ntp::config",
+                "ntp",
+                "config",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "notify"
+            ],
+            "time": "2015-02-13T13:21:16.277+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/init.pp",
+            "level": "debug",
+            "line": 59,
+            "message": "requires Class[Ntp::Config]",
+            "source": "/Stage[main]/Ntp::Install/before",
+            "tags": [
+                "debug",
+                "class",
+                "ntp::install",
+                "ntp",
+                "install",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "before"
+            ],
+            "time": "2015-02-13T13:21:16.276+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/init.pp",
+            "level": "debug",
+            "line": 58,
+            "message": "requires Class[Ntp::Install]",
+            "source": "/Stage[main]/Ntp/Anchor[ntp::begin]/before",
+            "tags": [
+                "debug",
+                "anchor",
+                "ntp::begin",
+                "ntp",
+                "begin",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "before"
+            ],
+            "time": "2015-02-13T13:21:16.271+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loaded state in 0.04 seconds",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.269+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Creating default schedules",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.207+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/gnupg/manifests/install.pp",
+            "level": "debug",
+            "line": 4,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[gnupg]",
+            "tags": [
+                "debug",
+                "package",
+                "gnupg",
+                "class",
+                "gnupg::install",
+                "install",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.19+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "debug",
+            "line": 71,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[gunicorn]",
+            "tags": [
+                "debug",
+                "package",
+                "gunicorn",
+                "class",
+                "python::install",
+                "python",
+                "install",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.187+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "debug",
+            "line": 62,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[python]",
+            "tags": [
+                "debug",
+                "package",
+                "python",
+                "class",
+                "python::install",
+                "install",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.186+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "debug",
+            "line": 61,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[python-dev]",
+            "tags": [
+                "debug",
+                "package",
+                "python-dev",
+                "class",
+                "python::install",
+                "python",
+                "install",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.185+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "debug",
+            "line": 60,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[python-pip]",
+            "tags": [
+                "debug",
+                "package",
+                "python-pip",
+                "class",
+                "python::install",
+                "python",
+                "install",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.184+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "debug",
+            "line": 59,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[python-virtualenv]",
+            "tags": [
+                "debug",
+                "package",
+                "python-virtualenv",
+                "class",
+                "python::install",
+                "python",
+                "install",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.183+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "debug",
+            "line": 405,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[snmpd]",
+            "tags": [
+                "debug",
+                "package",
+                "snmpd",
+                "class",
+                "snmp",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.177+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "level": "debug",
+            "line": 76,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[snmp-client]",
+            "tags": [
+                "debug",
+                "package",
+                "snmp-client",
+                "class",
+                "snmp::client",
+                "snmp",
+                "client",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.175+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/git/manifests/init.pp",
+            "level": "debug",
+            "line": 12,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[git]",
+            "tags": [
+                "debug",
+                "package",
+                "git",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.172+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "debug",
+            "line": 41,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[etckeeper]",
+            "tags": [
+                "debug",
+                "package",
+                "etckeeper",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.17+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Vcsrepo::ProviderCvs: file cvs does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.165+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Vcsrepo::ProviderHg: file hg does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.164+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Vcsrepo::ProviderSvn: file svn does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.163+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Vcsrepo::ProviderBzr: file bzr does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.163+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/install.pp",
+            "level": "debug",
+            "line": 4,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[ntp]",
+            "tags": [
+                "debug",
+                "package",
+                "ntp",
+                "class",
+                "ntp::install",
+                "install",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:16.159+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Service::ProviderRunit: file /usr/bin/sv does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.155+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Service::ProviderGentoo: file /sbin/rc-update does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.155+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Service::ProviderLaunchd: file /bin/launchctl does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.154+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Service::ProviderUpstart: 0 confines (of 2) were true",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.154+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Service::ProviderOpenrc: file /bin/rc-status does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.153+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Service::ProviderDaemontools: file /usr/bin/svc does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.153+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Service::ProviderRedhat: file /sbin/chkconfig does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.152+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Service::ProviderSystemd: file systemctl does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:16.152+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for pg1.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:16.135+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Caching connection for https://puppet:8140",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:15.783+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Using cached connection for https://puppet:8140",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:15.35+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "catalog supports formats: pson b64_zlib_yaml yaml dot raw",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:15.349+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Network::Format[msgpack]: feature msgpack is missing",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:15.349+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Failed to load library 'msgpack' for feature 'msgpack'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:15.348+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Executing '/usr/bin/dpkg-query -W --showformat '${Status} ${Package} ${Version}\\n' python'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:15.302+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[python]",
+            "tags": [
+                "debug",
+                "package",
+                "python"
+            ],
+            "time": "2015-02-13T13:21:14.371+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[python-pip]",
+            "tags": [
+                "debug",
+                "package",
+                "python-pip"
+            ],
+            "time": "2015-02-13T13:21:14.369+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+            "source": "/Package[virtualenv]",
+            "tags": [
+                "debug",
+                "package",
+                "virtualenv"
+            ],
+            "time": "2015-02-13T13:21:14.368+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderPacman: file /usr/bin/pacman does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.367+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderPkg: file /usr/bin/pkg does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.366+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderZypper: file /usr/bin/zypper does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.366+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderAptrpm: file rpm does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.365+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderSunfreeware: file pkg-get does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.365+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderHpux: file /usr/sbin/swinstall does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.364+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderNim: file /usr/sbin/nimclient does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.364+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderUrpmi: file urpmi does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.363+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderUp2date: file /usr/sbin/up2date-nox does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.362+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderRug: file /usr/bin/rug does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.362+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderPortupgrade: file /usr/local/sbin/portupgrade does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.362+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderYum: file yum does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.361+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderRpm: file rpm does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.361+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderFink: file /sw/bin/fink does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.36+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderPorts: file /usr/local/sbin/portupgrade does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.359+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderFreebsd: file /usr/sbin/pkg_info does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.359+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderOpenbsd: file pkg_info does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.358+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderOpkg: file opkg does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.358+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderPkgin: file pkgin does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.357+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderSun: file /usr/bin/pkginfo does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.357+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderPortage: file /usr/bin/emerge does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.356+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Type::Package::ProviderAix: file /usr/bin/lslpp does not exist",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:14.355+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/puppet_vardir.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.849+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/root_home.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.849+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/ip6tables_version.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.849+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/git_version.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.848+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/facter_dot_d.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.848+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/iptables_version.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.847+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/python_version.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.847+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/git_exec_path.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.846+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/apt_package_updates.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.846+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/git_html_path.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.846+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/pip_version.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.845+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/virtualenv_version.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.845+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/concat_basedir.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.844+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/apt_security_updates.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.844+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/apt_updates.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.843+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/pe_version.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.843+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading facts from /var/lib/puppet/lib/facter/iptables_persistent_version.rb",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.842+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:13.842+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Loading external facts from /var/lib/puppet/facts.d",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.841+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Finishing transaction 11350920",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.82+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Caching connection for https://puppet:8140",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.6+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Using cached connection for https://puppet:8140",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.56+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "file_metadata supports formats: pson b64_zlib_yaml yaml raw",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.559+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Network::Format[msgpack]: feature msgpack is missing",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.559+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Failed to load library 'msgpack' for feature 'msgpack'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.558+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:13.401+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Finishing transaction 21451200",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.4+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Caching connection for https://puppet:8140",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.398+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Using cached connection for https://puppet:8140",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.39+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "file_metadata supports formats: pson b64_zlib_yaml yaml raw",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.389+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Network::Format[msgpack]: feature msgpack is missing",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.389+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Failed to load library 'msgpack' for feature 'msgpack'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.388+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:13.365+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Caching connection for https://puppet:8140",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.35+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Starting connection for https://puppet:8140",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.305+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Using cached certificate_revocation_list for ca",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.305+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Creating new connection for https://puppet:8140",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.304+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Using cached certificate for pg1.vm",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.304+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Using cached certificate for ca",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.303+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "node supports formats: pson b64_zlib_yaml yaml raw",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.302+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Puppet::Network::Format[msgpack]: feature msgpack is missing",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.301+00:00"
+        },
+        {
+            "file": null,
+            "level": "debug",
+            "line": null,
+            "message": "Failed to load library 'msgpack' for feature 'msgpack'",
+            "source": "Puppet",
+            "tags": [
+                "debug"
+            ],
+            "time": "2015-02-13T13:21:13.301+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.000524479
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 0.809646404
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.015701975
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.04500305600000001
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 0.000115401
+        },
+        {
+            "category": "time",
+            "name": "gnupg_key",
+            "value": 0.0245873
+        },
+        {
+            "category": "time",
+            "name": "ini_setting",
+            "value": 0.000374412
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.00119644
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.018980525999999994
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.00055239
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.085381164
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 1.0023958039999998
+        },
+        {
+            "category": "time",
+            "name": "vcsrepo",
+            "value": 0.000332257
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 4
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 47
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "noop",
+            "value": 4
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 4
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 0
+        }
+    ],
+    "noop": true,
+    "puppet_version": "3.7.4",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Motd",
+                "File[/etc/motd]"
+            ],
+            "events": [
+                {
+                    "message": "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}6e10c92cc7cd37f8033108d9555eb33a (noop)",
+                    "new_value": "{md5}6e10c92cc7cd37f8033108d9555eb33a",
+                    "old_value": "{md5}a3f731187a6aaaa23d4a7b244f223f33",
+                    "property": "content",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:21:16.348Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "line": 33,
+            "resource_title": "/etc/motd",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:21:16.348Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be foo (noop)",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:21:16.393Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 3,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:21:16.393Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat::Fragment[tmpfile2]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be file (noop)",
+                    "new_value": "file",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:21:16.508Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "line": 113,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:21:16.508Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat::Fragment[tmpfile]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]"
+            ],
+            "events": [
+                {
+                    "message": "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)",
+                    "new_value": "{md5}3a010064e9f94f26236ba1167c7ee125",
+                    "old_value": "{md5}df14e44b311152c34358a675ae34afe0",
+                    "property": "content",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:21:16.523Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "line": 113,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:21:16.523Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:21:13.238Z",
+    "status": "unchanged",
+    "transaction_uuid": "ac63fb6f-d191-4d8a-94af-995ccaadb7dd"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-9956b77aba1f29fe276978cd68d4c169f2e34d69.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-9956b77aba1f29fe276978cd68d4c169f2e34d69.json
@@ -1,219 +1,318 @@
 {
-  "transaction_uuid" : "af8d1c1c-f1b9-450a-949d-f6990cf24d63",
-  "puppet_version" : "3.7.4",
-  "noop" : false,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 0.31 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:21:52.273+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "defined 'message' as 'foo'",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
-    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:52.096+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "notice",
-    "message" : "foo",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:21:52.095+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "content changed '{md5}02d304aace03a918311acc96cd339cc3' to '{md5}ed132dbd31efba0f517dda09d5fbb9b6'",
-    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
-    "tags" : [ "notice", "file", "class", "motd", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:21:52.053+00:00",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "line" : 33
-  }, {
-    "level" : "notice",
-    "message" : "\n--- /etc/motd\t2015-02-13 13:21:23.741473135 +0000\n+++ /tmp/puppet-file20150213-10724-1gn0ewj\t2015-02-13 13:21:52.037473517 +0000\n@@ -1,3 +1,3 @@\n The operating system is Debian\n-The free memory is 204.07 MB\n+The free memory is 202.91 MB\n The domain is vm\n",
-    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
-    "tags" : [ "notice", "file", "class", "motd", "loadtest", "node", "pg1.vm", "content" ],
-    "time" : "2015-02-13T13:21:52.051+00:00",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "line" : 33
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423833650'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:52.022+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for pg1.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:51.874+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:49.041+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:48.395+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:21:48.332+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:21:48.201Z",
-  "end_time" : "2015-02-13T13:21:49.346Z",
-  "resource_events" : [ {
-    "new_value" : "{md5}ed132dbd31efba0f517dda09d5fbb9b6",
-    "property" : "content",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "old_value" : "{md5}02d304aace03a918311acc96cd339cc3",
-    "line" : 33,
-    "resource_type" : "File",
-    "status" : "success",
-    "resource_title" : "/etc/motd",
-    "timestamp" : "2015-02-13T13:21:52.052Z",
-    "containment_path" : [ "Stage[main]", "Motd", "File[/etc/motd]" ],
-    "message" : "content changed '{md5}02d304aace03a918311acc96cd339cc3' to '{md5}ed132dbd31efba0f517dda09d5fbb9b6'"
-  }, {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 3,
-    "resource_type" : "Notify",
-    "status" : "success",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:21:52.095Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
-    "message" : "defined 'message' as 'foo'"
-  } ],
-  "status" : "changed",
-  "configuration_version" : "1423833650",
-  "environment" : "production",
-  "certname" : "pg1.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 4.4813199999999996E-4,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.993234538,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.014644488,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.031661835,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 8.5529E-5,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.010125739,
-    "name" : "gnupg_key"
-  }, {
-    "category" : "time",
-    "value" : 3.55716E-4,
-    "name" : "ini_setting"
-  }, {
-    "category" : "time",
-    "value" : 0.001868988,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.017718799,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 5.12278E-4,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.073210798,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 1.1441704209999999,
-    "name" : "total"
-  }, {
-    "category" : "time",
-    "value" : 3.03581E-4,
-    "name" : "vcsrepo"
-  }, {
-    "category" : "resources",
-    "value" : 2,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 2,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 47,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 2,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 2,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 2,
-    "name" : "total"
-  } ]
+    "certname": "pg1.vm",
+    "configuration_version": "1423833650",
+    "end_time": "2015-02-13T13:21:49.346Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 0.31 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:21:52.273+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 3,
+            "message": "defined 'message' as 'foo'",
+            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
+            "tags": [
+                "notice",
+                "notify",
+                "foo",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:52.096+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "foo",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:21:52.095+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "level": "notice",
+            "line": 33,
+            "message": "content changed '{md5}02d304aace03a918311acc96cd339cc3' to '{md5}ed132dbd31efba0f517dda09d5fbb9b6'",
+            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
+            "tags": [
+                "notice",
+                "file",
+                "class",
+                "motd",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:21:52.053+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "level": "notice",
+            "line": 33,
+            "message": "\n--- /etc/motd\t2015-02-13 13:21:23.741473135 +0000\n+++ /tmp/puppet-file20150213-10724-1gn0ewj\t2015-02-13 13:21:52.037473517 +0000\n@@ -1,3 +1,3 @@\n The operating system is Debian\n-The free memory is 204.07 MB\n+The free memory is 202.91 MB\n The domain is vm\n",
+            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
+            "tags": [
+                "notice",
+                "file",
+                "class",
+                "motd",
+                "loadtest",
+                "node",
+                "pg1.vm",
+                "content"
+            ],
+            "time": "2015-02-13T13:21:52.051+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423833650'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:52.022+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for pg1.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:51.874+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:49.041+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:48.395+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:21:48.332+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.00044813199999999996
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 0.993234538
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.014644488
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.031661835
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 8.5529e-05
+        },
+        {
+            "category": "time",
+            "name": "gnupg_key",
+            "value": 0.010125739
+        },
+        {
+            "category": "time",
+            "name": "ini_setting",
+            "value": 0.000355716
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.001868988
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.017718799
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.000512278
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.073210798
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 1.1441704209999999
+        },
+        {
+            "category": "time",
+            "name": "vcsrepo",
+            "value": 0.000303581
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 2
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 2
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 47
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 2
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 2
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 2
+        }
+    ],
+    "noop": false,
+    "puppet_version": "3.7.4",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Motd",
+                "File[/etc/motd]"
+            ],
+            "events": [
+                {
+                    "message": "content changed '{md5}02d304aace03a918311acc96cd339cc3' to '{md5}ed132dbd31efba0f517dda09d5fbb9b6'",
+                    "new_value": "{md5}ed132dbd31efba0f517dda09d5fbb9b6",
+                    "old_value": "{md5}02d304aace03a918311acc96cd339cc3",
+                    "property": "content",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:21:52.052Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "line": 33,
+            "resource_title": "/etc/motd",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:21:52.052Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "defined 'message' as 'foo'",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:21:52.095Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 3,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:21:52.095Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:21:48.201Z",
+    "status": "changed",
+    "transaction_uuid": "af8d1c1c-f1b9-450a-949d-f6990cf24d63"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-a454ec51cbadba8c31beb9c1d66e90e9482ff4a6.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-a454ec51cbadba8c31beb9c1d66e90e9482ff4a6.json
@@ -1,191 +1,260 @@
 {
-  "transaction_uuid" : "8659eaf5-90a6-41d7-8898-6b0aec08d106",
-  "puppet_version" : "3.7.4",
-  "noop" : false,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 0.30 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:22:45.298+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "defined 'message' as 'foo'",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
-    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "pg1.vm" ],
-    "time" : "2015-02-13T13:22:45.122+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "notice",
-    "message" : "foo",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:22:45.121+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423833741'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:22:45.06+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for pg1.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:22:44.906+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:22:42.642+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:22:42.172+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:22:42.133+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:22:42.019Z",
-  "end_time" : "2015-02-13T13:22:42.965Z",
-  "resource_events" : [ {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 3,
-    "resource_type" : "Notify",
-    "status" : "success",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:22:45.121Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
-    "message" : "defined 'message' as 'foo'"
-  } ],
-  "status" : "changed",
-  "configuration_version" : "1423833741",
-  "environment" : "production",
-  "certname" : "pg1.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 6.12874E-4,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.806047949,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.015268704,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.020647922999999995,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 8.8499E-5,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.01052339,
-    "name" : "gnupg_key"
-  }, {
-    "category" : "time",
-    "value" : 3.7523E-4,
-    "name" : "ini_setting"
-  }, {
-    "category" : "time",
-    "value" : 0.001848423,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.018125949000000002,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 5.236080000000001E-4,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.071202317,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 0.945464791,
-    "name" : "total"
-  }, {
-    "category" : "time",
-    "value" : 1.99925E-4,
-    "name" : "vcsrepo"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 47,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 1,
-    "name" : "total"
-  } ]
+    "certname": "pg1.vm",
+    "configuration_version": "1423833741",
+    "end_time": "2015-02-13T13:22:42.965Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 0.30 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:22:45.298+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 3,
+            "message": "defined 'message' as 'foo'",
+            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
+            "tags": [
+                "notice",
+                "notify",
+                "foo",
+                "class",
+                "loadtest",
+                "node",
+                "pg1.vm"
+            ],
+            "time": "2015-02-13T13:22:45.122+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "foo",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:22:45.121+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423833741'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:22:45.06+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for pg1.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:22:44.906+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:22:42.642+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:22:42.172+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:22:42.133+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.000612874
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 0.806047949
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.015268704
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.020647922999999995
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 8.8499e-05
+        },
+        {
+            "category": "time",
+            "name": "gnupg_key",
+            "value": 0.01052339
+        },
+        {
+            "category": "time",
+            "name": "ini_setting",
+            "value": 0.00037523
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.001848423
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.018125949000000002
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.0005236080000000001
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.071202317
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 0.945464791
+        },
+        {
+            "category": "time",
+            "name": "vcsrepo",
+            "value": 0.000199925
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 47
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 1
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 1
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 1
+        }
+    ],
+    "noop": false,
+    "puppet_version": "3.7.4",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "defined 'message' as 'foo'",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:22:45.121Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 3,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:22:45.121Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:22:42.019Z",
+    "status": "changed",
+    "transaction_uuid": "8659eaf5-90a6-41d7-8898-6b0aec08d106"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-193c2a3ae8b277158dbb1073a35290b406c3c073.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-193c2a3ae8b277158dbb1073a35290b406c3c073.json
@@ -1,1007 +1,1930 @@
 {
-  "transaction_uuid" : "1fb6bf81-0b2a-488c-b1d7-610a81b06b27",
-  "puppet_version" : "3.7.1",
-  "noop" : true,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 2.08 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:29:33.78+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 8 events",
-    "source" : "Stage[main]",
-    "tags" : [ "main", "completed_stage", "notice" ],
-    "time" : "2015-02-13T13:29:33.748+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 8 events",
-    "source" : "Class[Loadtest]",
-    "tags" : [ "completed_class", "loadtest", "notice" ],
-    "time" : "2015-02-13T13:29:33.746+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "err",
-    "message" : "Provider git is not functional on this host",
-    "source" : "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
-    "tags" : [ "class", "pg2.vm", "loadtest", "err", "vcsrepo", "node" ],
-    "time" : "2015-02-13T13:29:33.746+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 11
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 2 events",
-    "source" : "Class[Snmp::Client]",
-    "tags" : [ "completed_class", "snmp", "snmp::client", "client", "notice" ],
-    "time" : "2015-02-13T13:29:33.745+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp::Client/File[snmp.conf]/ensure",
-    "tags" : [ "class", "snmp", "pg2.vm", "snmp.conf", "loadtest", "file", "node", "snmp::client", "client", "notice" ],
-    "time" : "2015-02-13T13:29:33.744+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "line" : 85
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 3 events",
-    "source" : "Class[Python::Install]",
-    "tags" : [ "completed_class", "python::install", "install", "python", "notice" ],
-    "time" : "2015-02-13T13:29:33.741+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Python::Install/Package[python-virtualenv]/ensure",
-    "tags" : [ "class", "python::install", "pg2.vm", "python-virtualenv", "install", "python", "loadtest", "node", "package", "notice" ],
-    "time" : "2015-02-13T13:29:33.738+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 59
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Python::Install/Package[python-devel]/ensure",
-    "tags" : [ "python-devel", "class", "python::install", "pg2.vm", "install", "python", "loadtest", "node", "package", "notice" ],
-    "time" : "2015-02-13T13:29:33.688+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 61
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Python::Install/Package[python-pip]/ensure",
-    "tags" : [ "class", "python-pip", "python::install", "pg2.vm", "install", "python", "loadtest", "node", "package", "notice" ],
-    "time" : "2015-02-13T13:29:33.66+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 60
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Git]",
-    "tags" : [ "completed_class", "git", "notice" ],
-    "time" : "2015-02-13T13:29:33.409+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Git/Package[git]/ensure",
-    "tags" : [ "class", "pg2.vm", "loadtest", "git", "node", "package", "notice" ],
-    "time" : "2015-02-13T13:29:33.407+00:00",
-    "file" : "/etc/puppet/modules/git/manifests/init.pp",
-    "line" : 12
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 8 events",
-    "source" : "Class[Snmp]",
-    "tags" : [ "completed_class", "snmp", "notice" ],
-    "time" : "2015-02-13T13:29:33.224+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Unscheduling refresh on Service[snmpd]",
-    "source" : "/Stage[main]/Snmp/Service[snmpd]",
-    "tags" : [ "snmpd", "class", "info", "snmp", "pg2.vm", "loadtest", "service", "node" ],
-    "time" : "2015-02-13T13:29:33.222+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 517
-  }, {
-    "level" : "notice",
-    "message" : "current_value stopped, should be running (noop)",
-    "source" : "/Stage[main]/Snmp/Service[snmpd]/ensure",
-    "tags" : [ "snmpd", "class", "snmp", "pg2.vm", "loadtest", "service", "node", "notice" ],
-    "time" : "2015-02-13T13:29:33.221+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 517
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[snmpd]",
-    "source" : "/Stage[main]/Snmp/File[snmpd.conf]",
-    "tags" : [ "class", "info", "snmp", "pg2.vm", "loadtest", "snmpd.conf", "file", "node" ],
-    "time" : "2015-02-13T13:29:33.124+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 429
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/File[snmpd.conf]/ensure",
-    "tags" : [ "class", "snmp", "pg2.vm", "loadtest", "snmpd.conf", "file", "node", "notice" ],
-    "time" : "2015-02-13T13:29:33.123+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 429
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Concat::Fragment[tmpfile]",
-    "tags" : [ "completed_concat::fragment", "fragment", "completed_concat", "tmpfile", "notice" ],
-    "time" : "2015-02-13T13:29:33.121+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 6 events",
-    "source" : "Concat[/tmp/file]",
-    "tags" : [ "completed_concat", "notice" ],
-    "time" : "2015-02-13T13:29:33.119+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "err",
-    "message" : "Could not evaluate: Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/tmp/file]",
-    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "err", "file", "node" ],
-    "time" : "2015-02-13T13:29:33.117+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 169
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 4 events",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "node", "exec", "notice" ],
-    "time" : "2015-02-13T13:29:33.114+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "notice",
-    "message" : "current_value notrun, should be 0 (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/returns",
-    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "node", "exec", "notice" ],
-    "time" : "2015-02-13T13:29:33.113+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-    "tags" : [ "concat::fragment", "class", "concat", "info", "pg2.vm", "fragment", "loadtest", "tmpfile", "file", "node" ],
-    "time" : "2015-02-13T13:29:33.046+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be file (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/ensure",
-    "tags" : [ "concat::fragment", "class", "concat", "pg2.vm", "fragment", "loadtest", "tmpfile", "file", "node", "notice" ],
-    "time" : "2015-02-13T13:29:33.045+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Concat::Fragment[tmpfile2]",
-    "tags" : [ "completed_concat::fragment", "tmpfile2", "fragment", "completed_concat", "notice" ],
-    "time" : "2015-02-13T13:29:33.042+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-    "tags" : [ "concat::fragment", "class", "concat", "info", "pg2.vm", "tmpfile2", "fragment", "loadtest", "file", "node" ],
-    "time" : "2015-02-13T13:29:32.973+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be file (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
-    "tags" : [ "concat::fragment", "class", "concat", "pg2.vm", "tmpfile2", "fragment", "loadtest", "file", "node", "notice" ],
-    "time" : "2015-02-13T13:29:32.973+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
-    "tags" : [ "concat", "class", "info", "pg2.vm", "loadtest", "file", "node" ],
-    "time" : "2015-02-13T13:29:32.972+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 149
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be directory (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/ensure",
-    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "file", "node", "notice" ],
-    "time" : "2015-02-13T13:29:32.971+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 149
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 2 events",
-    "source" : "/Stage[main]/Snmp/Service[snmptrapd]",
-    "tags" : [ "class", "snmp", "pg2.vm", "snmptrapd", "loadtest", "service", "node", "notice" ],
-    "time" : "2015-02-13T13:29:32.967+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 476
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]/ensure",
-    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "file", "node", "notice" ],
-    "time" : "2015-02-13T13:29:32.716+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 164
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]/ensure",
-    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "file", "node", "notice" ],
-    "time" : "2015-02-13T13:29:32.715+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 159
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
-    "tags" : [ "concat", "class", "info", "pg2.vm", "loadtest", "file", "node" ],
-    "time" : "2015-02-13T13:29:32.714+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 144
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be directory (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]/ensure",
-    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "file", "node", "notice" ],
-    "time" : "2015-02-13T13:29:32.714+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 144
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[snmptrapd]",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]",
-    "tags" : [ "snmptrapd.conf", "class", "info", "snmp", "pg2.vm", "loadtest", "file", "node" ],
-    "time" : "2015-02-13T13:29:32.712+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 453
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]/ensure",
-    "tags" : [ "snmptrapd.conf", "class", "snmp", "pg2.vm", "loadtest", "file", "node", "notice" ],
-    "time" : "2015-02-13T13:29:32.711+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 453
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]/ensure",
-    "tags" : [ "gnupg_key", "class", "pg2.vm", "loadtest", "hkp_server_20bc0a86", "node", "notice" ],
-    "time" : "2015-02-13T13:29:32.444+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 69
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Ntp::Service]",
-    "tags" : [ "completed_class", "ntp", "service", "ntp::service", "notice" ],
-    "time" : "2015-02-13T13:29:32.418+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Unscheduling refresh on Service[ntp]",
-    "source" : "/Stage[main]/Ntp::Service/Service[ntp]",
-    "tags" : [ "ntp", "class", "info", "pg2.vm", "loadtest", "service", "node", "ntp::service" ],
-    "time" : "2015-02-13T13:29:32.416+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
-    "line" : 9
-  }, {
-    "level" : "notice",
-    "message" : "current_value stopped, should be running (noop)",
-    "source" : "/Stage[main]/Ntp::Service/Service[ntp]/ensure",
-    "tags" : [ "ntp", "class", "pg2.vm", "loadtest", "service", "node", "ntp::service", "notice" ],
-    "time" : "2015-02-13T13:29:32.416+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
-    "line" : 9
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be directory (noop)",
-    "source" : "/Stage[main]/Snmp/File[var-net-snmp]/ensure",
-    "tags" : [ "class", "var-net-snmp", "snmp", "pg2.vm", "loadtest", "file", "node", "notice" ],
-    "time" : "2015-02-13T13:29:32.336+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 410
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Loadtest/Ini_setting[sample setting]/ensure",
-    "tags" : [ "class", "ini_setting", "pg2.vm", "loadtest", "node", "notice" ],
-    "time" : "2015-02-13T13:29:32.334+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 45
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[ntp]",
-    "source" : "Class[Ntp::Service]",
-    "tags" : [ "ntp", "info", "admissible_class", "service", "ntp::service" ],
-    "time" : "2015-02-13T13:29:32.333+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Ntp::Service]",
-    "tags" : [ "ntp", "admissible_class", "service", "ntp::service", "notice" ],
-    "time" : "2015-02-13T13:29:32.333+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Class[Ntp::Service]",
-    "source" : "Class[Ntp::Config]",
-    "tags" : [ "completed_class", "ntp", "info", "ntp::config", "config" ],
-    "time" : "2015-02-13T13:29:32.332+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Ntp::Config]",
-    "tags" : [ "completed_class", "ntp", "ntp::config", "config", "notice" ],
-    "time" : "2015-02-13T13:29:32.331+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
-    "source" : "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
-    "tags" : [ "class", "ntp", "pg2.vm", "ntp::config", "loadtest", "file", "node", "config", "notice" ],
-    "time" : "2015-02-13T13:29:32.328+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
-    "line" : 14
-  }, {
-    "level" : "notice",
-    "message" : "\n--- /etc/ntp.conf\t2013-07-15 10:18:47.000000000 +0100\n+++ /tmp/puppet-file20150213-62287-xahzaj-0\t2015-02-13 13:29:32.296877887 +0000\n@@ -1,53 +1,19 @@\n-# For more information about this file, see the man pages\n-# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).\n+# ntp.conf: Managed by puppet.\n+#\n+# Keep ntpd from panicking in the event of a large clock skew\n+# when a VM guest is suspended and resumed.\n+tinker panic 0\n \n-driftfile /var/lib/ntp/drift\n \n # Permit time synchronization with our time source, but do not\n # permit the source to query or modify the service on this system.\n-restrict default kod nomodify notrap nopeer noquery\n-restrict -6 default kod nomodify notrap nopeer noquery\n+restrict 127.0.0.1\n+\n \n-# Permit all access over the loopback interface.  This could\n-# be tightened as well, but to do so would effect some of\n-# the administrative functions.\n-restrict 127.0.0.1 \n-restrict -6 ::1\n-\n-# Hosts on local network are less restricted.\n-#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap\n-\n-# Use public servers from the pool.ntp.org project.\n-# Please consider joining the pool (http://www.pool.ntp.org/join.html).\n-server 0.centos.pool.ntp.org iburst\n-server 1.centos.pool.ntp.org iburst\n-server 2.centos.pool.ntp.org iburst\n-server 3.centos.pool.ntp.org iburst\n-\n-#broadcast 192.168.1.255 autokey\t# broadcast server\n-#broadcastclient\t\t\t# broadcast client\n-#broadcast 224.0.1.1 autokey\t\t# multicast server\n-#multicastclient 224.0.1.1\t\t# multicast client\n-#manycastserver 239.255.254.254\t\t# manycast server\n-#manycastclient 239.255.254.254 autokey # manycast client\n-\n-# Enable public key cryptography.\n-#crypto\n-\n-includefile /etc/ntp/crypto/pw\n-\n-# Key file containing the keys and key identifiers used when operating\n-# with symmetric key cryptography. \n-keys /etc/ntp/keys\n-\n-# Specify the key identifiers which are trusted.\n-#trustedkey 4 8 42\n+server ntp.pool.org\n \n-# Specify the key identifier to use with the ntpdc utility.\n-#requestkey 8\n \n-# Specify the key identifier to use with the ntpq utility.\n-#controlkey 8\n+# Driftfile.\n+driftfile /var/lib/ntp/drift\n+\n \n-# Enable writing of statistics records.\n-#statistics clockstats cryptostats loopstats peerstats\n",
-    "source" : "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
-    "tags" : [ "class", "ntp", "pg2.vm", "ntp::config", "loadtest", "file", "node", "config", "content", "notice" ],
-    "time" : "2015-02-13T13:29:32.324+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
-    "line" : 14
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[snmpd]",
-    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]",
-    "tags" : [ "snmpd.sysconfig", "class", "info", "snmp", "pg2.vm", "loadtest", "file", "node" ],
-    "time" : "2015-02-13T13:29:32.293+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 441
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]/ensure",
-    "tags" : [ "snmpd.sysconfig", "class", "snmp", "pg2.vm", "loadtest", "file", "node", "notice" ],
-    "time" : "2015-02-13T13:29:32.292+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 441
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[snmptrapd]",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.sysconfig]",
-    "tags" : [ "class", "info", "snmp", "pg2.vm", "loadtest", "file", "node", "snmptrapd.sysconfig" ],
-    "time" : "2015-02-13T13:29:32.285+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 465
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.sysconfig]/ensure",
-    "tags" : [ "class", "snmp", "pg2.vm", "loadtest", "file", "node", "snmptrapd.sysconfig", "notice" ],
-    "time" : "2015-02-13T13:29:32.285+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 465
-  }, {
-    "level" : "info",
-    "message" : "Unscheduling refresh on Service[cron]",
-    "source" : "/Stage[main]/Loadtest/Service[cron]",
-    "tags" : [ "class", "info", "pg2.vm", "loadtest", "service", "cron", "node" ],
-    "time" : "2015-02-13T13:29:32.281+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 4
-  }, {
-    "level" : "notice",
-    "message" : "current_value stopped, should be running (noop)",
-    "source" : "/Stage[main]/Loadtest/Service[cron]/ensure",
-    "tags" : [ "class", "pg2.vm", "loadtest", "service", "cron", "node", "notice" ],
-    "time" : "2015-02-13T13:29:32.28+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 4
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be foo (noop)",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
-    "tags" : [ "class", "pg2.vm", "loadtest", "foo", "node", "notify", "notice" ],
-    "time" : "2015-02-13T13:29:32.178+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/Package[snmpd]/ensure",
-    "tags" : [ "snmpd", "class", "snmp", "pg2.vm", "loadtest", "node", "package", "notice" ],
-    "time" : "2015-02-13T13:29:32.176+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 405
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be latest (noop)",
-    "source" : "/Stage[main]/Loadtest/Package[etckeeper]/ensure",
-    "tags" : [ "etckeeper", "class", "pg2.vm", "loadtest", "node", "package", "notice" ],
-    "time" : "2015-02-13T13:29:32.134+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 41
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp::Client/Package[snmp-client]/ensure",
-    "tags" : [ "snmp-client", "class", "snmp", "pg2.vm", "loadtest", "node", "snmp::client", "package", "client", "notice" ],
-    "time" : "2015-02-13T13:29:32.09+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "line" : 76
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Motd]",
-    "tags" : [ "completed_class", "motd", "notice" ],
-    "time" : "2015-02-13T13:29:31.93+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
-    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
-    "tags" : [ "class", "pg2.vm", "loadtest", "file", "motd", "node", "notice" ],
-    "time" : "2015-02-13T13:29:31.924+00:00",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "line" : 33
-  }, {
-    "level" : "notice",
-    "message" : "\n--- /etc/motd\t2010-01-12 13:28:22.000000000 +0000\n+++ /tmp/puppet-file20150213-62287-jf1btv-0\t2015-02-13 13:29:31.882877889 +0000\n@@ -0,0 +1 @@\n+Welcome to my test host!\n\\ No newline at end of file\n",
-    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
-    "tags" : [ "class", "pg2.vm", "loadtest", "file", "motd", "node", "content", "notice" ],
-    "time" : "2015-02-13T13:29:31.923+00:00",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "line" : 33
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423834124'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:31.774+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "warning",
-    "message" : "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
-    "source" : "Puppet",
-    "tags" : [ "warning" ],
-    "time" : "2015-02-13T13:29:31.381+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for pg2.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:31.286+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:29.241+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:26.991+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:26.912+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:29:26.846Z",
-  "end_time" : "2015-02-13T13:29:29.626Z",
-  "resource_events" : [ {
-    "new_value" : "{md5}a3f731187a6aaaa23d4a7b244f223f33",
-    "property" : "content",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "old_value" : "{md5}d41d8cd98f00b204e9800998ecf8427e",
-    "line" : 33,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/etc/motd",
-    "timestamp" : "2015-02-13T13:29:31.924Z",
-    "containment_path" : [ "Stage[main]", "Motd", "File[/etc/motd]" ],
-    "message" : "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "old_value" : "absent",
-    "line" : 76,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "snmp-client",
-    "timestamp" : "2015-02-13T13:29:32.090Z",
-    "containment_path" : [ "Stage[main]", "Snmp::Client", "Package[snmp-client]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "latest",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 41,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "etckeeper",
-    "timestamp" : "2015-02-13T13:29:32.134Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Package[etckeeper]" ],
-    "message" : "current_value absent, should be latest (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 405,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "snmpd",
-    "timestamp" : "2015-02-13T13:29:32.175Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "Package[snmpd]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 3,
-    "resource_type" : "Notify",
-    "status" : "noop",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:29:32.178Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
-    "message" : "current_value absent, should be foo (noop)"
-  }, {
-    "new_value" : "running",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "stopped",
-    "line" : 4,
-    "resource_type" : "Service",
-    "status" : "noop",
-    "resource_title" : "cron",
-    "timestamp" : "2015-02-13T13:29:32.280Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Service[cron]" ],
-    "message" : "current_value stopped, should be running (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 465,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmptrapd.sysconfig",
-    "timestamp" : "2015-02-13T13:29:32.284Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[snmptrapd.sysconfig]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 441,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmpd.sysconfig",
-    "timestamp" : "2015-02-13T13:29:32.292Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[snmpd.sysconfig]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "{md5}eb918d28434c9fefcc05875c29c3ba1a",
-    "property" : "content",
-    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
-    "old_value" : "{md5}7fda24f62b1c7ae951db0f746dc6e0cc",
-    "line" : 14,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/etc/ntp.conf",
-    "timestamp" : "2015-02-13T13:29:32.328Z",
-    "containment_path" : [ "Stage[main]", "Ntp::Config", "File[/etc/ntp.conf]" ],
-    "message" : "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 45,
-    "resource_type" : "Ini_setting",
-    "status" : "noop",
-    "resource_title" : "sample setting",
-    "timestamp" : "2015-02-13T13:29:32.334Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Ini_setting[sample setting]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "directory",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 410,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "var-net-snmp",
-    "timestamp" : "2015-02-13T13:29:32.336Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[var-net-snmp]" ],
-    "message" : "current_value absent, should be directory (noop)"
-  }, {
-    "new_value" : "running",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
-    "old_value" : "stopped",
-    "line" : 9,
-    "resource_type" : "Service",
-    "status" : "noop",
-    "resource_title" : "ntp",
-    "timestamp" : "2015-02-13T13:29:32.416Z",
-    "containment_path" : [ "Stage[main]", "Ntp::Service", "Service[ntp]" ],
-    "message" : "current_value stopped, should be running (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 69,
-    "resource_type" : "Gnupg_key",
-    "status" : "noop",
-    "resource_title" : "hkp_server_20BC0A86",
-    "timestamp" : "2015-02-13T13:29:32.444Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Gnupg_key[hkp_server_20BC0A86]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 453,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmptrapd.conf",
-    "timestamp" : "2015-02-13T13:29:32.711Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[snmptrapd.conf]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "directory",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 144,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file",
-    "timestamp" : "2015-02-13T13:29:32.713Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/var/lib/puppet/concat/_tmp_file]" ],
-    "message" : "current_value absent, should be directory (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 159,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments.concat",
-    "timestamp" : "2015-02-13T13:29:32.715Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/var/lib/puppet/concat/_tmp_file/fragments.concat]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 164,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-    "timestamp" : "2015-02-13T13:29:32.716Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "directory",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 149,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments",
-    "timestamp" : "2015-02-13T13:29:32.971Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/var/lib/puppet/concat/_tmp_file/fragments]" ],
-    "message" : "current_value absent, should be directory (noop)"
-  }, {
-    "new_value" : "file",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "old_value" : "absent",
-    "line" : 113,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
-    "timestamp" : "2015-02-13T13:29:32.973Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat::Fragment[tmpfile2]", "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]" ],
-    "message" : "current_value absent, should be file (noop)"
-  }, {
-    "new_value" : "file",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "old_value" : "absent",
-    "line" : 113,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
-    "timestamp" : "2015-02-13T13:29:33.045Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat::Fragment[tmpfile]", "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]" ],
-    "message" : "current_value absent, should be file (noop)"
-  }, {
-    "new_value" : [ "0" ],
-    "property" : "returns",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "notrun",
-    "line" : 187,
-    "resource_type" : "Exec",
-    "status" : "noop",
-    "resource_title" : "concat_/tmp/file",
-    "timestamp" : "2015-02-13T13:29:33.112Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "Exec[concat_/tmp/file]" ],
-    "message" : "current_value notrun, should be 0 (noop)"
-  }, {
-    "new_value" : null,
-    "property" : null,
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : null,
-    "line" : 169,
-    "resource_type" : "File",
-    "status" : "failure",
-    "resource_title" : "/tmp/file",
-    "timestamp" : "2015-02-13T13:29:33.118Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/tmp/file]" ],
-    "message" : "Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 429,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmpd.conf",
-    "timestamp" : "2015-02-13T13:29:33.123Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[snmpd.conf]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "running",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "stopped",
-    "line" : 517,
-    "resource_type" : "Service",
-    "status" : "noop",
-    "resource_title" : "snmpd",
-    "timestamp" : "2015-02-13T13:29:33.221Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "Service[snmpd]" ],
-    "message" : "current_value stopped, should be running (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/git/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 12,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "git",
-    "timestamp" : "2015-02-13T13:29:33.407Z",
-    "containment_path" : [ "Stage[main]", "Git", "Package[git]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "old_value" : "absent",
-    "line" : 60,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "python-pip",
-    "timestamp" : "2015-02-13T13:29:33.660Z",
-    "containment_path" : [ "Stage[main]", "Python::Install", "Package[python-pip]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "old_value" : "absent",
-    "line" : 61,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "python-devel",
-    "timestamp" : "2015-02-13T13:29:33.687Z",
-    "containment_path" : [ "Stage[main]", "Python::Install", "Package[python-devel]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "old_value" : "absent",
-    "line" : 59,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "python-virtualenv",
-    "timestamp" : "2015-02-13T13:29:33.738Z",
-    "containment_path" : [ "Stage[main]", "Python::Install", "Package[python-virtualenv]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "old_value" : "absent",
-    "line" : 85,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmp.conf",
-    "timestamp" : "2015-02-13T13:29:33.744Z",
-    "containment_path" : [ "Stage[main]", "Snmp::Client", "File[snmp.conf]" ],
-    "message" : "current_value absent, should be present (noop)"
-  } ],
-  "status" : "failed",
-  "configuration_version" : "1423834124",
-  "environment" : "production",
-  "certname" : "pg2.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 0.001046,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.049918,
-    "name" : "augeas"
-  }, {
-    "category" : "time",
-    "value" : 1.2285521030426,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.454854,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.232939,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 1.35E-4,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.024507,
-    "name" : "gnupg_key"
-  }, {
-    "category" : "time",
-    "value" : 6.65E-4,
-    "name" : "ini_setting"
-  }, {
-    "category" : "time",
-    "value" : 8.4E-4,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.25077,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 6.28E-4,
-    "name" : "postgresql_conf"
-  }, {
-    "category" : "time",
-    "value" : 0.002515,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.532835,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 2.7802041030426,
-    "name" : "total"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 2,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 29,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 88,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 28,
-    "name" : "noop"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 29,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 0,
-    "name" : "total"
-  } ]
+    "certname": "pg2.vm",
+    "configuration_version": "1423834124",
+    "end_time": "2015-02-13T13:29:29.626Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 2.08 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.78+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 8 events",
+            "source": "Stage[main]",
+            "tags": [
+                "main",
+                "completed_stage",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.748+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 8 events",
+            "source": "Class[Loadtest]",
+            "tags": [
+                "completed_class",
+                "loadtest",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.746+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "err",
+            "line": 11,
+            "message": "Provider git is not functional on this host",
+            "source": "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
+            "tags": [
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "err",
+                "vcsrepo",
+                "node"
+            ],
+            "time": "2015-02-13T13:29:33.746+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 2 events",
+            "source": "Class[Snmp::Client]",
+            "tags": [
+                "completed_class",
+                "snmp",
+                "snmp::client",
+                "client",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.745+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "level": "notice",
+            "line": 85,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp::Client/File[snmp.conf]/ensure",
+            "tags": [
+                "class",
+                "snmp",
+                "pg2.vm",
+                "snmp.conf",
+                "loadtest",
+                "file",
+                "node",
+                "snmp::client",
+                "client",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.744+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 3 events",
+            "source": "Class[Python::Install]",
+            "tags": [
+                "completed_class",
+                "python::install",
+                "install",
+                "python",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.741+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "notice",
+            "line": 59,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Python::Install/Package[python-virtualenv]/ensure",
+            "tags": [
+                "class",
+                "python::install",
+                "pg2.vm",
+                "python-virtualenv",
+                "install",
+                "python",
+                "loadtest",
+                "node",
+                "package",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.738+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "notice",
+            "line": 61,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Python::Install/Package[python-devel]/ensure",
+            "tags": [
+                "python-devel",
+                "class",
+                "python::install",
+                "pg2.vm",
+                "install",
+                "python",
+                "loadtest",
+                "node",
+                "package",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.688+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "notice",
+            "line": 60,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Python::Install/Package[python-pip]/ensure",
+            "tags": [
+                "class",
+                "python-pip",
+                "python::install",
+                "pg2.vm",
+                "install",
+                "python",
+                "loadtest",
+                "node",
+                "package",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.66+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Git]",
+            "tags": [
+                "completed_class",
+                "git",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.409+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/git/manifests/init.pp",
+            "level": "notice",
+            "line": 12,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Git/Package[git]/ensure",
+            "tags": [
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "git",
+                "node",
+                "package",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.407+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 8 events",
+            "source": "Class[Snmp]",
+            "tags": [
+                "completed_class",
+                "snmp",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.224+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 517,
+            "message": "Unscheduling refresh on Service[snmpd]",
+            "source": "/Stage[main]/Snmp/Service[snmpd]",
+            "tags": [
+                "snmpd",
+                "class",
+                "info",
+                "snmp",
+                "pg2.vm",
+                "loadtest",
+                "service",
+                "node"
+            ],
+            "time": "2015-02-13T13:29:33.222+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 517,
+            "message": "current_value stopped, should be running (noop)",
+            "source": "/Stage[main]/Snmp/Service[snmpd]/ensure",
+            "tags": [
+                "snmpd",
+                "class",
+                "snmp",
+                "pg2.vm",
+                "loadtest",
+                "service",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.221+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 429,
+            "message": "Scheduling refresh of Service[snmpd]",
+            "source": "/Stage[main]/Snmp/File[snmpd.conf]",
+            "tags": [
+                "class",
+                "info",
+                "snmp",
+                "pg2.vm",
+                "loadtest",
+                "snmpd.conf",
+                "file",
+                "node"
+            ],
+            "time": "2015-02-13T13:29:33.124+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 429,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/File[snmpd.conf]/ensure",
+            "tags": [
+                "class",
+                "snmp",
+                "pg2.vm",
+                "loadtest",
+                "snmpd.conf",
+                "file",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.123+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Concat::Fragment[tmpfile]",
+            "tags": [
+                "completed_concat::fragment",
+                "fragment",
+                "completed_concat",
+                "tmpfile",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.121+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 6 events",
+            "source": "Concat[/tmp/file]",
+            "tags": [
+                "completed_concat",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.119+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "err",
+            "line": 169,
+            "message": "Could not evaluate: Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/tmp/file]",
+            "tags": [
+                "concat",
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "err",
+                "file",
+                "node"
+            ],
+            "time": "2015-02-13T13:29:33.117+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 187,
+            "message": "Would have triggered 'refresh' from 4 events",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+            "tags": [
+                "concat",
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "node",
+                "exec",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.114+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 187,
+            "message": "current_value notrun, should be 0 (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/returns",
+            "tags": [
+                "concat",
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "node",
+                "exec",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.113+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "info",
+            "line": 113,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+            "tags": [
+                "concat::fragment",
+                "class",
+                "concat",
+                "info",
+                "pg2.vm",
+                "fragment",
+                "loadtest",
+                "tmpfile",
+                "file",
+                "node"
+            ],
+            "time": "2015-02-13T13:29:33.046+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "notice",
+            "line": 113,
+            "message": "current_value absent, should be file (noop)",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/ensure",
+            "tags": [
+                "concat::fragment",
+                "class",
+                "concat",
+                "pg2.vm",
+                "fragment",
+                "loadtest",
+                "tmpfile",
+                "file",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.045+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Concat::Fragment[tmpfile2]",
+            "tags": [
+                "completed_concat::fragment",
+                "tmpfile2",
+                "fragment",
+                "completed_concat",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:33.042+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "info",
+            "line": 113,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+            "tags": [
+                "concat::fragment",
+                "class",
+                "concat",
+                "info",
+                "pg2.vm",
+                "tmpfile2",
+                "fragment",
+                "loadtest",
+                "file",
+                "node"
+            ],
+            "time": "2015-02-13T13:29:32.973+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "notice",
+            "line": 113,
+            "message": "current_value absent, should be file (noop)",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
+            "tags": [
+                "concat::fragment",
+                "class",
+                "concat",
+                "pg2.vm",
+                "tmpfile2",
+                "fragment",
+                "loadtest",
+                "file",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.973+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "info",
+            "line": 149,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
+            "tags": [
+                "concat",
+                "class",
+                "info",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "node"
+            ],
+            "time": "2015-02-13T13:29:32.972+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 149,
+            "message": "current_value absent, should be directory (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/ensure",
+            "tags": [
+                "concat",
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.971+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 476,
+            "message": "Would have triggered 'refresh' from 2 events",
+            "source": "/Stage[main]/Snmp/Service[snmptrapd]",
+            "tags": [
+                "class",
+                "snmp",
+                "pg2.vm",
+                "snmptrapd",
+                "loadtest",
+                "service",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.967+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 164,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]/ensure",
+            "tags": [
+                "concat",
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.716+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 159,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]/ensure",
+            "tags": [
+                "concat",
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.715+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "info",
+            "line": 144,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
+            "tags": [
+                "concat",
+                "class",
+                "info",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "node"
+            ],
+            "time": "2015-02-13T13:29:32.714+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 144,
+            "message": "current_value absent, should be directory (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]/ensure",
+            "tags": [
+                "concat",
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.714+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 453,
+            "message": "Scheduling refresh of Service[snmptrapd]",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]",
+            "tags": [
+                "snmptrapd.conf",
+                "class",
+                "info",
+                "snmp",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "node"
+            ],
+            "time": "2015-02-13T13:29:32.712+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 453,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]/ensure",
+            "tags": [
+                "snmptrapd.conf",
+                "class",
+                "snmp",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.711+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 69,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]/ensure",
+            "tags": [
+                "gnupg_key",
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "hkp_server_20bc0a86",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.444+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Ntp::Service]",
+            "tags": [
+                "completed_class",
+                "ntp",
+                "service",
+                "ntp::service",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.418+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
+            "level": "info",
+            "line": 9,
+            "message": "Unscheduling refresh on Service[ntp]",
+            "source": "/Stage[main]/Ntp::Service/Service[ntp]",
+            "tags": [
+                "ntp",
+                "class",
+                "info",
+                "pg2.vm",
+                "loadtest",
+                "service",
+                "node",
+                "ntp::service"
+            ],
+            "time": "2015-02-13T13:29:32.416+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
+            "level": "notice",
+            "line": 9,
+            "message": "current_value stopped, should be running (noop)",
+            "source": "/Stage[main]/Ntp::Service/Service[ntp]/ensure",
+            "tags": [
+                "ntp",
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "service",
+                "node",
+                "ntp::service",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.416+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 410,
+            "message": "current_value absent, should be directory (noop)",
+            "source": "/Stage[main]/Snmp/File[var-net-snmp]/ensure",
+            "tags": [
+                "class",
+                "var-net-snmp",
+                "snmp",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.336+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 45,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Loadtest/Ini_setting[sample setting]/ensure",
+            "tags": [
+                "class",
+                "ini_setting",
+                "pg2.vm",
+                "loadtest",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.334+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Service[ntp]",
+            "source": "Class[Ntp::Service]",
+            "tags": [
+                "ntp",
+                "info",
+                "admissible_class",
+                "service",
+                "ntp::service"
+            ],
+            "time": "2015-02-13T13:29:32.333+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Ntp::Service]",
+            "tags": [
+                "ntp",
+                "admissible_class",
+                "service",
+                "ntp::service",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.333+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Class[Ntp::Service]",
+            "source": "Class[Ntp::Config]",
+            "tags": [
+                "completed_class",
+                "ntp",
+                "info",
+                "ntp::config",
+                "config"
+            ],
+            "time": "2015-02-13T13:29:32.332+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Ntp::Config]",
+            "tags": [
+                "completed_class",
+                "ntp",
+                "ntp::config",
+                "config",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.331+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
+            "level": "notice",
+            "line": 14,
+            "message": "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
+            "source": "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
+            "tags": [
+                "class",
+                "ntp",
+                "pg2.vm",
+                "ntp::config",
+                "loadtest",
+                "file",
+                "node",
+                "config",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.328+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
+            "level": "notice",
+            "line": 14,
+            "message": "\n--- /etc/ntp.conf\t2013-07-15 10:18:47.000000000 +0100\n+++ /tmp/puppet-file20150213-62287-xahzaj-0\t2015-02-13 13:29:32.296877887 +0000\n@@ -1,53 +1,19 @@\n-# For more information about this file, see the man pages\n-# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).\n+# ntp.conf: Managed by puppet.\n+#\n+# Keep ntpd from panicking in the event of a large clock skew\n+# when a VM guest is suspended and resumed.\n+tinker panic 0\n \n-driftfile /var/lib/ntp/drift\n \n # Permit time synchronization with our time source, but do not\n # permit the source to query or modify the service on this system.\n-restrict default kod nomodify notrap nopeer noquery\n-restrict -6 default kod nomodify notrap nopeer noquery\n+restrict 127.0.0.1\n+\n \n-# Permit all access over the loopback interface.  This could\n-# be tightened as well, but to do so would effect some of\n-# the administrative functions.\n-restrict 127.0.0.1 \n-restrict -6 ::1\n-\n-# Hosts on local network are less restricted.\n-#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap\n-\n-# Use public servers from the pool.ntp.org project.\n-# Please consider joining the pool (http://www.pool.ntp.org/join.html).\n-server 0.centos.pool.ntp.org iburst\n-server 1.centos.pool.ntp.org iburst\n-server 2.centos.pool.ntp.org iburst\n-server 3.centos.pool.ntp.org iburst\n-\n-#broadcast 192.168.1.255 autokey\t# broadcast server\n-#broadcastclient\t\t\t# broadcast client\n-#broadcast 224.0.1.1 autokey\t\t# multicast server\n-#multicastclient 224.0.1.1\t\t# multicast client\n-#manycastserver 239.255.254.254\t\t# manycast server\n-#manycastclient 239.255.254.254 autokey # manycast client\n-\n-# Enable public key cryptography.\n-#crypto\n-\n-includefile /etc/ntp/crypto/pw\n-\n-# Key file containing the keys and key identifiers used when operating\n-# with symmetric key cryptography. \n-keys /etc/ntp/keys\n-\n-# Specify the key identifiers which are trusted.\n-#trustedkey 4 8 42\n+server ntp.pool.org\n \n-# Specify the key identifier to use with the ntpdc utility.\n-#requestkey 8\n \n-# Specify the key identifier to use with the ntpq utility.\n-#controlkey 8\n+# Driftfile.\n+driftfile /var/lib/ntp/drift\n+\n \n-# Enable writing of statistics records.\n-#statistics clockstats cryptostats loopstats peerstats\n",
+            "source": "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
+            "tags": [
+                "class",
+                "ntp",
+                "pg2.vm",
+                "ntp::config",
+                "loadtest",
+                "file",
+                "node",
+                "config",
+                "content",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.324+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 441,
+            "message": "Scheduling refresh of Service[snmpd]",
+            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]",
+            "tags": [
+                "snmpd.sysconfig",
+                "class",
+                "info",
+                "snmp",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "node"
+            ],
+            "time": "2015-02-13T13:29:32.293+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 441,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]/ensure",
+            "tags": [
+                "snmpd.sysconfig",
+                "class",
+                "snmp",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.292+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 465,
+            "message": "Scheduling refresh of Service[snmptrapd]",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.sysconfig]",
+            "tags": [
+                "class",
+                "info",
+                "snmp",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "node",
+                "snmptrapd.sysconfig"
+            ],
+            "time": "2015-02-13T13:29:32.285+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 465,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.sysconfig]/ensure",
+            "tags": [
+                "class",
+                "snmp",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "node",
+                "snmptrapd.sysconfig",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.285+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "info",
+            "line": 4,
+            "message": "Unscheduling refresh on Service[cron]",
+            "source": "/Stage[main]/Loadtest/Service[cron]",
+            "tags": [
+                "class",
+                "info",
+                "pg2.vm",
+                "loadtest",
+                "service",
+                "cron",
+                "node"
+            ],
+            "time": "2015-02-13T13:29:32.281+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 4,
+            "message": "current_value stopped, should be running (noop)",
+            "source": "/Stage[main]/Loadtest/Service[cron]/ensure",
+            "tags": [
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "service",
+                "cron",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.28+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 3,
+            "message": "current_value absent, should be foo (noop)",
+            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
+            "tags": [
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "foo",
+                "node",
+                "notify",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.178+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 405,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/Package[snmpd]/ensure",
+            "tags": [
+                "snmpd",
+                "class",
+                "snmp",
+                "pg2.vm",
+                "loadtest",
+                "node",
+                "package",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.176+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 41,
+            "message": "current_value absent, should be latest (noop)",
+            "source": "/Stage[main]/Loadtest/Package[etckeeper]/ensure",
+            "tags": [
+                "etckeeper",
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "node",
+                "package",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.134+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "level": "notice",
+            "line": 76,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp::Client/Package[snmp-client]/ensure",
+            "tags": [
+                "snmp-client",
+                "class",
+                "snmp",
+                "pg2.vm",
+                "loadtest",
+                "node",
+                "snmp::client",
+                "package",
+                "client",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:32.09+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Motd]",
+            "tags": [
+                "completed_class",
+                "motd",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:31.93+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "level": "notice",
+            "line": 33,
+            "message": "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
+            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
+            "tags": [
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "motd",
+                "node",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:31.924+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "level": "notice",
+            "line": 33,
+            "message": "\n--- /etc/motd\t2010-01-12 13:28:22.000000000 +0000\n+++ /tmp/puppet-file20150213-62287-jf1btv-0\t2015-02-13 13:29:31.882877889 +0000\n@@ -0,0 +1 @@\n+Welcome to my test host!\n\\ No newline at end of file\n",
+            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
+            "tags": [
+                "class",
+                "pg2.vm",
+                "loadtest",
+                "file",
+                "motd",
+                "node",
+                "content",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:31.923+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423834124'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:31.774+00:00"
+        },
+        {
+            "file": null,
+            "level": "warning",
+            "line": null,
+            "message": "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
+            "source": "Puppet",
+            "tags": [
+                "warning"
+            ],
+            "time": "2015-02-13T13:29:31.381+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for pg2.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:31.286+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:29.241+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:26.991+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:26.912+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.001046
+        },
+        {
+            "category": "time",
+            "name": "augeas",
+            "value": 0.049918
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 1.2285521030426
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.454854
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.232939
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 0.000135
+        },
+        {
+            "category": "time",
+            "name": "gnupg_key",
+            "value": 0.024507
+        },
+        {
+            "category": "time",
+            "name": "ini_setting",
+            "value": 0.000665
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.00084
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.25077
+        },
+        {
+            "category": "time",
+            "name": "postgresql_conf",
+            "value": 0.000628
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.002515
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.532835
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 2.7802041030426
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 2
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 29
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 88
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 1
+        },
+        {
+            "category": "events",
+            "name": "noop",
+            "value": 28
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 29
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 0
+        }
+    ],
+    "noop": true,
+    "puppet_version": "3.7.1",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp::Client",
+                "File[snmp.conf]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:33.744Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "line": 85,
+            "resource_title": "snmp.conf",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:33.744Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.716Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 164,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.716Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp::Client",
+                "Package[snmp-client]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.090Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "line": 76,
+            "resource_title": "snmp-client",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.090Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat::Fragment[tmpfile2]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be file (noop)",
+                    "new_value": "file",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.973Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "line": 113,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.973Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Package[etckeeper]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be latest (noop)",
+                    "new_value": "latest",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.134Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 41,
+            "resource_title": "etckeeper",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.134Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Motd",
+                "File[/etc/motd]"
+            ],
+            "events": [
+                {
+                    "message": "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
+                    "new_value": "{md5}a3f731187a6aaaa23d4a7b244f223f33",
+                    "old_value": "{md5}d41d8cd98f00b204e9800998ecf8427e",
+                    "property": "content",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:31.924Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "line": 33,
+            "resource_title": "/etc/motd",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:31.924Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/tmp/file]"
+            ],
+            "events": [
+                {
+                    "message": "Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
+                    "new_value": null,
+                    "old_value": null,
+                    "property": null,
+                    "status": "failure",
+                    "timestamp": "2015-02-13T13:29:33.118Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 169,
+            "resource_title": "/tmp/file",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:33.118Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be foo (noop)",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.178Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 3,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.178Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[snmptrapd.sysconfig]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.284Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 465,
+            "resource_title": "snmptrapd.sysconfig",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.284Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat::Fragment[tmpfile]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be file (noop)",
+                    "new_value": "file",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:33.045Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "line": 113,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:33.045Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[var-net-snmp]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be directory (noop)",
+                    "new_value": "directory",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.336Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 410,
+            "resource_title": "var-net-snmp",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.336Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Python::Install",
+                "Package[python-pip]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:33.660Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "line": 60,
+            "resource_title": "python-pip",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:33.660Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "Service[snmpd]"
+            ],
+            "events": [
+                {
+                    "message": "current_value stopped, should be running (noop)",
+                    "new_value": "running",
+                    "old_value": "stopped",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:33.221Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 517,
+            "resource_title": "snmpd",
+            "resource_type": "Service",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:33.221Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[snmpd.sysconfig]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.292Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 441,
+            "resource_title": "snmpd.sysconfig",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.292Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Git",
+                "Package[git]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:33.407Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/git/manifests/init.pp",
+            "line": 12,
+            "resource_title": "git",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:33.407Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Python::Install",
+                "Package[python-virtualenv]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:33.738Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "line": 59,
+            "resource_title": "python-virtualenv",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:33.738Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "Package[snmpd]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.175Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 405,
+            "resource_title": "snmpd",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.175Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Ntp::Service",
+                "Service[ntp]"
+            ],
+            "events": [
+                {
+                    "message": "current_value stopped, should be running (noop)",
+                    "new_value": "running",
+                    "old_value": "stopped",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.416Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
+            "line": 9,
+            "resource_title": "ntp",
+            "resource_type": "Service",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.416Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Python::Install",
+                "Package[python-devel]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:33.687Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "line": 61,
+            "resource_title": "python-devel",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:33.687Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[snmptrapd.conf]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.711Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 453,
+            "resource_title": "snmptrapd.conf",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.711Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/var/lib/puppet/concat/_tmp_file]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be directory (noop)",
+                    "new_value": "directory",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.713Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 144,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.713Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Gnupg_key[hkp_server_20BC0A86]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.444Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 69,
+            "resource_title": "hkp_server_20BC0A86",
+            "resource_type": "Gnupg_key",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.444Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be directory (noop)",
+                    "new_value": "directory",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.971Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 149,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.971Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments.concat]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.715Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 159,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.715Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[snmpd.conf]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:33.123Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 429,
+            "resource_title": "snmpd.conf",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:33.123Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "Exec[concat_/tmp/file]"
+            ],
+            "events": [
+                {
+                    "message": "current_value notrun, should be 0 (noop)",
+                    "new_value": [
+                        "0"
+                    ],
+                    "old_value": "notrun",
+                    "property": "returns",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:33.112Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 187,
+            "resource_title": "concat_/tmp/file",
+            "resource_type": "Exec",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:33.112Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Ini_setting[sample setting]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.334Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 45,
+            "resource_title": "sample setting",
+            "resource_type": "Ini_setting",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.334Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Service[cron]"
+            ],
+            "events": [
+                {
+                    "message": "current_value stopped, should be running (noop)",
+                    "new_value": "running",
+                    "old_value": "stopped",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.280Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 4,
+            "resource_title": "cron",
+            "resource_type": "Service",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.280Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Ntp::Config",
+                "File[/etc/ntp.conf]"
+            ],
+            "events": [
+                {
+                    "message": "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
+                    "new_value": "{md5}eb918d28434c9fefcc05875c29c3ba1a",
+                    "old_value": "{md5}7fda24f62b1c7ae951db0f746dc6e0cc",
+                    "property": "content",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:32.328Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
+            "line": 14,
+            "resource_title": "/etc/ntp.conf",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:32.328Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:29:26.846Z",
+    "status": "failed",
+    "transaction_uuid": "1fb6bf81-0b2a-488c-b1d7-610a81b06b27"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-19fce4fd5281b1df9b42d58c808fecb2a783da3b.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-19fce4fd5281b1df9b42d58c808fecb2a783da3b.json
@@ -1,1007 +1,1930 @@
 {
-  "transaction_uuid" : "1fe685d2-cf15-46ba-8a07-84854c584703",
-  "puppet_version" : "3.7.1",
-  "noop" : true,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 2.19 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:28:48.73+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 8 events",
-    "source" : "Stage[main]",
-    "tags" : [ "completed_stage", "main", "notice" ],
-    "time" : "2015-02-13T13:28:48.698+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 8 events",
-    "source" : "Class[Loadtest]",
-    "tags" : [ "completed_class", "loadtest", "notice" ],
-    "time" : "2015-02-13T13:28:48.697+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "err",
-    "message" : "Provider git is not functional on this host",
-    "source" : "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
-    "tags" : [ "pg2.vm", "vcsrepo", "loadtest", "class", "node", "err" ],
-    "time" : "2015-02-13T13:28:48.696+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 11
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 2 events",
-    "source" : "Class[Snmp::Client]",
-    "tags" : [ "completed_class", "client", "snmp", "snmp::client", "notice" ],
-    "time" : "2015-02-13T13:28:48.695+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp::Client/File[snmp.conf]/ensure",
-    "tags" : [ "pg2.vm", "client", "file", "loadtest", "class", "snmp", "snmp.conf", "snmp::client", "notice", "node" ],
-    "time" : "2015-02-13T13:28:48.694+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "line" : 85
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 3 events",
-    "source" : "Class[Python::Install]",
-    "tags" : [ "completed_class", "notice", "python::install", "install", "python" ],
-    "time" : "2015-02-13T13:28:48.691+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Python::Install/Package[python-virtualenv]/ensure",
-    "tags" : [ "pg2.vm", "python-virtualenv", "loadtest", "class", "notice", "python::install", "install", "node", "package", "python" ],
-    "time" : "2015-02-13T13:28:48.688+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 59
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Python::Install/Package[python-devel]/ensure",
-    "tags" : [ "pg2.vm", "python-devel", "loadtest", "class", "notice", "python::install", "install", "node", "package", "python" ],
-    "time" : "2015-02-13T13:28:48.637+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 61
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Python::Install/Package[python-pip]/ensure",
-    "tags" : [ "pg2.vm", "python-pip", "loadtest", "class", "notice", "python::install", "install", "node", "package", "python" ],
-    "time" : "2015-02-13T13:28:48.609+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 60
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Git]",
-    "tags" : [ "completed_class", "git", "notice" ],
-    "time" : "2015-02-13T13:28:48.353+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Git/Package[git]/ensure",
-    "tags" : [ "pg2.vm", "git", "loadtest", "class", "notice", "node", "package" ],
-    "time" : "2015-02-13T13:28:48.351+00:00",
-    "file" : "/etc/puppet/modules/git/manifests/init.pp",
-    "line" : 12
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 8 events",
-    "source" : "Class[Snmp]",
-    "tags" : [ "completed_class", "snmp", "notice" ],
-    "time" : "2015-02-13T13:28:48.168+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Unscheduling refresh on Service[snmpd]",
-    "source" : "/Stage[main]/Snmp/Service[snmpd]",
-    "tags" : [ "pg2.vm", "info", "snmpd", "loadtest", "class", "snmp", "service", "node" ],
-    "time" : "2015-02-13T13:28:48.166+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 517
-  }, {
-    "level" : "notice",
-    "message" : "current_value stopped, should be running (noop)",
-    "source" : "/Stage[main]/Snmp/Service[snmpd]/ensure",
-    "tags" : [ "pg2.vm", "snmpd", "loadtest", "class", "snmp", "notice", "service", "node" ],
-    "time" : "2015-02-13T13:28:48.164+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 517
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[snmpd]",
-    "source" : "/Stage[main]/Snmp/File[snmpd.conf]",
-    "tags" : [ "pg2.vm", "snmpd.conf", "info", "file", "loadtest", "class", "snmp", "node" ],
-    "time" : "2015-02-13T13:28:48.068+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 429
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/File[snmpd.conf]/ensure",
-    "tags" : [ "pg2.vm", "snmpd.conf", "file", "loadtest", "class", "snmp", "notice", "node" ],
-    "time" : "2015-02-13T13:28:48.067+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 429
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Concat::Fragment[tmpfile]",
-    "tags" : [ "tmpfile", "fragment", "completed_concat", "completed_concat::fragment", "notice" ],
-    "time" : "2015-02-13T13:28:48.064+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 6 events",
-    "source" : "Concat[/tmp/file]",
-    "tags" : [ "completed_concat", "notice" ],
-    "time" : "2015-02-13T13:28:48.062+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "err",
-    "message" : "Could not evaluate: Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/tmp/file]",
-    "tags" : [ "pg2.vm", "file", "loadtest", "class", "concat", "node", "err" ],
-    "time" : "2015-02-13T13:28:48.06+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 169
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 4 events",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-    "tags" : [ "pg2.vm", "exec", "loadtest", "class", "notice", "concat", "node" ],
-    "time" : "2015-02-13T13:28:48.057+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "notice",
-    "message" : "current_value notrun, should be 0 (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/returns",
-    "tags" : [ "pg2.vm", "exec", "loadtest", "class", "notice", "concat", "node" ],
-    "time" : "2015-02-13T13:28:48.056+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-    "tags" : [ "concat::fragment", "pg2.vm", "tmpfile", "info", "file", "loadtest", "fragment", "class", "node", "concat" ],
-    "time" : "2015-02-13T13:28:47.989+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be file (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/ensure",
-    "tags" : [ "concat::fragment", "pg2.vm", "tmpfile", "file", "loadtest", "fragment", "class", "notice", "node", "concat" ],
-    "time" : "2015-02-13T13:28:47.989+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Concat::Fragment[tmpfile2]",
-    "tags" : [ "fragment", "completed_concat", "tmpfile2", "completed_concat::fragment", "notice" ],
-    "time" : "2015-02-13T13:28:47.986+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-    "tags" : [ "concat::fragment", "pg2.vm", "info", "file", "loadtest", "fragment", "class", "tmpfile2", "node", "concat" ],
-    "time" : "2015-02-13T13:28:47.985+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be file (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
-    "tags" : [ "concat::fragment", "pg2.vm", "file", "loadtest", "fragment", "class", "tmpfile2", "notice", "node", "concat" ],
-    "time" : "2015-02-13T13:28:47.982+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
-    "tags" : [ "pg2.vm", "info", "file", "loadtest", "class", "concat", "node" ],
-    "time" : "2015-02-13T13:28:47.919+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 149
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be directory (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/ensure",
-    "tags" : [ "pg2.vm", "file", "loadtest", "class", "notice", "concat", "node" ],
-    "time" : "2015-02-13T13:28:47.919+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 149
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 2 events",
-    "source" : "/Stage[main]/Snmp/Service[snmptrapd]",
-    "tags" : [ "pg2.vm", "loadtest", "class", "snmp", "snmptrapd", "notice", "service", "node" ],
-    "time" : "2015-02-13T13:28:47.915+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 476
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]/ensure",
-    "tags" : [ "pg2.vm", "file", "loadtest", "class", "notice", "concat", "node" ],
-    "time" : "2015-02-13T13:28:47.705+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 164
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]/ensure",
-    "tags" : [ "pg2.vm", "file", "loadtest", "class", "notice", "concat", "node" ],
-    "time" : "2015-02-13T13:28:47.703+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 159
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
-    "tags" : [ "pg2.vm", "info", "file", "loadtest", "class", "concat", "node" ],
-    "time" : "2015-02-13T13:28:47.702+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 144
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be directory (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]/ensure",
-    "tags" : [ "pg2.vm", "file", "loadtest", "class", "notice", "concat", "node" ],
-    "time" : "2015-02-13T13:28:47.702+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 144
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[snmptrapd]",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]",
-    "tags" : [ "pg2.vm", "snmptrapd.conf", "info", "file", "loadtest", "class", "snmp", "node" ],
-    "time" : "2015-02-13T13:28:47.699+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 453
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]/ensure",
-    "tags" : [ "pg2.vm", "snmptrapd.conf", "file", "loadtest", "class", "snmp", "notice", "node" ],
-    "time" : "2015-02-13T13:28:47.699+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 453
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]/ensure",
-    "tags" : [ "pg2.vm", "hkp_server_20bc0a86", "loadtest", "class", "notice", "node", "gnupg_key" ],
-    "time" : "2015-02-13T13:28:47.439+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 69
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Ntp::Service]",
-    "tags" : [ "completed_class", "ntp", "ntp::service", "notice", "service" ],
-    "time" : "2015-02-13T13:28:47.396+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Unscheduling refresh on Service[ntp]",
-    "source" : "/Stage[main]/Ntp::Service/Service[ntp]",
-    "tags" : [ "ntp", "pg2.vm", "ntp::service", "info", "loadtest", "class", "node", "service" ],
-    "time" : "2015-02-13T13:28:47.394+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
-    "line" : 9
-  }, {
-    "level" : "notice",
-    "message" : "current_value stopped, should be running (noop)",
-    "source" : "/Stage[main]/Ntp::Service/Service[ntp]/ensure",
-    "tags" : [ "ntp", "pg2.vm", "ntp::service", "loadtest", "class", "notice", "node", "service" ],
-    "time" : "2015-02-13T13:28:47.393+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
-    "line" : 9
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be directory (noop)",
-    "source" : "/Stage[main]/Snmp/File[var-net-snmp]/ensure",
-    "tags" : [ "pg2.vm", "file", "loadtest", "var-net-snmp", "class", "snmp", "notice", "node" ],
-    "time" : "2015-02-13T13:28:47.234+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 410
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Loadtest/Ini_setting[sample setting]/ensure",
-    "tags" : [ "pg2.vm", "loadtest", "class", "ini_setting", "notice", "node" ],
-    "time" : "2015-02-13T13:28:47.231+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 45
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[ntp]",
-    "source" : "Class[Ntp::Service]",
-    "tags" : [ "ntp", "ntp::service", "info", "admissible_class", "service" ],
-    "time" : "2015-02-13T13:28:47.23+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Ntp::Service]",
-    "tags" : [ "ntp", "ntp::service", "notice", "admissible_class", "service" ],
-    "time" : "2015-02-13T13:28:47.229+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Class[Ntp::Service]",
-    "source" : "Class[Ntp::Config]",
-    "tags" : [ "completed_class", "ntp", "config", "info", "ntp::config" ],
-    "time" : "2015-02-13T13:28:47.229+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Ntp::Config]",
-    "tags" : [ "completed_class", "ntp", "config", "notice", "ntp::config" ],
-    "time" : "2015-02-13T13:28:47.228+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
-    "source" : "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
-    "tags" : [ "ntp", "config", "pg2.vm", "file", "loadtest", "class", "notice", "node", "ntp::config" ],
-    "time" : "2015-02-13T13:28:47.225+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
-    "line" : 14
-  }, {
-    "level" : "notice",
-    "message" : "\n--- /etc/ntp.conf\t2013-07-15 10:18:47.000000000 +0100\n+++ /tmp/puppet-file20150213-61500-1so4rsh-0\t2015-02-13 13:28:47.197877918 +0000\n@@ -1,53 +1,19 @@\n-# For more information about this file, see the man pages\n-# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).\n+# ntp.conf: Managed by puppet.\n+#\n+# Keep ntpd from panicking in the event of a large clock skew\n+# when a VM guest is suspended and resumed.\n+tinker panic 0\n \n-driftfile /var/lib/ntp/drift\n \n # Permit time synchronization with our time source, but do not\n # permit the source to query or modify the service on this system.\n-restrict default kod nomodify notrap nopeer noquery\n-restrict -6 default kod nomodify notrap nopeer noquery\n+restrict 127.0.0.1\n+\n \n-# Permit all access over the loopback interface.  This could\n-# be tightened as well, but to do so would effect some of\n-# the administrative functions.\n-restrict 127.0.0.1 \n-restrict -6 ::1\n-\n-# Hosts on local network are less restricted.\n-#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap\n-\n-# Use public servers from the pool.ntp.org project.\n-# Please consider joining the pool (http://www.pool.ntp.org/join.html).\n-server 0.centos.pool.ntp.org iburst\n-server 1.centos.pool.ntp.org iburst\n-server 2.centos.pool.ntp.org iburst\n-server 3.centos.pool.ntp.org iburst\n-\n-#broadcast 192.168.1.255 autokey\t# broadcast server\n-#broadcastclient\t\t\t# broadcast client\n-#broadcast 224.0.1.1 autokey\t\t# multicast server\n-#multicastclient 224.0.1.1\t\t# multicast client\n-#manycastserver 239.255.254.254\t\t# manycast server\n-#manycastclient 239.255.254.254 autokey # manycast client\n-\n-# Enable public key cryptography.\n-#crypto\n-\n-includefile /etc/ntp/crypto/pw\n-\n-# Key file containing the keys and key identifiers used when operating\n-# with symmetric key cryptography. \n-keys /etc/ntp/keys\n-\n-# Specify the key identifiers which are trusted.\n-#trustedkey 4 8 42\n+server ntp.pool.org\n \n-# Specify the key identifier to use with the ntpdc utility.\n-#requestkey 8\n \n-# Specify the key identifier to use with the ntpq utility.\n-#controlkey 8\n+# Driftfile.\n+driftfile /var/lib/ntp/drift\n+\n \n-# Enable writing of statistics records.\n-#statistics clockstats cryptostats loopstats peerstats\n",
-    "source" : "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
-    "tags" : [ "ntp", "config", "pg2.vm", "file", "loadtest", "class", "content", "notice", "node", "ntp::config" ],
-    "time" : "2015-02-13T13:28:47.221+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
-    "line" : 14
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[snmpd]",
-    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]",
-    "tags" : [ "pg2.vm", "info", "file", "loadtest", "snmpd.sysconfig", "class", "snmp", "node" ],
-    "time" : "2015-02-13T13:28:47.191+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 441
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]/ensure",
-    "tags" : [ "pg2.vm", "file", "loadtest", "snmpd.sysconfig", "class", "snmp", "notice", "node" ],
-    "time" : "2015-02-13T13:28:47.191+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 441
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[snmptrapd]",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.sysconfig]",
-    "tags" : [ "pg2.vm", "info", "file", "loadtest", "class", "snmp", "snmptrapd.sysconfig", "node" ],
-    "time" : "2015-02-13T13:28:47.182+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 465
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.sysconfig]/ensure",
-    "tags" : [ "pg2.vm", "file", "loadtest", "class", "snmp", "snmptrapd.sysconfig", "notice", "node" ],
-    "time" : "2015-02-13T13:28:47.182+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 465
-  }, {
-    "level" : "info",
-    "message" : "Unscheduling refresh on Service[cron]",
-    "source" : "/Stage[main]/Loadtest/Service[cron]",
-    "tags" : [ "pg2.vm", "info", "loadtest", "class", "service", "cron", "node" ],
-    "time" : "2015-02-13T13:28:47.178+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 4
-  }, {
-    "level" : "notice",
-    "message" : "current_value stopped, should be running (noop)",
-    "source" : "/Stage[main]/Loadtest/Service[cron]/ensure",
-    "tags" : [ "pg2.vm", "loadtest", "class", "notice", "service", "cron", "node" ],
-    "time" : "2015-02-13T13:28:47.177+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 4
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be foo (noop)",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
-    "tags" : [ "foo", "pg2.vm", "notify", "loadtest", "class", "notice", "node" ],
-    "time" : "2015-02-13T13:28:47.072+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/Package[snmpd]/ensure",
-    "tags" : [ "pg2.vm", "snmpd", "loadtest", "class", "snmp", "notice", "node", "package" ],
-    "time" : "2015-02-13T13:28:47.069+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 405
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be latest (noop)",
-    "source" : "/Stage[main]/Loadtest/Package[etckeeper]/ensure",
-    "tags" : [ "pg2.vm", "loadtest", "etckeeper", "class", "notice", "node", "package" ],
-    "time" : "2015-02-13T13:28:47.026+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 41
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp::Client/Package[snmp-client]/ensure",
-    "tags" : [ "pg2.vm", "snmp-client", "client", "loadtest", "class", "snmp", "snmp::client", "notice", "node", "package" ],
-    "time" : "2015-02-13T13:28:46.98+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "line" : 76
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Motd]",
-    "tags" : [ "completed_class", "motd", "notice" ],
-    "time" : "2015-02-13T13:28:46.803+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
-    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
-    "tags" : [ "motd", "pg2.vm", "file", "loadtest", "class", "notice", "node" ],
-    "time" : "2015-02-13T13:28:46.797+00:00",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "line" : 33
-  }, {
-    "level" : "notice",
-    "message" : "\n--- /etc/motd\t2010-01-12 13:28:22.000000000 +0000\n+++ /tmp/puppet-file20150213-61500-ay65od-0\t2015-02-13 13:28:46.727877920 +0000\n@@ -0,0 +1 @@\n+Welcome to my test host!\n\\ No newline at end of file\n",
-    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
-    "tags" : [ "motd", "pg2.vm", "file", "loadtest", "class", "content", "notice", "node" ],
-    "time" : "2015-02-13T13:28:46.795+00:00",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "line" : 33
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423834124'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:28:46.616+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "warning",
-    "message" : "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
-    "source" : "Puppet",
-    "tags" : [ "warning" ],
-    "time" : "2015-02-13T13:28:46.219+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for pg2.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:28:46.118+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:28:43.601+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:28:41.319+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:28:41.273+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:28:41.219Z",
-  "end_time" : "2015-02-13T13:28:44.696Z",
-  "resource_events" : [ {
-    "new_value" : "{md5}a3f731187a6aaaa23d4a7b244f223f33",
-    "property" : "content",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "old_value" : "{md5}d41d8cd98f00b204e9800998ecf8427e",
-    "line" : 33,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/etc/motd",
-    "timestamp" : "2015-02-13T13:28:46.797Z",
-    "containment_path" : [ "Stage[main]", "Motd", "File[/etc/motd]" ],
-    "message" : "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "old_value" : "absent",
-    "line" : 76,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "snmp-client",
-    "timestamp" : "2015-02-13T13:28:46.980Z",
-    "containment_path" : [ "Stage[main]", "Snmp::Client", "Package[snmp-client]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "latest",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 41,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "etckeeper",
-    "timestamp" : "2015-02-13T13:28:47.026Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Package[etckeeper]" ],
-    "message" : "current_value absent, should be latest (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 405,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "snmpd",
-    "timestamp" : "2015-02-13T13:28:47.069Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "Package[snmpd]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 3,
-    "resource_type" : "Notify",
-    "status" : "noop",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:28:47.072Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
-    "message" : "current_value absent, should be foo (noop)"
-  }, {
-    "new_value" : "running",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "stopped",
-    "line" : 4,
-    "resource_type" : "Service",
-    "status" : "noop",
-    "resource_title" : "cron",
-    "timestamp" : "2015-02-13T13:28:47.177Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Service[cron]" ],
-    "message" : "current_value stopped, should be running (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 465,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmptrapd.sysconfig",
-    "timestamp" : "2015-02-13T13:28:47.182Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[snmptrapd.sysconfig]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 441,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmpd.sysconfig",
-    "timestamp" : "2015-02-13T13:28:47.191Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[snmpd.sysconfig]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "{md5}eb918d28434c9fefcc05875c29c3ba1a",
-    "property" : "content",
-    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
-    "old_value" : "{md5}7fda24f62b1c7ae951db0f746dc6e0cc",
-    "line" : 14,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/etc/ntp.conf",
-    "timestamp" : "2015-02-13T13:28:47.224Z",
-    "containment_path" : [ "Stage[main]", "Ntp::Config", "File[/etc/ntp.conf]" ],
-    "message" : "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 45,
-    "resource_type" : "Ini_setting",
-    "status" : "noop",
-    "resource_title" : "sample setting",
-    "timestamp" : "2015-02-13T13:28:47.231Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Ini_setting[sample setting]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "directory",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 410,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "var-net-snmp",
-    "timestamp" : "2015-02-13T13:28:47.234Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[var-net-snmp]" ],
-    "message" : "current_value absent, should be directory (noop)"
-  }, {
-    "new_value" : "running",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
-    "old_value" : "stopped",
-    "line" : 9,
-    "resource_type" : "Service",
-    "status" : "noop",
-    "resource_title" : "ntp",
-    "timestamp" : "2015-02-13T13:28:47.393Z",
-    "containment_path" : [ "Stage[main]", "Ntp::Service", "Service[ntp]" ],
-    "message" : "current_value stopped, should be running (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 69,
-    "resource_type" : "Gnupg_key",
-    "status" : "noop",
-    "resource_title" : "hkp_server_20BC0A86",
-    "timestamp" : "2015-02-13T13:28:47.439Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Gnupg_key[hkp_server_20BC0A86]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 453,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmptrapd.conf",
-    "timestamp" : "2015-02-13T13:28:47.699Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[snmptrapd.conf]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "directory",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 144,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file",
-    "timestamp" : "2015-02-13T13:28:47.701Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/var/lib/puppet/concat/_tmp_file]" ],
-    "message" : "current_value absent, should be directory (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 159,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments.concat",
-    "timestamp" : "2015-02-13T13:28:47.703Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/var/lib/puppet/concat/_tmp_file/fragments.concat]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 164,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-    "timestamp" : "2015-02-13T13:28:47.705Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "directory",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 149,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments",
-    "timestamp" : "2015-02-13T13:28:47.919Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/var/lib/puppet/concat/_tmp_file/fragments]" ],
-    "message" : "current_value absent, should be directory (noop)"
-  }, {
-    "new_value" : "file",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "old_value" : "absent",
-    "line" : 113,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
-    "timestamp" : "2015-02-13T13:28:47.921Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat::Fragment[tmpfile2]", "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]" ],
-    "message" : "current_value absent, should be file (noop)"
-  }, {
-    "new_value" : "file",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "old_value" : "absent",
-    "line" : 113,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
-    "timestamp" : "2015-02-13T13:28:47.989Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat::Fragment[tmpfile]", "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]" ],
-    "message" : "current_value absent, should be file (noop)"
-  }, {
-    "new_value" : [ "0" ],
-    "property" : "returns",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "notrun",
-    "line" : 187,
-    "resource_type" : "Exec",
-    "status" : "noop",
-    "resource_title" : "concat_/tmp/file",
-    "timestamp" : "2015-02-13T13:28:48.056Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "Exec[concat_/tmp/file]" ],
-    "message" : "current_value notrun, should be 0 (noop)"
-  }, {
-    "new_value" : null,
-    "property" : null,
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : null,
-    "line" : 169,
-    "resource_type" : "File",
-    "status" : "failure",
-    "resource_title" : "/tmp/file",
-    "timestamp" : "2015-02-13T13:28:48.062Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/tmp/file]" ],
-    "message" : "Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 429,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmpd.conf",
-    "timestamp" : "2015-02-13T13:28:48.067Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[snmpd.conf]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "running",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "stopped",
-    "line" : 517,
-    "resource_type" : "Service",
-    "status" : "noop",
-    "resource_title" : "snmpd",
-    "timestamp" : "2015-02-13T13:28:48.164Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "Service[snmpd]" ],
-    "message" : "current_value stopped, should be running (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/git/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 12,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "git",
-    "timestamp" : "2015-02-13T13:28:48.351Z",
-    "containment_path" : [ "Stage[main]", "Git", "Package[git]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "old_value" : "absent",
-    "line" : 60,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "python-pip",
-    "timestamp" : "2015-02-13T13:28:48.609Z",
-    "containment_path" : [ "Stage[main]", "Python::Install", "Package[python-pip]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "old_value" : "absent",
-    "line" : 61,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "python-devel",
-    "timestamp" : "2015-02-13T13:28:48.637Z",
-    "containment_path" : [ "Stage[main]", "Python::Install", "Package[python-devel]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "old_value" : "absent",
-    "line" : 59,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "python-virtualenv",
-    "timestamp" : "2015-02-13T13:28:48.688Z",
-    "containment_path" : [ "Stage[main]", "Python::Install", "Package[python-virtualenv]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "old_value" : "absent",
-    "line" : 85,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmp.conf",
-    "timestamp" : "2015-02-13T13:28:48.694Z",
-    "containment_path" : [ "Stage[main]", "Snmp::Client", "File[snmp.conf]" ],
-    "message" : "current_value absent, should be present (noop)"
-  } ],
-  "status" : "failed",
-  "configuration_version" : "1423834124",
-  "environment" : "production",
-  "certname" : "pg2.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 0.001149,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.050034,
-    "name" : "augeas"
-  }, {
-    "category" : "time",
-    "value" : 1.71986413002014,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.451339,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.322403,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 1.29E-4,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.041761,
-    "name" : "gnupg_key"
-  }, {
-    "category" : "time",
-    "value" : 8.04E-4,
-    "name" : "ini_setting"
-  }, {
-    "category" : "time",
-    "value" : 8.86E-4,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.257424,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 6.36E-4,
-    "name" : "postgresql_conf"
-  }, {
-    "category" : "time",
-    "value" : 0.053516,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.576265,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 3.47621013002014,
-    "name" : "total"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 2,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 29,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 88,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 28,
-    "name" : "noop"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 29,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 0,
-    "name" : "total"
-  } ]
+    "certname": "pg2.vm",
+    "configuration_version": "1423834124",
+    "end_time": "2015-02-13T13:28:44.696Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 2.19 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:28:48.73+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 8 events",
+            "source": "Stage[main]",
+            "tags": [
+                "completed_stage",
+                "main",
+                "notice"
+            ],
+            "time": "2015-02-13T13:28:48.698+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 8 events",
+            "source": "Class[Loadtest]",
+            "tags": [
+                "completed_class",
+                "loadtest",
+                "notice"
+            ],
+            "time": "2015-02-13T13:28:48.697+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "err",
+            "line": 11,
+            "message": "Provider git is not functional on this host",
+            "source": "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
+            "tags": [
+                "pg2.vm",
+                "vcsrepo",
+                "loadtest",
+                "class",
+                "node",
+                "err"
+            ],
+            "time": "2015-02-13T13:28:48.696+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 2 events",
+            "source": "Class[Snmp::Client]",
+            "tags": [
+                "completed_class",
+                "client",
+                "snmp",
+                "snmp::client",
+                "notice"
+            ],
+            "time": "2015-02-13T13:28:48.695+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "level": "notice",
+            "line": 85,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp::Client/File[snmp.conf]/ensure",
+            "tags": [
+                "pg2.vm",
+                "client",
+                "file",
+                "loadtest",
+                "class",
+                "snmp",
+                "snmp.conf",
+                "snmp::client",
+                "notice",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:48.694+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 3 events",
+            "source": "Class[Python::Install]",
+            "tags": [
+                "completed_class",
+                "notice",
+                "python::install",
+                "install",
+                "python"
+            ],
+            "time": "2015-02-13T13:28:48.691+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "notice",
+            "line": 59,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Python::Install/Package[python-virtualenv]/ensure",
+            "tags": [
+                "pg2.vm",
+                "python-virtualenv",
+                "loadtest",
+                "class",
+                "notice",
+                "python::install",
+                "install",
+                "node",
+                "package",
+                "python"
+            ],
+            "time": "2015-02-13T13:28:48.688+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "notice",
+            "line": 61,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Python::Install/Package[python-devel]/ensure",
+            "tags": [
+                "pg2.vm",
+                "python-devel",
+                "loadtest",
+                "class",
+                "notice",
+                "python::install",
+                "install",
+                "node",
+                "package",
+                "python"
+            ],
+            "time": "2015-02-13T13:28:48.637+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "notice",
+            "line": 60,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Python::Install/Package[python-pip]/ensure",
+            "tags": [
+                "pg2.vm",
+                "python-pip",
+                "loadtest",
+                "class",
+                "notice",
+                "python::install",
+                "install",
+                "node",
+                "package",
+                "python"
+            ],
+            "time": "2015-02-13T13:28:48.609+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Git]",
+            "tags": [
+                "completed_class",
+                "git",
+                "notice"
+            ],
+            "time": "2015-02-13T13:28:48.353+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/git/manifests/init.pp",
+            "level": "notice",
+            "line": 12,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Git/Package[git]/ensure",
+            "tags": [
+                "pg2.vm",
+                "git",
+                "loadtest",
+                "class",
+                "notice",
+                "node",
+                "package"
+            ],
+            "time": "2015-02-13T13:28:48.351+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 8 events",
+            "source": "Class[Snmp]",
+            "tags": [
+                "completed_class",
+                "snmp",
+                "notice"
+            ],
+            "time": "2015-02-13T13:28:48.168+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 517,
+            "message": "Unscheduling refresh on Service[snmpd]",
+            "source": "/Stage[main]/Snmp/Service[snmpd]",
+            "tags": [
+                "pg2.vm",
+                "info",
+                "snmpd",
+                "loadtest",
+                "class",
+                "snmp",
+                "service",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:48.166+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 517,
+            "message": "current_value stopped, should be running (noop)",
+            "source": "/Stage[main]/Snmp/Service[snmpd]/ensure",
+            "tags": [
+                "pg2.vm",
+                "snmpd",
+                "loadtest",
+                "class",
+                "snmp",
+                "notice",
+                "service",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:48.164+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 429,
+            "message": "Scheduling refresh of Service[snmpd]",
+            "source": "/Stage[main]/Snmp/File[snmpd.conf]",
+            "tags": [
+                "pg2.vm",
+                "snmpd.conf",
+                "info",
+                "file",
+                "loadtest",
+                "class",
+                "snmp",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:48.068+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 429,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/File[snmpd.conf]/ensure",
+            "tags": [
+                "pg2.vm",
+                "snmpd.conf",
+                "file",
+                "loadtest",
+                "class",
+                "snmp",
+                "notice",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:48.067+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Concat::Fragment[tmpfile]",
+            "tags": [
+                "tmpfile",
+                "fragment",
+                "completed_concat",
+                "completed_concat::fragment",
+                "notice"
+            ],
+            "time": "2015-02-13T13:28:48.064+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 6 events",
+            "source": "Concat[/tmp/file]",
+            "tags": [
+                "completed_concat",
+                "notice"
+            ],
+            "time": "2015-02-13T13:28:48.062+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "err",
+            "line": 169,
+            "message": "Could not evaluate: Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/tmp/file]",
+            "tags": [
+                "pg2.vm",
+                "file",
+                "loadtest",
+                "class",
+                "concat",
+                "node",
+                "err"
+            ],
+            "time": "2015-02-13T13:28:48.06+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 187,
+            "message": "Would have triggered 'refresh' from 4 events",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+            "tags": [
+                "pg2.vm",
+                "exec",
+                "loadtest",
+                "class",
+                "notice",
+                "concat",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:48.057+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 187,
+            "message": "current_value notrun, should be 0 (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/returns",
+            "tags": [
+                "pg2.vm",
+                "exec",
+                "loadtest",
+                "class",
+                "notice",
+                "concat",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:48.056+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "info",
+            "line": 113,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+            "tags": [
+                "concat::fragment",
+                "pg2.vm",
+                "tmpfile",
+                "info",
+                "file",
+                "loadtest",
+                "fragment",
+                "class",
+                "node",
+                "concat"
+            ],
+            "time": "2015-02-13T13:28:47.989+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "notice",
+            "line": 113,
+            "message": "current_value absent, should be file (noop)",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/ensure",
+            "tags": [
+                "concat::fragment",
+                "pg2.vm",
+                "tmpfile",
+                "file",
+                "loadtest",
+                "fragment",
+                "class",
+                "notice",
+                "node",
+                "concat"
+            ],
+            "time": "2015-02-13T13:28:47.989+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Concat::Fragment[tmpfile2]",
+            "tags": [
+                "fragment",
+                "completed_concat",
+                "tmpfile2",
+                "completed_concat::fragment",
+                "notice"
+            ],
+            "time": "2015-02-13T13:28:47.986+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "info",
+            "line": 113,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+            "tags": [
+                "concat::fragment",
+                "pg2.vm",
+                "info",
+                "file",
+                "loadtest",
+                "fragment",
+                "class",
+                "tmpfile2",
+                "node",
+                "concat"
+            ],
+            "time": "2015-02-13T13:28:47.985+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "notice",
+            "line": 113,
+            "message": "current_value absent, should be file (noop)",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
+            "tags": [
+                "concat::fragment",
+                "pg2.vm",
+                "file",
+                "loadtest",
+                "fragment",
+                "class",
+                "tmpfile2",
+                "notice",
+                "node",
+                "concat"
+            ],
+            "time": "2015-02-13T13:28:47.982+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "info",
+            "line": 149,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
+            "tags": [
+                "pg2.vm",
+                "info",
+                "file",
+                "loadtest",
+                "class",
+                "concat",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.919+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 149,
+            "message": "current_value absent, should be directory (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/ensure",
+            "tags": [
+                "pg2.vm",
+                "file",
+                "loadtest",
+                "class",
+                "notice",
+                "concat",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.919+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 476,
+            "message": "Would have triggered 'refresh' from 2 events",
+            "source": "/Stage[main]/Snmp/Service[snmptrapd]",
+            "tags": [
+                "pg2.vm",
+                "loadtest",
+                "class",
+                "snmp",
+                "snmptrapd",
+                "notice",
+                "service",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.915+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 164,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]/ensure",
+            "tags": [
+                "pg2.vm",
+                "file",
+                "loadtest",
+                "class",
+                "notice",
+                "concat",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.705+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 159,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]/ensure",
+            "tags": [
+                "pg2.vm",
+                "file",
+                "loadtest",
+                "class",
+                "notice",
+                "concat",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.703+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "info",
+            "line": 144,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
+            "tags": [
+                "pg2.vm",
+                "info",
+                "file",
+                "loadtest",
+                "class",
+                "concat",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.702+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 144,
+            "message": "current_value absent, should be directory (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]/ensure",
+            "tags": [
+                "pg2.vm",
+                "file",
+                "loadtest",
+                "class",
+                "notice",
+                "concat",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.702+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 453,
+            "message": "Scheduling refresh of Service[snmptrapd]",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]",
+            "tags": [
+                "pg2.vm",
+                "snmptrapd.conf",
+                "info",
+                "file",
+                "loadtest",
+                "class",
+                "snmp",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.699+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 453,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]/ensure",
+            "tags": [
+                "pg2.vm",
+                "snmptrapd.conf",
+                "file",
+                "loadtest",
+                "class",
+                "snmp",
+                "notice",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.699+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 69,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]/ensure",
+            "tags": [
+                "pg2.vm",
+                "hkp_server_20bc0a86",
+                "loadtest",
+                "class",
+                "notice",
+                "node",
+                "gnupg_key"
+            ],
+            "time": "2015-02-13T13:28:47.439+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Ntp::Service]",
+            "tags": [
+                "completed_class",
+                "ntp",
+                "ntp::service",
+                "notice",
+                "service"
+            ],
+            "time": "2015-02-13T13:28:47.396+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
+            "level": "info",
+            "line": 9,
+            "message": "Unscheduling refresh on Service[ntp]",
+            "source": "/Stage[main]/Ntp::Service/Service[ntp]",
+            "tags": [
+                "ntp",
+                "pg2.vm",
+                "ntp::service",
+                "info",
+                "loadtest",
+                "class",
+                "node",
+                "service"
+            ],
+            "time": "2015-02-13T13:28:47.394+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
+            "level": "notice",
+            "line": 9,
+            "message": "current_value stopped, should be running (noop)",
+            "source": "/Stage[main]/Ntp::Service/Service[ntp]/ensure",
+            "tags": [
+                "ntp",
+                "pg2.vm",
+                "ntp::service",
+                "loadtest",
+                "class",
+                "notice",
+                "node",
+                "service"
+            ],
+            "time": "2015-02-13T13:28:47.393+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 410,
+            "message": "current_value absent, should be directory (noop)",
+            "source": "/Stage[main]/Snmp/File[var-net-snmp]/ensure",
+            "tags": [
+                "pg2.vm",
+                "file",
+                "loadtest",
+                "var-net-snmp",
+                "class",
+                "snmp",
+                "notice",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.234+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 45,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Loadtest/Ini_setting[sample setting]/ensure",
+            "tags": [
+                "pg2.vm",
+                "loadtest",
+                "class",
+                "ini_setting",
+                "notice",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.231+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Service[ntp]",
+            "source": "Class[Ntp::Service]",
+            "tags": [
+                "ntp",
+                "ntp::service",
+                "info",
+                "admissible_class",
+                "service"
+            ],
+            "time": "2015-02-13T13:28:47.23+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Ntp::Service]",
+            "tags": [
+                "ntp",
+                "ntp::service",
+                "notice",
+                "admissible_class",
+                "service"
+            ],
+            "time": "2015-02-13T13:28:47.229+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Class[Ntp::Service]",
+            "source": "Class[Ntp::Config]",
+            "tags": [
+                "completed_class",
+                "ntp",
+                "config",
+                "info",
+                "ntp::config"
+            ],
+            "time": "2015-02-13T13:28:47.229+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Ntp::Config]",
+            "tags": [
+                "completed_class",
+                "ntp",
+                "config",
+                "notice",
+                "ntp::config"
+            ],
+            "time": "2015-02-13T13:28:47.228+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
+            "level": "notice",
+            "line": 14,
+            "message": "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
+            "source": "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
+            "tags": [
+                "ntp",
+                "config",
+                "pg2.vm",
+                "file",
+                "loadtest",
+                "class",
+                "notice",
+                "node",
+                "ntp::config"
+            ],
+            "time": "2015-02-13T13:28:47.225+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
+            "level": "notice",
+            "line": 14,
+            "message": "\n--- /etc/ntp.conf\t2013-07-15 10:18:47.000000000 +0100\n+++ /tmp/puppet-file20150213-61500-1so4rsh-0\t2015-02-13 13:28:47.197877918 +0000\n@@ -1,53 +1,19 @@\n-# For more information about this file, see the man pages\n-# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).\n+# ntp.conf: Managed by puppet.\n+#\n+# Keep ntpd from panicking in the event of a large clock skew\n+# when a VM guest is suspended and resumed.\n+tinker panic 0\n \n-driftfile /var/lib/ntp/drift\n \n # Permit time synchronization with our time source, but do not\n # permit the source to query or modify the service on this system.\n-restrict default kod nomodify notrap nopeer noquery\n-restrict -6 default kod nomodify notrap nopeer noquery\n+restrict 127.0.0.1\n+\n \n-# Permit all access over the loopback interface.  This could\n-# be tightened as well, but to do so would effect some of\n-# the administrative functions.\n-restrict 127.0.0.1 \n-restrict -6 ::1\n-\n-# Hosts on local network are less restricted.\n-#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap\n-\n-# Use public servers from the pool.ntp.org project.\n-# Please consider joining the pool (http://www.pool.ntp.org/join.html).\n-server 0.centos.pool.ntp.org iburst\n-server 1.centos.pool.ntp.org iburst\n-server 2.centos.pool.ntp.org iburst\n-server 3.centos.pool.ntp.org iburst\n-\n-#broadcast 192.168.1.255 autokey\t# broadcast server\n-#broadcastclient\t\t\t# broadcast client\n-#broadcast 224.0.1.1 autokey\t\t# multicast server\n-#multicastclient 224.0.1.1\t\t# multicast client\n-#manycastserver 239.255.254.254\t\t# manycast server\n-#manycastclient 239.255.254.254 autokey # manycast client\n-\n-# Enable public key cryptography.\n-#crypto\n-\n-includefile /etc/ntp/crypto/pw\n-\n-# Key file containing the keys and key identifiers used when operating\n-# with symmetric key cryptography. \n-keys /etc/ntp/keys\n-\n-# Specify the key identifiers which are trusted.\n-#trustedkey 4 8 42\n+server ntp.pool.org\n \n-# Specify the key identifier to use with the ntpdc utility.\n-#requestkey 8\n \n-# Specify the key identifier to use with the ntpq utility.\n-#controlkey 8\n+# Driftfile.\n+driftfile /var/lib/ntp/drift\n+\n \n-# Enable writing of statistics records.\n-#statistics clockstats cryptostats loopstats peerstats\n",
+            "source": "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
+            "tags": [
+                "ntp",
+                "config",
+                "pg2.vm",
+                "file",
+                "loadtest",
+                "class",
+                "content",
+                "notice",
+                "node",
+                "ntp::config"
+            ],
+            "time": "2015-02-13T13:28:47.221+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 441,
+            "message": "Scheduling refresh of Service[snmpd]",
+            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]",
+            "tags": [
+                "pg2.vm",
+                "info",
+                "file",
+                "loadtest",
+                "snmpd.sysconfig",
+                "class",
+                "snmp",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.191+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 441,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]/ensure",
+            "tags": [
+                "pg2.vm",
+                "file",
+                "loadtest",
+                "snmpd.sysconfig",
+                "class",
+                "snmp",
+                "notice",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.191+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 465,
+            "message": "Scheduling refresh of Service[snmptrapd]",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.sysconfig]",
+            "tags": [
+                "pg2.vm",
+                "info",
+                "file",
+                "loadtest",
+                "class",
+                "snmp",
+                "snmptrapd.sysconfig",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.182+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 465,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.sysconfig]/ensure",
+            "tags": [
+                "pg2.vm",
+                "file",
+                "loadtest",
+                "class",
+                "snmp",
+                "snmptrapd.sysconfig",
+                "notice",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.182+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "info",
+            "line": 4,
+            "message": "Unscheduling refresh on Service[cron]",
+            "source": "/Stage[main]/Loadtest/Service[cron]",
+            "tags": [
+                "pg2.vm",
+                "info",
+                "loadtest",
+                "class",
+                "service",
+                "cron",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.178+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 4,
+            "message": "current_value stopped, should be running (noop)",
+            "source": "/Stage[main]/Loadtest/Service[cron]/ensure",
+            "tags": [
+                "pg2.vm",
+                "loadtest",
+                "class",
+                "notice",
+                "service",
+                "cron",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.177+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 3,
+            "message": "current_value absent, should be foo (noop)",
+            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
+            "tags": [
+                "foo",
+                "pg2.vm",
+                "notify",
+                "loadtest",
+                "class",
+                "notice",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:47.072+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 405,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/Package[snmpd]/ensure",
+            "tags": [
+                "pg2.vm",
+                "snmpd",
+                "loadtest",
+                "class",
+                "snmp",
+                "notice",
+                "node",
+                "package"
+            ],
+            "time": "2015-02-13T13:28:47.069+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 41,
+            "message": "current_value absent, should be latest (noop)",
+            "source": "/Stage[main]/Loadtest/Package[etckeeper]/ensure",
+            "tags": [
+                "pg2.vm",
+                "loadtest",
+                "etckeeper",
+                "class",
+                "notice",
+                "node",
+                "package"
+            ],
+            "time": "2015-02-13T13:28:47.026+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "level": "notice",
+            "line": 76,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp::Client/Package[snmp-client]/ensure",
+            "tags": [
+                "pg2.vm",
+                "snmp-client",
+                "client",
+                "loadtest",
+                "class",
+                "snmp",
+                "snmp::client",
+                "notice",
+                "node",
+                "package"
+            ],
+            "time": "2015-02-13T13:28:46.98+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Motd]",
+            "tags": [
+                "completed_class",
+                "motd",
+                "notice"
+            ],
+            "time": "2015-02-13T13:28:46.803+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "level": "notice",
+            "line": 33,
+            "message": "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
+            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
+            "tags": [
+                "motd",
+                "pg2.vm",
+                "file",
+                "loadtest",
+                "class",
+                "notice",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:46.797+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "level": "notice",
+            "line": 33,
+            "message": "\n--- /etc/motd\t2010-01-12 13:28:22.000000000 +0000\n+++ /tmp/puppet-file20150213-61500-ay65od-0\t2015-02-13 13:28:46.727877920 +0000\n@@ -0,0 +1 @@\n+Welcome to my test host!\n\\ No newline at end of file\n",
+            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
+            "tags": [
+                "motd",
+                "pg2.vm",
+                "file",
+                "loadtest",
+                "class",
+                "content",
+                "notice",
+                "node"
+            ],
+            "time": "2015-02-13T13:28:46.795+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423834124'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:28:46.616+00:00"
+        },
+        {
+            "file": null,
+            "level": "warning",
+            "line": null,
+            "message": "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
+            "source": "Puppet",
+            "tags": [
+                "warning"
+            ],
+            "time": "2015-02-13T13:28:46.219+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for pg2.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:28:46.118+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:28:43.601+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:28:41.319+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:28:41.273+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.001149
+        },
+        {
+            "category": "time",
+            "name": "augeas",
+            "value": 0.050034
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 1.71986413002014
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.451339
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.322403
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 0.000129
+        },
+        {
+            "category": "time",
+            "name": "gnupg_key",
+            "value": 0.041761
+        },
+        {
+            "category": "time",
+            "name": "ini_setting",
+            "value": 0.000804
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.000886
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.257424
+        },
+        {
+            "category": "time",
+            "name": "postgresql_conf",
+            "value": 0.000636
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.053516
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.576265
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 3.47621013002014
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 2
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 29
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 88
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 1
+        },
+        {
+            "category": "events",
+            "name": "noop",
+            "value": 28
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 29
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 0
+        }
+    ],
+    "noop": true,
+    "puppet_version": "3.7.1",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Ini_setting[sample setting]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.231Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 45,
+            "resource_title": "sample setting",
+            "resource_type": "Ini_setting",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.231Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Service[cron]"
+            ],
+            "events": [
+                {
+                    "message": "current_value stopped, should be running (noop)",
+                    "new_value": "running",
+                    "old_value": "stopped",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.177Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 4,
+            "resource_title": "cron",
+            "resource_type": "Service",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.177Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Python::Install",
+                "Package[python-virtualenv]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:48.688Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "line": 59,
+            "resource_title": "python-virtualenv",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:48.688Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be foo (noop)",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.072Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 3,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.072Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be directory (noop)",
+                    "new_value": "directory",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.919Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 149,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.919Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Python::Install",
+                "Package[python-devel]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:48.637Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "line": 61,
+            "resource_title": "python-devel",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:48.637Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Python::Install",
+                "Package[python-pip]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:48.609Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "line": 60,
+            "resource_title": "python-pip",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:48.609Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/var/lib/puppet/concat/_tmp_file]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be directory (noop)",
+                    "new_value": "directory",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.701Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 144,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.701Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "Service[snmpd]"
+            ],
+            "events": [
+                {
+                    "message": "current_value stopped, should be running (noop)",
+                    "new_value": "running",
+                    "old_value": "stopped",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:48.164Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 517,
+            "resource_title": "snmpd",
+            "resource_type": "Service",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:48.164Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Package[etckeeper]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be latest (noop)",
+                    "new_value": "latest",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.026Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 41,
+            "resource_title": "etckeeper",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.026Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat::Fragment[tmpfile2]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be file (noop)",
+                    "new_value": "file",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.921Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "line": 113,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.921Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.705Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 164,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.705Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Git",
+                "Package[git]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:48.351Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/git/manifests/init.pp",
+            "line": 12,
+            "resource_title": "git",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:48.351Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat::Fragment[tmpfile]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be file (noop)",
+                    "new_value": "file",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.989Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "line": 113,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.989Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "Exec[concat_/tmp/file]"
+            ],
+            "events": [
+                {
+                    "message": "current_value notrun, should be 0 (noop)",
+                    "new_value": [
+                        "0"
+                    ],
+                    "old_value": "notrun",
+                    "property": "returns",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:48.056Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 187,
+            "resource_title": "concat_/tmp/file",
+            "resource_type": "Exec",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:48.056Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments.concat]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.703Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 159,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.703Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[snmpd.conf]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:48.067Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 429,
+            "resource_title": "snmpd.conf",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:48.067Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp::Client",
+                "Package[snmp-client]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:46.980Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "line": 76,
+            "resource_title": "snmp-client",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:46.980Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/tmp/file]"
+            ],
+            "events": [
+                {
+                    "message": "Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
+                    "new_value": null,
+                    "old_value": null,
+                    "property": null,
+                    "status": "failure",
+                    "timestamp": "2015-02-13T13:28:48.062Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 169,
+            "resource_title": "/tmp/file",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:48.062Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Ntp::Config",
+                "File[/etc/ntp.conf]"
+            ],
+            "events": [
+                {
+                    "message": "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
+                    "new_value": "{md5}eb918d28434c9fefcc05875c29c3ba1a",
+                    "old_value": "{md5}7fda24f62b1c7ae951db0f746dc6e0cc",
+                    "property": "content",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.224Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
+            "line": 14,
+            "resource_title": "/etc/ntp.conf",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.224Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[var-net-snmp]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be directory (noop)",
+                    "new_value": "directory",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.234Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 410,
+            "resource_title": "var-net-snmp",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.234Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "Package[snmpd]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.069Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 405,
+            "resource_title": "snmpd",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.069Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Motd",
+                "File[/etc/motd]"
+            ],
+            "events": [
+                {
+                    "message": "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
+                    "new_value": "{md5}a3f731187a6aaaa23d4a7b244f223f33",
+                    "old_value": "{md5}d41d8cd98f00b204e9800998ecf8427e",
+                    "property": "content",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:46.797Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "line": 33,
+            "resource_title": "/etc/motd",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:46.797Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Gnupg_key[hkp_server_20BC0A86]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.439Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 69,
+            "resource_title": "hkp_server_20BC0A86",
+            "resource_type": "Gnupg_key",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.439Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Ntp::Service",
+                "Service[ntp]"
+            ],
+            "events": [
+                {
+                    "message": "current_value stopped, should be running (noop)",
+                    "new_value": "running",
+                    "old_value": "stopped",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.393Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
+            "line": 9,
+            "resource_title": "ntp",
+            "resource_type": "Service",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.393Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[snmptrapd.sysconfig]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.182Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 465,
+            "resource_title": "snmptrapd.sysconfig",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.182Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[snmpd.sysconfig]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.191Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 441,
+            "resource_title": "snmpd.sysconfig",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.191Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp::Client",
+                "File[snmp.conf]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:48.694Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "line": 85,
+            "resource_title": "snmp.conf",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:48.694Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[snmptrapd.conf]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:28:47.699Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 453,
+            "resource_title": "snmptrapd.conf",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:28:47.699Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:28:41.219Z",
+    "status": "failed",
+    "transaction_uuid": "1fe685d2-cf15-46ba-8a07-84854c584703"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-34ecfe5dcfebc9510d159d2ec010d6e1f9094fb1.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-34ecfe5dcfebc9510d159d2ec010d6e1f9094fb1.json
@@ -1,399 +1,730 @@
 {
-  "transaction_uuid" : "9df4e7ce-5646-4178-8ff8-db6add84e9fc",
-  "puppet_version" : "3.7.1",
-  "noop" : true,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 4.55 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:27:01.557+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Triggered 'refresh' from 1 events",
-    "source" : "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::end]",
-    "tags" : [ "node", "notice", "postgresql::server::service::end", "postgresql", "postgresql::server", "anchor", "postgresql::server::service", "server", "pg2.vm", "end", "class", "service" ],
-    "time" : "2015-02-13T13:27:01.513+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-    "line" : 41
-  }, {
-    "level" : "notice",
-    "message" : "Triggered 'refresh' from 1 events",
-    "source" : "/Stage[main]/Postgresql::Server::Service/Postgresql::Validate_db_connection[validate_service_is_running]/Exec[validate postgres connection for /postgres]",
-    "tags" : [ "node", "notice", "validate_service_is_running", "postgresql", "postgresql::server", "postgresql::server::service", "server", "validate_db_connection", "pg2.vm", "exec", "class", "postgresql::validate_db_connection", "service" ],
-    "time" : "2015-02-13T13:27:01.509+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/validate_db_connection.pp",
-    "line" : 51
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[validate postgres connection for /postgres]",
-    "source" : "Postgresql::Validate_db_connection[validate_service_is_running]",
-    "tags" : [ "admissible_postgresql", "validate_service_is_running", "validate_db_connection", "admissible_postgresql::validate_db_connection", "info" ],
-    "time" : "2015-02-13T13:27:01.378+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Unscheduling refresh on Service[postgresqld]",
-    "source" : "/Stage[main]/Postgresql::Server::Service/Service[postgresqld]",
-    "tags" : [ "node", "postgresqld", "postgresql", "postgresql::server", "postgresql::server::service", "server", "pg2.vm", "info", "class", "service" ],
-    "time" : "2015-02-13T13:27:01.376+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-    "line" : 14
-  }, {
-    "level" : "notice",
-    "message" : "ensure changed 'stopped' to 'running'",
-    "source" : "/Stage[main]/Postgresql::Server::Service/Service[postgresqld]/ensure",
-    "tags" : [ "node", "notice", "postgresqld", "postgresql", "postgresql::server", "postgresql::server::service", "server", "pg2.vm", "class", "service" ],
-    "time" : "2015-02-13T13:27:01.375+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-    "line" : 14
-  }, {
-    "level" : "notice",
-    "message" : "Triggered 'refresh' from 1 events",
-    "source" : "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::begin]",
-    "tags" : [ "node", "notice", "begin", "postgresql::server::service::begin", "postgresql", "postgresql::server", "anchor", "postgresql::server::service", "server", "pg2.vm", "class", "service" ],
-    "time" : "2015-02-13T13:26:59.222+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-    "line" : 12
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Anchor[postgresql::server::service::begin]",
-    "source" : "Class[Postgresql::Server::Service]",
-    "tags" : [ "admissible_class", "postgresql", "postgresql::server::service", "server", "info", "service" ],
-    "time" : "2015-02-13T13:26:59.221+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Anchor[postgresql::server::service::end]",
-    "source" : "Class[Postgresql::Server::Service]",
-    "tags" : [ "admissible_class", "postgresql", "postgresql::server::service", "server", "info", "service" ],
-    "time" : "2015-02-13T13:26:59.22+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Postgresql::Validate_db_connection[validate_service_is_running]",
-    "source" : "Class[Postgresql::Server::Service]",
-    "tags" : [ "admissible_class", "postgresql", "postgresql::server::service", "server", "info", "service" ],
-    "time" : "2015-02-13T13:26:59.22+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[postgresqld]",
-    "source" : "Class[Postgresql::Server::Service]",
-    "tags" : [ "admissible_class", "postgresql", "postgresql::server::service", "server", "info", "service" ],
-    "time" : "2015-02-13T13:26:59.22+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "defined 'message' as 'foo'",
-    "source" : "/Stage[main]/Main/Node[pg2.vm]/Notify[foo]/message",
-    "tags" : [ "node", "notice", "foo", "pg2.vm", "class", "notify" ],
-    "time" : "2015-02-13T13:26:58.976+00:00",
-    "file" : "/etc/puppet/manifests/site.pp",
-    "line" : 6
-  }, {
-    "level" : "notice",
-    "message" : "foo",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:26:58.976+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Class[Postgresql::Server::Service]",
-    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]",
-    "tags" : [ "node", "postgresql::server::config", "postgresql::server::config_entry", "postgresql_conf", "data_directory", "postgresql::server", "postgresql", "server", "pg2.vm", "config_entry", "config", "info", "class" ],
-    "time" : "2015-02-13T13:26:58.824+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "line" : 105
-  }, {
-    "level" : "info",
-    "message" : "Computing checksum on file /var/lib/pgsql/data/postgresql.conf",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:26:58.815+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "created",
-    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]/ensure",
-    "tags" : [ "node", "notice", "postgresql::server::config", "postgresql::server::config_entry", "postgresql_conf", "data_directory", "postgresql::server", "postgresql", "server", "pg2.vm", "config_entry", "config", "class" ],
-    "time" : "2015-02-13T13:26:58.814+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "line" : 105
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Class[Postgresql::Server::Service]",
-    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]",
-    "tags" : [ "node", "postgresql::server::config", "postgresql::server::config_entry", "data_directory", "postgresql::server", "postgresql", "augeas", "server", "pg2.vm", "config_entry", "config", "info", "class" ],
-    "time" : "2015-02-13T13:26:58.806+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "line" : 90
-  }, {
-    "level" : "notice",
-    "message" : "executed successfully",
-    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]/returns",
-    "tags" : [ "node", "notice", "postgresql::server::config", "postgresql::server::config_entry", "data_directory", "postgresql::server", "postgresql", "augeas", "server", "pg2.vm", "config_entry", "config", "class" ],
-    "time" : "2015-02-13T13:26:58.805+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "line" : 90
-  }, {
-    "level" : "notice",
-    "message" : "\n--- /etc/sysconfig/pgsql/postgresql\t2014-09-18 15:48:23.129826040 +0100\n+++ /etc/sysconfig/pgsql/postgresql.augnew\t2015-02-13 13:26:58.619877991 +0000\n@@ -1,2 +1,3 @@\n \n PGPORT=5432\n+PGDATA=/var/lib/pgsql/data\n",
-    "source" : "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql](provider=augeas)",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:26:58.78+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "created",
-    "source" : "/Stage[main]/Postgresql::Server::Config/File[/etc/sysconfig/pgsql/postgresql-8.4]/ensure",
-    "tags" : [ "node", "notice", "postgresql::server::config", "file", "postgresql::server", "postgresql", "server", "pg2.vm", "config", "class" ],
-    "time" : "2015-02-13T13:26:58.583+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config.pp",
-    "line" : 120
-  }, {
-    "level" : "notice",
-    "message" : "executed successfully",
-    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Exec[postgresql_data_directory]/returns",
-    "tags" : [ "node", "notice", "postgresql_data_directory", "postgresql::server::config", "postgresql::server::config_entry", "data_directory", "postgresql::server", "postgresql", "server", "pg2.vm", "config_entry", "config", "exec", "class" ],
-    "time" : "2015-02-13T13:26:58.57+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "line" : 83
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423833741'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:26:57.059+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "warning",
-    "message" : "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
-    "source" : "Puppet",
-    "tags" : [ "warning" ],
-    "time" : "2015-02-13T13:26:56.789+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for pg2.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:26:56.714+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:26:54.936+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:26:52.669+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:26:52.621+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:26:52.564Z",
-  "end_time" : "2015-02-13T13:26:57.691Z",
-  "resource_events" : [ {
-    "new_value" : [ "0" ],
-    "property" : "returns",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "old_value" : "notrun",
-    "line" : 83,
-    "resource_type" : "Exec",
-    "status" : "success",
-    "resource_title" : "postgresql_data_directory",
-    "timestamp" : "2015-02-13T13:26:57.409Z",
-    "containment_path" : [ "Stage[main]", "Postgresql::Server::Config", "Postgresql::Server::Config_entry[data_directory]", "Exec[postgresql_data_directory]" ],
-    "message" : "executed successfully"
-  }, {
-    "new_value" : "link",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config.pp",
-    "old_value" : "absent",
-    "line" : 120,
-    "resource_type" : "File",
-    "status" : "success",
-    "resource_title" : "/etc/sysconfig/pgsql/postgresql-8.4",
-    "timestamp" : "2015-02-13T13:26:58.573Z",
-    "containment_path" : [ "Stage[main]", "Postgresql::Server::Config", "File[/etc/sysconfig/pgsql/postgresql-8.4]" ],
-    "message" : "created"
-  }, {
-    "new_value" : 0,
-    "property" : "returns",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "old_value" : "need_to_run",
-    "line" : 90,
-    "resource_type" : "Augeas",
-    "status" : "success",
-    "resource_title" : "override PGDATA in /etc/sysconfig/pgsql/postgresql",
-    "timestamp" : "2015-02-13T13:26:58.781Z",
-    "containment_path" : [ "Stage[main]", "Postgresql::Server::Config", "Postgresql::Server::Config_entry[data_directory]", "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]" ],
-    "message" : "executed successfully"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "old_value" : "absent",
-    "line" : 105,
-    "resource_type" : "Postgresql_conf",
-    "status" : "success",
-    "resource_title" : "data_directory",
-    "timestamp" : "2015-02-13T13:26:58.814Z",
-    "containment_path" : [ "Stage[main]", "Postgresql::Server::Config", "Postgresql::Server::Config_entry[data_directory]", "Postgresql_conf[data_directory]" ],
-    "message" : "created"
-  }, {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/manifests/site.pp",
-    "old_value" : "absent",
-    "line" : 6,
-    "resource_type" : "Notify",
-    "status" : "success",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:26:58.975Z",
-    "containment_path" : [ "Stage[main]", "Main", "Node[pg2.vm]", "Notify[foo]" ],
-    "message" : "defined 'message' as 'foo'"
-  }, {
-    "new_value" : "running",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-    "old_value" : "stopped",
-    "line" : 14,
-    "resource_type" : "Service",
-    "status" : "success",
-    "resource_title" : "postgresqld",
-    "timestamp" : "2015-02-13T13:26:59.281Z",
-    "containment_path" : [ "Stage[main]", "Postgresql::Server::Service", "Service[postgresqld]" ],
-    "message" : "ensure changed 'stopped' to 'running'"
-  } ],
-  "status" : "changed",
-  "configuration_version" : "1423833741",
-  "environment" : "production",
-  "certname" : "pg2.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 5.67E-4,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.250754,
-    "name" : "augeas"
-  }, {
-    "category" : "time",
-    "value" : 0.956570863723755,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 1.549255,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.202946,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 1.01E-4,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.00144,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.001022,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 0.01103,
-    "name" : "postgresql_conf"
-  }, {
-    "category" : "time",
-    "value" : 9.22E-4,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 2.152731,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 5.12733886372376,
-    "name" : "total"
-  }, {
-    "category" : "resources",
-    "value" : 6,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 6,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 3,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 50,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 6,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 6,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 6,
-    "name" : "total"
-  } ]
+    "certname": "pg2.vm",
+    "configuration_version": "1423833741",
+    "end_time": "2015-02-13T13:26:57.691Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 4.55 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:27:01.557+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+            "level": "notice",
+            "line": 41,
+            "message": "Triggered 'refresh' from 1 events",
+            "source": "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::end]",
+            "tags": [
+                "node",
+                "notice",
+                "postgresql::server::service::end",
+                "postgresql",
+                "postgresql::server",
+                "anchor",
+                "postgresql::server::service",
+                "server",
+                "pg2.vm",
+                "end",
+                "class",
+                "service"
+            ],
+            "time": "2015-02-13T13:27:01.513+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/validate_db_connection.pp",
+            "level": "notice",
+            "line": 51,
+            "message": "Triggered 'refresh' from 1 events",
+            "source": "/Stage[main]/Postgresql::Server::Service/Postgresql::Validate_db_connection[validate_service_is_running]/Exec[validate postgres connection for /postgres]",
+            "tags": [
+                "node",
+                "notice",
+                "validate_service_is_running",
+                "postgresql",
+                "postgresql::server",
+                "postgresql::server::service",
+                "server",
+                "validate_db_connection",
+                "pg2.vm",
+                "exec",
+                "class",
+                "postgresql::validate_db_connection",
+                "service"
+            ],
+            "time": "2015-02-13T13:27:01.509+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Exec[validate postgres connection for /postgres]",
+            "source": "Postgresql::Validate_db_connection[validate_service_is_running]",
+            "tags": [
+                "admissible_postgresql",
+                "validate_service_is_running",
+                "validate_db_connection",
+                "admissible_postgresql::validate_db_connection",
+                "info"
+            ],
+            "time": "2015-02-13T13:27:01.378+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+            "level": "info",
+            "line": 14,
+            "message": "Unscheduling refresh on Service[postgresqld]",
+            "source": "/Stage[main]/Postgresql::Server::Service/Service[postgresqld]",
+            "tags": [
+                "node",
+                "postgresqld",
+                "postgresql",
+                "postgresql::server",
+                "postgresql::server::service",
+                "server",
+                "pg2.vm",
+                "info",
+                "class",
+                "service"
+            ],
+            "time": "2015-02-13T13:27:01.376+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+            "level": "notice",
+            "line": 14,
+            "message": "ensure changed 'stopped' to 'running'",
+            "source": "/Stage[main]/Postgresql::Server::Service/Service[postgresqld]/ensure",
+            "tags": [
+                "node",
+                "notice",
+                "postgresqld",
+                "postgresql",
+                "postgresql::server",
+                "postgresql::server::service",
+                "server",
+                "pg2.vm",
+                "class",
+                "service"
+            ],
+            "time": "2015-02-13T13:27:01.375+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+            "level": "notice",
+            "line": 12,
+            "message": "Triggered 'refresh' from 1 events",
+            "source": "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::begin]",
+            "tags": [
+                "node",
+                "notice",
+                "begin",
+                "postgresql::server::service::begin",
+                "postgresql",
+                "postgresql::server",
+                "anchor",
+                "postgresql::server::service",
+                "server",
+                "pg2.vm",
+                "class",
+                "service"
+            ],
+            "time": "2015-02-13T13:26:59.222+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Anchor[postgresql::server::service::begin]",
+            "source": "Class[Postgresql::Server::Service]",
+            "tags": [
+                "admissible_class",
+                "postgresql",
+                "postgresql::server::service",
+                "server",
+                "info",
+                "service"
+            ],
+            "time": "2015-02-13T13:26:59.221+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Anchor[postgresql::server::service::end]",
+            "source": "Class[Postgresql::Server::Service]",
+            "tags": [
+                "admissible_class",
+                "postgresql",
+                "postgresql::server::service",
+                "server",
+                "info",
+                "service"
+            ],
+            "time": "2015-02-13T13:26:59.22+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Postgresql::Validate_db_connection[validate_service_is_running]",
+            "source": "Class[Postgresql::Server::Service]",
+            "tags": [
+                "admissible_class",
+                "postgresql",
+                "postgresql::server::service",
+                "server",
+                "info",
+                "service"
+            ],
+            "time": "2015-02-13T13:26:59.22+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Service[postgresqld]",
+            "source": "Class[Postgresql::Server::Service]",
+            "tags": [
+                "admissible_class",
+                "postgresql",
+                "postgresql::server::service",
+                "server",
+                "info",
+                "service"
+            ],
+            "time": "2015-02-13T13:26:59.22+00:00"
+        },
+        {
+            "file": "/etc/puppet/manifests/site.pp",
+            "level": "notice",
+            "line": 6,
+            "message": "defined 'message' as 'foo'",
+            "source": "/Stage[main]/Main/Node[pg2.vm]/Notify[foo]/message",
+            "tags": [
+                "node",
+                "notice",
+                "foo",
+                "pg2.vm",
+                "class",
+                "notify"
+            ],
+            "time": "2015-02-13T13:26:58.976+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "foo",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:26:58.976+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "level": "info",
+            "line": 105,
+            "message": "Scheduling refresh of Class[Postgresql::Server::Service]",
+            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]",
+            "tags": [
+                "node",
+                "postgresql::server::config",
+                "postgresql::server::config_entry",
+                "postgresql_conf",
+                "data_directory",
+                "postgresql::server",
+                "postgresql",
+                "server",
+                "pg2.vm",
+                "config_entry",
+                "config",
+                "info",
+                "class"
+            ],
+            "time": "2015-02-13T13:26:58.824+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Computing checksum on file /var/lib/pgsql/data/postgresql.conf",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:26:58.815+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "level": "notice",
+            "line": 105,
+            "message": "created",
+            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]/ensure",
+            "tags": [
+                "node",
+                "notice",
+                "postgresql::server::config",
+                "postgresql::server::config_entry",
+                "postgresql_conf",
+                "data_directory",
+                "postgresql::server",
+                "postgresql",
+                "server",
+                "pg2.vm",
+                "config_entry",
+                "config",
+                "class"
+            ],
+            "time": "2015-02-13T13:26:58.814+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "level": "info",
+            "line": 90,
+            "message": "Scheduling refresh of Class[Postgresql::Server::Service]",
+            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]",
+            "tags": [
+                "node",
+                "postgresql::server::config",
+                "postgresql::server::config_entry",
+                "data_directory",
+                "postgresql::server",
+                "postgresql",
+                "augeas",
+                "server",
+                "pg2.vm",
+                "config_entry",
+                "config",
+                "info",
+                "class"
+            ],
+            "time": "2015-02-13T13:26:58.806+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "level": "notice",
+            "line": 90,
+            "message": "executed successfully",
+            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]/returns",
+            "tags": [
+                "node",
+                "notice",
+                "postgresql::server::config",
+                "postgresql::server::config_entry",
+                "data_directory",
+                "postgresql::server",
+                "postgresql",
+                "augeas",
+                "server",
+                "pg2.vm",
+                "config_entry",
+                "config",
+                "class"
+            ],
+            "time": "2015-02-13T13:26:58.805+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "\n--- /etc/sysconfig/pgsql/postgresql\t2014-09-18 15:48:23.129826040 +0100\n+++ /etc/sysconfig/pgsql/postgresql.augnew\t2015-02-13 13:26:58.619877991 +0000\n@@ -1,2 +1,3 @@\n \n PGPORT=5432\n+PGDATA=/var/lib/pgsql/data\n",
+            "source": "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql](provider=augeas)",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:26:58.78+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config.pp",
+            "level": "notice",
+            "line": 120,
+            "message": "created",
+            "source": "/Stage[main]/Postgresql::Server::Config/File[/etc/sysconfig/pgsql/postgresql-8.4]/ensure",
+            "tags": [
+                "node",
+                "notice",
+                "postgresql::server::config",
+                "file",
+                "postgresql::server",
+                "postgresql",
+                "server",
+                "pg2.vm",
+                "config",
+                "class"
+            ],
+            "time": "2015-02-13T13:26:58.583+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "level": "notice",
+            "line": 83,
+            "message": "executed successfully",
+            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Exec[postgresql_data_directory]/returns",
+            "tags": [
+                "node",
+                "notice",
+                "postgresql_data_directory",
+                "postgresql::server::config",
+                "postgresql::server::config_entry",
+                "data_directory",
+                "postgresql::server",
+                "postgresql",
+                "server",
+                "pg2.vm",
+                "config_entry",
+                "config",
+                "exec",
+                "class"
+            ],
+            "time": "2015-02-13T13:26:58.57+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423833741'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:26:57.059+00:00"
+        },
+        {
+            "file": null,
+            "level": "warning",
+            "line": null,
+            "message": "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
+            "source": "Puppet",
+            "tags": [
+                "warning"
+            ],
+            "time": "2015-02-13T13:26:56.789+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for pg2.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:26:56.714+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:26:54.936+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:26:52.669+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:26:52.621+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.000567
+        },
+        {
+            "category": "time",
+            "name": "augeas",
+            "value": 0.250754
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 0.956570863723755
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 1.549255
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.202946
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 0.000101
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.00144
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.001022
+        },
+        {
+            "category": "time",
+            "name": "postgresql_conf",
+            "value": 0.01103
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.000922
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 2.152731
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 5.12733886372376
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 6
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 6
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 3
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 50
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 6
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 6
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 6
+        }
+    ],
+    "noop": true,
+    "puppet_version": "3.7.1",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Postgresql::Server::Config",
+                "Postgresql::Server::Config_entry[data_directory]",
+                "Exec[postgresql_data_directory]"
+            ],
+            "events": [
+                {
+                    "message": "executed successfully",
+                    "new_value": [
+                        "0"
+                    ],
+                    "old_value": "notrun",
+                    "property": "returns",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:26:57.409Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "line": 83,
+            "resource_title": "postgresql_data_directory",
+            "resource_type": "Exec",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:26:57.409Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Postgresql::Server::Config",
+                "File[/etc/sysconfig/pgsql/postgresql-8.4]"
+            ],
+            "events": [
+                {
+                    "message": "created",
+                    "new_value": "link",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:26:58.573Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config.pp",
+            "line": 120,
+            "resource_title": "/etc/sysconfig/pgsql/postgresql-8.4",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:26:58.573Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Postgresql::Server::Config",
+                "Postgresql::Server::Config_entry[data_directory]",
+                "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]"
+            ],
+            "events": [
+                {
+                    "message": "executed successfully",
+                    "new_value": 0,
+                    "old_value": "need_to_run",
+                    "property": "returns",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:26:58.781Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "line": 90,
+            "resource_title": "override PGDATA in /etc/sysconfig/pgsql/postgresql",
+            "resource_type": "Augeas",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:26:58.781Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Postgresql::Server::Config",
+                "Postgresql::Server::Config_entry[data_directory]",
+                "Postgresql_conf[data_directory]"
+            ],
+            "events": [
+                {
+                    "message": "created",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:26:58.814Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "line": 105,
+            "resource_title": "data_directory",
+            "resource_type": "Postgresql_conf",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:26:58.814Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Main",
+                "Node[pg2.vm]",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "defined 'message' as 'foo'",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:26:58.975Z"
+                }
+            ],
+            "file": "/etc/puppet/manifests/site.pp",
+            "line": 6,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:26:58.975Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Postgresql::Server::Service",
+                "Service[postgresqld]"
+            ],
+            "events": [
+                {
+                    "message": "ensure changed 'stopped' to 'running'",
+                    "new_value": "running",
+                    "old_value": "stopped",
+                    "property": "ensure",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:26:59.281Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+            "line": 14,
+            "resource_title": "postgresqld",
+            "resource_type": "Service",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:26:59.281Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:26:52.564Z",
+    "status": "changed",
+    "transaction_uuid": "9df4e7ce-5646-4178-8ff8-db6add84e9fc"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-b73c37f620703406b5666e7c919afff00c511f1e.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-b73c37f620703406b5666e7c919afff00c511f1e.json
@@ -1,195 +1,266 @@
 {
-  "transaction_uuid" : "5c4f17ad-d6df-4514-881b-e31ef107076e",
-  "puppet_version" : "3.7.1",
-  "noop" : true,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 1.17 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:27:18.498+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "defined 'message' as 'foo'",
-    "source" : "/Stage[main]/Main/Node[pg2.vm]/Notify[foo]/message",
-    "tags" : [ "node", "notify", "notice", "class", "foo", "pg2.vm" ],
-    "time" : "2015-02-13T13:27:17.957+00:00",
-    "file" : "/etc/puppet/manifests/site.pp",
-    "line" : 6
-  }, {
-    "level" : "notice",
-    "message" : "foo",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:27:17.956+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423833741'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:27:17.38+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "warning",
-    "message" : "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
-    "source" : "Puppet",
-    "tags" : [ "warning" ],
-    "time" : "2015-02-13T13:27:17.108+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for pg2.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:27:17.037+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:27:15.24+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:27:13.024+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:27:12.945+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:27:12.891Z",
-  "end_time" : "2015-02-13T13:27:14.717Z",
-  "resource_events" : [ {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/manifests/site.pp",
-    "old_value" : "absent",
-    "line" : 6,
-    "resource_type" : "Notify",
-    "status" : "success",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:27:17.956Z",
-    "containment_path" : [ "Stage[main]", "Main", "Node[pg2.vm]", "Notify[foo]" ],
-    "message" : "defined 'message' as 'foo'"
-  } ],
-  "status" : "changed",
-  "configuration_version" : "1423833741",
-  "environment" : "production",
-  "certname" : "pg2.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 4.62E-4,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.050606,
-    "name" : "augeas"
-  }, {
-    "category" : "time",
-    "value" : 0.944538116455078,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.566681,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.176818,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 1.0E-4,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 7.68E-4,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 9.95E-4,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 8.86E-4,
-    "name" : "postgresql_conf"
-  }, {
-    "category" : "time",
-    "value" : 7.59E-4,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.08334,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 1.82595311645508,
-    "name" : "total"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 50,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 1,
-    "name" : "total"
-  } ]
+    "certname": "pg2.vm",
+    "configuration_version": "1423833741",
+    "end_time": "2015-02-13T13:27:14.717Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 1.17 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:27:18.498+00:00"
+        },
+        {
+            "file": "/etc/puppet/manifests/site.pp",
+            "level": "notice",
+            "line": 6,
+            "message": "defined 'message' as 'foo'",
+            "source": "/Stage[main]/Main/Node[pg2.vm]/Notify[foo]/message",
+            "tags": [
+                "node",
+                "notify",
+                "notice",
+                "class",
+                "foo",
+                "pg2.vm"
+            ],
+            "time": "2015-02-13T13:27:17.957+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "foo",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:27:17.956+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423833741'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:27:17.38+00:00"
+        },
+        {
+            "file": null,
+            "level": "warning",
+            "line": null,
+            "message": "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
+            "source": "Puppet",
+            "tags": [
+                "warning"
+            ],
+            "time": "2015-02-13T13:27:17.108+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for pg2.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:27:17.037+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:27:15.24+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:27:13.024+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:27:12.945+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.000462
+        },
+        {
+            "category": "time",
+            "name": "augeas",
+            "value": 0.050606
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 0.944538116455078
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.566681
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.176818
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 0.0001
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.000768
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.000995
+        },
+        {
+            "category": "time",
+            "name": "postgresql_conf",
+            "value": 0.000886
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.000759
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.08334
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 1.82595311645508
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 50
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 1
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 1
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 1
+        }
+    ],
+    "noop": true,
+    "puppet_version": "3.7.1",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Main",
+                "Node[pg2.vm]",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "defined 'message' as 'foo'",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:27:17.956Z"
+                }
+            ],
+            "file": "/etc/puppet/manifests/site.pp",
+            "line": 6,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:27:17.956Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:27:12.891Z",
+    "status": "changed",
+    "transaction_uuid": "5c4f17ad-d6df-4514-881b-e31ef107076e"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-bb3cea0e4f72a38fde935e93a9efca44e540ec3c.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-bb3cea0e4f72a38fde935e93a9efca44e540ec3c.json
@@ -1,1055 +1,2004 @@
 {
-  "transaction_uuid" : "f2b3642a-27e8-4311-a213-aad48859b9ac",
-  "puppet_version" : "3.7.1",
-  "noop" : true,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 1.98 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:29:10.931+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 8 events",
-    "source" : "Stage[main]",
-    "tags" : [ "main", "completed_stage", "notice" ],
-    "time" : "2015-02-13T13:29:10.897+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 8 events",
-    "source" : "Class[Loadtest]",
-    "tags" : [ "notice", "completed_class", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.895+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "err",
-    "message" : "Provider git is not functional on this host",
-    "source" : "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
-    "tags" : [ "class", "vcsrepo", "node", "pg2.vm", "err", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.894+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 11
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 2 events",
-    "source" : "Class[Snmp::Client]",
-    "tags" : [ "snmp", "client", "snmp::client", "notice", "completed_class" ],
-    "time" : "2015-02-13T13:29:10.893+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp::Client/File[snmp.conf]/ensure",
-    "tags" : [ "snmp", "class", "node", "snmp.conf", "client", "pg2.vm", "snmp::client", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.892+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "line" : 85
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 3 events",
-    "source" : "Class[Python::Install]",
-    "tags" : [ "python", "python::install", "install", "notice", "completed_class" ],
-    "time" : "2015-02-13T13:29:10.888+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Python::Install/Package[python-virtualenv]/ensure",
-    "tags" : [ "package", "class", "python", "python-virtualenv", "node", "pg2.vm", "python::install", "install", "notice", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.885+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 59
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Python::Install/Package[python-devel]/ensure",
-    "tags" : [ "package", "class", "python", "node", "python-devel", "pg2.vm", "python::install", "install", "notice", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.82+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 61
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Python::Install/Package[python-pip]/ensure",
-    "tags" : [ "package", "class", "python", "node", "python-pip", "pg2.vm", "python::install", "install", "notice", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.787+00:00",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "line" : 60
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Git]",
-    "tags" : [ "notice", "git", "completed_class" ],
-    "time" : "2015-02-13T13:29:10.506+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Git/Package[git]/ensure",
-    "tags" : [ "package", "class", "node", "pg2.vm", "notice", "git", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.504+00:00",
-    "file" : "/etc/puppet/modules/git/manifests/init.pp",
-    "line" : 12
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 8 events",
-    "source" : "Class[Snmp]",
-    "tags" : [ "snmp", "notice", "completed_class" ],
-    "time" : "2015-02-13T13:29:10.276+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Unscheduling refresh on Service[snmpd]",
-    "source" : "/Stage[main]/Snmp/Service[snmpd]",
-    "tags" : [ "snmpd", "snmp", "class", "node", "service", "info", "pg2.vm", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.276+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 517
-  }, {
-    "level" : "notice",
-    "message" : "current_value stopped, should be running (noop)",
-    "source" : "/Stage[main]/Snmp/Service[snmpd]/ensure",
-    "tags" : [ "snmpd", "snmp", "class", "node", "service", "pg2.vm", "notice", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.275+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 517
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[snmpd]",
-    "source" : "/Stage[main]/Snmp/File[snmpd.conf]",
-    "tags" : [ "snmp", "class", "snmpd.conf", "node", "info", "pg2.vm", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.236+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 429
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/File[snmpd.conf]/ensure",
-    "tags" : [ "snmp", "class", "snmpd.conf", "node", "pg2.vm", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.235+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 429
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Concat::Fragment[tmpfile]",
-    "tags" : [ "fragment", "completed_concat", "completed_concat::fragment", "tmpfile", "notice" ],
-    "time" : "2015-02-13T13:29:10.234+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 6 events",
-    "source" : "Concat[/tmp/file]",
-    "tags" : [ "completed_concat", "notice" ],
-    "time" : "2015-02-13T13:29:10.233+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "err",
-    "message" : "Could not evaluate: Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/tmp/file]",
-    "tags" : [ "concat", "class", "node", "pg2.vm", "err", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.232+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 169
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 4 events",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-    "tags" : [ "concat", "class", "node", "exec", "pg2.vm", "notice", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.231+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "notice",
-    "message" : "current_value notrun, should be 0 (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/returns",
-    "tags" : [ "concat", "class", "node", "exec", "pg2.vm", "notice", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.23+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 187
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-    "tags" : [ "concat", "class", "concat::fragment", "fragment", "node", "info", "tmpfile", "pg2.vm", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.165+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be file (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/ensure",
-    "tags" : [ "concat", "class", "concat::fragment", "fragment", "node", "tmpfile", "pg2.vm", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.164+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Concat::Fragment[tmpfile2]",
-    "tags" : [ "fragment", "completed_concat", "completed_concat::fragment", "tmpfile2", "notice" ],
-    "time" : "2015-02-13T13:29:10.161+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-    "tags" : [ "concat", "class", "concat::fragment", "fragment", "node", "info", "pg2.vm", "tmpfile2", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.161+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be file (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
-    "tags" : [ "concat", "class", "concat::fragment", "fragment", "node", "pg2.vm", "tmpfile2", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.16+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "line" : 113
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
-    "tags" : [ "concat", "class", "node", "info", "pg2.vm", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.159+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 149
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be directory (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/ensure",
-    "tags" : [ "concat", "class", "node", "pg2.vm", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.159+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 149
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 2 events",
-    "source" : "/Stage[main]/Snmp/Service[snmptrapd]",
-    "tags" : [ "snmp", "class", "snmptrapd", "node", "service", "pg2.vm", "notice", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.155+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 476
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]/ensure",
-    "tags" : [ "concat", "class", "node", "pg2.vm", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.114+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 164
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]/ensure",
-    "tags" : [ "concat", "class", "node", "pg2.vm", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.112+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 159
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
-    "tags" : [ "concat", "class", "node", "info", "pg2.vm", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.111+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 144
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be directory (noop)",
-    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]/ensure",
-    "tags" : [ "concat", "class", "node", "pg2.vm", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.11+00:00",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "line" : 144
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[snmptrapd]",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]",
-    "tags" : [ "snmp", "class", "node", "info", "pg2.vm", "snmptrapd.conf", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.108+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 453
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]/ensure",
-    "tags" : [ "snmp", "class", "node", "pg2.vm", "snmptrapd.conf", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:10.108+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 453
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]/ensure",
-    "tags" : [ "class", "node", "hkp_server_20bc0a86", "gnupg_key", "pg2.vm", "notice", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.902+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 69
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Ntp::Service]",
-    "tags" : [ "ntp", "service", "notice", "completed_class", "ntp::service" ],
-    "time" : "2015-02-13T13:29:09.873+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Unscheduling refresh on Service[ntp]",
-    "source" : "/Stage[main]/Ntp::Service/Service[ntp]",
-    "tags" : [ "class", "ntp", "node", "service", "info", "pg2.vm", "ntp::service", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.872+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
-    "line" : 9
-  }, {
-    "level" : "notice",
-    "message" : "current_value stopped, should be running (noop)",
-    "source" : "/Stage[main]/Ntp::Service/Service[ntp]/ensure",
-    "tags" : [ "class", "ntp", "node", "service", "pg2.vm", "notice", "ntp::service", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.871+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
-    "line" : 9
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be directory (noop)",
-    "source" : "/Stage[main]/Snmp/File[var-net-snmp]/ensure",
-    "tags" : [ "snmp", "class", "var-net-snmp", "node", "pg2.vm", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.751+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 410
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Loadtest/Ini_setting[sample setting]/ensure",
-    "tags" : [ "class", "node", "pg2.vm", "notice", "ini_setting", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.749+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 45
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[ntp]",
-    "source" : "Class[Ntp::Service]",
-    "tags" : [ "ntp", "admissible_class", "service", "info", "ntp::service" ],
-    "time" : "2015-02-13T13:29:09.747+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Ntp::Service]",
-    "tags" : [ "ntp", "admissible_class", "service", "notice", "ntp::service" ],
-    "time" : "2015-02-13T13:29:09.747+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Class[Ntp::Service]",
-    "source" : "Class[Ntp::Config]",
-    "tags" : [ "ntp", "ntp::config", "config", "info", "completed_class" ],
-    "time" : "2015-02-13T13:29:09.746+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Ntp::Config]",
-    "tags" : [ "ntp", "ntp::config", "config", "notice", "completed_class" ],
-    "time" : "2015-02-13T13:29:09.745+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
-    "source" : "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
-    "tags" : [ "class", "ntp", "ntp::config", "config", "node", "pg2.vm", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.741+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
-    "line" : 14
-  }, {
-    "level" : "notice",
-    "message" : "\n--- /etc/ntp.conf\t2013-07-15 10:18:47.000000000 +0100\n+++ /tmp/puppet-file20150213-61841-934rx4-0\t2015-02-13 13:29:09.708877903 +0000\n@@ -1,53 +1,19 @@\n-# For more information about this file, see the man pages\n-# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).\n+# ntp.conf: Managed by puppet.\n+#\n+# Keep ntpd from panicking in the event of a large clock skew\n+# when a VM guest is suspended and resumed.\n+tinker panic 0\n \n-driftfile /var/lib/ntp/drift\n \n # Permit time synchronization with our time source, but do not\n # permit the source to query or modify the service on this system.\n-restrict default kod nomodify notrap nopeer noquery\n-restrict -6 default kod nomodify notrap nopeer noquery\n+restrict 127.0.0.1\n+\n \n-# Permit all access over the loopback interface.  This could\n-# be tightened as well, but to do so would effect some of\n-# the administrative functions.\n-restrict 127.0.0.1 \n-restrict -6 ::1\n-\n-# Hosts on local network are less restricted.\n-#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap\n-\n-# Use public servers from the pool.ntp.org project.\n-# Please consider joining the pool (http://www.pool.ntp.org/join.html).\n-server 0.centos.pool.ntp.org iburst\n-server 1.centos.pool.ntp.org iburst\n-server 2.centos.pool.ntp.org iburst\n-server 3.centos.pool.ntp.org iburst\n-\n-#broadcast 192.168.1.255 autokey\t# broadcast server\n-#broadcastclient\t\t\t# broadcast client\n-#broadcast 224.0.1.1 autokey\t\t# multicast server\n-#multicastclient 224.0.1.1\t\t# multicast client\n-#manycastserver 239.255.254.254\t\t# manycast server\n-#manycastclient 239.255.254.254 autokey # manycast client\n-\n-# Enable public key cryptography.\n-#crypto\n-\n-includefile /etc/ntp/crypto/pw\n-\n-# Key file containing the keys and key identifiers used when operating\n-# with symmetric key cryptography. \n-keys /etc/ntp/keys\n-\n-# Specify the key identifiers which are trusted.\n-#trustedkey 4 8 42\n+server ntp.pool.org\n \n-# Specify the key identifier to use with the ntpdc utility.\n-#requestkey 8\n \n-# Specify the key identifier to use with the ntpq utility.\n-#controlkey 8\n+# Driftfile.\n+driftfile /var/lib/ntp/drift\n+\n \n-# Enable writing of statistics records.\n-#statistics clockstats cryptostats loopstats peerstats\n",
-    "source" : "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
-    "tags" : [ "class", "ntp", "ntp::config", "config", "node", "pg2.vm", "content", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.737+00:00",
-    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
-    "line" : 14
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[snmpd]",
-    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]",
-    "tags" : [ "snmp", "class", "node", "info", "pg2.vm", "snmpd.sysconfig", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.703+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 441
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]/ensure",
-    "tags" : [ "snmp", "class", "node", "pg2.vm", "notice", "snmpd.sysconfig", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.703+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 441
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[snmptrapd]",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.sysconfig]",
-    "tags" : [ "snmp", "class", "snmptrapd.sysconfig", "node", "info", "pg2.vm", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.694+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 465
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/File[snmptrapd.sysconfig]/ensure",
-    "tags" : [ "snmp", "class", "snmptrapd.sysconfig", "node", "pg2.vm", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.693+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 465
-  }, {
-    "level" : "info",
-    "message" : "Unscheduling refresh on Service[cron]",
-    "source" : "/Stage[main]/Loadtest/Service[cron]",
-    "tags" : [ "class", "cron", "node", "service", "info", "pg2.vm", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.688+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 4
-  }, {
-    "level" : "notice",
-    "message" : "current_value stopped, should be running (noop)",
-    "source" : "/Stage[main]/Loadtest/Service[cron]/ensure",
-    "tags" : [ "class", "cron", "node", "service", "pg2.vm", "notice", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.687+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 4
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be foo (noop)",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
-    "tags" : [ "class", "node", "notify", "foo", "pg2.vm", "notice", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.523+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp/Package[snmpd]/ensure",
-    "tags" : [ "package", "snmpd", "snmp", "class", "node", "pg2.vm", "notice", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.521+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "line" : 405
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be latest (noop)",
-    "source" : "/Stage[main]/Loadtest/Package[etckeeper]/ensure",
-    "tags" : [ "package", "class", "etckeeper", "node", "pg2.vm", "notice", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.423+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 41
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Snmp::Client/Package[snmp-client]/ensure",
-    "tags" : [ "package", "snmp", "class", "node", "snmp-client", "client", "pg2.vm", "snmp::client", "notice", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.325+00:00",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "line" : 76
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Motd]",
-    "tags" : [ "motd", "notice", "completed_class" ],
-    "time" : "2015-02-13T13:29:09.093+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
-    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
-    "tags" : [ "class", "node", "motd", "pg2.vm", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.09+00:00",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "line" : 33
-  }, {
-    "level" : "notice",
-    "message" : "\n--- /etc/motd\t2010-01-12 13:28:22.000000000 +0000\n+++ /tmp/puppet-file20150213-61841-isxd4q-0\t2015-02-13 13:29:09.073877903 +0000\n@@ -0,0 +1 @@\n+Welcome to my test host!\n\\ No newline at end of file\n",
-    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
-    "tags" : [ "class", "node", "motd", "pg2.vm", "content", "notice", "file", "loadtest" ],
-    "time" : "2015-02-13T13:29:09.09+00:00",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "line" : 33
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423834124'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:09.021+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "warning",
-    "message" : "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
-    "source" : "Puppet",
-    "tags" : [ "warning" ],
-    "time" : "2015-02-13T13:29:08.608+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for pg2.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:08.547+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:02.517+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "err",
-    "message" : "Could not evaluate: Could not retrieve file metadata for puppet://puppet/plugins: Network is unreachable - connect(2)\nWrapped exception:\nNetwork is unreachable - connect(2)",
-    "source" : "/File[/var/lib/puppet/lib]",
-    "tags" : [ "plugin", "err", "file" ],
-    "time" : "2015-02-13T13:29:02.507+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "err",
-    "message" : "Failed to generate additional resources using 'eval_generate': Network is unreachable - connect(2)",
-    "source" : "/File[/var/lib/puppet/lib]",
-    "tags" : [ "plugin", "err", "file" ],
-    "time" : "2015-02-13T13:29:02.502+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:01.367+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "err",
-    "message" : "Could not evaluate: Could not retrieve file metadata for puppet://puppet/pluginfacts: Network is unreachable - connect(2)\nWrapped exception:\nNetwork is unreachable - connect(2)",
-    "source" : "/File[/var/lib/puppet/facts.d]",
-    "tags" : [ "pluginfacts", "err", "file" ],
-    "time" : "2015-02-13T13:29:01.367+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "err",
-    "message" : "Failed to generate additional resources using 'eval_generate': Network is unreachable - connect(2)",
-    "source" : "/File[/var/lib/puppet/facts.d]",
-    "tags" : [ "pluginfacts", "err", "file" ],
-    "time" : "2015-02-13T13:29:01.364+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:01.353+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "warning",
-    "message" : "Network is unreachable - connect(2)",
-    "source" : "Puppet",
-    "tags" : [ "warning" ],
-    "time" : "2015-02-13T13:29:01.352+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "warning",
-    "message" : "Unable to fetch my node definition, but the agent run will continue:",
-    "source" : "Puppet",
-    "tags" : [ "warning" ],
-    "time" : "2015-02-13T13:29:01.352+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:29:01.341Z",
-  "end_time" : "2015-02-13T13:29:04.147Z",
-  "resource_events" : [ {
-    "new_value" : "{md5}a3f731187a6aaaa23d4a7b244f223f33",
-    "property" : "content",
-    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
-    "old_value" : "{md5}d41d8cd98f00b204e9800998ecf8427e",
-    "line" : 33,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/etc/motd",
-    "timestamp" : "2015-02-13T13:29:09.090Z",
-    "containment_path" : [ "Stage[main]", "Motd", "File[/etc/motd]" ],
-    "message" : "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "old_value" : "absent",
-    "line" : 76,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "snmp-client",
-    "timestamp" : "2015-02-13T13:29:09.325Z",
-    "containment_path" : [ "Stage[main]", "Snmp::Client", "Package[snmp-client]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "latest",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 41,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "etckeeper",
-    "timestamp" : "2015-02-13T13:29:09.423Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Package[etckeeper]" ],
-    "message" : "current_value absent, should be latest (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 405,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "snmpd",
-    "timestamp" : "2015-02-13T13:29:09.521Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "Package[snmpd]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 3,
-    "resource_type" : "Notify",
-    "status" : "noop",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:29:09.523Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
-    "message" : "current_value absent, should be foo (noop)"
-  }, {
-    "new_value" : "running",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "stopped",
-    "line" : 4,
-    "resource_type" : "Service",
-    "status" : "noop",
-    "resource_title" : "cron",
-    "timestamp" : "2015-02-13T13:29:09.687Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Service[cron]" ],
-    "message" : "current_value stopped, should be running (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 465,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmptrapd.sysconfig",
-    "timestamp" : "2015-02-13T13:29:09.693Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[snmptrapd.sysconfig]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 441,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmpd.sysconfig",
-    "timestamp" : "2015-02-13T13:29:09.702Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[snmpd.sysconfig]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "{md5}eb918d28434c9fefcc05875c29c3ba1a",
-    "property" : "content",
-    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
-    "old_value" : "{md5}7fda24f62b1c7ae951db0f746dc6e0cc",
-    "line" : 14,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/etc/ntp.conf",
-    "timestamp" : "2015-02-13T13:29:09.741Z",
-    "containment_path" : [ "Stage[main]", "Ntp::Config", "File[/etc/ntp.conf]" ],
-    "message" : "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 45,
-    "resource_type" : "Ini_setting",
-    "status" : "noop",
-    "resource_title" : "sample setting",
-    "timestamp" : "2015-02-13T13:29:09.749Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Ini_setting[sample setting]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "directory",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 410,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "var-net-snmp",
-    "timestamp" : "2015-02-13T13:29:09.751Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[var-net-snmp]" ],
-    "message" : "current_value absent, should be directory (noop)"
-  }, {
-    "new_value" : "running",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
-    "old_value" : "stopped",
-    "line" : 9,
-    "resource_type" : "Service",
-    "status" : "noop",
-    "resource_title" : "ntp",
-    "timestamp" : "2015-02-13T13:29:09.871Z",
-    "containment_path" : [ "Stage[main]", "Ntp::Service", "Service[ntp]" ],
-    "message" : "current_value stopped, should be running (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 69,
-    "resource_type" : "Gnupg_key",
-    "status" : "noop",
-    "resource_title" : "hkp_server_20BC0A86",
-    "timestamp" : "2015-02-13T13:29:09.901Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Gnupg_key[hkp_server_20BC0A86]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 453,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmptrapd.conf",
-    "timestamp" : "2015-02-13T13:29:10.108Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[snmptrapd.conf]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "directory",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 144,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file",
-    "timestamp" : "2015-02-13T13:29:10.110Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/var/lib/puppet/concat/_tmp_file]" ],
-    "message" : "current_value absent, should be directory (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 159,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments.concat",
-    "timestamp" : "2015-02-13T13:29:10.112Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/var/lib/puppet/concat/_tmp_file/fragments.concat]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 164,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-    "timestamp" : "2015-02-13T13:29:10.114Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "directory",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 149,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments",
-    "timestamp" : "2015-02-13T13:29:10.158Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/var/lib/puppet/concat/_tmp_file/fragments]" ],
-    "message" : "current_value absent, should be directory (noop)"
-  }, {
-    "new_value" : "file",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "old_value" : "absent",
-    "line" : 113,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
-    "timestamp" : "2015-02-13T13:29:10.160Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat::Fragment[tmpfile2]", "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]" ],
-    "message" : "current_value absent, should be file (noop)"
-  }, {
-    "new_value" : "file",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
-    "old_value" : "absent",
-    "line" : 113,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
-    "timestamp" : "2015-02-13T13:29:10.164Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat::Fragment[tmpfile]", "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]" ],
-    "message" : "current_value absent, should be file (noop)"
-  }, {
-    "new_value" : [ "0" ],
-    "property" : "returns",
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : "notrun",
-    "line" : 187,
-    "resource_type" : "Exec",
-    "status" : "noop",
-    "resource_title" : "concat_/tmp/file",
-    "timestamp" : "2015-02-13T13:29:10.230Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "Exec[concat_/tmp/file]" ],
-    "message" : "current_value notrun, should be 0 (noop)"
-  }, {
-    "new_value" : null,
-    "property" : null,
-    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
-    "old_value" : null,
-    "line" : 169,
-    "resource_type" : "File",
-    "status" : "failure",
-    "resource_title" : "/tmp/file",
-    "timestamp" : "2015-02-13T13:29:10.233Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Concat[/tmp/file]", "File[/tmp/file]" ],
-    "message" : "Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 429,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmpd.conf",
-    "timestamp" : "2015-02-13T13:29:10.235Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "File[snmpd.conf]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "running",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
-    "old_value" : "stopped",
-    "line" : 517,
-    "resource_type" : "Service",
-    "status" : "noop",
-    "resource_title" : "snmpd",
-    "timestamp" : "2015-02-13T13:29:10.275Z",
-    "containment_path" : [ "Stage[main]", "Snmp", "Service[snmpd]" ],
-    "message" : "current_value stopped, should be running (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/git/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 12,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "git",
-    "timestamp" : "2015-02-13T13:29:10.504Z",
-    "containment_path" : [ "Stage[main]", "Git", "Package[git]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "old_value" : "absent",
-    "line" : 60,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "python-pip",
-    "timestamp" : "2015-02-13T13:29:10.786Z",
-    "containment_path" : [ "Stage[main]", "Python::Install", "Package[python-pip]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "old_value" : "absent",
-    "line" : 61,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "python-devel",
-    "timestamp" : "2015-02-13T13:29:10.820Z",
-    "containment_path" : [ "Stage[main]", "Python::Install", "Package[python-devel]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/python/manifests/install.pp",
-    "old_value" : "absent",
-    "line" : 59,
-    "resource_type" : "Package",
-    "status" : "noop",
-    "resource_title" : "python-virtualenv",
-    "timestamp" : "2015-02-13T13:29:10.885Z",
-    "containment_path" : [ "Stage[main]", "Python::Install", "Package[python-virtualenv]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
-    "old_value" : "absent",
-    "line" : 85,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "snmp.conf",
-    "timestamp" : "2015-02-13T13:29:10.892Z",
-    "containment_path" : [ "Stage[main]", "Snmp::Client", "File[snmp.conf]" ],
-    "message" : "current_value absent, should be present (noop)"
-  } ],
-  "status" : "failed",
-  "configuration_version" : "1423834124",
-  "environment" : "production",
-  "certname" : "pg2.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 0.00119,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.0566330000000001,
-    "name" : "augeas"
-  }, {
-    "category" : "time",
-    "value" : 1.24377989768982,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.393671,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.302035,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 4.69E-4,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.026254,
-    "name" : "gnupg_key"
-  }, {
-    "category" : "time",
-    "value" : 8.23E-4,
-    "name" : "ini_setting"
-  }, {
-    "category" : "time",
-    "value" : 6.11E-4,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.450188,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 6.8E-4,
-    "name" : "postgresql_conf"
-  }, {
-    "category" : "time",
-    "value" : 0.001031,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.329234,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 2.80659889768982,
-    "name" : "total"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 2,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 29,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 88,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 28,
-    "name" : "noop"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 29,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 0,
-    "name" : "total"
-  } ]
+    "certname": "pg2.vm",
+    "configuration_version": "1423834124",
+    "end_time": "2015-02-13T13:29:04.147Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 1.98 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:10.931+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 8 events",
+            "source": "Stage[main]",
+            "tags": [
+                "main",
+                "completed_stage",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:10.897+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 8 events",
+            "source": "Class[Loadtest]",
+            "tags": [
+                "notice",
+                "completed_class",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.895+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "err",
+            "line": 11,
+            "message": "Provider git is not functional on this host",
+            "source": "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
+            "tags": [
+                "class",
+                "vcsrepo",
+                "node",
+                "pg2.vm",
+                "err",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.894+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 2 events",
+            "source": "Class[Snmp::Client]",
+            "tags": [
+                "snmp",
+                "client",
+                "snmp::client",
+                "notice",
+                "completed_class"
+            ],
+            "time": "2015-02-13T13:29:10.893+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "level": "notice",
+            "line": 85,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp::Client/File[snmp.conf]/ensure",
+            "tags": [
+                "snmp",
+                "class",
+                "node",
+                "snmp.conf",
+                "client",
+                "pg2.vm",
+                "snmp::client",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.892+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 3 events",
+            "source": "Class[Python::Install]",
+            "tags": [
+                "python",
+                "python::install",
+                "install",
+                "notice",
+                "completed_class"
+            ],
+            "time": "2015-02-13T13:29:10.888+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "notice",
+            "line": 59,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Python::Install/Package[python-virtualenv]/ensure",
+            "tags": [
+                "package",
+                "class",
+                "python",
+                "python-virtualenv",
+                "node",
+                "pg2.vm",
+                "python::install",
+                "install",
+                "notice",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.885+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "notice",
+            "line": 61,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Python::Install/Package[python-devel]/ensure",
+            "tags": [
+                "package",
+                "class",
+                "python",
+                "node",
+                "python-devel",
+                "pg2.vm",
+                "python::install",
+                "install",
+                "notice",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.82+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "level": "notice",
+            "line": 60,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Python::Install/Package[python-pip]/ensure",
+            "tags": [
+                "package",
+                "class",
+                "python",
+                "node",
+                "python-pip",
+                "pg2.vm",
+                "python::install",
+                "install",
+                "notice",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.787+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Git]",
+            "tags": [
+                "notice",
+                "git",
+                "completed_class"
+            ],
+            "time": "2015-02-13T13:29:10.506+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/git/manifests/init.pp",
+            "level": "notice",
+            "line": 12,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Git/Package[git]/ensure",
+            "tags": [
+                "package",
+                "class",
+                "node",
+                "pg2.vm",
+                "notice",
+                "git",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.504+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 8 events",
+            "source": "Class[Snmp]",
+            "tags": [
+                "snmp",
+                "notice",
+                "completed_class"
+            ],
+            "time": "2015-02-13T13:29:10.276+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 517,
+            "message": "Unscheduling refresh on Service[snmpd]",
+            "source": "/Stage[main]/Snmp/Service[snmpd]",
+            "tags": [
+                "snmpd",
+                "snmp",
+                "class",
+                "node",
+                "service",
+                "info",
+                "pg2.vm",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.276+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 517,
+            "message": "current_value stopped, should be running (noop)",
+            "source": "/Stage[main]/Snmp/Service[snmpd]/ensure",
+            "tags": [
+                "snmpd",
+                "snmp",
+                "class",
+                "node",
+                "service",
+                "pg2.vm",
+                "notice",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.275+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 429,
+            "message": "Scheduling refresh of Service[snmpd]",
+            "source": "/Stage[main]/Snmp/File[snmpd.conf]",
+            "tags": [
+                "snmp",
+                "class",
+                "snmpd.conf",
+                "node",
+                "info",
+                "pg2.vm",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.236+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 429,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/File[snmpd.conf]/ensure",
+            "tags": [
+                "snmp",
+                "class",
+                "snmpd.conf",
+                "node",
+                "pg2.vm",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.235+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Concat::Fragment[tmpfile]",
+            "tags": [
+                "fragment",
+                "completed_concat",
+                "completed_concat::fragment",
+                "tmpfile",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:10.234+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 6 events",
+            "source": "Concat[/tmp/file]",
+            "tags": [
+                "completed_concat",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:10.233+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "err",
+            "line": 169,
+            "message": "Could not evaluate: Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/tmp/file]",
+            "tags": [
+                "concat",
+                "class",
+                "node",
+                "pg2.vm",
+                "err",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.232+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 187,
+            "message": "Would have triggered 'refresh' from 4 events",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+            "tags": [
+                "concat",
+                "class",
+                "node",
+                "exec",
+                "pg2.vm",
+                "notice",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.231+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 187,
+            "message": "current_value notrun, should be 0 (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/returns",
+            "tags": [
+                "concat",
+                "class",
+                "node",
+                "exec",
+                "pg2.vm",
+                "notice",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.23+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "info",
+            "line": 113,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+            "tags": [
+                "concat",
+                "class",
+                "concat::fragment",
+                "fragment",
+                "node",
+                "info",
+                "tmpfile",
+                "pg2.vm",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.165+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "notice",
+            "line": 113,
+            "message": "current_value absent, should be file (noop)",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/ensure",
+            "tags": [
+                "concat",
+                "class",
+                "concat::fragment",
+                "fragment",
+                "node",
+                "tmpfile",
+                "pg2.vm",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.164+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Concat::Fragment[tmpfile2]",
+            "tags": [
+                "fragment",
+                "completed_concat",
+                "completed_concat::fragment",
+                "tmpfile2",
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:10.161+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "info",
+            "line": 113,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+            "tags": [
+                "concat",
+                "class",
+                "concat::fragment",
+                "fragment",
+                "node",
+                "info",
+                "pg2.vm",
+                "tmpfile2",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.161+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "level": "notice",
+            "line": 113,
+            "message": "current_value absent, should be file (noop)",
+            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
+            "tags": [
+                "concat",
+                "class",
+                "concat::fragment",
+                "fragment",
+                "node",
+                "pg2.vm",
+                "tmpfile2",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.16+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "info",
+            "line": 149,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
+            "tags": [
+                "concat",
+                "class",
+                "node",
+                "info",
+                "pg2.vm",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.159+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 149,
+            "message": "current_value absent, should be directory (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/ensure",
+            "tags": [
+                "concat",
+                "class",
+                "node",
+                "pg2.vm",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.159+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 476,
+            "message": "Would have triggered 'refresh' from 2 events",
+            "source": "/Stage[main]/Snmp/Service[snmptrapd]",
+            "tags": [
+                "snmp",
+                "class",
+                "snmptrapd",
+                "node",
+                "service",
+                "pg2.vm",
+                "notice",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.155+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 164,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]/ensure",
+            "tags": [
+                "concat",
+                "class",
+                "node",
+                "pg2.vm",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.114+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 159,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]/ensure",
+            "tags": [
+                "concat",
+                "class",
+                "node",
+                "pg2.vm",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.112+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "info",
+            "line": 144,
+            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
+            "tags": [
+                "concat",
+                "class",
+                "node",
+                "info",
+                "pg2.vm",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.111+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "level": "notice",
+            "line": 144,
+            "message": "current_value absent, should be directory (noop)",
+            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]/ensure",
+            "tags": [
+                "concat",
+                "class",
+                "node",
+                "pg2.vm",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.11+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 453,
+            "message": "Scheduling refresh of Service[snmptrapd]",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]",
+            "tags": [
+                "snmp",
+                "class",
+                "node",
+                "info",
+                "pg2.vm",
+                "snmptrapd.conf",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.108+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 453,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]/ensure",
+            "tags": [
+                "snmp",
+                "class",
+                "node",
+                "pg2.vm",
+                "snmptrapd.conf",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:10.108+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 69,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]/ensure",
+            "tags": [
+                "class",
+                "node",
+                "hkp_server_20bc0a86",
+                "gnupg_key",
+                "pg2.vm",
+                "notice",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.902+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Ntp::Service]",
+            "tags": [
+                "ntp",
+                "service",
+                "notice",
+                "completed_class",
+                "ntp::service"
+            ],
+            "time": "2015-02-13T13:29:09.873+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
+            "level": "info",
+            "line": 9,
+            "message": "Unscheduling refresh on Service[ntp]",
+            "source": "/Stage[main]/Ntp::Service/Service[ntp]",
+            "tags": [
+                "class",
+                "ntp",
+                "node",
+                "service",
+                "info",
+                "pg2.vm",
+                "ntp::service",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.872+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
+            "level": "notice",
+            "line": 9,
+            "message": "current_value stopped, should be running (noop)",
+            "source": "/Stage[main]/Ntp::Service/Service[ntp]/ensure",
+            "tags": [
+                "class",
+                "ntp",
+                "node",
+                "service",
+                "pg2.vm",
+                "notice",
+                "ntp::service",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.871+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 410,
+            "message": "current_value absent, should be directory (noop)",
+            "source": "/Stage[main]/Snmp/File[var-net-snmp]/ensure",
+            "tags": [
+                "snmp",
+                "class",
+                "var-net-snmp",
+                "node",
+                "pg2.vm",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.751+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 45,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Loadtest/Ini_setting[sample setting]/ensure",
+            "tags": [
+                "class",
+                "node",
+                "pg2.vm",
+                "notice",
+                "ini_setting",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.749+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Service[ntp]",
+            "source": "Class[Ntp::Service]",
+            "tags": [
+                "ntp",
+                "admissible_class",
+                "service",
+                "info",
+                "ntp::service"
+            ],
+            "time": "2015-02-13T13:29:09.747+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Ntp::Service]",
+            "tags": [
+                "ntp",
+                "admissible_class",
+                "service",
+                "notice",
+                "ntp::service"
+            ],
+            "time": "2015-02-13T13:29:09.747+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Class[Ntp::Service]",
+            "source": "Class[Ntp::Config]",
+            "tags": [
+                "ntp",
+                "ntp::config",
+                "config",
+                "info",
+                "completed_class"
+            ],
+            "time": "2015-02-13T13:29:09.746+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Ntp::Config]",
+            "tags": [
+                "ntp",
+                "ntp::config",
+                "config",
+                "notice",
+                "completed_class"
+            ],
+            "time": "2015-02-13T13:29:09.745+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
+            "level": "notice",
+            "line": 14,
+            "message": "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
+            "source": "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
+            "tags": [
+                "class",
+                "ntp",
+                "ntp::config",
+                "config",
+                "node",
+                "pg2.vm",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.741+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
+            "level": "notice",
+            "line": 14,
+            "message": "\n--- /etc/ntp.conf\t2013-07-15 10:18:47.000000000 +0100\n+++ /tmp/puppet-file20150213-61841-934rx4-0\t2015-02-13 13:29:09.708877903 +0000\n@@ -1,53 +1,19 @@\n-# For more information about this file, see the man pages\n-# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).\n+# ntp.conf: Managed by puppet.\n+#\n+# Keep ntpd from panicking in the event of a large clock skew\n+# when a VM guest is suspended and resumed.\n+tinker panic 0\n \n-driftfile /var/lib/ntp/drift\n \n # Permit time synchronization with our time source, but do not\n # permit the source to query or modify the service on this system.\n-restrict default kod nomodify notrap nopeer noquery\n-restrict -6 default kod nomodify notrap nopeer noquery\n+restrict 127.0.0.1\n+\n \n-# Permit all access over the loopback interface.  This could\n-# be tightened as well, but to do so would effect some of\n-# the administrative functions.\n-restrict 127.0.0.1 \n-restrict -6 ::1\n-\n-# Hosts on local network are less restricted.\n-#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap\n-\n-# Use public servers from the pool.ntp.org project.\n-# Please consider joining the pool (http://www.pool.ntp.org/join.html).\n-server 0.centos.pool.ntp.org iburst\n-server 1.centos.pool.ntp.org iburst\n-server 2.centos.pool.ntp.org iburst\n-server 3.centos.pool.ntp.org iburst\n-\n-#broadcast 192.168.1.255 autokey\t# broadcast server\n-#broadcastclient\t\t\t# broadcast client\n-#broadcast 224.0.1.1 autokey\t\t# multicast server\n-#multicastclient 224.0.1.1\t\t# multicast client\n-#manycastserver 239.255.254.254\t\t# manycast server\n-#manycastclient 239.255.254.254 autokey # manycast client\n-\n-# Enable public key cryptography.\n-#crypto\n-\n-includefile /etc/ntp/crypto/pw\n-\n-# Key file containing the keys and key identifiers used when operating\n-# with symmetric key cryptography. \n-keys /etc/ntp/keys\n-\n-# Specify the key identifiers which are trusted.\n-#trustedkey 4 8 42\n+server ntp.pool.org\n \n-# Specify the key identifier to use with the ntpdc utility.\n-#requestkey 8\n \n-# Specify the key identifier to use with the ntpq utility.\n-#controlkey 8\n+# Driftfile.\n+driftfile /var/lib/ntp/drift\n+\n \n-# Enable writing of statistics records.\n-#statistics clockstats cryptostats loopstats peerstats\n",
+            "source": "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
+            "tags": [
+                "class",
+                "ntp",
+                "ntp::config",
+                "config",
+                "node",
+                "pg2.vm",
+                "content",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.737+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 441,
+            "message": "Scheduling refresh of Service[snmpd]",
+            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]",
+            "tags": [
+                "snmp",
+                "class",
+                "node",
+                "info",
+                "pg2.vm",
+                "snmpd.sysconfig",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.703+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 441,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]/ensure",
+            "tags": [
+                "snmp",
+                "class",
+                "node",
+                "pg2.vm",
+                "notice",
+                "snmpd.sysconfig",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.703+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "info",
+            "line": 465,
+            "message": "Scheduling refresh of Service[snmptrapd]",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.sysconfig]",
+            "tags": [
+                "snmp",
+                "class",
+                "snmptrapd.sysconfig",
+                "node",
+                "info",
+                "pg2.vm",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.694+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 465,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/File[snmptrapd.sysconfig]/ensure",
+            "tags": [
+                "snmp",
+                "class",
+                "snmptrapd.sysconfig",
+                "node",
+                "pg2.vm",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.693+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "info",
+            "line": 4,
+            "message": "Unscheduling refresh on Service[cron]",
+            "source": "/Stage[main]/Loadtest/Service[cron]",
+            "tags": [
+                "class",
+                "cron",
+                "node",
+                "service",
+                "info",
+                "pg2.vm",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.688+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 4,
+            "message": "current_value stopped, should be running (noop)",
+            "source": "/Stage[main]/Loadtest/Service[cron]/ensure",
+            "tags": [
+                "class",
+                "cron",
+                "node",
+                "service",
+                "pg2.vm",
+                "notice",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.687+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 3,
+            "message": "current_value absent, should be foo (noop)",
+            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
+            "tags": [
+                "class",
+                "node",
+                "notify",
+                "foo",
+                "pg2.vm",
+                "notice",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.523+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "level": "notice",
+            "line": 405,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp/Package[snmpd]/ensure",
+            "tags": [
+                "package",
+                "snmpd",
+                "snmp",
+                "class",
+                "node",
+                "pg2.vm",
+                "notice",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.521+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 41,
+            "message": "current_value absent, should be latest (noop)",
+            "source": "/Stage[main]/Loadtest/Package[etckeeper]/ensure",
+            "tags": [
+                "package",
+                "class",
+                "etckeeper",
+                "node",
+                "pg2.vm",
+                "notice",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.423+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "level": "notice",
+            "line": 76,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Snmp::Client/Package[snmp-client]/ensure",
+            "tags": [
+                "package",
+                "snmp",
+                "class",
+                "node",
+                "snmp-client",
+                "client",
+                "pg2.vm",
+                "snmp::client",
+                "notice",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.325+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Motd]",
+            "tags": [
+                "motd",
+                "notice",
+                "completed_class"
+            ],
+            "time": "2015-02-13T13:29:09.093+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "level": "notice",
+            "line": 33,
+            "message": "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
+            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
+            "tags": [
+                "class",
+                "node",
+                "motd",
+                "pg2.vm",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.09+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "level": "notice",
+            "line": 33,
+            "message": "\n--- /etc/motd\t2010-01-12 13:28:22.000000000 +0000\n+++ /tmp/puppet-file20150213-61841-isxd4q-0\t2015-02-13 13:29:09.073877903 +0000\n@@ -0,0 +1 @@\n+Welcome to my test host!\n\\ No newline at end of file\n",
+            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
+            "tags": [
+                "class",
+                "node",
+                "motd",
+                "pg2.vm",
+                "content",
+                "notice",
+                "file",
+                "loadtest"
+            ],
+            "time": "2015-02-13T13:29:09.09+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423834124'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:09.021+00:00"
+        },
+        {
+            "file": null,
+            "level": "warning",
+            "line": null,
+            "message": "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
+            "source": "Puppet",
+            "tags": [
+                "warning"
+            ],
+            "time": "2015-02-13T13:29:08.608+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for pg2.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:08.547+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:02.517+00:00"
+        },
+        {
+            "file": null,
+            "level": "err",
+            "line": null,
+            "message": "Could not evaluate: Could not retrieve file metadata for puppet://puppet/plugins: Network is unreachable - connect(2)\nWrapped exception:\nNetwork is unreachable - connect(2)",
+            "source": "/File[/var/lib/puppet/lib]",
+            "tags": [
+                "plugin",
+                "err",
+                "file"
+            ],
+            "time": "2015-02-13T13:29:02.507+00:00"
+        },
+        {
+            "file": null,
+            "level": "err",
+            "line": null,
+            "message": "Failed to generate additional resources using 'eval_generate': Network is unreachable - connect(2)",
+            "source": "/File[/var/lib/puppet/lib]",
+            "tags": [
+                "plugin",
+                "err",
+                "file"
+            ],
+            "time": "2015-02-13T13:29:02.502+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:01.367+00:00"
+        },
+        {
+            "file": null,
+            "level": "err",
+            "line": null,
+            "message": "Could not evaluate: Could not retrieve file metadata for puppet://puppet/pluginfacts: Network is unreachable - connect(2)\nWrapped exception:\nNetwork is unreachable - connect(2)",
+            "source": "/File[/var/lib/puppet/facts.d]",
+            "tags": [
+                "pluginfacts",
+                "err",
+                "file"
+            ],
+            "time": "2015-02-13T13:29:01.367+00:00"
+        },
+        {
+            "file": null,
+            "level": "err",
+            "line": null,
+            "message": "Failed to generate additional resources using 'eval_generate': Network is unreachable - connect(2)",
+            "source": "/File[/var/lib/puppet/facts.d]",
+            "tags": [
+                "pluginfacts",
+                "err",
+                "file"
+            ],
+            "time": "2015-02-13T13:29:01.364+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:01.353+00:00"
+        },
+        {
+            "file": null,
+            "level": "warning",
+            "line": null,
+            "message": "Network is unreachable - connect(2)",
+            "source": "Puppet",
+            "tags": [
+                "warning"
+            ],
+            "time": "2015-02-13T13:29:01.352+00:00"
+        },
+        {
+            "file": null,
+            "level": "warning",
+            "line": null,
+            "message": "Unable to fetch my node definition, but the agent run will continue:",
+            "source": "Puppet",
+            "tags": [
+                "warning"
+            ],
+            "time": "2015-02-13T13:29:01.352+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.00119
+        },
+        {
+            "category": "time",
+            "name": "augeas",
+            "value": 0.0566330000000001
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 1.24377989768982
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.393671
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.302035
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 0.000469
+        },
+        {
+            "category": "time",
+            "name": "gnupg_key",
+            "value": 0.026254
+        },
+        {
+            "category": "time",
+            "name": "ini_setting",
+            "value": 0.000823
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.000611
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.450188
+        },
+        {
+            "category": "time",
+            "name": "postgresql_conf",
+            "value": 0.00068
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.001031
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.329234
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 2.80659889768982
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 2
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 29
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 88
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 1
+        },
+        {
+            "category": "events",
+            "name": "noop",
+            "value": 28
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 29
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 0
+        }
+    ],
+    "noop": true,
+    "puppet_version": "3.7.1",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat::Fragment[tmpfile]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be file (noop)",
+                    "new_value": "file",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.164Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "line": 113,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.164Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/var/lib/puppet/concat/_tmp_file]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be directory (noop)",
+                    "new_value": "directory",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.110Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 144,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.110Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Ntp::Config",
+                "File[/etc/ntp.conf]"
+            ],
+            "events": [
+                {
+                    "message": "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
+                    "new_value": "{md5}eb918d28434c9fefcc05875c29c3ba1a",
+                    "old_value": "{md5}7fda24f62b1c7ae951db0f746dc6e0cc",
+                    "property": "content",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:09.741Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
+            "line": 14,
+            "resource_title": "/etc/ntp.conf",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:09.741Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "Exec[concat_/tmp/file]"
+            ],
+            "events": [
+                {
+                    "message": "current_value notrun, should be 0 (noop)",
+                    "new_value": [
+                        "0"
+                    ],
+                    "old_value": "notrun",
+                    "property": "returns",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.230Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 187,
+            "resource_title": "concat_/tmp/file",
+            "resource_type": "Exec",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.230Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Python::Install",
+                "Package[python-virtualenv]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.885Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "line": 59,
+            "resource_title": "python-virtualenv",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.885Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Git",
+                "Package[git]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.504Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/git/manifests/init.pp",
+            "line": 12,
+            "resource_title": "git",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.504Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Package[etckeeper]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be latest (noop)",
+                    "new_value": "latest",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:09.423Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 41,
+            "resource_title": "etckeeper",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:09.423Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp::Client",
+                "Package[snmp-client]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:09.325Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "line": 76,
+            "resource_title": "snmp-client",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:09.325Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[var-net-snmp]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be directory (noop)",
+                    "new_value": "directory",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:09.751Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 410,
+            "resource_title": "var-net-snmp",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:09.751Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "Package[snmpd]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:09.521Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 405,
+            "resource_title": "snmpd",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:09.521Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be directory (noop)",
+                    "new_value": "directory",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.158Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 149,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.158Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "Service[snmpd]"
+            ],
+            "events": [
+                {
+                    "message": "current_value stopped, should be running (noop)",
+                    "new_value": "running",
+                    "old_value": "stopped",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.275Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 517,
+            "resource_title": "snmpd",
+            "resource_type": "Service",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.275Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Ntp::Service",
+                "Service[ntp]"
+            ],
+            "events": [
+                {
+                    "message": "current_value stopped, should be running (noop)",
+                    "new_value": "running",
+                    "old_value": "stopped",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:09.871Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
+            "line": 9,
+            "resource_title": "ntp",
+            "resource_type": "Service",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:09.871Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Python::Install",
+                "Package[python-devel]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.820Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "line": 61,
+            "resource_title": "python-devel",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.820Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[snmpd.sysconfig]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:09.702Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 441,
+            "resource_title": "snmpd.sysconfig",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:09.702Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Motd",
+                "File[/etc/motd]"
+            ],
+            "events": [
+                {
+                    "message": "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
+                    "new_value": "{md5}a3f731187a6aaaa23d4a7b244f223f33",
+                    "old_value": "{md5}d41d8cd98f00b204e9800998ecf8427e",
+                    "property": "content",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:09.090Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "line": 33,
+            "resource_title": "/etc/motd",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:09.090Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[snmptrapd.conf]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.108Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 453,
+            "resource_title": "snmptrapd.conf",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.108Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[snmptrapd.sysconfig]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:09.693Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 465,
+            "resource_title": "snmptrapd.sysconfig",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:09.693Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat::Fragment[tmpfile2]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be file (noop)",
+                    "new_value": "file",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.160Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
+            "line": 113,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.160Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp::Client",
+                "File[snmp.conf]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.892Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
+            "line": 85,
+            "resource_title": "snmp.conf",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.892Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.114Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 164,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.114Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/tmp/file]"
+            ],
+            "events": [
+                {
+                    "message": "Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
+                    "new_value": null,
+                    "old_value": null,
+                    "property": null,
+                    "status": "failure",
+                    "timestamp": "2015-02-13T13:29:10.233Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 169,
+            "resource_title": "/tmp/file",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.233Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Snmp",
+                "File[snmpd.conf]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.235Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
+            "line": 429,
+            "resource_title": "snmpd.conf",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.235Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be foo (noop)",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:09.523Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 3,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:09.523Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Python::Install",
+                "Package[python-pip]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.786Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "line": 60,
+            "resource_title": "python-pip",
+            "resource_type": "Package",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.786Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Ini_setting[sample setting]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:09.749Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 45,
+            "resource_title": "sample setting",
+            "resource_type": "Ini_setting",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:09.749Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Concat[/tmp/file]",
+                "File[/var/lib/puppet/concat/_tmp_file/fragments.concat]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:10.112Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "line": 159,
+            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:10.112Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Gnupg_key[hkp_server_20BC0A86]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:09.901Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 69,
+            "resource_title": "hkp_server_20BC0A86",
+            "resource_type": "Gnupg_key",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:09.901Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Service[cron]"
+            ],
+            "events": [
+                {
+                    "message": "current_value stopped, should be running (noop)",
+                    "new_value": "running",
+                    "old_value": "stopped",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:29:09.687Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 4,
+            "resource_title": "cron",
+            "resource_type": "Service",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:09.687Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:29:01.341Z",
+    "status": "failed",
+    "transaction_uuid": "f2b3642a-27e8-4311-a213-aad48859b9ac"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-cfdc33f7bb68d2c25d3b3758f3dca50b851b96ea.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-cfdc33f7bb68d2c25d3b3758f3dca50b851b96ea.json
@@ -1,439 +1,803 @@
 {
-  "transaction_uuid" : "441eb073-d81a-4c3d-9c75-8c4bb1ca1cd1",
-  "puppet_version" : "3.7.1",
-  "noop" : false,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 2.36 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:26:35.81+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 3 events",
-    "source" : "Stage[main]",
-    "tags" : [ "notice", "completed_stage", "main" ],
-    "time" : "2015-02-13T13:26:35.778+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 4 events",
-    "source" : "Class[Postgresql::Server::Service]",
-    "tags" : [ "completed_class", "notice", "server", "service", "postgresql::server::service", "postgresql" ],
-    "time" : "2015-02-13T13:26:35.771+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::end]",
-    "tags" : [ "pg2.vm", "node", "anchor", "postgresql::server", "notice", "server", "service", "end", "postgresql::server::service", "class", "postgresql::server::service::end", "postgresql" ],
-    "time" : "2015-02-13T13:26:35.77+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-    "line" : 41
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Postgresql::Validate_db_connection[validate_service_is_running]",
-    "tags" : [ "completed_postgresql", "completed_postgresql::validate_db_connection", "notice", "validate_service_is_running", "validate_db_connection" ],
-    "time" : "2015-02-13T13:26:35.768+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "/Stage[main]/Postgresql::Server::Service/Postgresql::Validate_db_connection[validate_service_is_running]/Exec[validate postgres connection for /postgres]",
-    "tags" : [ "pg2.vm", "exec", "node", "postgresql::server", "notice", "server", "postgresql::validate_db_connection", "service", "postgresql::server::service", "validate_service_is_running", "class", "validate_db_connection", "postgresql" ],
-    "time" : "2015-02-13T13:26:35.765+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/validate_db_connection.pp",
-    "line" : 51
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Exec[validate postgres connection for /postgres]",
-    "source" : "Postgresql::Validate_db_connection[validate_service_is_running]",
-    "tags" : [ "admissible_postgresql::validate_db_connection", "validate_service_is_running", "validate_db_connection", "admissible_postgresql", "info" ],
-    "time" : "2015-02-13T13:26:35.578+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Postgresql::Validate_db_connection[validate_service_is_running]",
-    "tags" : [ "admissible_postgresql::validate_db_connection", "notice", "validate_service_is_running", "validate_db_connection", "admissible_postgresql" ],
-    "time" : "2015-02-13T13:26:35.578+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "/Stage[main]/Postgresql::Server::Service/Service[postgresqld]",
-    "tags" : [ "pg2.vm", "node", "postgresql::server", "notice", "server", "service", "postgresqld", "postgresql::server::service", "class", "postgresql" ],
-    "time" : "2015-02-13T13:26:35.576+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-    "line" : 14
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::begin]",
-    "tags" : [ "begin", "pg2.vm", "postgresql::server::service::begin", "node", "anchor", "postgresql::server", "notice", "server", "service", "postgresql::server::service", "class", "postgresql" ],
-    "time" : "2015-02-13T13:26:35.494+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-    "line" : 12
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Service[postgresqld]",
-    "source" : "Class[Postgresql::Server::Service]",
-    "tags" : [ "admissible_class", "server", "service", "postgresql::server::service", "info", "postgresql" ],
-    "time" : "2015-02-13T13:26:35.492+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Anchor[postgresql::server::service::begin]",
-    "source" : "Class[Postgresql::Server::Service]",
-    "tags" : [ "admissible_class", "server", "service", "postgresql::server::service", "info", "postgresql" ],
-    "time" : "2015-02-13T13:26:35.492+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Anchor[postgresql::server::service::end]",
-    "source" : "Class[Postgresql::Server::Service]",
-    "tags" : [ "admissible_class", "server", "service", "postgresql::server::service", "info", "postgresql" ],
-    "time" : "2015-02-13T13:26:35.492+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Postgresql::Validate_db_connection[validate_service_is_running]",
-    "source" : "Class[Postgresql::Server::Service]",
-    "tags" : [ "admissible_class", "server", "service", "postgresql::server::service", "info", "postgresql" ],
-    "time" : "2015-02-13T13:26:35.492+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 2 events",
-    "source" : "Class[Postgresql::Server::Service]",
-    "tags" : [ "admissible_class", "notice", "server", "service", "postgresql::server::service", "postgresql" ],
-    "time" : "2015-02-13T13:26:35.491+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 2 events",
-    "source" : "Class[Postgresql::Server::Config]",
-    "tags" : [ "config", "postgresql::server::config", "completed_class", "notice", "server", "postgresql" ],
-    "time" : "2015-02-13T13:26:35.49+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Class[Main]",
-    "tags" : [ "completed_class", "notice", "main" ],
-    "time" : "2015-02-13T13:26:35.191+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 1 events",
-    "source" : "Node[pg2.vm]",
-    "tags" : [ "pg2.vm", "notice", "completed_node" ],
-    "time" : "2015-02-13T13:26:35.126+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be foo (noop)",
-    "source" : "/Stage[main]/Main/Node[pg2.vm]/Notify[foo]/message",
-    "tags" : [ "pg2.vm", "notify", "node", "foo", "notice", "class" ],
-    "time" : "2015-02-13T13:26:35.125+00:00",
-    "file" : "/etc/puppet/manifests/site.pp",
-    "line" : 6
-  }, {
-    "level" : "notice",
-    "message" : "Would have triggered 'refresh' from 3 events",
-    "source" : "Postgresql::Server::Config_entry[data_directory]",
-    "tags" : [ "data_directory", "completed_postgresql", "notice", "server", "config_entry", "completed_postgresql::server::config_entry" ],
-    "time" : "2015-02-13T13:26:34.499+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Class[Postgresql::Server::Service]",
-    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]",
-    "tags" : [ "data_directory", "config", "pg2.vm", "postgresql::server::config_entry", "postgresql::server::config", "node", "postgresql::server", "config_entry", "server", "postgresql_conf", "class", "info", "postgresql" ],
-    "time" : "2015-02-13T13:26:34.498+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "line" : 105
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be present (noop)",
-    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]/ensure",
-    "tags" : [ "data_directory", "config", "pg2.vm", "postgresql::server::config_entry", "postgresql::server::config", "node", "postgresql::server", "notice", "config_entry", "server", "postgresql_conf", "class", "postgresql" ],
-    "time" : "2015-02-13T13:26:34.498+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "line" : 105
-  }, {
-    "level" : "info",
-    "message" : "Scheduling refresh of Class[Postgresql::Server::Service]",
-    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]",
-    "tags" : [ "data_directory", "config", "pg2.vm", "augeas", "postgresql::server::config_entry", "postgresql::server::config", "node", "postgresql::server", "config_entry", "server", "class", "info", "postgresql" ],
-    "time" : "2015-02-13T13:26:34.489+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "line" : 90
-  }, {
-    "level" : "notice",
-    "message" : "current_value need_to_run, should be 0 (noop)",
-    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]/returns",
-    "tags" : [ "data_directory", "config", "pg2.vm", "augeas", "postgresql::server::config_entry", "postgresql::server::config", "node", "postgresql::server", "notice", "config_entry", "server", "class", "postgresql" ],
-    "time" : "2015-02-13T13:26:34.489+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "line" : 90
-  }, {
-    "level" : "notice",
-    "message" : "\n--- /etc/sysconfig/pgsql/postgresql\t2014-09-18 15:48:23.129826040 +0100\n+++ /etc/sysconfig/pgsql/postgresql.augnew\t2015-02-13 13:26:34.465878008 +0000\n@@ -1,2 +1,3 @@\n \n PGPORT=5432\n+PGDATA=/var/lib/pgsql/data\n",
-    "source" : "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql](provider=augeas)",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:26:34.486+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "current_value absent, should be link (noop)",
-    "source" : "/Stage[main]/Postgresql::Server::Config/File[/etc/sysconfig/pgsql/postgresql-8.4]/ensure",
-    "tags" : [ "config", "pg2.vm", "postgresql::server::config", "node", "postgresql::server", "notice", "server", "file", "class", "postgresql" ],
-    "time" : "2015-02-13T13:26:34.425+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config.pp",
-    "line" : 120
-  }, {
-    "level" : "notice",
-    "message" : "current_value notrun, should be 0 (noop)",
-    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Exec[postgresql_data_directory]/returns",
-    "tags" : [ "postgresql_data_directory", "data_directory", "config", "pg2.vm", "postgresql::server::config_entry", "postgresql::server::config", "exec", "node", "postgresql::server", "notice", "config_entry", "server", "class", "postgresql" ],
-    "time" : "2015-02-13T13:26:34.422+00:00",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "line" : 83
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423833741'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:26:33.496+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "warning",
-    "message" : "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
-    "source" : "Puppet",
-    "tags" : [ "warning" ],
-    "time" : "2015-02-13T13:26:33.119+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for pg2.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:26:33.01+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:26:30.946+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:26:28.652+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:26:28.606+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:26:28.549Z",
-  "end_time" : "2015-02-13T13:26:31.273Z",
-  "resource_events" : [ {
-    "new_value" : [ "0" ],
-    "property" : "returns",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "old_value" : "notrun",
-    "line" : 83,
-    "resource_type" : "Exec",
-    "status" : "noop",
-    "resource_title" : "postgresql_data_directory",
-    "timestamp" : "2015-02-13T13:26:34.422Z",
-    "containment_path" : [ "Stage[main]", "Postgresql::Server::Config", "Postgresql::Server::Config_entry[data_directory]", "Exec[postgresql_data_directory]" ],
-    "message" : "current_value notrun, should be 0 (noop)"
-  }, {
-    "new_value" : "link",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config.pp",
-    "old_value" : "absent",
-    "line" : 120,
-    "resource_type" : "File",
-    "status" : "noop",
-    "resource_title" : "/etc/sysconfig/pgsql/postgresql-8.4",
-    "timestamp" : "2015-02-13T13:26:34.425Z",
-    "containment_path" : [ "Stage[main]", "Postgresql::Server::Config", "File[/etc/sysconfig/pgsql/postgresql-8.4]" ],
-    "message" : "current_value absent, should be link (noop)"
-  }, {
-    "new_value" : 0,
-    "property" : "returns",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "old_value" : "need_to_run",
-    "line" : 90,
-    "resource_type" : "Augeas",
-    "status" : "noop",
-    "resource_title" : "override PGDATA in /etc/sysconfig/pgsql/postgresql",
-    "timestamp" : "2015-02-13T13:26:34.488Z",
-    "containment_path" : [ "Stage[main]", "Postgresql::Server::Config", "Postgresql::Server::Config_entry[data_directory]", "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]" ],
-    "message" : "current_value need_to_run, should be 0 (noop)"
-  }, {
-    "new_value" : "present",
-    "property" : "ensure",
-    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-    "old_value" : "absent",
-    "line" : 105,
-    "resource_type" : "Postgresql_conf",
-    "status" : "noop",
-    "resource_title" : "data_directory",
-    "timestamp" : "2015-02-13T13:26:34.498Z",
-    "containment_path" : [ "Stage[main]", "Postgresql::Server::Config", "Postgresql::Server::Config_entry[data_directory]", "Postgresql_conf[data_directory]" ],
-    "message" : "current_value absent, should be present (noop)"
-  }, {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/manifests/site.pp",
-    "old_value" : "absent",
-    "line" : 6,
-    "resource_type" : "Notify",
-    "status" : "noop",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:26:35.125Z",
-    "containment_path" : [ "Stage[main]", "Main", "Node[pg2.vm]", "Notify[foo]" ],
-    "message" : "current_value absent, should be foo (noop)"
-  } ],
-  "status" : "unchanged",
-  "configuration_version" : "1423833741",
-  "environment" : "production",
-  "certname" : "pg2.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 5.46E-4,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.089285,
-    "name" : "augeas"
-  }, {
-    "category" : "time",
-    "value" : 1.24463891983032,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 1.178981,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.126266,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 1.12E-4,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 6.67E-4,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.001085,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 0.001515,
-    "name" : "postgresql_conf"
-  }, {
-    "category" : "time",
-    "value" : 6.58E-4,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.080169,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 2.72392291983032,
-    "name" : "total"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 5,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 50,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 5,
-    "name" : "noop"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 5,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 0,
-    "name" : "total"
-  } ]
+    "certname": "pg2.vm",
+    "configuration_version": "1423833741",
+    "end_time": "2015-02-13T13:26:31.273Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 2.36 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:26:35.81+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 3 events",
+            "source": "Stage[main]",
+            "tags": [
+                "notice",
+                "completed_stage",
+                "main"
+            ],
+            "time": "2015-02-13T13:26:35.778+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 4 events",
+            "source": "Class[Postgresql::Server::Service]",
+            "tags": [
+                "completed_class",
+                "notice",
+                "server",
+                "service",
+                "postgresql::server::service",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:35.771+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+            "level": "notice",
+            "line": 41,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::end]",
+            "tags": [
+                "pg2.vm",
+                "node",
+                "anchor",
+                "postgresql::server",
+                "notice",
+                "server",
+                "service",
+                "end",
+                "postgresql::server::service",
+                "class",
+                "postgresql::server::service::end",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:35.77+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Postgresql::Validate_db_connection[validate_service_is_running]",
+            "tags": [
+                "completed_postgresql",
+                "completed_postgresql::validate_db_connection",
+                "notice",
+                "validate_service_is_running",
+                "validate_db_connection"
+            ],
+            "time": "2015-02-13T13:26:35.768+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/validate_db_connection.pp",
+            "level": "notice",
+            "line": 51,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "/Stage[main]/Postgresql::Server::Service/Postgresql::Validate_db_connection[validate_service_is_running]/Exec[validate postgres connection for /postgres]",
+            "tags": [
+                "pg2.vm",
+                "exec",
+                "node",
+                "postgresql::server",
+                "notice",
+                "server",
+                "postgresql::validate_db_connection",
+                "service",
+                "postgresql::server::service",
+                "validate_service_is_running",
+                "class",
+                "validate_db_connection",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:35.765+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Exec[validate postgres connection for /postgres]",
+            "source": "Postgresql::Validate_db_connection[validate_service_is_running]",
+            "tags": [
+                "admissible_postgresql::validate_db_connection",
+                "validate_service_is_running",
+                "validate_db_connection",
+                "admissible_postgresql",
+                "info"
+            ],
+            "time": "2015-02-13T13:26:35.578+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Postgresql::Validate_db_connection[validate_service_is_running]",
+            "tags": [
+                "admissible_postgresql::validate_db_connection",
+                "notice",
+                "validate_service_is_running",
+                "validate_db_connection",
+                "admissible_postgresql"
+            ],
+            "time": "2015-02-13T13:26:35.578+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+            "level": "notice",
+            "line": 14,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "/Stage[main]/Postgresql::Server::Service/Service[postgresqld]",
+            "tags": [
+                "pg2.vm",
+                "node",
+                "postgresql::server",
+                "notice",
+                "server",
+                "service",
+                "postgresqld",
+                "postgresql::server::service",
+                "class",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:35.576+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+            "level": "notice",
+            "line": 12,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::begin]",
+            "tags": [
+                "begin",
+                "pg2.vm",
+                "postgresql::server::service::begin",
+                "node",
+                "anchor",
+                "postgresql::server",
+                "notice",
+                "server",
+                "service",
+                "postgresql::server::service",
+                "class",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:35.494+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Service[postgresqld]",
+            "source": "Class[Postgresql::Server::Service]",
+            "tags": [
+                "admissible_class",
+                "server",
+                "service",
+                "postgresql::server::service",
+                "info",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:35.492+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Anchor[postgresql::server::service::begin]",
+            "source": "Class[Postgresql::Server::Service]",
+            "tags": [
+                "admissible_class",
+                "server",
+                "service",
+                "postgresql::server::service",
+                "info",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:35.492+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Anchor[postgresql::server::service::end]",
+            "source": "Class[Postgresql::Server::Service]",
+            "tags": [
+                "admissible_class",
+                "server",
+                "service",
+                "postgresql::server::service",
+                "info",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:35.492+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Scheduling refresh of Postgresql::Validate_db_connection[validate_service_is_running]",
+            "source": "Class[Postgresql::Server::Service]",
+            "tags": [
+                "admissible_class",
+                "server",
+                "service",
+                "postgresql::server::service",
+                "info",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:35.492+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 2 events",
+            "source": "Class[Postgresql::Server::Service]",
+            "tags": [
+                "admissible_class",
+                "notice",
+                "server",
+                "service",
+                "postgresql::server::service",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:35.491+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 2 events",
+            "source": "Class[Postgresql::Server::Config]",
+            "tags": [
+                "config",
+                "postgresql::server::config",
+                "completed_class",
+                "notice",
+                "server",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:35.49+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Class[Main]",
+            "tags": [
+                "completed_class",
+                "notice",
+                "main"
+            ],
+            "time": "2015-02-13T13:26:35.191+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 1 events",
+            "source": "Node[pg2.vm]",
+            "tags": [
+                "pg2.vm",
+                "notice",
+                "completed_node"
+            ],
+            "time": "2015-02-13T13:26:35.126+00:00"
+        },
+        {
+            "file": "/etc/puppet/manifests/site.pp",
+            "level": "notice",
+            "line": 6,
+            "message": "current_value absent, should be foo (noop)",
+            "source": "/Stage[main]/Main/Node[pg2.vm]/Notify[foo]/message",
+            "tags": [
+                "pg2.vm",
+                "notify",
+                "node",
+                "foo",
+                "notice",
+                "class"
+            ],
+            "time": "2015-02-13T13:26:35.125+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Would have triggered 'refresh' from 3 events",
+            "source": "Postgresql::Server::Config_entry[data_directory]",
+            "tags": [
+                "data_directory",
+                "completed_postgresql",
+                "notice",
+                "server",
+                "config_entry",
+                "completed_postgresql::server::config_entry"
+            ],
+            "time": "2015-02-13T13:26:34.499+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "level": "info",
+            "line": 105,
+            "message": "Scheduling refresh of Class[Postgresql::Server::Service]",
+            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]",
+            "tags": [
+                "data_directory",
+                "config",
+                "pg2.vm",
+                "postgresql::server::config_entry",
+                "postgresql::server::config",
+                "node",
+                "postgresql::server",
+                "config_entry",
+                "server",
+                "postgresql_conf",
+                "class",
+                "info",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:34.498+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "level": "notice",
+            "line": 105,
+            "message": "current_value absent, should be present (noop)",
+            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]/ensure",
+            "tags": [
+                "data_directory",
+                "config",
+                "pg2.vm",
+                "postgresql::server::config_entry",
+                "postgresql::server::config",
+                "node",
+                "postgresql::server",
+                "notice",
+                "config_entry",
+                "server",
+                "postgresql_conf",
+                "class",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:34.498+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "level": "info",
+            "line": 90,
+            "message": "Scheduling refresh of Class[Postgresql::Server::Service]",
+            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]",
+            "tags": [
+                "data_directory",
+                "config",
+                "pg2.vm",
+                "augeas",
+                "postgresql::server::config_entry",
+                "postgresql::server::config",
+                "node",
+                "postgresql::server",
+                "config_entry",
+                "server",
+                "class",
+                "info",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:34.489+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "level": "notice",
+            "line": 90,
+            "message": "current_value need_to_run, should be 0 (noop)",
+            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]/returns",
+            "tags": [
+                "data_directory",
+                "config",
+                "pg2.vm",
+                "augeas",
+                "postgresql::server::config_entry",
+                "postgresql::server::config",
+                "node",
+                "postgresql::server",
+                "notice",
+                "config_entry",
+                "server",
+                "class",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:34.489+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "\n--- /etc/sysconfig/pgsql/postgresql\t2014-09-18 15:48:23.129826040 +0100\n+++ /etc/sysconfig/pgsql/postgresql.augnew\t2015-02-13 13:26:34.465878008 +0000\n@@ -1,2 +1,3 @@\n \n PGPORT=5432\n+PGDATA=/var/lib/pgsql/data\n",
+            "source": "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql](provider=augeas)",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:26:34.486+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config.pp",
+            "level": "notice",
+            "line": 120,
+            "message": "current_value absent, should be link (noop)",
+            "source": "/Stage[main]/Postgresql::Server::Config/File[/etc/sysconfig/pgsql/postgresql-8.4]/ensure",
+            "tags": [
+                "config",
+                "pg2.vm",
+                "postgresql::server::config",
+                "node",
+                "postgresql::server",
+                "notice",
+                "server",
+                "file",
+                "class",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:34.425+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "level": "notice",
+            "line": 83,
+            "message": "current_value notrun, should be 0 (noop)",
+            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Exec[postgresql_data_directory]/returns",
+            "tags": [
+                "postgresql_data_directory",
+                "data_directory",
+                "config",
+                "pg2.vm",
+                "postgresql::server::config_entry",
+                "postgresql::server::config",
+                "exec",
+                "node",
+                "postgresql::server",
+                "notice",
+                "config_entry",
+                "server",
+                "class",
+                "postgresql"
+            ],
+            "time": "2015-02-13T13:26:34.422+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423833741'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:26:33.496+00:00"
+        },
+        {
+            "file": null,
+            "level": "warning",
+            "line": null,
+            "message": "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
+            "source": "Puppet",
+            "tags": [
+                "warning"
+            ],
+            "time": "2015-02-13T13:26:33.119+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for pg2.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:26:33.01+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:26:30.946+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:26:28.652+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:26:28.606+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.000546
+        },
+        {
+            "category": "time",
+            "name": "augeas",
+            "value": 0.089285
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 1.24463891983032
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 1.178981
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.126266
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 0.000112
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.000667
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.001085
+        },
+        {
+            "category": "time",
+            "name": "postgresql_conf",
+            "value": 0.001515
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.000658
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.080169
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 2.72392291983032
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 5
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 50
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "noop",
+            "value": 5
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 5
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 0
+        }
+    ],
+    "noop": false,
+    "puppet_version": "3.7.1",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Postgresql::Server::Config",
+                "Postgresql::Server::Config_entry[data_directory]",
+                "Exec[postgresql_data_directory]"
+            ],
+            "events": [
+                {
+                    "message": "current_value notrun, should be 0 (noop)",
+                    "new_value": [
+                        "0"
+                    ],
+                    "old_value": "notrun",
+                    "property": "returns",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:26:34.422Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "line": 83,
+            "resource_title": "postgresql_data_directory",
+            "resource_type": "Exec",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:26:34.422Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Postgresql::Server::Config",
+                "File[/etc/sysconfig/pgsql/postgresql-8.4]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be link (noop)",
+                    "new_value": "link",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:26:34.425Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config.pp",
+            "line": 120,
+            "resource_title": "/etc/sysconfig/pgsql/postgresql-8.4",
+            "resource_type": "File",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:26:34.425Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Postgresql::Server::Config",
+                "Postgresql::Server::Config_entry[data_directory]",
+                "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]"
+            ],
+            "events": [
+                {
+                    "message": "current_value need_to_run, should be 0 (noop)",
+                    "new_value": 0,
+                    "old_value": "need_to_run",
+                    "property": "returns",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:26:34.488Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "line": 90,
+            "resource_title": "override PGDATA in /etc/sysconfig/pgsql/postgresql",
+            "resource_type": "Augeas",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:26:34.488Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Postgresql::Server::Config",
+                "Postgresql::Server::Config_entry[data_directory]",
+                "Postgresql_conf[data_directory]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be present (noop)",
+                    "new_value": "present",
+                    "old_value": "absent",
+                    "property": "ensure",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:26:34.498Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+            "line": 105,
+            "resource_title": "data_directory",
+            "resource_type": "Postgresql_conf",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:26:34.498Z"
+        },
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Main",
+                "Node[pg2.vm]",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "current_value absent, should be foo (noop)",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "noop",
+                    "timestamp": "2015-02-13T13:26:35.125Z"
+                }
+            ],
+            "file": "/etc/puppet/manifests/site.pp",
+            "line": 6,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:26:35.125Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:26:28.549Z",
+    "status": "unchanged",
+    "transaction_uuid": "441eb073-d81a-4c3d-9c75-8c4bb1ca1cd1"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-02f72d7b1e2ded2074c4c3d6e2f415f6978d5932.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-02f72d7b1e2ded2074c4c3d6e2f415f6978d5932.json
@@ -1,191 +1,260 @@
 {
-  "transaction_uuid" : "ed18c9ae-0998-483d-ba93-0e97b24b6ac1",
-  "puppet_version" : "3.7.2",
-  "noop" : false,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 0.48 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:20:12.618+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "defined 'message' as 'foo'",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
-    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "puppetdb1.vm" ],
-    "time" : "2015-02-13T13:20:12.32+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "notice",
-    "message" : "foo",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:20:12.32+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423833558'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:20:12.2+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for puppetdb1.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:20:11.959+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:20:10.484+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:20:10.038+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:20:09.994+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:20:09.897Z",
-  "end_time" : "2015-02-13T13:20:11.029Z",
-  "resource_events" : [ {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 3,
-    "resource_type" : "Notify",
-    "status" : "success",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:20:12.320Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
-    "message" : "defined 'message' as 'foo'"
-  } ],
-  "status" : "changed",
-  "configuration_version" : "1423833558",
-  "environment" : "production",
-  "certname" : "puppetdb1.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 5.43372E-4,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.873328382,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.035544066,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.04061068300000001,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 6.2054E-5,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.024042923,
-    "name" : "gnupg_key"
-  }, {
-    "category" : "time",
-    "value" : 3.57036E-4,
-    "name" : "ini_setting"
-  }, {
-    "category" : "time",
-    "value" : 0.001911588,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.030850836,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 6.00556E-4,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.12383608900000001,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 1.131887902,
-    "name" : "total"
-  }, {
-    "category" : "time",
-    "value" : 2.00317E-4,
-    "name" : "vcsrepo"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 46,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 1,
-    "name" : "total"
-  } ]
+    "certname": "puppetdb1.vm",
+    "configuration_version": "1423833558",
+    "end_time": "2015-02-13T13:20:11.029Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 0.48 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:20:12.618+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 3,
+            "message": "defined 'message' as 'foo'",
+            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
+            "tags": [
+                "notice",
+                "notify",
+                "foo",
+                "class",
+                "loadtest",
+                "node",
+                "puppetdb1.vm"
+            ],
+            "time": "2015-02-13T13:20:12.32+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "foo",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:20:12.32+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423833558'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:20:12.2+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for puppetdb1.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:20:11.959+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:20:10.484+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:20:10.038+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:20:09.994+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.000543372
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 0.873328382
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.035544066
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.04061068300000001
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 6.2054e-05
+        },
+        {
+            "category": "time",
+            "name": "gnupg_key",
+            "value": 0.024042923
+        },
+        {
+            "category": "time",
+            "name": "ini_setting",
+            "value": 0.000357036
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.001911588
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.030850836
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.000600556
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.12383608900000001
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 1.131887902
+        },
+        {
+            "category": "time",
+            "name": "vcsrepo",
+            "value": 0.000200317
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 46
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 1
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 1
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 1
+        }
+    ],
+    "noop": false,
+    "puppet_version": "3.7.2",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "defined 'message' as 'foo'",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:20:12.320Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 3,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:20:12.320Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:20:09.897Z",
+    "status": "changed",
+    "transaction_uuid": "ed18c9ae-0998-483d-ba93-0e97b24b6ac1"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-05ce58a44a6441dc967559bf89fd82619068f72c.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-05ce58a44a6441dc967559bf89fd82619068f72c.json
@@ -1,191 +1,260 @@
 {
-  "transaction_uuid" : "9e531f81-426c-4d91-8e10-649f067cf8a2",
-  "puppet_version" : "3.7.2",
-  "noop" : false,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 0.59 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:29:58.198+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "defined 'message' as 'foo'",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
-    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "puppetdb1.vm" ],
-    "time" : "2015-02-13T13:29:57.796+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "notice",
-    "message" : "foo",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:29:57.795+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423834124'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:57.688+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for puppetdb1.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:57.537+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:56.198+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:55.764+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:29:55.727+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:29:55.639Z",
-  "end_time" : "2015-02-13T13:29:56.692Z",
-  "resource_events" : [ {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 3,
-    "resource_type" : "Notify",
-    "status" : "success",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:29:57.795Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
-    "message" : "defined 'message' as 'foo'"
-  } ],
-  "status" : "changed",
-  "configuration_version" : "1423834124",
-  "environment" : "production",
-  "certname" : "puppetdb1.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 7.229879999999999E-4,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.682468514,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.058694755,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.040055161,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 1.37144E-4,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.051567308,
-    "name" : "gnupg_key"
-  }, {
-    "category" : "time",
-    "value" : 3.59073E-4,
-    "name" : "ini_setting"
-  }, {
-    "category" : "time",
-    "value" : 0.001915414,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.03984193700000001,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 5.18732E-4,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.17672955,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 1.053324719,
-    "name" : "total"
-  }, {
-    "category" : "time",
-    "value" : 3.14143E-4,
-    "name" : "vcsrepo"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 47,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 1,
-    "name" : "total"
-  } ]
+    "certname": "puppetdb1.vm",
+    "configuration_version": "1423834124",
+    "end_time": "2015-02-13T13:29:56.692Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 0.59 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:58.198+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 3,
+            "message": "defined 'message' as 'foo'",
+            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
+            "tags": [
+                "notice",
+                "notify",
+                "foo",
+                "class",
+                "loadtest",
+                "node",
+                "puppetdb1.vm"
+            ],
+            "time": "2015-02-13T13:29:57.796+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "foo",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:29:57.795+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423834124'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:57.688+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for puppetdb1.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:57.537+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:56.198+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:55.764+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:29:55.727+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.0007229879999999999
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 0.682468514
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.058694755
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.040055161
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 0.000137144
+        },
+        {
+            "category": "time",
+            "name": "gnupg_key",
+            "value": 0.051567308
+        },
+        {
+            "category": "time",
+            "name": "ini_setting",
+            "value": 0.000359073
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.001915414
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.03984193700000001
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.000518732
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.17672955
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 1.053324719
+        },
+        {
+            "category": "time",
+            "name": "vcsrepo",
+            "value": 0.000314143
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 47
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 1
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 1
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 1
+        }
+    ],
+    "noop": false,
+    "puppet_version": "3.7.2",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "defined 'message' as 'foo'",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:29:57.795Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 3,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:29:57.795Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:29:55.639Z",
+    "status": "changed",
+    "transaction_uuid": "9e531f81-426c-4d91-8e10-649f067cf8a2"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-5ba2c61aeb5f3ed8722e45f9c2c7b53d606e402e.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-5ba2c61aeb5f3ed8722e45f9c2c7b53d606e402e.json
@@ -1,191 +1,260 @@
 {
-  "transaction_uuid" : "3c99e9cc-bc56-45a5-bc71-e1b4fa2aff37",
-  "puppet_version" : "3.7.2",
-  "noop" : false,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 0.59 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:30:30.882+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "defined 'message' as 'foo'",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
-    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "puppetdb1.vm" ],
-    "time" : "2015-02-13T13:30:30.478+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "notice",
-    "message" : "foo",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:30:30.477+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423834124'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:30:30.373+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for puppetdb1.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:30:30.226+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:30:28.956+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:30:28.531+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:30:28.461+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:30:28.352Z",
-  "end_time" : "2015-02-13T13:30:29.332Z",
-  "resource_events" : [ {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 3,
-    "resource_type" : "Notify",
-    "status" : "success",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:30:30.477Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
-    "message" : "defined 'message' as 'foo'"
-  } ],
-  "status" : "changed",
-  "configuration_version" : "1423834124",
-  "environment" : "production",
-  "certname" : "puppetdb1.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 5.22122E-4,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.605934475,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.06095043,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.04168878300000001,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 6.7981E-5,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.052758734,
-    "name" : "gnupg_key"
-  }, {
-    "category" : "time",
-    "value" : 4.27311E-4,
-    "name" : "ini_setting"
-  }, {
-    "category" : "time",
-    "value" : 0.001462416,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.03715446999999999,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 4.53319E-4,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.178737151,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 0.980443806,
-    "name" : "total"
-  }, {
-    "category" : "time",
-    "value" : 2.86614E-4,
-    "name" : "vcsrepo"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 47,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 1,
-    "name" : "total"
-  } ]
+    "certname": "puppetdb1.vm",
+    "configuration_version": "1423834124",
+    "end_time": "2015-02-13T13:30:29.332Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 0.59 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:30:30.882+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 3,
+            "message": "defined 'message' as 'foo'",
+            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
+            "tags": [
+                "notice",
+                "notify",
+                "foo",
+                "class",
+                "loadtest",
+                "node",
+                "puppetdb1.vm"
+            ],
+            "time": "2015-02-13T13:30:30.478+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "foo",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:30:30.477+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423834124'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:30:30.373+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for puppetdb1.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:30:30.226+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:30:28.956+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:30:28.531+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:30:28.461+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.000522122
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 0.605934475
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.06095043
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.04168878300000001
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 6.7981e-05
+        },
+        {
+            "category": "time",
+            "name": "gnupg_key",
+            "value": 0.052758734
+        },
+        {
+            "category": "time",
+            "name": "ini_setting",
+            "value": 0.000427311
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.001462416
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.03715446999999999
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.000453319
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.178737151
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 0.980443806
+        },
+        {
+            "category": "time",
+            "name": "vcsrepo",
+            "value": 0.000286614
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 47
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 1
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 1
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 1
+        }
+    ],
+    "noop": false,
+    "puppet_version": "3.7.2",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "defined 'message' as 'foo'",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:30:30.477Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 3,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:30:30.477Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:30:28.352Z",
+    "status": "changed",
+    "transaction_uuid": "3c99e9cc-bc56-45a5-bc71-e1b4fa2aff37"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-6eade546c696f0c045ec29f955bdb4d6a39a8291.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-6eade546c696f0c045ec29f955bdb4d6a39a8291.json
@@ -1,191 +1,260 @@
 {
-  "transaction_uuid" : "f0099317-b053-4b88-8c9c-198945c1b8a8",
-  "puppet_version" : "3.7.2",
-  "noop" : false,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 0.48 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:23:57.259+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "defined 'message' as 'foo'",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
-    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "puppetdb1.vm" ],
-    "time" : "2015-02-13T13:23:56.966+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "notice",
-    "message" : "foo",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:23:56.965+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423833741'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:23:56.851+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for puppetdb1.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:23:56.685+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:23:55.455+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:23:55.039+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:23:55.001+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:23:54.881Z",
-  "end_time" : "2015-02-13T13:23:55.758Z",
-  "resource_events" : [ {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 3,
-    "resource_type" : "Notify",
-    "status" : "success",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:23:56.965Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
-    "message" : "defined 'message' as 'foo'"
-  } ],
-  "status" : "changed",
-  "configuration_version" : "1423833741",
-  "environment" : "production",
-  "certname" : "puppetdb1.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 3.7396200000000004E-4,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.61813028,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.035425543,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.040791153999999996,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 1.06967E-4,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.023943093,
-    "name" : "gnupg_key"
-  }, {
-    "category" : "time",
-    "value" : 3.41525E-4,
-    "name" : "ini_setting"
-  }, {
-    "category" : "time",
-    "value" : 0.001772577,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.029407727,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 5.31606E-4,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.12628271,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 0.8772784490000001,
-    "name" : "total"
-  }, {
-    "category" : "time",
-    "value" : 1.71305E-4,
-    "name" : "vcsrepo"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 47,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 1,
-    "name" : "total"
-  } ]
+    "certname": "puppetdb1.vm",
+    "configuration_version": "1423833741",
+    "end_time": "2015-02-13T13:23:55.758Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 0.48 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:23:57.259+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 3,
+            "message": "defined 'message' as 'foo'",
+            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
+            "tags": [
+                "notice",
+                "notify",
+                "foo",
+                "class",
+                "loadtest",
+                "node",
+                "puppetdb1.vm"
+            ],
+            "time": "2015-02-13T13:23:56.966+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "foo",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:23:56.965+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423833741'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:23:56.851+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for puppetdb1.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:23:56.685+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:23:55.455+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:23:55.039+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:23:55.001+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.00037396200000000004
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 0.61813028
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.035425543
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.040791153999999996
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 0.000106967
+        },
+        {
+            "category": "time",
+            "name": "gnupg_key",
+            "value": 0.023943093
+        },
+        {
+            "category": "time",
+            "name": "ini_setting",
+            "value": 0.000341525
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.001772577
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.029407727
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.000531606
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.12628271
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 0.8772784490000001
+        },
+        {
+            "category": "time",
+            "name": "vcsrepo",
+            "value": 0.000171305
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 47
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 1
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 1
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 1
+        }
+    ],
+    "noop": false,
+    "puppet_version": "3.7.2",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "defined 'message' as 'foo'",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:23:56.965Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 3,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:23:56.965Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:23:54.881Z",
+    "status": "changed",
+    "transaction_uuid": "f0099317-b053-4b88-8c9c-198945c1b8a8"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-9eeca12cedb235b2e8f616967bf1f46d3e1de812.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-9eeca12cedb235b2e8f616967bf1f46d3e1de812.json
@@ -1,191 +1,260 @@
 {
-  "transaction_uuid" : "d6c4f3f3-afc5-41e6-8b1b-73e84400ca70",
-  "puppet_version" : "3.7.2",
-  "noop" : false,
-  "logs" : [ {
-    "level" : "notice",
-    "message" : "Finished catalog run in 0.46 seconds",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:23:50.423+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "notice",
-    "message" : "defined 'message' as 'foo'",
-    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
-    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "puppetdb1.vm" ],
-    "time" : "2015-02-13T13:23:50.137+00:00",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "line" : 3
-  }, {
-    "level" : "notice",
-    "message" : "foo",
-    "source" : "Puppet",
-    "tags" : [ "notice" ],
-    "time" : "2015-02-13T13:23:50.136+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Applying configuration version '1423833741'",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:23:50.025+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Caching catalog for puppetdb1.vm",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:23:49.878+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Loading facts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:23:48.611+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving plugin",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:23:48.197+00:00",
-    "file" : null,
-    "line" : null
-  }, {
-    "level" : "info",
-    "message" : "Retrieving pluginfacts",
-    "source" : "Puppet",
-    "tags" : [ "info" ],
-    "time" : "2015-02-13T13:23:48.16+00:00",
-    "file" : null,
-    "line" : null
-  } ],
-  "report_format" : 4,
-  "start_time" : "2015-02-13T13:23:48.073Z",
-  "end_time" : "2015-02-13T13:23:48.963Z",
-  "resource_events" : [ {
-    "new_value" : "foo",
-    "property" : "message",
-    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
-    "old_value" : "absent",
-    "line" : 3,
-    "resource_type" : "Notify",
-    "status" : "success",
-    "resource_title" : "foo",
-    "timestamp" : "2015-02-13T13:23:50.136Z",
-    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
-    "message" : "defined 'message' as 'foo'"
-  } ],
-  "status" : "changed",
-  "configuration_version" : "1423833741",
-  "environment" : "production",
-  "certname" : "puppetdb1.vm",
-  "metrics" : [ {
-    "category" : "time",
-    "value" : 4.6438E-4,
-    "name" : "anchor"
-  }, {
-    "category" : "time",
-    "value" : 0.642441669,
-    "name" : "config_retrieval"
-  }, {
-    "category" : "time",
-    "value" : 0.035339224,
-    "name" : "exec"
-  }, {
-    "category" : "time",
-    "value" : 0.03945806099999999,
-    "name" : "file"
-  }, {
-    "category" : "time",
-    "value" : 7.8804E-5,
-    "name" : "filebucket"
-  }, {
-    "category" : "time",
-    "value" : 0.023286625,
-    "name" : "gnupg_key"
-  }, {
-    "category" : "time",
-    "value" : 3.22749E-4,
-    "name" : "ini_setting"
-  }, {
-    "category" : "time",
-    "value" : 0.001025265,
-    "name" : "notify"
-  }, {
-    "category" : "time",
-    "value" : 0.029765502,
-    "name" : "package"
-  }, {
-    "category" : "time",
-    "value" : 4.72722E-4,
-    "name" : "schedule"
-  }, {
-    "category" : "time",
-    "value" : 0.117534308,
-    "name" : "service"
-  }, {
-    "category" : "time",
-    "value" : 0.890498771,
-    "name" : "total"
-  }, {
-    "category" : "time",
-    "value" : 3.09462E-4,
-    "name" : "vcsrepo"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "changed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "failed_to_restart"
-  }, {
-    "category" : "resources",
-    "value" : 1,
-    "name" : "out_of_sync"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "restarted"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "scheduled"
-  }, {
-    "category" : "resources",
-    "value" : 0,
-    "name" : "skipped"
-  }, {
-    "category" : "resources",
-    "value" : 47,
-    "name" : "total"
-  }, {
-    "category" : "events",
-    "value" : 0,
-    "name" : "failure"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "success"
-  }, {
-    "category" : "events",
-    "value" : 1,
-    "name" : "total"
-  }, {
-    "category" : "changes",
-    "value" : 1,
-    "name" : "total"
-  } ]
+    "certname": "puppetdb1.vm",
+    "configuration_version": "1423833741",
+    "end_time": "2015-02-13T13:23:48.963Z",
+    "environment": "production",
+    "logs": [
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "Finished catalog run in 0.46 seconds",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:23:50.423+00:00"
+        },
+        {
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "level": "notice",
+            "line": 3,
+            "message": "defined 'message' as 'foo'",
+            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
+            "tags": [
+                "notice",
+                "notify",
+                "foo",
+                "class",
+                "loadtest",
+                "node",
+                "puppetdb1.vm"
+            ],
+            "time": "2015-02-13T13:23:50.137+00:00"
+        },
+        {
+            "file": null,
+            "level": "notice",
+            "line": null,
+            "message": "foo",
+            "source": "Puppet",
+            "tags": [
+                "notice"
+            ],
+            "time": "2015-02-13T13:23:50.136+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Applying configuration version '1423833741'",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:23:50.025+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Caching catalog for puppetdb1.vm",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:23:49.878+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Loading facts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:23:48.611+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving plugin",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:23:48.197+00:00"
+        },
+        {
+            "file": null,
+            "level": "info",
+            "line": null,
+            "message": "Retrieving pluginfacts",
+            "source": "Puppet",
+            "tags": [
+                "info"
+            ],
+            "time": "2015-02-13T13:23:48.16+00:00"
+        }
+    ],
+    "metrics": [
+        {
+            "category": "time",
+            "name": "anchor",
+            "value": 0.00046438
+        },
+        {
+            "category": "time",
+            "name": "config_retrieval",
+            "value": 0.642441669
+        },
+        {
+            "category": "time",
+            "name": "exec",
+            "value": 0.035339224
+        },
+        {
+            "category": "time",
+            "name": "file",
+            "value": 0.03945806099999999
+        },
+        {
+            "category": "time",
+            "name": "filebucket",
+            "value": 7.8804e-05
+        },
+        {
+            "category": "time",
+            "name": "gnupg_key",
+            "value": 0.023286625
+        },
+        {
+            "category": "time",
+            "name": "ini_setting",
+            "value": 0.000322749
+        },
+        {
+            "category": "time",
+            "name": "notify",
+            "value": 0.001025265
+        },
+        {
+            "category": "time",
+            "name": "package",
+            "value": 0.029765502
+        },
+        {
+            "category": "time",
+            "name": "schedule",
+            "value": 0.000472722
+        },
+        {
+            "category": "time",
+            "name": "service",
+            "value": 0.117534308
+        },
+        {
+            "category": "time",
+            "name": "total",
+            "value": 0.890498771
+        },
+        {
+            "category": "time",
+            "name": "vcsrepo",
+            "value": 0.000309462
+        },
+        {
+            "category": "resources",
+            "name": "changed",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "failed",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "failed_to_restart",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "out_of_sync",
+            "value": 1
+        },
+        {
+            "category": "resources",
+            "name": "restarted",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "scheduled",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "skipped",
+            "value": 0
+        },
+        {
+            "category": "resources",
+            "name": "total",
+            "value": 47
+        },
+        {
+            "category": "events",
+            "name": "failure",
+            "value": 0
+        },
+        {
+            "category": "events",
+            "name": "success",
+            "value": 1
+        },
+        {
+            "category": "events",
+            "name": "total",
+            "value": 1
+        },
+        {
+            "category": "changes",
+            "name": "total",
+            "value": 1
+        }
+    ],
+    "noop": false,
+    "puppet_version": "3.7.2",
+    "report_format": 4,
+    "resources": [
+        {
+            "containment_path": [
+                "Stage[main]",
+                "Loadtest",
+                "Notify[foo]"
+            ],
+            "events": [
+                {
+                    "message": "defined 'message' as 'foo'",
+                    "new_value": "foo",
+                    "old_value": "absent",
+                    "property": "message",
+                    "status": "success",
+                    "timestamp": "2015-02-13T13:23:50.136Z"
+                }
+            ],
+            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "line": 3,
+            "resource_title": "foo",
+            "resource_type": "Notify",
+            "skipped": false,
+            "timestamp": "2015-02-13T13:23:50.136Z"
+        }
+    ],
+    "start_time": "2015-02-13T13:23:48.073Z",
+    "status": "changed",
+    "transaction_uuid": "d6c4f3f3-afc5-41e6-8b1b-73e84400ca70"
 }

--- a/src/puppetlabs/puppetdb/anonymizer.clj
+++ b/src/puppetlabs/puppetdb/anonymizer.clj
@@ -70,8 +70,7 @@
   {:post [(boolean? %)]}
   (cond
    (string? test) (if (pattern-string? test)
-                    (let [pattern (pattern->regexp test)]
-                      (boolean (and (not (nil? value)) (re-find pattern value))))
+                    (boolean (some->> value (re-find (pattern->regexp test))))
                     (= test value))
    (vector? test) (boolean (some true? (map #(matcher-match? % value) test)))))
 
@@ -86,13 +85,10 @@
   {:pre [(map? rule)
          (map? context)]
    :post [(boolean? %)]}
-  (let [rule-context (get rule "context")
-        context-keys (keys context)
-        rule-keys    (keys rule-context)]
+  (let [rule-context (get rule "context")]
     (every? true?
-            (for [k    rule-keys
-                  :let [test  (get rule-context k)
-                        value (get context k)]]
+            (for [[k test] rule-context
+                  :let [value (get context k)]]
               (if (and (coll? value) (empty? value))
                 false
                 (matcher-match? test value))))))
@@ -104,31 +100,29 @@
   {:pre [(or (coll? rules) (nil? rules))
          (map? context)]
    :post [(boolean? %)]}
-  (loop [x rules]
-    (if (empty? x)
+  (loop [[x :as xs] rules]
+    (cond
       ;; Default to returning true if there is no match
-      true
-      (let [rule (first x)]
-        (if (rule-match? rule context)
-          (get rule "anonymize")
-          (recur (rest x)))))))
+      (empty? xs) true
+      (rule-match? x context) (get x "anonymize")
+      :else (recur (rest xs)))))
 
 ;; Functions for anonymizing the final leaf data
 (defn anonymize-leaf-value
   "Based on the input value, return an appropriate random replacement"
   [value]
   (cond
-   (string? value)            (random-string 30)
-   (integer? value)           (rand-int 300)
-   (float? value)             (rand)
-   (boolean? value)           (random-bool)
-   (vector? value)            (vec (map anonymize-leaf-value value))
-   (seq? value)               (seq (map anonymize-leaf-value value))
-   (map? value)               (zipmap (take (count value)
-                                            (repeatedly #(random-string 10)))
-                                      (vals (utils/update-vals value (keys value)
-                                                               anonymize-leaf-value)))
-   (nil? value)               nil
+   (string? value) (random-string 30)
+   (integer? value) (rand-int 300)
+   (float? value) (rand)
+   (boolean? value) (random-bool)
+   (vector? value) (mapv anonymize-leaf-value value)
+   (seq? value) (seq (map anonymize-leaf-value value))
+   (map? value) (zipmap (take (count value)
+                              (repeatedly #(random-string 10)))
+                        (vals (utils/update-vals value (keys value)
+                                                 anonymize-leaf-value)))
+   (nil? value) nil
    :else (random-string 30)))
 
 (def anonymize-leaf-memoize
@@ -154,14 +148,10 @@
 (defn anonymize-leaf
   "Anonymize leaf data, if the context matches a rule"
   [value ltype context config]
-  (let [rules      (get config "rules")
-        type-rules (get rules (name ltype))]
-    ;; Preserve nils and booleans
-    (if (or (nil? value) (boolean? value))
-      value
-      (if (rules-match type-rules context)
-        (anonymize-leaf-memoize ltype value)
-        value))))
+  (let [type-rules (get-in config ["rules" (name ltype)])]
+    (if (rules-match type-rules context)
+      (anonymize-leaf-memoize ltype value)
+      value)))
 
 ;; Functions for anonymizing data structures
 
@@ -173,12 +163,12 @@
   (let [[_ rel-type rel-title] (re-matches #"(.+)\[(.+)\]" rel)
         ;; here we modify the context, as the anonymization of a reference
         ;; is not about where it appears
-        newcontext             {"node"  (get context "node")
-                                "title" rel-title
-                                "type"  rel-type}
+        newcontext {"node" (get context "node")
+                    "title" rel-title
+                    "type" rel-type}
         ;; optionally anonymize each part
-        new-type               (anonymize-leaf rel-type :type newcontext config)
-        new-title              (anonymize-leaf rel-title :title newcontext config)]
+        new-type (anonymize-leaf rel-type :type newcontext config)
+        new-title (anonymize-leaf rel-title :title newcontext config)]
     (str new-type "[" new-title "]")))
 
 (defn anonymize-references
@@ -187,7 +177,7 @@
   {:pre  [(or (coll? rels) (string? rels))]
    :post [(= (type %) (type rels))]}
   (if (coll? rels)
-    (vec (map #(anonymize-reference % context config) rels))
+    (mapv #(anonymize-reference % context config) rels)
     (anonymize-reference rels context config)))
 
 (defn anonymize-aliases
@@ -195,29 +185,32 @@
   [aliases context config]
   {:pre  [(or (coll? aliases) (string? aliases) (nil? aliases))]
    :post [(= (type %) (type aliases))]}
-  (if (coll? aliases)
-    (vec (map #(anonymize-leaf % :title context config) aliases))
-    (if (string? aliases)
-      (anonymize-leaf aliases :title context config)
-      aliases)))
+  (when-not (nil? aliases)
+    (if (coll? aliases)
+      (mapv #(anonymize-leaf % :title context config) aliases)
+      (anonymize-leaf aliases :title context config))))
 
 (defn anonymize-parameter
   "Anonymize a parameter/value pair"
   [parameter context config]
   {:pre  [(coll? parameter)]
    :post [(coll? %)]}
-  (let [[key val]  parameter
-        newcontext (assoc-in context ["parameter-value"] val)]
+  (let [[key val] parameter
+        newcontext (assoc context "parameter-value" val)]
     (case key
       ;; Metaparameters are special
-      ("stage" "tag")        [key (anonymize-leaf val :title newcontext config)]
-      "alias"                [key (anonymize-aliases val newcontext config)]
+      ("stage" "tag")
+      [key (anonymize-leaf val :title newcontext config)]
+      "alias"
+      [key (anonymize-aliases val newcontext config)]
+
       ;; References get randomized in a special way
-      ("require" "before"
-       "notify" "subscribe") [key (anonymize-references val newcontext config)]
-       ;; Everything else gets anonymized as per normal
-       [(anonymize-leaf key :parameter-name newcontext config)
-        (anonymize-leaf val :parameter-value newcontext config)])))
+      ("require" "before" "notify" "subscribe")
+      [key (anonymize-references val newcontext config)]
+
+      ;; Everything else gets anonymized as per normal
+      [(anonymize-leaf key :parameter-name newcontext config)
+       (anonymize-leaf val :parameter-value newcontext config)])))
 
 (defn anonymize-parameters
   "Anonymize the parameters keys and values for a resource"
@@ -238,7 +231,7 @@
   [tag context config]
   {:pre  [(string? tag)]
    :post [(string? %)]}
-  (let [newtag     (capitalize-resource-type tag)
+  (let [newtag (capitalize-resource-type tag)
         newcontext {"node" (get context "node")
                     "type" newtag}]
     (str/lower-case (anonymize-leaf newtag :type newcontext config))))
@@ -287,9 +280,8 @@
 (defn anonymize-containment-path
   "Anonymize a collection of containment path resource references from an event"
   [path context config]
-  {:pre  [(coll? path)]
-   :post [(coll? %)]}
-  (map #(anonymize-containment-path-element % context config) path))
+  (some->> path
+           (map #(anonymize-containment-path-element % context config))))
 
 (defn anonymize-log-source
   "assumes that capital words are types, bracketed phrases are parameter names,
@@ -304,40 +296,29 @@
         (str/replace param-name-pattern #(anonymize-leaf % :parameter-name context config))
         (str/replace title-pattern #(anonymize-leaf % :title context config)))))
 
-(defn update-in-nil
-  "Wrapper around update-in that ignores keys with nil"
-  [m [k] f & args]
-  (if (nil? (get m k))
-    m
-    (if args
-      (apply update-in m [k] f args)
-      (apply update-in m [k] f))))
-
-(defn anonymize-resource
-  "Anonymize a resource"
+(defn anonymize-catalog-resource
   [resource context config]
   {:pre  [(resource? resource)]
    :post [(resource? %)]}
-  (let [newcontext {"node"  (get context "node")
+  (let [newcontext {"node" (get context "node")
                     "title" (get resource "title")
-                    "tags"  (get resource "tags")
-                    "file"  (get resource "file")
-                    "line"  (get resource "line")
-                    "type"  (get resource "type")}]
+                    "tags" (get resource "tags")
+                    "file" (get resource "file")
+                    "line" (get resource "line")
+                    "type" (get resource "type")}]
     (-> resource
-        (update-in-nil ["file"]       anonymize-leaf :file newcontext config)
-        (update-in-nil ["line"]       anonymize-leaf :line newcontext config)
-        (update-in     ["parameters"] anonymize-parameters newcontext config)
-        (update-in     ["tags"]       anonymize-tags newcontext config)
-        (update-in     ["title"]      anonymize-leaf :title newcontext config)
-        (update-in     ["type"]       anonymize-leaf :type newcontext config))))
+        (utils/update-when ["file"] anonymize-leaf :file newcontext config)
+        (utils/update-when ["line"] anonymize-leaf :line newcontext config)
+        (update "parameters" anonymize-parameters newcontext config)
+        (update "tags" anonymize-tags newcontext config)
+        (update "title" anonymize-leaf :title newcontext config)
+        (update "type" anonymize-leaf :type newcontext config))))
 
-(defn anonymize-resources
-  "Anonymize a collection of resources"
+(defn anonymize-catalog-resources
   [resources context config]
   {:pre  [(coll? resources)]
    :post [(coll? %)]}
-  (map #(anonymize-resource % context config) resources))
+  (map #(anonymize-catalog-resource % context config) resources))
 
 (pls/defn-validated anonymize-resource-event :- resource-event-schema-str
   "Anonymize a resource event from a report"
@@ -371,28 +352,24 @@
    context
    config]
   (if (= "time" (get metric "category"))
-    (update-in metric ["name"] #(anonymize-lowercase-type % context config))
+    (update metric "name" #(anonymize-lowercase-type % context config))
     metric))
 
 (pls/defn-validated anonymize-metrics :- [metric-schema-str]
-  [metrics :- (s/maybe [metric-schema-str])
+  [metrics :- [metric-schema-str]
    context
    config]
-  (when metrics
-    (map #(anonymize-metric % context config) metrics)))
+  (map #(anonymize-metric % context config) metrics))
 
-(pls/defn-validated anonymize-log :- log-schema-str
-  [log :- log-schema-str
-   context
-   config]
+(defn anonymize-log [log context config]
   (-> log
-      (update-in ["message"] anonymize-leaf :log-message context config)
-      (update-in ["source"] anonymize-log-source context config)
-      (update-in ["tags"] anonymize-tags context config)
-      (update-in ["file"] anonymize-leaf :file context config)
-      (update-in ["line"] anonymize-leaf :line context config)))
+      (update "message" anonymize-leaf :log-message context config)
+      (update "source" anonymize-log-source context config)
+      (update "tags" anonymize-tags context config)
+      (update "file" anonymize-leaf :file context config)
+      (update "line" anonymize-leaf :line context config)))
 
-(pls/defn-validated anonymize-logs :- (s/maybe [log-schema-str])
+(pls/defn-validated anonymize-logs :- [log-schema-str]
   [logs :- [log-schema-str]
    context
    config]
@@ -451,9 +428,9 @@
   [config wire-facts]
   (let [context {"node" (get wire-facts "certname")}]
     (-> wire-facts
-        (update-in ["certname"] anonymize-leaf :node context config)
-        (update-in ["values"] anonymize-fact-values context config)
-        (update-in ["environment"] anonymize-leaf :environment context config))))
+        (update "certname" anonymize-leaf :node context config)
+        (update "values" anonymize-fact-values context config)
+        (update "environment" anonymize-leaf :environment context config))))
 
 (def anon-profiles
   ^{:doc "Hard coded rule engine profiles indexed by profile name"}

--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -47,6 +47,7 @@
             [puppetlabs.kitchensink.core :as kitchensink]
             [clj-time.core :as time]
             [puppetlabs.puppetdb.client :as client]
+            [puppetlabs.puppetdb.reports :as reports]
             [puppetlabs.puppetdb.random :refer [random-string random-bool]]
             [puppetlabs.puppetdb.archive :as archive]
             [slingshot.slingshot :refer [try+ throw+]]
@@ -150,7 +151,9 @@
              "transaction_uuid" uuid
              "start_time" (time/minus stamp (time/seconds 10))
              "end_time" (time/minus stamp (time/seconds 5))
-             "producer_timestamp" stamp)))
+             "producer_timestamp" stamp)
+      clojure.walk/keywordize-keys
+      reports/sanitize-report))
 
 (defn randomize-map-leaf
   "Randomizes a fact leaf."
@@ -198,9 +201,9 @@
                        (update-report uuid stamp))
         factset (some-> factset
                         (update-factset rand-percentage stamp))]
-    (when catalog (>!! command-send-ch [:catalog 6 (json/generate-string catalog)]))
-    (when report (>!! command-send-ch [:report 5 (json/generate-string report)]))
-    (when factset (>!! command-send-ch [:factset 4 (json/generate-string factset)]))
+    (when catalog (>!! command-send-ch [:catalog 6 catalog]))
+    (when report (>!! command-send-ch [:report 5 report]))
+    (when factset (>!! command-send-ch [:factset 4 factset]))
 
     (assoc state
            :catalog catalog

--- a/src/puppetlabs/puppetdb/client.clj
+++ b/src/puppetlabs/puppetdb/client.clj
@@ -9,7 +9,6 @@
             [puppetlabs.puppetdb.schema :refer [defn-validated]]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.kitchensink.core :as kitchensink]
-            [clojure.walk :refer  [keywordize-keys]]
             [schema.core :as s]))
 
 (defn-validated submit-command-via-http!
@@ -58,12 +57,11 @@
   command-processing endpoint located at `puppetdb-host`:`puppetdb-port`."
   [base-url :- utils/base-url-schema
    command-version :- s/Int
-   catalog-payload :- s/Str]
-  (let [payload (json/parse-string catalog-payload)
-        result (submit-command-via-http!
-                           base-url
-                           (command-names :replace-catalog) command-version
-                           payload)]
+   catalog-payload]
+  (let [result (submit-command-via-http!
+                base-url
+                (command-names :replace-catalog) command-version
+                catalog-payload)]
     (when-not (= http/status-ok (:status result))
       (log/error result))))
 
@@ -72,15 +70,11 @@
   command-processing endpoint located at `puppetdb-host`:`puppetdb-port`."
   [base-url :- utils/base-url-schema
    command-version :- s/Int
-   report-payload :- s/Str]
-  (let [payload (-> report-payload
-                    json/parse-string
-                    keywordize-keys
-                    reports/sanitize-report)
-        result  (submit-command-via-http!
-                 base-url
-                 (command-names :store-report) command-version
-                 payload)]
+   report-payload]
+  (let [result (submit-command-via-http!
+                base-url
+                (command-names :store-report) command-version
+                report-payload)]
     (when-not (= http/status-ok (:status result))
       (log/error result))))
 
@@ -89,14 +83,10 @@
   command-processing endpoint located at `puppetdb-host`:`puppetdb-port`."
   [base-url :- utils/base-url-schema
    facts-version :- s/Int
-   fact-payload :- s/Str]
-  (let [payload (case facts-version
-                  1 fact-payload
-                  (json/parse-string fact-payload))
-        result  (submit-command-via-http!
+   fact-payload]
+  (let [result  (submit-command-via-http!
                  base-url
-                 (command-names :replace-facts)
-                 facts-version
-                 payload)]
+                 (command-names :replace-facts) facts-version
+                 fact-payload)]
     (when-not (= http/status-ok (:status result))
       (log/error result))))

--- a/src/puppetlabs/puppetdb/export.clj
+++ b/src/puppetlabs/puppetdb/export.clj
@@ -24,7 +24,7 @@
   ;;  version of the `catalog` endpoint... or even to query what the latest
   ;;  version of a command is.  We should improve that.
   {:replace_catalog 6
-   :store_report 5
+   :store_report 6
    :replace_facts 4})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -90,7 +90,7 @@
               :query->wire-fn catalogs/catalogs-query->wire-v6
               :anonymize-fn anon/anonymize-catalog}
    :reports {:child-fields [:metrics :logs :resource_events]
-             :query->wire-fn reports/reports-query->wire-v5
+             :query->wire-fn reports/reports-query->wire-v6
              :anonymize-fn anon/anonymize-report}
    :factsets {:child-fields [:facts]
               :query->wire-fn factsets/factsets-query->wire-v4

--- a/src/puppetlabs/puppetdb/import.clj
+++ b/src/puppetlabs/puppetdb/import.clj
@@ -40,7 +40,7 @@
       (do (log/infof "Importing report from archive entry '%s'" path)
           (command-fn :store-report
                       (:store_report command-versions)
-                      (reports/sanitize-report (utils/read-json-content tar-reader true))))
+                      (utils/read-json-content tar-reader true)))
       (file-pattern "facts")
       (do (log/infof "Importing facts from archive entry '%s'" path)
           (command-fn :replace-facts

--- a/src/puppetlabs/puppetdb/reports.clj
+++ b/src/puppetlabs/puppetdb/reports.clj
@@ -139,18 +139,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Reports Query -> Wire format conversions
 
-(defn remove-reports-metadata [resource-events]
-  (map #(dissoc %
-                :report :certname :containing_class :configuration_version
-                :run_start_time :run_end_time :report_receive_time :environment)
-       resource-events))
-
 (pls/defn-validated resource-events-query->wire-v5 :- [resource-event-v5-wireformat-schema]
   [resource-events :- resource-events-expanded-query-schema]
   (->> resource-events
        :data
-       remove-reports-metadata
-       (sort-by #(mapv % [:timestamp :resource_type :resource_title :property]))))
+       (map #(dissoc %
+                     :report :certname :containing_class :configuration_version
+                     :run_start_time :run_end_time :report_receive_time :environment))))
 
 (pls/defn-validated report-query->wire-v5 :- report-v5-wireformat-schema
   [report :- report-query-schema]

--- a/src/puppetlabs/puppetdb/reports.clj
+++ b/src/puppetlabs/puppetdb/reports.clj
@@ -225,7 +225,6 @@
    is left over."
   [payload]
   (as-> payload $
-    (wire-v5->wire-v6 $)
     (pls/strip-unknown-keys report-wireformat-schema $)
     (update $ :resources sanitize-resources)))
 

--- a/test/puppetlabs/puppetdb/anonymizer_test.clj
+++ b/test/puppetlabs/puppetdb/anonymizer_test.clj
@@ -265,7 +265,7 @@
       (is (coll? (anonymize-edges [test-edge] {} {})))
       (is (= 1 (count (anonymize-edges [test-edge] {} {})))))))
 
-(deftest test-anonymize-resource
+(deftest test-anonymize-catalog-resource
   (testing "should handle a resource"
     (let [test-resource {"parameters" {"ensure" "present"}
                          "exported"   true
@@ -274,7 +274,7 @@
                          "tags"       ["package"]
                          "title"      "foo"
                          "type"       "Package"}
-          result        (anonymize-resource test-resource {} {})]
+          result (anonymize-catalog-resource test-resource {} {})]
       (is (map? result))
       (is (= #{"parameters" "exported" "line" "title" "tags" "type" "file"} (ks/keyset result)))))
   (testing "should handle nil for file and line"
@@ -283,11 +283,11 @@
                          "tags"       ["package"]
                          "title"      "foo"
                          "type"       "Package"}
-          result        (anonymize-resource test-resource {} {})]
+          result        (anonymize-catalog-resource test-resource {} {})]
       (is (map? result))
       (is (= #{"parameters" "exported" "title" "tags" "type"} (ks/keyset result))))))
 
-(deftest test-anonymize-resources
+(deftest test-anonymize-catalog-resources
   (testing "should handle a resource"
     (let [test-resource {"parameters" {"ensure" "present"}
                          "exported"   true
@@ -296,7 +296,7 @@
                          "tags"       ["package"]
                          "title"      "foo"
                          "type"       "Package"}
-          result (first (anonymize-resources [test-resource] {} {}))]
+          result (first (anonymize-catalog-resources [test-resource] {} {}))]
 
       (is (= (ks/keyset test-resource)
              (ks/keyset result)))
@@ -310,52 +310,48 @@
            "type"
            "file"))))
 
-(deftest test-anonymize-resource-event
-  (testing "should handle a resource event"
+(deftest test-anonymize-event
+  (testing "should handle a event"
     (let [test-event {"status"           "noop"
                       "timestamp"        "2013-03-04T19:56:34.000Z"
-                      "resource_title"   "foo"
                       "property"         "ensure"
                       "message"          "Ensure was absent now present"
                       "new_value"        "present"
-                      "old_value"        "absent"
-                      "resource_type"    "Package"
-                      "file"             "/home/user/site.pp"
-                      "line"             1
-                      "containment_path" ["Stage[main]" "Foo" "Notify[hi]"]}
-          anonymized-event (anonymize-resource-event test-event {} {})]
-      (is (map? anonymized-event))
-      (is (= (keys test-event) (keys anonymized-event)))))
-  (testing "should handle a resource event with optionals"
-    (let [test-event {"status"           "noop"
-                      "timestamp"        "2013-03-04T19:56:34.000Z"
-                      "resource_title"   "foo"
-                      "property"         "ensure"
-                      "message"          "Ensure was absent now present"
-                      "new_value"        "present"
-                      "old_value"        "absent"
-                      "resource_type"    "Package"
-                      "file"             nil
-                      "line"             nil
-                      "containment_path" nil}
-          anonymized-event (anonymize-resource-event test-event {} {})]
+                      "old_value"        "absent"}
+          anonymized-event (anonymize-event test-event {} {})]
       (is (map? anonymized-event))
       (is (= (keys test-event) (keys anonymized-event))))))
 
-(deftest test-anonymize-resource-events
+(deftest test-anonymize-report-resource
   (testing "should handle a resource event"
-    (let [test-event {"status"           "noop"
-                      "timestamp"        "2013-03-04T19:56:34.000Z"
-                      "resource_title"   "foo"
-                      "property"         "ensure"
-                      "message"          "Ensure was absent now present"
-                      "new_value"        "present"
-                      "old_value"        "absent"
-                      "resource_type"    "Package"
-                      "file"             nil
-                      "line"             nil
-                      "containment_path" nil}]
-      (is (coll? (anonymize-resource-events [test-event] {} {}))))))
+    (let [test-resource {"events" [{"status" "noop"
+                                    "timestamp" "2013-03-04T19:56:34.000Z"
+                                    "property" "ensure"
+                                    "message" "Ensure was absent now present"
+                                    "new_value" "present"
+                                    "old_value" "absent"}]
+                         "timestamp" "2013-03-04T19:56:34.000Z"
+                         "resource_title" "foo"
+                         "resource_type" "Package"
+                         "skipped" false
+                         "file" "/home/user/site.pp"
+                         "line" 1
+                         "containment_path" ["Stage[main]" "Foo" "Notify[hi]"]}
+          anonymized-resource (anonymize-report-resource test-resource {} {})]
+      (is (map? anonymized-resource))
+      (is (= (keys test-resource) (keys anonymized-resource)))))
+  (testing "should handle a resource event with optionals"
+    (let [test-resource {"timestamp" "2013-03-04T19:56:34.000Z"
+                         "resource_title" "foo"
+                         "events" []
+                         "resource_type" "Package"
+                         "skipped" true
+                         "file" nil
+                         "line" nil
+                         "containment_path" nil}
+          anonymized-resource (anonymize-report-resource test-resource {} {})]
+      (is (map? anonymized-resource))
+      (is (= (keys test-resource) (keys anonymized-resource))))))
 
 (deftest test-anonymize-catalog
   (testing "should accept basic valid data"

--- a/test/puppetlabs/puppetdb/cli/benchmark_test.clj
+++ b/test/puppetlabs/puppetdb/cli/benchmark_test.clj
@@ -1,7 +1,6 @@
 (ns puppetlabs.puppetdb.cli.benchmark-test
   (:require [puppetlabs.puppetdb.cli.benchmark :as benchmark]
             [clojure.test :refer :all]
-            [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.archive :as archive]
             [puppetlabs.puppetdb.client :as client]
             [puppetlabs.trapperkeeper.config :as config]
@@ -18,7 +17,7 @@
             :base-url base-url
             :version version
             :payload-string payload-string
-            :payload (json/parse-string payload-string true)})))
+            :payload (clojure.walk/keywordize-keys payload-string)})))
 
 (defn run-benchmark [config & cli-args]
   (let [submitted-records (atom [])]

--- a/test/puppetlabs/puppetdb/reports_test.clj
+++ b/test/puppetlabs/puppetdb/reports_test.clj
@@ -31,7 +31,7 @@
 (deftest test-sanitize-report
   (testing "no action on valid reports"
     (let [test-data (:basic reports)]
-      (= (sanitize-report test-data) test-data))))
+      (= (sanitize-report (wire-v5->wire-v6 test-data)) test-data))))
 
 (defn underscore->dash-report-keys [m]
   (->> m

--- a/test/puppetlabs/puppetdb/reports_test.clj
+++ b/test/puppetlabs/puppetdb/reports_test.clj
@@ -28,29 +28,6 @@
            RuntimeException #":timestamp \(not \(datetime\? \"foo\"\)\)"
            (s/validate report-wireformat-schema (assoc-in report [:resources 0 :timestamp] "foo")))))))
 
-(deftest test-sanitize-v5-resource-events
-  (testing "ensure extraneous keys are removed"
-    (let [test-data {:containment_path
-                     ["Stage[main]"
-                      "My_pg"
-                      "My_pg::Extension[puppetdb:pg_stat_statements]"
-                      "Postgresql_psql[create extension pg_stat_statements on puppetdb]"]
-                     :new_value "CREATE EXTENSION pg_stat_statements"
-                     :message
-                     "command changed '' to 'CREATE EXTENSION pg_stat_statements'"
-                     :old_value nil
-                     :status "success"
-                     :line 16
-                     :property "command"
-                     :timestamp "2014-01-09T17:52:56.795Z"
-                     :resource_type "Postgresql_psql"
-                     :resource_title  "create extension pg_stat_statements on puppetdb"
-                     :file  "/etc/puppet/modules/my_pg/manifests/extension.pp"
-                     :extradata  "foo"}
-          santized (sanitize-v5-resource-events [test-data])
-          expected [(dissoc test-data "extradata")]]
-      (= santized expected))))
-
 (deftest test-sanitize-report
   (testing "no action on valid reports"
     (let [test-data (:basic reports)]


### PR DESCRIPTION
This PR cleans up some of the anonymizer code syntax to make it more readable and a little faster.

This PR removes some redundant validation and sanitization we were using in a bunch of different places regarding reports wireformats.

This PR removes some JSON roundtripping we we're doing in the benchmarking tool which was preventing us from freely moving around some of the sanitization code used by the benchmarking tool on reports. Essentially our benchmarking tool obeyed the `pdb-client` API for submitting data but that API made no sense,  submit a jsonified report to the client, unjson it, sanitize, rejson, submit it to PDB. Therefore this API for the pdb-client was changed (only used by benchmarking anyways) to not need a jsonified report. To make the api consistent, the other entities were changed as well.

This PR also moves the anonymization and export code to use v6 of reports.

This PR updates the example reports for the benchmarking tool to be v6 using https://gist.github.com/ajroetker/5e9e8b9f8f70620d3685.

This PR DOES NOT migrate the example reports in testutils to be v6 that work will follow in a subsequent PR. 