### PR TITLE
(PDB-2004) Alter tests to fix Travis jdk_switcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,31 @@
 language: clojure
+
 lein: lein2
+
+jdk:
+  - openjdk7
+  - oraclejdk8
+  - oraclejdk7
+
 env:
-  - T_TEST=java:oraclejdk7:hsqldb
-  - T_TEST=java:oraclejdk8:hsqldb
-  - T_TEST=java:openjdk7:hsqldb
-  - T_TEST=java:oraclejdk7:postgres
-  - T_TEST=java:oraclejdk8:postgres
-  - T_TEST=java:openjdk7:postgres
-  - T_TEST=ruby:default:none
-script: ./ext/travisci/test.sh
+  - PDB_TEST_LANG=clojure PDB_TEST_DB=hsqldb
+  - PDB_TEST_LANG=clojure PDB_TEST_DB=postgres
+  - PDB_TEST_LANG=ruby
+
+# Only run one ruby test
+matrix:
+  exclude:
+    - jdk: oraclejdk8
+      env: PDB_TEST_LANG=ruby
+    - jdk: oraclejdk7
+      env: PDB_TEST_LANG=ruby
+
+script: ext/travisci/test.sh
+
 notifications:
   email: false
+
 addons:
   postgresql: "9.4"
+
 services: postgresql
-before_install:
-  - rvm use 1.9.3

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,44 +1,41 @@
 #!/bin/bash
 
-T_TEST_ARRAY=(${T_TEST//:/ })
+set -ueo pipefail
+set -x
 
-T_LANG=${T_TEST_ARRAY[0]}
-T_VERSION=${T_TEST_ARRAY[1]}
-T_DB=${T_TEST_ARRAY[2]}
+ulimit -u 4096
 
-echo "Running tests in language: ${T_LANG} version: ${T_VERSION}"
-
-if [ $T_LANG == "ruby" ]; then
-  # Using `rvm use` in travis-ci needs a lot more work, so just accepting
-  # the default version for now.
-  ruby -v
-  gem install bundler
-  bundle install --without acceptance
-  cd puppet
-  bundle exec rspec spec/
-else
-  if [ $T_LANG == "java" ]; then
-    ulimit -u 4096
-    jdk_switcher use $T_VERSION
+case "$PDB_TEST_LANG" in
+  clojure)
     java -version
-    if [ $T_DB == "postgres" ]; then
-      psql -c 'create database puppetdb_test;' -U postgres
-      PUPPETDB_DBTYPE=$T_DB \
-      PUPPETDB_DBUSER=postgres \
-      PUPPETDB_DBSUBNAME=//127.0.0.1:5432/puppetdb_test \
-      PUPPETDB_DBPASSWORD= \
-      lein2 test
-    else
-      if [ $T_DB == "hsqldb" ]; then
-        PUPPETDB_DBTYPE=$T_DB \
-        lein2 test
-      else
-        echo "Invalid database ${T_DB}"
+    case "$PDB_TEST_DB" in
+      postgres)
+        psql -c 'create database puppetdb_test;' -U postgres
+        PUPPETDB_DBTYPE=postgres \
+          PUPPETDB_DBUSER=postgres \
+          PUPPETDB_DBSUBNAME=//127.0.0.1:5432/puppetdb_test \
+          PUPPETDB_DBPASSWORD= \
+            lein2 test
+        ;;
+      hsqldb)
+        PUPPETDB_DBTYPE=hsqldb lein2 test
+        ;;
+      *)
+        echo "Invalid database: $PDB_TEST_DB" 1>&2
         exit 1
-      fi
-    fi
-  else
-    echo "Invalid language ${T_LANG}"
+        ;;
+    esac
+    ;;
+  ruby)
+    rvm use 1.9.3
+    ruby -v
+    gem install bundler
+    bundle install --without acceptance
+    cd puppet
+    bundle exec rspec spec/
+    ;;
+  *)
+    echo "Invalid language: $PDB_TEST_LANG" 1>&2
     exit 1
-  fi
-fi
+    ;;
+esac


### PR DESCRIPTION
Let Travis handle the jdk selection.  Right now jdk_switcher doesn't
actually exist.  This means Travis generates the test matrix more
implicitly, so use exclusions to make sure we only test ruby on one
db/jdk combination.

Add "set -ueo pipefail" to catch errors.