### PR TITLE
(PDB-1614) anonymize path and value independently

### DIFF
--- a/test/puppetlabs/puppetdb/anonymizer_test.clj
+++ b/test/puppetlabs/puppetdb/anonymizer_test.clj
@@ -125,6 +125,16 @@
     (is (string? (anonymize-leaf-memoize :parameter-name "good old string")))
     (is (= 10 (count (anonymize-leaf-memoize :parameter-name "good old string"))))))
 
+(deftest anonymize-fact-value
+  (testing "identical paths with different values should be memoized"
+    (let [facts1 {:b {:baz 3000}}
+          facts2 {:b {:baz 2000}}
+          anon1 (anonymize-fact-values facts1 {} {})
+          anon2 (anonymize-fact-values facts2 {} {})]
+      (is (= (keys anon1) (keys anon2)))
+      (is (= (keys (first (vals anon1))) (keys (first (vals anon2)))))
+      (is (not= anon1 anon2)))))
+
 (deftest test-anonymize-leaf-value
   (testing "should return the same string twice"
     (is (= (anonymize-leaf-memoize :parameter-value "test string") (anonymize-leaf-memoize :parameter-value "test string"))))
@@ -139,8 +149,6 @@
     (is (integer? (anonymize-leaf-value 100))))
   (testing "should return an float when passed an float"
     (is (float? (anonymize-leaf-value 3.14))))
-  (testing "should return a vector when passed a vector"
-    (is (vector? (anonymize-leaf-value ["asdf" "asdf"]))))
   (testing "should return a map when passed a map"
     (is (map? (anonymize-leaf-value {"foo" "bar"}))))
   (testing "maps should retain their child types"
@@ -152,6 +160,11 @@
   (testing "should return a string 50 characters long"
     (is (string? (anonymize-leaf-memoize :message "good old string")))
     (is (= 50 (count (anonymize-leaf-memoize :message "good old string"))))))
+
+(deftest test-memoized-vector-elements
+  (testing "should memoize individual vector elements"
+    (is (= (take 2 (anonymize-leaf-memoize :fact-value [1 2 3]))
+           (take 2 (anonymize-leaf-memoize :fact-value [1 2 10]))))))
 
 (deftest test-anonymize-leaf-file
   (testing "should return a string 54 characters long"


### PR DESCRIPTION
This changes our anonymization code so that structured facts like
{:foo {:bar "baz"}} and {:foo {:bar "biz"}} will be identical when anonymized
except for the element that differs. This also changes our handling of arrays so
[1 2 3] and [1 2 4] will only differ in the last element when anonymized.
Finally, this bumps our use of (rand-int 300) to (rand-int (min value 20)),
which should ensure that the integers we get are sufficiently diverse.