### PR TITLE
(PDB-1924) Add missing subquery selects

### DIFF
--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -4,11 +4,17 @@ layout: default
 canonical: "/puppetdb/latest/api/query/v4/operators.html"
 ---
 
-[resources]: ./resources.html
+[catalogs]: ./catalogs.html
+[edges]: ./edges.html
+[environments]: ./environments.html
+[events]: ./events.html
 [facts]: ./facts.html
+[fact-contents]: ./fact-contents.html
+[fact-paths]: ./fact-paths.html
 [nodes]: ./nodes.html
 [query]: ./query.html
-[fact-contents]: ./fact-contents.html
+[reports]: ./reports.html
+[resources]: ./resources.html
 
 PuppetDB's [query strings][query] can use several common operators.
 
@@ -171,10 +177,11 @@ To get the average uptime for your nodes,
 ## Subquery Operators
 
 Subqueries allow you to correlate data from multiple sources or multiple
-rows. (For instance, a query such as "fetch the IP addresses of all nodes with
-`Class[Apache]`" would have to use both facts and resources to return a list of facts.)
+rows. For instance, a query such as "fetch the IP addresses of all nodes with
+`Class[Apache]`" would have to use both facts and resources to return a list of facts.
 
-Subqueries are unlike the other operators listed above. They always appear together in the following form:
+Subqueries are unlike the other operators listed above. They always appear together
+in the following form:
 
     ["in", ["<FIELDS>"], ["extract", ["<FIELDS>"], <SUBQUERY STATEMENT>] ]
 
@@ -195,8 +202,6 @@ Subquery | Extract | In
 Every resource whose type is "Class" and title is "Apache." (Note that all resource objects have a `certname` field, among other fields.) | Every `certname` field from the results of the subquery. | Match if the `certname` field is present in the list from the `extract` statement.
 
 The complete `in` statement described in the table above would match any object that shares a `certname` with a node that has `Class[Apache]`. This could be combined with a boolean operator to get a specific fact from every node that matches the `in` statement.
-
-**Note:** Unlike in the v4 API, the v2 and v3 'in' and 'extract' operators do not permit vector-valued fields.
 
 ### `in`
 
@@ -231,14 +236,18 @@ As the second argument of an `extract` statement, a subquery statement acts as a
 
 ### Available Subqueries
 
-Each subquery acts as a normal query to one of the PuppetDB endpoints. For info on constructing useful queries, see the docs page for that endpoint.
+Each subquery acts as a normal query to one of the PuppetDB endpoints. For info on constructing useful queries, see the docs page for the endpoint matching the subquery:
 
-The available subqueries are:
-
-* `select_facts` (queries the [facts][] endpoint)
-* `select_fact_contents` (queries the [fact-contents][] endpoint)
-* `select_nodes` (queries the [nodes][] endpoint)
-* `select_resources` (queries the [resources][] endpoint)
+* [`select_catalogs`][catalogs]
+* [`select_edges`][edges]
+* [`select_environments`][environments]
+* [`select_events`][events]
+* [`select_facts`][facts]
+* [`select_fact_contents`][fact-contents]
+* [`select_fact_paths`][fact-paths]
+* [`select_nodes`][nodes]
+* [`select_reports`][reports]
+* [`select_resources`][resources]
 
 ### Subquery Examples
 
@@ -285,14 +294,15 @@ facts_environment `production`:
           ["select_nodes",
             ["=", "facts_environment", "production"]]]]]
 
-To find node information for a host that has a macaddress of `aa:bb:cc:dd:ee:00`, you could use this query on '/nodes':
+To find node information for a host that has a macaddress of `aa:bb:cc:dd:ee:00` as
+its first macaddress on the interface `eth0`, you could use this query on '/nodes':
 
     ["in", "certname",
       ["extract", "certname",
         ["select_fact_contents",
           ["and",
-            ["=", "path", [ "networking", "eth0", "macaddresses", 0 ]],
-            ["=", "value", "aa:bb:cc:dd:ee:00" ]]]]]
+            ["=", "path", ["networking", "eth0", "macaddresses", 0]],
+            ["=", "value", "aa:bb:cc:dd:ee:00"]]]]]
 
 To exhibit a subquery using multiple fields, you could use the following
 on '/facts' to list all top-level facts containing fact contents with paths

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -190,7 +190,6 @@
                                      :queryable? false
                                      :query-only? true
                                      :field :fp.path}
-
                              "value" {:type :multi
                                       :queryable? true
                                       :field :fv.value}
@@ -901,11 +900,18 @@
 ;;;              language
 
 (def user-name->query-rec-name
-  {"select_facts" facts-query
+  {"select_catalogs" catalog-query
+   "select_edges" edges-query
+   "select_environments" environments-query
+   "select_events" report-events-query
+   "select_facts" facts-query
+   "select_factsets" factsets-query
    "select_fact_contents" fact-contents-query
+   "select_fact_paths" fact-paths-query
    "select_nodes" nodes-query
    "select_latest_report" latest-report-query
    "select_params" resource-params-query
+   "select_reports" reports-query
    "select_resources" resources-query})
 
 (defn user-query->logical-obj

--- a/test/puppetlabs/puppetdb/http/catalogs_test.clj
+++ b/test/puppetlabs/puppetdb/http/catalogs_test.clj
@@ -8,7 +8,9 @@
             [puppetlabs.puppetdb.http :as http]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.testutils :refer [get-request deftestseq strip-hash]]
-            [puppetlabs.puppetdb.testutils.http :refer [query-response vector-param]]
+            [puppetlabs.puppetdb.testutils.http :refer [query-response
+                                                        query-result
+                                                        vector-param]]
             [puppetlabs.puppetdb.testutils.catalogs :as testcat]))
 
 (def endpoints [[:v4 "/v4/catalogs"]])
@@ -140,6 +142,38 @@
     (let [{:keys [body]} (query-response method (str endpoint "/myhost.localdomain"))
           response-body  (json/parse-string body true)]
       (is (= "myhost.localdomain" (:certname response-body))))))
+
+(deftestseq catalog-subqueries
+  [[version endpoint] endpoints
+   method [:get :post]]
+
+  (testcat/replace-catalog (json/generate-string catalog1))
+  (testcat/replace-catalog (json/generate-string catalog2))
+
+  (are [query expected]
+      (is (= (query-result method endpoint query {} strip-hash)
+             expected))
+
+    ;;;;;;;;;;
+    ;; Resources
+    ;;;;;;;;;;
+
+    ["extract" "certname"
+     ["in" "certname"
+      ["extract" "certname"
+       ["select_resources"
+        ["=" "type" "Apt::Pin"]]]]]
+    #{{:certname "myhost.localdomain"}
+      {:certname "host2.localdomain"}}
+
+    ;; Edges
+    ["extract" "certname"
+     ["in" "certname"
+      ["extract" "certname"
+       ["select_edges"
+        ["=" "target_type" "File"]]]]]
+    #{{:certname "host2.localdomain"}
+      {:certname "myhost.localdomain"}}))
 
 (def no-parent-endpoints [[:v4 "/v4/catalogs/foo/edges"]
                           [:v4 "/v4/catalogs/foo/resources"]])

--- a/test/puppetlabs/puppetdb/http/environments_test.clj
+++ b/test/puppetlabs/puppetdb/http/environments_test.clj
@@ -86,6 +86,7 @@
            {:name "bar"}
            {:name "baz"}}
 
+         ;; Facts
          ["in" "name"
           ["extract" "environment"
            ["select_facts"
@@ -105,6 +106,7 @@
            {:name "bar"}
            {:name "baz"}}
 
+         ;; Facts with resources
          ["in" "name"
           ["extract" "environment"
            ["select_facts"
@@ -113,20 +115,19 @@
              ["in" "value"
               ["extract" "title"
                ["select_resources"
-                ["and"
-                 ["=" "type" "Class"]]]]]]]]]
+                ["=" "type" "Class"]]]]]]]]
          #{{:name "DEV"}}))
 
   (testing "failed comparison"
     (are [query]
-         (let [{:keys [status body]} (query-response method endpoint query)]
-           (re-find
+          (let [{:keys [status body]} (query-response method endpoint query)]
+            (re-find
              #"Query operators >,>=,<,<= are not allowed on field name" body))
 
-         ["<=" "name" "foo"]
-         [">=" "name" "foo"]
-         ["<" "name" "foo"]
-         [">" "name" "foo"])))
+      ["<=" "name" "foo"]
+      [">=" "name" "foo"]
+      ["<" "name" "foo"]
+      [">" "name" "foo"])))
 
 (def no-parent-endpoints [[:v4 "/v4/environments/foo/events"]
                           [:v4 "/v4/environments/foo/facts"]

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -574,6 +574,26 @@
     (is (= 1 (count basic-result)))
     (is (= basic-result (munge-reports-for-comparison [basic])))))
 
+(deftestseq report-subqueries
+  [[version endpoint] endpoints
+   method [:get :post]]
+
+  (store-example-report! (:basic reports) (now))
+  (store-example-report! (:basic2 reports) (now))
+  (store-example-report! (:basic3 reports) (now))
+
+  (are [query expected]
+      (is (= expected
+             (query-result method endpoint query)))
+
+    ;; Events
+    ["extract" "certname"
+     ["in" "hash"
+      ["extract" "report"
+       ["select_events"
+        ["=" "file" "bar"]]]]]
+    #{{:certname "foo.local"}}))
+
 (def invalid-projection-queries
   (omap/ordered-map
     ;; Top level extract using invalid fields should throw an error


### PR DESCRIPTION
This patch fleshes out the rest of the selects for subqueries, to allow
subqueries across all the remaining (meaningful) endpoints.

Signed-off-by: Ken Barber <ken@bob.sh>