### PR TITLE
(PDB-1100) Remove validation regex for classnames in terminus

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -284,22 +284,6 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
                 resource_hash = {'type' => resource['type'], 'title' => resource['title']}
                 other_hash = resource_ref_to_hash(other_ref)
 
-                # Puppet doesn't always seem to check this correctly. If we don't
-                # users will later get an invalid relationship error instead.
-                #
-                # Primarily we are trying to catch the non-capitalized resourceref
-                # case problem here: http://projects.puppetlabs.com/issues/19474
-                # Once that problem is solved and older versions of Puppet that have
-                # the bug are no longer supported we can probably remove this code.
-                unless other_ref =~ /^[A-Z][a-z0-9_-]*(::[A-Z][a-z0-9_-]*)*\[.*\]/m
-                  rel = edge_to_s(resource_hash_to_ref(resource_hash), other_ref, param)
-                  raise Puppet::Error, "Invalid relationship: #{rel}, because " +
-                    "#{other_ref} doesn't seem to be in the correct format. " +
-                    "Resource references should be formatted as: " +
-                    "Classname['title'] or Modulename::Classname['title'] (take " +
-                    "careful note of the capitalization)."
-                end
-
                 # This is an unfortunate hack.  Puppet does some weird things w/rt
                 # munging off trailing slashes from file resources, and users may
                 # legally specify relationships using a different number of trailing

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -608,14 +608,6 @@ describe Puppet::Resource::Catalog::Puppetdb do
         }.to raise_error(Puppet::Error, "Invalid relationship: Notify[anyone] { subscribe => Notify[non-existent] }, because Notify[non-existent] doesn't seem to be in the catalog")
       end
 
-      it "should produce a reasonable error message for an invalid resourceref" do
-        resource[:subscribe] = 'Foobar::baz[name]'
-
-        hash = subject.add_parameters_if_missing(catalog_data_hash)
-        expect {
-          subject.synthesize_edges(hash, catalog)
-        }.to raise_error(Puppet::Error, "Invalid relationship: Notify[anyone] { subscribe => Foobar::baz[name] }, because Foobar::baz[name] doesn't seem to be in the correct format. Resource references should be formatted as: Classname['title'] or Modulename::Classname['title'] (take careful note of the capitalization).")
-      end
     end #synthesize_edges
 
     describe "#munge_catalog" do


### PR DESCRIPTION
This commit removes the classname validation regex in the terminus now
that we no longer support Puppet <4 for PuppetDB.