### PR TITLE
Adding cms-puppetdb-tools to list of community add-ons

### DIFF
--- a/documentation/community_add_ons.markdown
+++ b/documentation/community_add_ons.markdown
@@ -50,5 +50,3 @@ runs - that is, something is changing back and forth over and over again.
 * `puppetdb-tooquiet` - lists hosts that have not checked in over the last two hours (configurable)
 
 There are also a variety of tools for querying specific system facts and providing useful reports, which are tied to the upstream environment fact list.  
-
-* 

--- a/documentation/community_add_ons.markdown
+++ b/documentation/community_add_ons.markdown
@@ -12,12 +12,12 @@ canonical: "/puppetdb/latest/community_add_ons.html"
 [query]: https://github.com/dalen/puppet-puppetdbquery
 [exports]: http://forge.puppetlabs.com/zack/exports
 [exported]: /puppet/latest/reference/lang_exported.html
+[cms-puppetdb-tools]: https://github.com/tskirvin/cms-puppetdb-tools
 
 [Jason Hancock --- nagios-puppetdb][nagios]
 -----
 
 [A collection of Nagios scripts/plugins for monitoring PuppetDB.][nagios] These plugins get data using [PuppetDB's metrics APIs](./api/query/v1/metrics.html). Pulling this data into Nagios lets you monitor key metrics over time and receive alerts when they cross certain thresholds. This can partially or completely replace the [built-in performance dashboard][dashboard]. Especially useful for knowing when the heap size or thread count needs tuning.
-
 
 [Erik Dalén --- PuppetDB query functions for Puppet][query]
 -----
@@ -38,3 +38,17 @@ canonical: "/puppetdb/latest/community_add_ons.html"
 * `puppet node exports`
 * `puppet node exports file`
 * `puppet node exports file,user`
+
+[Tim Skirvin -- cms-puppetdb-tools (puppetdb CLI tools)][cms-puppetdb-tools]
+-----
+
+[A set of command-line scripts for querying the puppetdb.][cms-puppetdb-tools].  This was originally written for use in a specific puppet environment, and includes a few scripts that are more generally useful.  This includes:
+
+* `puppetdb-tangled` - lists "tangled" host - that is, where  the most recent report was a success in which something changed (an event status changed), and some number of these changes have occurred several time in the last several
+runs - that is, something is changing back and forth over and over again.  
+* `puppetdb-failed` - lists hosts that failed in their last puppet run.
+* `puppetdb-tooquiet` - lists hosts that have not checked in over the last two hours (configurable)
+
+There are also a variety of tools for querying specific system facts and providing useful reports, which are tied to the upstream environment fact list.  
+
+* 


### PR DESCRIPTION
cms-puppetdb-tools contains a set of CLI puppetbb query scripts, and is probably ready enough for people to look at.