### PR TITLE
(PDB-2039) WIP - Proof of concept code on securing at the node level

### DIFF
--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -90,13 +90,14 @@
 (defn- enqueue-command-handler
   "Enqueues the command in request and returns a UUID"
   [enqueue-fn get-response-pub]
-  (fn [{:keys [body-string params] :as request}]
+  (fn [{:keys [body-string params ssl-client-cn] :as request}]
+    (clojure.pprint/pprint request)
     (let [uuid (kitchensink/uuid)
           completion-timeout-ms (some-> params
                                         (get "secondsToWaitForCompletion")
                                         Double/parseDouble
                                         (* 1000))
-          do-submit #(enqueue-fn body-string uuid)]
+          do-submit #(enqueue-fn body-string uuid ssl-client-cn)]
       (if (some-> completion-timeout-ms pos?)
         (blocking-submit-command do-submit (get-response-pub) uuid completion-timeout-ms)
         (do

--- a/src/puppetlabs/puppetdb/mq.clj
+++ b/src/puppetlabs/puppetdb/mq.clj
@@ -150,6 +150,7 @@
   "Creates a map of custom headers included in `message`, currently only
   supports String headers."
   [^Message msg]
+  (println "the thing: " (enumeration-seq (.getPropertyNames msg)))
   (reduce (fn [acc k]
             (assoc acc
               (keyword k)
@@ -199,6 +200,7 @@
   {:-to-jms-message (fn [x properties session]
                       (let [msg (.createTextMessage session x)]
                         (doseq [[name value] properties]
+                          (println (format "Setting name: %s and value: %s" name value))
                           (-set-jms-property! value name msg))
                         msg))})
 
@@ -214,6 +216,7 @@
 (defn to-jms-message
   "Converts x to a JMSMessage with the given properties via session."
   [session x properties]
+  (println "Properties: " properties)
   (-to-jms-message x properties session))
 
 (defmacro commit-or-rollback

--- a/src/puppetlabs/puppetdb/mq_listener.clj
+++ b/src/puppetlabs/puppetdb/mq_listener.clj
@@ -346,7 +346,9 @@
      (reify MessageListener
        (onMessage [this msg]
          (try
-           (mq/commit-or-rollback sess (handle (mq/convert-jms-message msg)))
+           (let [converted-message (mq/convert-jms-message msg)]
+             (println "converted message " converted-message)
+             (mq/commit-or-rollback sess (handle converted-message)))
            (catch Throwable ex
              (log/error ex "message receive failed")
              (throw ex))))))
@@ -398,5 +400,6 @@
   (process-message [this message]
     (if-let [handler-fn (matching-handler @(:listeners (service-context this))
                                           message)]
-      (handler-fn message)
+      (do (println "calling handler-fn with " message)
+          (handler-fn message))
       (log/warnf "No message handler found for %s" message))))

--- a/test-resources/puppetlabs/puppetdb/cli/export/tiny-catalog.json
+++ b/test-resources/puppetlabs/puppetdb/cli/export/tiny-catalog.json
@@ -1,5 +1,7 @@
-{
-    "certname" : "myhost.localdomain",
+{"command": "replace catalog",
+ "version": 6,
+ "payload": {
+    "certname" : "centos7.vm",
     "producer_timestamp": "2014-07-10T22:33:54.781Z",
     "edges" : [ {
         "relationship" : "contains",
@@ -44,4 +46,5 @@
     "version" : "1330463446",
     "transaction_uuid" : "68b08e2a-eeb1-4322-b241-bfdf151d294c",
     "environment" : "DEV"
+}
 }


### PR DESCRIPTION
This commit hacks in the ssl client cert to the JMS message header to be
validated when the command is pulled off the queue.

There's still plenty of work left. Currently this is just a hack. There
needs to be a config option to turn this on. It needs to be added to
each command type (currently it's only on catalogs) and we also need to
have a cert whitelist check. There's probably a bunch of broken tests too.