### PR TITLE
(pdb-2034) schema error on replace-facts with escape-quoted strings

### DIFF
--- a/src/puppetlabs/puppetdb/facts.clj
+++ b/src/puppetlabs/puppetdb/facts.clj
@@ -69,7 +69,7 @@
 (defn unescape-string
   "Strip escaped quotes from a string."
   [^String s]
-  (if (= \" (.charAt s 0))
+  (if (= \" (first s) (last s))
     (subs s 1 (dec (.length s)))
     s))
 

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -958,6 +958,7 @@
   (if-let [pathstrs (seq pathstrs)]
     (let [existing-path-ids (existing-row-ids :fact_paths "path" pathstrs identity
                                               String "text")
+
           missing-db-paths (set/difference (set pathstrs)
                                            (set (keys existing-path-ids)))]
       (merge existing-path-ids
@@ -1022,7 +1023,8 @@
       (insert-facts-pv-pairs! (certname-to-factset-id certname)
                               (map #(vector (get paths-to-ids %1)
                                             (get vhashes-to-ids %2))
-                                   pathstrs vhashes))))))
+                                   (map facts/unescape-string pathstrs)
+                                   vhashes))))))
 
 (defn-validated update-facts!
   "Given a certname, querys the DB for existing facts for that
@@ -1051,7 +1053,8 @@
          ;; Add new facts and remove obsolete facts.
          replacement-pv-pairs (set (map #(vector (paths-to-ids %1)
                                                  (vhashes-to-ids %2))
-                                        pathstrs vhashes))
+                                        (map facts/unescape-string pathstrs)
+                                        vhashes))
          current-pairs (set (select-pid-vid-pairs-for-factset factset-id))
          [new-pairs rm-pairs] (data/diff replacement-pv-pairs current-pairs)]
 

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -56,6 +56,22 @@
     (zipmap (map :name result)
             (map :value result))))
 
+(deftest escaped-string-factnames
+  (testing "should work with escaped strings"
+    (let [certname "some_certname"
+          facts {"\"hello\"" "world"
+                 "foo#~bar" "baz"
+                 "\"foo" "bar"
+                 "foo#~" "bar"
+                 "foo" "bar"}]
+      (add-certname! certname)
+
+      (add-facts! {:certname certname
+                   :values facts
+                   :timestamp previous-time
+                   :environment nil
+                   :producer_timestamp previous-time}))))
+
 (deftest fact-persistence
   (testing "Persisted facts"
     (let [certname "some_certname"


### PR DESCRIPTION
Without this commit we're broken on escape-quoted fact names and fact names
containing #~. Some escape-quoting we do before storage was causing different
names to come out of realize-paths! than went in, which caused an empty key
lookup that led to the error.