### PR TITLE
(pdb-2034) schema error on replace-facts with escape-quoted strings

### DIFF
--- a/src/puppetlabs/puppetdb/facts.clj
+++ b/src/puppetlabs/puppetdb/facts.clj
@@ -66,13 +66,6 @@
     (str "\"" string "\"")
     string))
 
-(defn unescape-string
-  "Strip escaped quotes from a string."
-  [^String s]
-  (if (= \" (.charAt s 0))
-    (subs s 1 (dec (.length s)))
-    s))
-
 (pls/defn-validated encode-factpath-element :- s/Str
   "Converts a fact-path-element to an encoded string ready for database storage."
   [element :- fact-path-element]
@@ -100,14 +93,17 @@
       (catch Exception e
         nil))))
 
+(def escape-quoted-num
+  (re-pattern "^\"\\d+\"$"))
+
 (defn unencode-path-segment
   "Attempt to coerce string to number, otherwise unescape."
   [^String s]
   (if-let [num (str->num s)]
     num
-    (-> s
-        unescape-string
-        unescape-delimiter)))
+    (if (re-matches escape-quoted-num s)
+      (subs s 1 (dec (.length s)))
+      (unescape-delimiter s))))
 
 (pls/defn-validated string-to-factpath :- fact-path
   "Converts a database encoded string back to a factpath."

--- a/test/puppetlabs/puppetdb/facts_test.clj
+++ b/test/puppetlabs/puppetdb/facts_test.clj
@@ -11,23 +11,13 @@
        nil "foo"
        nil "123foo"))
 
-(deftest test-unescape-string
-  (are [unescaped s] (= unescaped (unescape-string s))
-
-       "foo" "\"foo\""
-       "foo" "foo"
-       "123" "123"
-       "123foo" "\"123foo\""))
-
 (deftest test-unencode-path-segment
   (are [path-segment s] (= path-segment (unencode-path-segment s))
-
-       "foo" "\"foo\""
-       "\"foo\"" "\"\"foo\"\""
+       "\"foo\"" "\"foo\""
+       "\"\"foo\"\"" "\"\"foo\"\""
        "foo" "foo"
-
        "123" "\"123\""
-       "123foo" "\"123foo\""
+       "\"123foo\"" "\"123foo\""
        1 "1"
        123 "123"))
 

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -91,6 +91,26 @@
                     first
                     :c)))))))
 
+(deftest escaped-string-factnames
+  (testing "should work with escaped strings"
+    (let [certname "some_certname"
+          facts {"\"hello\"" "world"
+                 "foo#~bar" "baz"
+                 "\"foo" "bar"
+                 "foo#~" "bar"
+                 "foo" "bar"}]
+      (add-certname! certname)
+
+      (add-facts! {:certname certname
+                   :values facts
+                   :timestamp previous-time
+                   :environment nil
+                   :producer_timestamp previous-time})
+      (let [stored-names (->> (jdbc/query ["SELECT name from fact_paths"])
+                              (map :name)
+                              set)]
+        (is (= stored-names (set (keys facts))))))))
+
 (deftest fact-persistence
   (testing "Persisted facts"
     (let [certname "some_certname"


### PR DESCRIPTION
Without this commit we're broken on escape-quoted fact names and fact names
containing #~. Some escape-quoting we do before storage was causing different
names to come out of realize-paths! than went in, which caused an empty key
lookup that led to the error.