### PR TITLE
(PDB-1996) Make query-recs defs rather than defns

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -57,28 +57,17 @@
      :resources {:munge resources/munge-result-rows
                  :rec eng/resources-query}}))
 
-(defn assoc-in-idx!
-  "assoc into the entity index as if query recs were maps"
-  [[entity & ks] v]
-  (if (and (= :rec (first ks)) (next ks))
-    ;; if it's a query rec and we're updating a nested component, call the
-    ;; existing rec and wrap val in a function
-    (let [rec' (-> ((get-in @entity-fn-idx [entity :rec]))
-                   (assoc-in (next ks) v))]
-      (swap! entity-fn-idx assoc-in [entity :rec] (fn [] rec')))
-    (swap! entity-fn-idx assoc-in (cons entity ks) v)))
-
 (defn get-munge
   [entity]
   (get-in @entity-fn-idx [entity :munge]))
 
 (defn orderable-columns
   [query-rec]
-  (if-not query-rec
-    []
-    (for [[projection-key projection-value] (:projections (query-rec))
-          :when (and (not= projection-key "value") (:queryable? projection-value))]
-      (keyword projection-key))))
+  (vec
+   (for [[projection-key projection-value] (:projections query-rec)
+         :when (and (not= projection-key "value")
+                    (:queryable? projection-value))]
+     (keyword projection-key))))
 
 (defn query->sql
   "Converts a vector-structured `query` to a corresponding SQL query which will

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -55,12 +55,11 @@
   [{:keys [entity] :as query-rec}]
   (cond-> query-rec
     (= :facts entity) (assoc-in [:projections "value" :field]
-                        (h/coalesce :fv.value_string
-                                    (h/scast :fv.value_boolean :text)))))
+                                (h/coalesce :fv.value_string
+                                            (h/scast :fv.value_boolean :text)))))
 
-(defn nodes-query
+(def nodes-query
   "Query for nodes entities, mostly used currently for subqueries"
-  []
   (map->Query {:projections {"certname" {:type :string
                                          :queryable? true
                                          :field :certnames.certname}
@@ -125,9 +124,8 @@
                :alias "nodes"
                :subquery? false}))
 
-(defn resource-params-query
+(def resource-params-query
   "Query for the resource-params query, mostly used as a subquery"
-  []
   (map->Query {:projections {"res_param_resource" {:type :string
                                                    :queryable? true
                                                    :field (hsql-hash-as-str :resource)}
@@ -143,9 +141,8 @@
                :alias "resource_params"
                :subquery? false}))
 
-(defn fact-paths-query
+(def fact-paths-query
   "Query for the resource-params query, mostly used as a subquery"
-  []
   (map->Query {:projections {"type" {:type :string
                                      :queryable? true
                                      :field :type}
@@ -168,8 +165,7 @@
                :alias "fact_paths"
                :subquery? false}))
 
-(defn fact-names-query
-  []
+(def fact-names-query
   (map->Query {:projections {"name" {:type :string
                                      :queryable? true
                                      :field :name}}
@@ -179,9 +175,8 @@
                :alias "fact_names"
                :subquery? false}))
 
-(defn facts-query
+(def facts-query
   "Query structured facts."
-  []
   (map->Query {:projections {"path" {:type :string
                                      :queryable? false
                                      :query-only? true
@@ -237,9 +232,8 @@
                :entity :facts
                :subquery? false}))
 
-(defn fact-contents-query
+(def fact-contents-query
   "Query for fact nodes"
-  []
   (map->Query {:projections {"path" {:type :path
                                      :queryable? true
                                      :field :fp.path}
@@ -288,10 +282,9 @@
                :source-table "facts"
                :subquery? false}))
 
-(defn report-logs-query
+(def report-logs-query
   "Query intended to be used by the `/reports/<hash>/logs` endpoint
   used for digging into the logs for a specific report."
-  []
   (map->Query {:projections {"logs" {:type :json
                                      :queryable? false
                                      :field (h/coalesce
@@ -307,10 +300,9 @@
                :entity :reports
                :source-table "reports"}))
 
-(defn report-metrics-query
+(def report-metrics-query
   "Query intended to be used by the `/reports/<hash>/metrics` endpoint
   used for digging into the metrics for a specific report."
-  []
   (map->Query {:projections {"metrics" {:type :json
                                         :queryable? false
                                         :field (h/coalesce
@@ -328,9 +320,8 @@
                :entity :reports
                :source-table "reports"}))
 
-(defn reports-query
+(def reports-query
   "Query for the reports entity"
-  []
   (map->Query
     {:projections
      {"hash"            {:type :string
@@ -418,9 +409,8 @@
      :entity :reports
      :source-table "reports"}))
 
-(defn catalog-query
+(def catalog-query
   "Query for the top level catalogs entity"
-  []
   (map->Query
     {:projections
      {"version" {:type :string
@@ -491,9 +481,8 @@
      :subquery? false
      :source-table "catalogs"}))
 
-(defn edges-query
+(def edges-query
   "Query for catalog edges"
-  []
   (map->Query {:projections {"certname" {:type :string
                                          :queryable? true
                                          :field :edges.certname}
@@ -530,9 +519,8 @@
                :subquery? false
                :source-table "edges"}))
 
-(defn resources-query
+(def resources-query
   "Query for the top level resource entity"
-  []
   (map->Query {:projections {"certname" {:type  :string
                                          :queryable? true
                                          :field :c.certname}
@@ -580,9 +568,8 @@
                :subquery? false
                :source-table "catalog_resources"}))
 
-(defn report-events-query
+(def report-events-query
   "Query for the top level reports entity"
-  []
   (map->Query {:projections {"certname" {:type :string
                                          :queryable? true
                                          :field :reports.certname}
@@ -654,9 +641,8 @@
                :entity :events
                :source-table "resource_events"}))
 
-(defn latest-report-query
+(def latest-report-query
   "Usually used as a subquery of reports"
-  []
   (map->Query {:projections {"latest_report_hash" {:type :string
                                                    :queryable? true
                                                    :field (hsql-hash-as-str :reports.hash)}}
@@ -668,9 +654,8 @@
                :subquery? false
                :source-table "latest_report"}))
 
-(defn environments-query
+(def environments-query
   "Basic environments query, more useful when used with subqueries"
-  []
   (map->Query {:projections {"name" {:type :string
                                      :queryable? true
                                      :field :environment}}
@@ -680,9 +665,8 @@
                :subquery? false
                :source-table "environments"}))
 
-(defn factsets-query
+(def factsets-query
   "Query for the top level facts query"
-  []
   (map->Query
     {:projections
      {"timestamp" {:type :timestamp
@@ -899,7 +883,9 @@
   "Keypairs of the stringified subquery keyword (found in user defined queries) to the
    appropriate plan node"
   [subquery]
-  (augment-for-subquery (assoc ((get user-name->query-rec-name subquery)) :subquery? true)))
+  (-> (get user-name->query-rec-name subquery)
+      (assoc :subquery? true)
+      augment-for-subquery))
 
 (def binary-operators
   #{"=" ">" "<" ">=" "<=" "~"})
@@ -1382,8 +1368,7 @@
   [query-rec user-query & [{:keys [include_total] :as paging-options}]]
   ;; Call the query-rec so we can evaluate query-rec functions
   ;; which depend on the db connection type
-  (let [query-rec (query-rec)
-        allowed-fields (map keyword (queryable-fields query-rec))
+  (let [allowed-fields (map keyword (queryable-fields query-rec))
         paging-options (some->> paging-options
                                 (paging/validate-order-by! allowed-fields)
                                 (paging/dealias-order-by query-rec))

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetdb.scf.storage :as scf-store]
             [puppetlabs.puppetdb.query-eng.engine :refer :all]
-            [puppetlabs.puppetdb.query-eng :refer [entity-fn-idx assoc-in-idx!]]
+            [puppetlabs.puppetdb.query-eng :refer [entity-fn-idx]]
             [clj-time.core :refer [now]]
             [puppetlabs.puppetdb.fixtures :as fixt]
             [puppetlabs.puppetdb.jdbc :refer [with-transacted-connection]]
@@ -96,7 +96,6 @@
                         #"'foo' is not a queryable object for resources, known queryable objects are.*"
                         (compile-user-query->sql resources-query ["=" "foo" "bar"]))))
 
-
 (defn fact-names-tests
   "test that we can modify a query rec. This is a function because the actual
    test needs to use the with-http-app fixture, which the rest of this ns
@@ -152,18 +151,19 @@
           (is (= result expected-result))))
 
       (testing "query rec is modifiable"
-        (assoc-in-idx! [:fact-names :munge] (fn [_ _] identity))
+        (swap! entity-fn-idx assoc-in [:fact-names :munge] (fn [_ _] identity))
 
-        (assoc-in-idx! [:fact-names :rec :projections "depth"] {:type :integer
-                                                                :queryable? true
-                                                                :field :depth})
+        (swap! entity-fn-idx
+               assoc-in [:fact-names :rec :projections "depth"] {:type :integer
+                                                                 :queryable? true
+                                                                 :field :depth})
         (let [request (get-request endpoint)
               {:keys [status body]} (fixt/*app* request)
               result (vec (parse-result body))]
           (is (= status http/status-ok))
           (is (= result (map #(hash-map :name % :depth 0) expected-result)))))
 
-      (swap! entity-fn-idx (fn [_] initial-idx))
+      (reset! entity-fn-idx initial-idx)
       (testing "fact-names back to normal"
         (let [request (get-request endpoint)
               {:keys [status body]} (fixt/*app* request)


### PR DESCRIPTION
This commit makes our query-recs defs rather than defns, now that hsqldb
has been removed.