### PR TITLE
(PDB-2007) array params with undef don't sort

### DIFF
--- a/acceptance/tests/storeconfigs/basic_collection.rb
+++ b/acceptance/tests/storeconfigs/basic_collection.rb
@@ -44,4 +44,27 @@ node "#{name}" {
       end
     end
   end
+
+  step "attempt export with undef array elements" do
+    manifest = <<-MANIFEST
+    @@notify { "test":
+            tag => [undef, "a", "b"],
+            }
+    MANIFEST
+
+    manifest_path = create_remote_site_pp(master, manifest)
+    with_puppet_running_on master, {
+      'master' => {
+        'autosign' => 'true',
+    },
+    'main' => {
+      'environmentpath' => manifest_path
+    }
+    } do
+
+      step "run agent on master to ensure no failure" do
+        run_agent_on master, "--test --server #{master}", :acceptable_exit_codes => [0,2]
+      end
+    end
+  end
 end

--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -214,7 +214,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
         params = resource['parameters']
         UnorderedMetaparams.each do |metaparam|
           if params[metaparam].kind_of? Array then
-            values = params[metaparam].sort
+            values = params[metaparam].sort_by {|x| x.to_s}
             params[metaparam] = values unless values.empty?
           end
         end


### PR DESCRIPTION
This fixes a discrepancy between JVM puppetserver and Puppet with respect to our
terminus, where manifests like

@@notify { "test":
    tag => [undef, "a", "b"],
}

would fail due to inability to compare symbols and strings. With this patch, we
sort by string representation rather than sorting the array directly.