### PR TITLE
(PDB-2049) Allow aggregates to omit subexpression

### DIFF
--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -149,8 +149,9 @@ Extract can also be used with a standalone function application:
 
     ["extract", [["function", "count"]], ["~", "certname", ".\*.com"]]
 
-At this time extract must always have an expression to extract from, like `["=", "certname", "foo.com"]`
-in the example above.
+or 
+
+    ["extract", [["function", "count"]]]
 
 ### `function`
 

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -1228,19 +1228,19 @@
                                         (not (empty? call)) (assoc :call call))]
               (create-extract-node query-rec-with-call cols nil))
 
-            [["extract" column expr]]
-            (let [[fargs cols] (strip-function-calls column)
-                  call (replace-numeric-args fargs)
-                  query-rec-with-call (cond-> query-rec
-                                        (not (empty? call)) (assoc :call call))]
-              (create-extract-node query-rec-with-call cols expr))
-
             [["extract" columns ["group_by" & clauses]]]
             (let [[fargs cols] (strip-function-calls columns)]
               (-> query-rec
                   (assoc :call (replace-numeric-args fargs))
                   (assoc :group-by clauses)
                   (create-extract-node cols nil)))
+
+            [["extract" column expr]]
+            (let [[fargs cols] (strip-function-calls column)
+                  call (replace-numeric-args fargs)
+                  query-rec-with-call (cond-> query-rec
+                                        (not (empty? call)) (assoc :call call))]
+              (create-extract-node query-rec-with-call cols expr))
 
             [["extract" columns expr ["group_by" & clauses]]]
             (let [[fargs cols] (strip-function-calls columns)]

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -1506,12 +1506,16 @@
      ["extract" [["function" "avg" "value"]] ["=" "name" "uptime_seconds"]]
      [{:avg 5000.0}]
 
-     ["extract" [["function" "count"] "value"] ["=" "name" "uptime_seconds"]
+     ["extract" [["function" "count"] "value"]
+      ["=" "name" "uptime_seconds"]
       ["group_by" "value"]]
-     [{:value 4000
-       :count 1}
-      {:value 6000
-       :count 1}]
+     [{:value 4000 :count 1}
+      {:value 6000 :count 1}]
+
+     ["extract" [["function" "count"] "value"]
+      ["group_by" "value"]]
+     [{:value 4000 :count 1}
+      {:value 6000 :count 1}]
 
      ["extract" [["function" "max" "name"] "environment"] ["~" "certname" ".*"]
       ["group_by" "environment"]]

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -74,6 +74,12 @@
       (is (= (query-result method endpoint ["extract" "certname"])
              #{{:certname "foo.local"} {:certname "bar.local"}})))
 
+    (testing "one projected column with no subquery and an aggregate function"
+      (is (= (query-result method endpoint ["extract" [["function" "count"] "certname"]
+                                            ["group_by" "certname"]])
+             #{{:count 1 :certname "foo.local"}
+               {:count 1 :certname "bar.local"}})))
+
     (testing "logs projected"
       (is (= (query-result method endpoint ["extract" "logs"
                                             ["=" "certname" (:certname basic)]])


### PR DESCRIPTION
This commit fixes a bug in `engine.clj` where the clauses for dealing
with `extract` were misordered so we had incorrect behavior when
handeling aggregates with a group-by clause without a subexpression.

This commit also removes some documentation claiming that a user must
supply a subexpression.