### PR TITLE
(PDB-1412) Update rspec dependency to `~> 3.1`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,8 @@ gem 'rake'
 
 group :test do
   # Pinning to work-around an incompatiblity with 2.14 in puppetlabs_spec_helper
-  gem 'rspec', '2.13.0'
-  gem 'puppetlabs_spec_helper', '0.4.1', :require => false
+  gem 'rspec', '~> 3.1'
+  gem 'puppetlabs_spec_helper', :require => false
 
   case puppet_branch
   when "latest"

--- a/puppet/spec/spec_helper.rb
+++ b/puppet/spec/spec_helper.rb
@@ -33,4 +33,8 @@ RSpec.configure do |config|
 
   end
 
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+
 end

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -85,7 +85,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
 
       it "should add nil transaction uuid if none was given" do
         result = subject.add_transaction_uuid(catalog_data_hash, nil)
-        result.has_key?('transaction_uuid').should be_true
+        result.has_key?('transaction_uuid').should be_truthy
         result['transaction_uuid'].should be_nil
       end
     end

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -105,7 +105,7 @@ describe processor do
           result = subject.send(:report_to_hash)
           # the server will populate the report id, so we validate that the
           # client doesn't include one
-          result.has_key?("report").should be_false
+          result.has_key?("report").should be_falsey
           result["certname"].should == subject.host
           result["puppet_version"].should == subject.puppet_version
           result["report_format"].should == subject.report_format

--- a/puppet/spec/unit/util/puppetdb/command_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/command_spec.rb
@@ -59,7 +59,7 @@ describe Puppet::Util::Puppetdb::Command do
   it "should not warn when the the string contains valid UTF-8 characters" do
     Puppet.expects(:warning).never
     cmd = described_class.new("command-1", 1, "foo.localdomain", {"foo" => "\u2192"})
-    cmd.payload.include?("\u2192").should be_true
+    cmd.payload.include?("\u2192").should be_truthy
   end
 
   describe "on ruby >= 1.9" do
@@ -67,7 +67,7 @@ describe Puppet::Util::Puppetdb::Command do
     it "should warn when a command payload includes non-ascii UTF-8 characters" do
       Puppet.expects(:warning).with {|msg| msg =~ /Error encoding a 'command-1' command for host 'foo.localdomain' ignoring invalid UTF-8 byte sequences/}
       cmd = described_class.new("command-1", 1, "foo.localdomain", {"foo" => [192].pack('c*')})
-      cmd.payload.include?("\ufffd").should be_true
+      cmd.payload.include?("\ufffd").should be_truthy
     end
 
     describe "Debug log testing of bad data" do
@@ -91,7 +91,7 @@ describe Puppet::Util::Puppetdb::Command do
             msg =~ /1 invalid\/undefined/
         end
         cmd = described_class.new("command-1", 1, "foo.localdomain", {"foo" => [192].pack('c*')})
-        cmd.payload.include?("\ufffd").should be_true
+        cmd.payload.include?("\ufffd").should be_truthy
       end
     end
   end

--- a/puppet/spec/unit/util/puppetdb/config_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/config_spec.rb
@@ -2,12 +2,6 @@ require 'spec_helper'
 require 'puppet/util/puppetdb/config'
 require 'puppet/util/puppetdb/command_names'
 
-# Create a local copy of these constants so that we don't have to refer to them
-# by their full namespaced name
-CommandReplaceCatalog   = Puppet::Util::Puppetdb::CommandNames::CommandReplaceCatalog
-CommandReplaceFacts     = Puppet::Util::Puppetdb::CommandNames::CommandReplaceFacts
-CommandStoreReport      = Puppet::Util::Puppetdb::CommandNames::CommandStoreReport
-
 describe Puppet::Util::Puppetdb::Config do
   describe "#load" do
     let(:confdir) do
@@ -62,7 +56,7 @@ soft_write_failure = true
 CONF
         config = described_class.load
         config.server_urls.should == [URI("https://main-server:1234")]
-        config.soft_write_failure.should be_true
+        config.soft_write_failure.should be_truthy
       end
 
       it "should use the default if no value is specified" do
@@ -70,7 +64,7 @@ CONF
 
         config = described_class.load
         config.server_urls.should == [URI("https://puppetdb:8081")]
-        config.soft_write_failure.should be_false
+        config.soft_write_failure.should be_falsey
       end
 
       it "should be insensitive to whitespace" do


### PR DESCRIPTION
This commit updates our rspec dependency to `~> 3.1` now that we no
longer support Puppet 3.