### PR TITLE
(PDB-2064) stop converting value equality queries to hash comparisons

### DIFF
--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -1774,7 +1774,7 @@
              [{"certname" "foo1", "name" "domain" "path" ["domain"], "value" "testing.com", "environment" "DEV"}
               {"certname" "foo2", "name" "domain" "path" ["domain"], "value" "testing.com", "environment" "DEV"}
               {"certname" "foo3", "name" "domain" "path" ["domain"], "value" "testing.com", "environment" "PROD"}]))
-      (is (= (into [] (response ["=" "value" nil]))
+      (is (= (into [] (response ["null?" "value" true]))
              [{"certname" "foo1", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "DEV"}
               {"certname" "foo3", "name" "my_structured_fact" "path" ["my_structured_fact" "f"], "value" nil, "environment" "PROD"}]))
       (is (= (into [] (response ["~" "name" "#~"]))


### PR DESCRIPTION
This changes our fact queries to use the proper string or boolean column
instead of converting equality queries to a comparison on value_hash.