### PR TITLE
(maint) add make and gcc to debian deps

### DIFF
--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -68,7 +68,7 @@ unless (test_config[:skip_presuite_provisioning])
           # Ubuntu 10.04 has rubygems 1.3.5 which is known to not be reliable, so therefore
           # we skip.
         else
-          on master, "apt-get install -y rubygems ruby-dev libsqlite3-dev"
+          on master, "apt-get install -y rubygems ruby-dev libsqlite3-dev build-essential"
           # this is to get around the activesupport dependency on Ruby 1.9.3 for
           # Ubuntu 12.04. We can remove it when we drop support for 1.8.7.
           on master, "gem install i18n -v 0.6.11"


### PR DESCRIPTION
I needed these on debian jessie to get the sqlite3 gem installed. No clue why
it's not needed on wheezy.  We can remove them and the rest of this code block
once we convince ourselves storeconfigs are dead.