### PR TITLE
(PDB-1798) add jessie to build targets

### DIFF
--- a/ext/jenkins/packaging.sh
+++ b/ext/jenkins/packaging.sh
@@ -12,7 +12,7 @@ echo "**********************************************"
 
 set -x
 
-export COW="base-precise-amd64.cow base-trusty-amd64.cow base-wheezy-amd64.cow"
+export COW="base-jessie-amd64.cow base-precise-amd64.cow base-trusty-amd64.cow base-wheezy-amd64.cow"
 export MOCK="pl-el-6-x86_64 pl-el-7-x86_64"
 tmp_m2=$(pwd)/$(mktemp -d m2-local.XXXX)
 


### PR DESCRIPTION
This adds jessie to our build targets. We probably shouldn't merge it until we
get a nightly run with a green cell on jessie.