### PR TITLE
(PDB-2096) Add not-found route to top-level `/pdb` route

### DIFF
--- a/src/puppetlabs/puppetdb/admin.clj
+++ b/src/puppetlabs/puppetdb/admin.clj
@@ -1,6 +1,5 @@
 (ns puppetlabs.puppetdb.admin
   (:require [compojure.core :as compojure]
-            [compojure.route :as route]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.export :as export]
             [puppetlabs.puppetdb.import :as import]
@@ -23,5 +22,4 @@
                             (http/json-response {:ok true}))))
        (compojure/GET "/v1/archive" [anonymization_profile]
                       (http/streamed-tar-response #(export/export! % query-fn anonymization_profile)
-                                                  (format "puppetdb-export-%s.tgz" (now))))
-       (route/not-found "Not Found"))))
+                                                  (format "puppetdb-export-%s.tgz" (now)))))))


### PR DESCRIPTION
This commit adds the `compojure.route/not-found` route at the top-level
of the PuppetDB routes so that new PuppetDB routes won't need to add the
not-found route. This also fixes an error where if a user hit any
non-existent route under `/pdb`, PDB would throw an exception related to
our middleware not playing nicely with not-founds which produced a
confusing `nil...status` error.