### PR TITLE
(PDB-1964) don't swallow errors in applied-migrations

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1486,7 +1486,9 @@
           results (jdbc/with-db-transaction []  (query-to-vec query))]
       (apply sorted-set (map :version results)))
     (catch java.sql.SQLException e
-      (sorted-set))))
+      (if (re-find #"\"schema_migrations\" does not exist" (.getMessage e))
+        (sorted-set)
+        (throw e)))))
 
 (defn pending-migrations
   "Returns a collection of pending migrations, ordered from oldest to latest."


### PR DESCRIPTION
We need to swallow the error that occurs when the schema_migrations table
doesn't exist, because that means it's a fresh DB. Everything else should be thrown.