### PR TITLE
(maint) Retire the old server and port terminus settings

### DIFF
--- a/documentation/puppetdb_connection.markdown
+++ b/documentation/puppetdb_connection.markdown
@@ -63,10 +63,3 @@ The default value is 30 seconds.
 This setting can let the Puppet master stay partially available during a PuppetDB outage. If set to `true`, Puppet can keep compiling and serving catalogs even if PuppetDB isn't accessible for command submission. (However, any catalogs that need to _query_ exported resources from PuppetDB will still fail.)
 
 The default value is false.
-
-### `server` and `port`
-
-> **Deprecated:** `server_urls` replaces these setting. These settings will be removed in the future.
-
-Hostname and port of the PuppetDB instance. `server_urls` takes precedence if both are defined.
-

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -9,8 +9,7 @@ require 'json'
 
 describe Puppet::Resource::Catalog::Puppetdb do
   before :each do
-    Puppet::Util::Puppetdb.stubs(:server).returns 'localhost'
-    Puppet::Util::Puppetdb.stubs(:port).returns 0
+    Puppet::Util::Puppetdb.stubs(:server_urls).returns 'https://localhost:0'
     create_environmentdir("my_environment")
   end
 

--- a/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
@@ -6,8 +6,7 @@ require 'json'
 
 describe Puppet::Resource::Puppetdb do
   before :each do
-    Puppet::Util::Puppetdb.stubs(:server).returns 'localhost'
-    Puppet::Util::Puppetdb.stubs(:port).returns 0
+    Puppet::Util::Puppetdb.stubs(:server_urls).returns 'https://localhost:0'
     Puppet::Resource.indirection.stubs(:terminus).returns(subject)
   end
 

--- a/puppet/spec/unit/util/puppetdb/config_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/config_spec.rb
@@ -50,8 +50,7 @@ CONF
       it "should use the config value if specified" do
         write_config <<CONF
 [main]
-server = main-server
-port = 1234
+server_urls = https://main-server:1234
 soft_write_failure = true
 CONF
         config = described_class.load
@@ -70,18 +69,18 @@ CONF
       it "should be insensitive to whitespace" do
         write_config <<CONF
 [main]
-  server = main-server
-    port    =  1234
+    server_urls = https://main-server:1234
+        soft_write_failure = true
 CONF
         config = described_class.load
         config.server_urls.should == [URI("https://main-server:1234")]
+        config.soft_write_failure.should be_truthy
       end
 
       it "should accept valid hostnames" do
         write_config <<CONF
 [main]
-server = foo.example-thing.com
-port = 8081
+server_urls = https://foo.example-thing.com:8081
 CONF
 
         config = described_class.load


### PR DESCRIPTION
This commit retires the deprecated server and port terminus settings
which were replaced by the server_urls setting.