### PR TITLE
(maint) tweaks to anonymization

### DIFF
--- a/src/puppetlabs/puppetdb/anonymizer.clj
+++ b/src/puppetlabs/puppetdb/anonymizer.clj
@@ -114,12 +114,11 @@
   "Based on the input value, return an appropriate random replacement"
   [value]
   (cond
-   (string? value) (random-string 30)
+   (string? value) (random-string (max 1 (count value)))
    (integer? value) (rand-int (max value 20))
-   (float? value) (rand)
+   (float? value) (rand (max value 1))
    (boolean? value) (random-bool)
-   (map? value) (zipmap (take (count value)
-                              (repeatedly #(random-string 10)))
+   (map? value) (zipmap (map #(random-string (max 1 (count (name %)))) (keys value))
                         (vals (utils/update-vals value (keys value)
                                                  anonymize-leaf-value)))
    (nil? value) nil
@@ -131,17 +130,15 @@
      (case ltype
        :node (random-node-name)
        :type (random-type-name)
-       :title (random-string 15)
-       :name (random-string 10)
-       :parameter-name (random-string-alpha 10)
-       :message (random-string 50)
-       :log-message (random-string (count value))
+       :title (random-string (max 1 (count value)))
+       :parameter-name (random-string-alpha (max 1 (count value)))
+       :message (random-string (max 1 (count value)))
+       :log-message (random-string (max 1 (count value)))
        :file (random-pp-path)
        :line (when value (rand-int (max value 20)))
-       :value (rand 100)
        :transaction_uuid (uuid)
-       :fact-name (random-string 15)
-       :environment (random-string 15)
+       :fact-name (random-string (max 1 (count (name value))))
+       :environment (random-string (max 1 (count value)))
        (:fact-value :parameter-value)
        (cond
          (vector? value) (map (partial anonymize-leaf-memoize ltype) value)

--- a/test/puppetlabs/puppetdb/anonymizer_test.clj
+++ b/test/puppetlabs/puppetdb/anonymizer_test.clj
@@ -119,11 +119,12 @@
 
 (deftest test-anonymize-leaf-parameter-name
   (testing "should return the same string twice"
-    (is (= (anonymize-leaf-memoize :parameter-name "test string") (anonymize-leaf-memoize :parameter-name "test string"))))
+    (is (= (anonymize-leaf-memoize :parameter-name "test string")
+           (anonymize-leaf-memoize :parameter-name "test string"))))
 
-  (testing "should return a string 10 characters long"
-    (is (string? (anonymize-leaf-memoize :parameter-name "good old string")))
-    (is (= 10 (count (anonymize-leaf-memoize :parameter-name "good old string"))))))
+  (testing "should return a string of equal length"
+    (is (string? (anonymize-leaf-memoize :parameter-name "good old string!")))
+    (is (= 16 (count (anonymize-leaf-memoize :parameter-name "good old string!"))))))
 
 (deftest anonymize-fact-value
   (testing "identical paths with different values should be memoized"
@@ -140,8 +141,8 @@
     (is (= (anonymize-leaf-memoize :parameter-value "test string") (anonymize-leaf-memoize :parameter-value "test string"))))
   (testing "should return the same string twice"
     (is  (=  (anonymize-leaf-memoize :fact-value  {"a" "b"})  (anonymize-leaf-memoize :fact-value  {"a" "b"}))))
-  (testing "should return a string 30 chars long when passed a string"
-    (is (= 30 (count (anonymize-leaf-value "good old string"))))
+  (testing "should return a string of equal length when passed a string"
+    (is (= 15 (count (anonymize-leaf-value "good old string"))))
     (is (string? (anonymize-leaf-value "some string"))))
   (testing "should return a boolean when passed a boolean"
     (is (boolean? (anonymize-leaf-value true))))
@@ -157,9 +158,9 @@
              (sort (map (comp str type) (anonymize-leaf-value mymap))))))))
 
 (deftest test-anonymize-leaf-message
-  (testing "should return a string 50 characters long"
+  (testing "should return a string of equal length"
     (is (string? (anonymize-leaf-memoize :message "good old string")))
-    (is (= 50 (count (anonymize-leaf-memoize :message "good old string"))))))
+    (is (= 15 (count (anonymize-leaf-memoize :message "good old string"))))))
 
 (deftest test-memoized-vector-elements
   (testing "should memoize individual vector elements"


### PR DESCRIPTION
* when randomizing strings, use a length equal to the length of the target
* when randomizing floats, cap the value with the target
* remove some unused leaf types