### PR TITLE
(maint) Update prismatic schema to 1.0.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -72,7 +72,7 @@
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]
-                 [prismatic/schema "1.0.2"]
+                 [prismatic/schema "1.0.3"]
                  [org.clojure/tools.macro "0.1.5"]
                  [com.novemberain/pantomime "2.1.0"]
                  [fast-zip-visit "1.0.2"]


### PR DESCRIPTION
This has a bugfix we need in s/constrained.