### PR TITLE
(MAINT) Add an INSTALL_MODE var to beaker-tests.sh

### DIFF
--- a/ext/jenkins/beaker-tests.sh
+++ b/ext/jenkins/beaker-tests.sh
@@ -25,6 +25,7 @@ export PUPPETDB_PACKAGE_REPO_HOST="puppetdb-prerelease.s3.amazonaws.com"
 export PUPPETDB_PACKAGE_REPO_URL="http://puppetdb-prerelease.s3.amazonaws.com/puppetdb/${PACKAGE_BUILD_VERSION}"
 export PUPPETDB_PACKAGE_BUILD_VERSION=$PACKAGE_BUILD_VERSION
 export BEAKER_CONFIG=$LAYOUT
+export INSTALL_MODE=$INSTALL_TYPE
 
 set -x
 # Now run our tests


### PR DESCRIPTION
We are currently not testing upgrades. The JJB jobs use an INSTALL_TYPE
environment variable to indicate whether we are testing an install or an
upgrade. PuppetDB does not recognize that variable and always assumes
were testing an install. This commit just sets the value of INSTALL_MODE
to what JJB has set for INSTALL_TYPE. This should fix things so our
upgrade tests go through the upgrade process.