### PR TITLE
(PDB-2100) ssl setup fails on nonproduction environments

### DIFF
--- a/acceptance/tests/security/puppetdb-ssl-setup/nonprod-environment.rb
+++ b/acceptance/tests/security/puppetdb-ssl-setup/nonprod-environment.rb
@@ -1,0 +1,14 @@
+test_name "puppetdb ssl-setup on nonproduction environment" do
+  confdir = on(database, puppet_master("--configprint confdir")).stdout.chomp
+  bin_loc = "#{puppetdb_bin_dir(database)}"
+  step "back up existing puppet.conf" do
+    on database, "cp #{confdir}/puppet.conf #{confdir}/puppet.conf.bak"
+  end
+  step "ensure proper exit code on ssl-setup" do
+    on database, "puppet config set environment foo --section main"
+    result = on database, "#{bin_loc}/puppetdb ssl-setup", :acceptable_exit_codes => [0]
+  end
+  step "restore original puppet.conf" do
+    on database, "mv #{confdir}/puppet.conf.bak #{confdir}/puppet.conf"
+  end
+end

--- a/resources/ext/cli/ssl-setup.erb
+++ b/resources/ext/cli/ssl-setup.erb
@@ -235,11 +235,11 @@ fi
 
 set -e
 
-mycertname=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint  certname`
+mycertname=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint  certname`
 
-orig_public_file=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint  hostcert`
-orig_private_file=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint hostprivkey`
-orig_ca_file=`puppet master --confdir=$agent_confdir --vardir=$agent_vardir --configprint localcacert`
+orig_public_file=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint  hostcert`
+orig_private_file=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint hostprivkey`
+orig_ca_file=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint localcacert`
 
 ssl_dir=${puppetdb_confdir}/ssl
 


### PR DESCRIPTION
This changes our ssl-setup script to use "puppet agent" rather than "puppet
master" when gathering its hostname and config file locations.