### PR TITLE
(maint) Update to latest ezbake

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -133,7 +133,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "0.3.20"
+                      :plugins [[puppetlabs/lein-ezbake "0.3.21"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}


### PR DESCRIPTION
Ezbake 0.3.21 was just released, so this updates to use that version.