### PR TITLE
(PDB-2075) Conflate unit test admin/user on jenkins

### DIFF
--- a/ext/jenkins/lein-test.sh
+++ b/ext/jenkins/lein-test.sh
@@ -5,18 +5,22 @@ set -x
 
 ulimit -u 4096
 
-export PGHOST=fixture-pg94.delivery.puppetlabs.net
-export PGPORT=5432
-export HTTP_CLIENT="wget --no-check-certificate -O"
+pghost=fixture-pg94.delivery.puppetlabs.net
+pgport=5432
 
-pgdir="$(pwd)/test-resources/var/pg"
-readonly pgdir
+export HTTP_CLIENT="wget --no-check-certificate -O"
 
 rm -f testreports.xml *.war *.jar
 
-PGUSER=puppetdb ext/bin/setup-pdb-pg "$pgdir"
+export PDB_TEST_DB_HOST="$pghost"
+export PDB_TEST_DB_PORT="$pgport"
+
+# For now, just conflate the normal test and admin users.
+export PDB_TEST_DB_USER=puppetdb
+export PDB_TEST_DB_ADMIN=puppetdb
+export PDB_TEST_DB_USER_PASSWORD=puppetdb137
+export PDB_TEST_DB_ADMIN_PASSWORD=puppetdb137
 
 lein --version
 lein clean
-
-exec ext/bin/pdb-test-env "$pgdir" lein test
+exec lein test


### PR DESCRIPTION
For now, use the existing puppetdb postgres user as both the unit test
admin and test runner.