### PR TITLE
(PDB-2075) Use the BUILD_TAG for PDB_TEST_ID

### DIFF
--- a/ext/jenkins/lein-test.sh
+++ b/ext/jenkins/lein-test.sh
@@ -21,7 +21,7 @@ export PDB_TEST_DB_ADMIN=puppetdb
 export PDB_TEST_DB_USER_PASSWORD=puppetdb137
 export PDB_TEST_DB_ADMIN_PASSWORD=puppetdb137
 
-PDB_TEST_ID="${PUPPETDB_BRANCH}_${BUILD_ID}_${BUILD_NUMBER}_${JDK}"
+PDB_TEST_ID="${BUILD_TAG}"
 PDB_TEST_ID="$(echo "$PDB_TEST_ID" | perl -pe 's/[^a-zA-Z0-9_]/_/gmo')"
 declare -rx PDB_TEST_ID
 


### PR DESCRIPTION
Which should be something like this:

  jenkins-enterprise_puppetdb_unit-clj-puppetdb_master-145