### PR TITLE
(PDB-2075) Use a UUID for PDB_TEST_ID

### DIFF
--- a/ext/jenkins/lein-test.sh
+++ b/ext/jenkins/lein-test.sh
@@ -21,7 +21,7 @@ export PDB_TEST_DB_ADMIN=puppetdb
 export PDB_TEST_DB_USER_PASSWORD=puppetdb137
 export PDB_TEST_DB_ADMIN_PASSWORD=puppetdb137
 
-PDB_TEST_ID="${BUILD_TAG}"
+PDB_TEST_ID="$(ruby -e "require 'securerandom';  puts SecureRandom.uuid")"
 PDB_TEST_ID="$(echo "$PDB_TEST_ID" | perl -pe 's/[^a-zA-Z0-9_]/_/gmo')"
 declare -rx PDB_TEST_ID
 


### PR DESCRIPTION
Since BUILD_TAG is pushing up against the postgres name length limit.