### PR TITLE
(maint) Run `pe-puppetdb-extensions` unit tests on FOSS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
     - jdk: oraclejdk7
       env: PDB_TEST_LANG=ruby
 
+before_install:
+- echo -e "machine github.com\n  login puppetlabs-ca\n  password $CI_USER_PASSWORD" >> ~/.netrc
+
 script: ext/travisci/test.sh
 
 notifications:

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -5,6 +5,10 @@ set -x
 
 ulimit -u 4096
 
+pushd ..
+git clone https://github.com/puppetlabs/pe-puppetdb-extensions.git
+popd
+
 run-unit-tests()
 (
   pgdir="$(pwd)/test-resources/var/pg"
@@ -13,6 +17,9 @@ run-unit-tests()
   export PGHOST=127.0.0.1
   export PGPORT=5432
   ext/bin/setup-pdb-pg "$pgdir"
+  ext/bin/pdb-test-env "$pgdir" lein2 test
+  cd ..
+  cd pe-puppetdb-extensions
   ext/bin/pdb-test-env "$pgdir" lein2 test
 )
 


### PR DESCRIPTION
This commit runs our `pe-puppetdb-extensions` on FOSS PRs using
Travis-CI.