### PR TITLE
(PDB-2098) tk status integration

### DIFF
--- a/documentation/_puppetdb_nav.html
+++ b/documentation/_puppetdb_nav.html
@@ -86,6 +86,11 @@
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/command/v1/commands.html">Commands Endpoint</a></li>
     </ul>
   </li>
+  <li><strong>Status API Version 1</strong>
+      <ul>
+          <li><a href="/puppetdb"/{{ puppetdb_version }}/api/status/v1/status.html>Status Endpoint</a></li>
+      </ul>
+  </li>
   <li><strong>Metadata API Version 1</strong>
     <ul>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/meta/v1/version.html">Version Endpoint</a></li>

--- a/documentation/api/status/v1/status.markdown
+++ b/documentation/api/status/v1/status.markdown
@@ -1,0 +1,45 @@
+---
+title: "PuppetDB 3.2 » Status API » v1 » Querying PuppetDB Status"
+layout: default
+canonical: "/puppetdb/latest/api/status/v1/status.html"
+---
+
+[curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
+[status-api]: https://docs.puppetlabs.com/pe/latest/status_api.html
+
+The `/status` endpoint implements the Puppet Labs Status API for coordinated
+monitoring of Puppet Labs services. See the [central documentation][status-api]
+for detailed information.
+
+## `/status/v1/services/puppetdb-status`
+
+This query endpoint will return status about the PuppetDB instance on a host.
+
+### Response Format
+
+The response will be in `application/json`, and will return a JSON map like the
+following:
+
+    {
+        "detail_level": "info",
+         "service_status_version": 1,
+         "service_version": "4.0.0-SNAPSHOT",
+         "state": "running",
+         "status": {
+             "maintenance_mode?": false,
+             "read_db_up?": true,
+             "write_db_up?": true
+         }
+    }
+
+* `detail_level`: info is currently the only level
+* `service_status_version`: version of the status API
+* `service_version`: version of PuppetDB
+* `state`: "running" if read and write databases are up, "error" if down
+* `status`:
+    * `maintenance_mode?`: indicates whether PuppetDB is in maintenance mode.
+    PuppetDB enters maintenance mode at startup and exits it after completing any
+    pending migrations. While in maintenance mode PuppetDB will not respond to
+    queries.
+    * `read_db_up?`: indicates whether the read database is responding to queries
+    * `write_db_up?`: indicates whether the write database is responding to queries

--- a/documentation/api/status/v1/status.markdown
+++ b/documentation/api/status/v1/status.markdown
@@ -36,7 +36,10 @@ following:
 * `detail_level`: info is currently the only level
 * `service_status_version`: version of the status API
 * `service_version`: version of PuppetDB
-* `state`: "running" if read and write databases are up, "error" if down
+* `state`: short description of PuppetDB's current state:
+    * "starting" if PuppetDB is in maintenance mode
+    * "running" if not in maintenance mode and read and write databases are up
+    * "error" if the read or write databases are down.
 * `status`:
     * `maintenance_mode?`: indicates whether PuppetDB is in maintenance mode.
     PuppetDB enters maintenance mode at startup and exits it after completing any

--- a/documentation/api/status/v1/status.markdown
+++ b/documentation/api/status/v1/status.markdown
@@ -28,7 +28,8 @@ following:
          "status": {
              "maintenance_mode?": false,
              "read_db_up?": true,
-             "write_db_up?": true
+             "write_db_up?": true,
+             "queue_depth": 0
          }
     }
 
@@ -39,7 +40,8 @@ following:
 * `status`:
     * `maintenance_mode?`: indicates whether PuppetDB is in maintenance mode.
     PuppetDB enters maintenance mode at startup and exits it after completing any
-    pending migrations. While in maintenance mode PuppetDB will not respond to
-    queries.
+    pending migrations and initial data synchronization (when using HA).
+    While in maintenance mode PuppetDB will not respond to queries.
     * `read_db_up?`: indicates whether the read database is responding to queries
     * `write_db_up?`: indicates whether the write database is responding to queries
+    * `queue_depth`: depth of the command queue

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
 (def tk-version "1.1.1")
 (def tk-jetty9-version "1.3.1")
 (def ks-version "1.1.0")
+(def tk-status-version "0.2.0")
 
 (def pdb-jvm-opts
   (case (System/getProperty "java.specification.version")
@@ -38,6 +39,7 @@
                  [org.clojure/math.numeric-tower "0.0.4"]
                  [org.clojure/tools.logging "0.3.1"]
                  [puppetlabs/tools.namespace "0.2.4.1"]
+                 [puppetlabs/jdbc-util "0.1.4" :exclusions [org.postgresql/postgresql]]
                  [clj-stacktrace "0.2.8"]
                  [metrics-clojure "0.7.0" :exclusions [org.clojure/clojure org.slf4j/slf4j-api]]
                  [clj-time "0.9.0"]
@@ -74,6 +76,7 @@
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]
                  [prismatic/schema "0.4.1"]
+                 [puppetlabs/trapperkeeper-status ~tk-status-version :exclusions [trptcolin/versioneer]]
                  [org.clojure/tools.macro "0.1.5"]
                  [com.novemberain/pantomime "2.1.0"]
                  [fast-zip-visit "1.0.2"]

--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,6 @@
                  [org.clojure/math.numeric-tower "0.0.4"]
                  [org.clojure/tools.logging "0.3.1"]
                  [puppetlabs/tools.namespace "0.2.4.1"]
-                 [puppetlabs/jdbc-util "0.1.4" :exclusions [org.postgresql/postgresql]]
                  [clj-stacktrace "0.2.8"]
                  [metrics-clojure "0.7.0" :exclusions [org.clojure/clojure org.slf4j/slf4j-api]]
                  [clj-time "0.9.0"]

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
 (def tk-version "1.1.1")
 (def tk-jetty9-version "1.3.1")
 (def ks-version "1.1.0")
-(def tk-status-version "0.2.0")
+(def tk-status-version "0.2.1")
 
 (def pdb-jvm-opts
   (case (System/getProperty "java.specification.version")

--- a/resources/puppetlabs/puppetdb/bootstrap.cfg
+++ b/resources/puppetlabs/puppetdb/bootstrap.cfg
@@ -9,6 +9,9 @@ puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
 # Webrouting
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 
+# TK status
+puppetlabs.trapperkeeper.services.status.status-service/status-service
+
 # PuppetDB Services
 puppetlabs.puppetdb.cli.services/puppetdb-service
 puppetlabs.puppetdb.metrics/metrics-service

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -46,6 +46,7 @@
             [clojure.java.io :as io]
             [clojure.tools.logging :as log]
             [compojure.core :as compojure]
+            [puppetlabs.trapperkeeper.services.status.status-core :as status-core]
             [overtone.at-at :refer [mk-pool interspaced]]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.cheshire :as json]

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -46,7 +46,6 @@
             [clojure.java.io :as io]
             [clojure.tools.logging :as log]
             [compojure.core :as compojure]
-            [puppetlabs.trapperkeeper.services.status.status-core :as status-core]
             [overtone.at-at :refer [mk-pool interspaced]]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.cheshire :as json]

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -345,6 +345,7 @@
 (defn add-web-routing-service-config
   [config-data]
   (let [default-web-router-service {:puppetlabs.puppetdb.metrics/metrics-service "/metrics"
+                                    :puppetlabs.trapperkeeper.services.status.status-service/status-service "/status"
                                     :puppetlabs.puppetdb.pdb-routing/pdb-routing-service "/pdb"}
         bootstrap-cfg (-> (find-bootstrap-config config-data)
                           slurp

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -2,15 +2,19 @@
   (:require [puppetlabs.trapperkeeper.core :as tk]
             [compojure.core :as compojure]
             [compojure.route :as route]
+            [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.trapperkeeper.services :as tksvc]
+            [puppetlabs.puppetdb.mq :as mq]
             [ring.middleware.resource :refer [resource-request]]
             [ring.util.request :as rreq]
-            [puppetlabs.jdbc-util.core :refer [db-up?]]
+            [puppetlabs.puppetdb.jdbc :as jdbc]
             [ring.util.response :as rr]
             [puppetlabs.puppetdb.meta :as meta]
             [puppetlabs.trapperkeeper.services.status.status-core :as status-core]
             [puppetlabs.puppetdb.admin :as admin]
             [puppetlabs.puppetdb.http.command :as cmd]
+            [clj-http.client :as client]
+            [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.http.server :as server]
             [clojure.tools.logging :as log]
             [puppetlabs.puppetdb.config :as conf]
@@ -112,19 +116,24 @@
                                                            query
                                                            enqueue-raw-command
                                                            response-pub)))
+
           (enable-maint-mode)
           (register-status "puppetdb-status"
                            (status-core/get-artifact-version "puppetlabs" "puppetdb")
                            1
                            (fn [level]
                              (let [globals (shared-globals)
-                                   read-db-up? (db-up? (:scf-read-db globals))
-                                   write-db-up? (db-up? (:scf-write-db globals))
+                                   queue-depth (->> [:command-processing :mq :endpoint]
+                                                    (get-in config)
+                                                    (mq/queue-size "localhost"))
+                                   read-db-up? (sutils/db-up? (:scf-read-db globals))
+                                   write-db-up? (sutils/db-up? (:scf-write-db globals))
                                    state (if (and read-db-up? write-db-up?)
                                            :running
                                            :error)]
                                {:state state
                                 :status {:maintenance_mode? (maint-mode?)
+                                         :queue_depth queue-depth
                                          :read_db_up? read-db-up?
                                          :write_db_up? write-db-up?}}))))
         context)

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -128,11 +128,13 @@
                                                     (mq/queue-size "localhost"))
                                    read-db-up? (sutils/db-up? (:scf-read-db globals))
                                    write-db-up? (sutils/db-up? (:scf-write-db globals))
-                                   state (if (and read-db-up? write-db-up?)
-                                           :running
-                                           :error)]
+                                   maintenance-mode? (maint-mode?)
+                                   state (cond
+                                           maintenance-mode? :starting
+                                           (and read-db-up? write-db-up?) :running
+                                           :else :error)]
                                {:state state
-                                :status {:maintenance_mode? (maint-mode?)
+                                :status {:maintenance_mode? maintenance-mode?
                                          :queue_depth queue-depth
                                          :read_db_up? read-db-up?
                                          :write_db_up? write-db-up?}}))))

--- a/src/puppetlabs/puppetdb/query/catalogs.clj
+++ b/src/puppetlabs/puppetdb/query/catalogs.clj
@@ -2,6 +2,7 @@
   "Catalog retrieval"
   (:require [puppetlabs.puppetdb.schema :as pls]
             [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.scf.storage-utils :as su]
             [schema.core :as s]))
 
 ;; MUNGE
@@ -11,13 +12,13 @@
   [base-url :- s/Str]
   (fn [row]
     (-> row
-        (utils/update-when [:edges] utils/child->expansion :catalogs :edges base-url)
-        (utils/update-when [:resources] utils/child->expansion :catalogs :resources base-url))))
+        (utils/update-when [:edges] su/child->expansion :catalogs :edges base-url)
+        (utils/update-when [:resources] su/child->expansion :catalogs :resources base-url))))
 
 (pls/defn-validated munge-result-rows
   "Reassemble rows from the database into the final expected format."
   [version :- s/Keyword
    url-prefix :- s/Str]
-  (let [base-url (utils/as-path url-prefix (name version))]
+  (let [base-url (su/as-path url-prefix (name version))]
     (fn [rows]
       (map (row->catalog base-url) rows))))

--- a/src/puppetlabs/puppetdb/query/factsets.clj
+++ b/src/puppetlabs/puppetdb/query/factsets.clj
@@ -3,6 +3,7 @@
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.schema :as pls]
             [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.scf.storage-utils :as su]
             [schema.core :as s]))
 
 ;; MUNGE
@@ -12,12 +13,12 @@
   [base-url :- s/Str]
   (fn [row]
     (-> row
-        (utils/update-when [:facts] utils/child->expansion :factsets :facts base-url)
+        (utils/update-when [:facts] su/child->expansion :factsets :facts base-url)
         (utils/update-when [:facts :data] (partial map #(update % :value json/parse-string))))))
 
 (pls/defn-validated munge-result-rows
   "Reassemble rows from the database into the final expected format."
   [version :- s/Keyword
    url-prefix :- s/Str]
-  (let [base-url (utils/as-path url-prefix (name version))]
+  (let [base-url (su/as-path url-prefix (name version))]
     (partial map (row->factset base-url))))

--- a/src/puppetlabs/puppetdb/query/reports.clj
+++ b/src/puppetlabs/puppetdb/query/reports.clj
@@ -5,6 +5,7 @@
             [puppetlabs.puppetdb.reports :as reports]
             [puppetlabs.puppetdb.schema :as pls]
             [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.scf.storage-utils :as su]
             [schema.core :as s]))
 
 ;; MUNGE
@@ -21,10 +22,10 @@
   [base-url :- s/Str]
   (fn [row]
     (-> row
-        (utils/update-when [:resource_events] utils/child->expansion :reports :events base-url)
+        (utils/update-when [:resource_events] su/child->expansion :reports :events base-url)
         (utils/update-when [:resource_events :data] (partial map rtj->event))
-        (utils/update-when [:metrics] utils/child->expansion :reports :metrics base-url)
-        (utils/update-when [:logs] utils/child->expansion :reports :logs base-url))))
+        (utils/update-when [:metrics] su/child->expansion :reports :metrics base-url)
+        (utils/update-when [:logs] su/child->expansion :reports :logs base-url))))
 
 (pls/defn-validated munge-result-rows
   "Reassemble report rows from the database into the final expected format."

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -5,6 +5,7 @@
             [puppetlabs.puppetdb.honeysql :as h]
             [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.puppetdb.schema :as pls]
+            [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.kitchensink.core :as kitchensink]
             [schema.core :as s])
   (:import [org.postgresql.util PGobject]))
@@ -342,3 +343,12 @@ must be supplied as the value to be matched."
       (str->pgobject "jsonb" json-str)
       json-str)))
 
+(defn db-up?
+  [db-spec]
+  (utils/with-timeout 1000 false
+    (jdbc/with-transacted-connection db-spec
+      (try (let [select-42 "SELECT (a - b) AS answer FROM (VALUES ((7 * 7), 7)) AS x(a, b)"
+                 [{:keys [answer]}] (jdbc/query [select-42])]
+             (= answer 42))
+           (catch Exception _
+             false)))))

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -276,25 +276,25 @@
                (assoc acc (schema.core/required-key (puppetlabs.puppetdb.utils/kwd->str k)) v))
              {} kwd-schema))
 
-(defn as-path
-  "Create a url path from arguments. Does not append a slash to the beginning
-   or end. Example:
-   (as-path '/v4' 'facts' "
-  [root & path]
-  (apply str root "/" (string/join "/" path)))
-
-(pls/defn-validated child->expansion
-  "Convert child to the expanded format."
-  [data :- (s/maybe (s/either PGobject s/Str))
-   parent :- s/Keyword
-   child :- s/Keyword
-   url-prefix :- s/Str]
-  (let [to-href #(as-path url-prefix (name parent) % (name child))]
-    (if (string? data)
-      ;; if it's a string it's just an identifier
-      {:href (to-href data)}
-      (-> (sutils/parse-db-json data)
-          (update :href to-href)))))
+;(defn as-path
+;  "Create a url path from arguments. Does not append a slash to the beginning
+;   or end. Example:
+;   (as-path '/v4' 'facts' "
+;  [root & path]
+;  (apply str root "/" (string/join "/" path)))
+;
+;(pls/defn-validated child->expansion
+;  "Convert child to the expanded format."
+;  [data :- (s/maybe (s/either PGobject s/Str))
+;   parent :- s/Keyword
+;   child :- s/Keyword
+;   url-prefix :- s/Str]
+;  (let [to-href #(as-path url-prefix (name parent) % (name child))]
+;    (if (string? data)
+;      ;; if it's a string it's just an identifier
+;      {:href (to-href data)}
+;      (-> (sutils/parse-db-json data)
+;          (update :href to-href)))))
 
 (defn hsql?
   "given a db-spec style database object, determine if hsqldb is being used."

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -8,7 +8,6 @@
             [clojure.set :as set]
             [puppetlabs.puppetdb.archive :as archive]
             [clojure.java.io :as io]
-            [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.cheshire :as json]
             [clojure.walk :as walk]
             [slingshot.slingshot :refer [try+ throw+]]
@@ -345,3 +344,8 @@
   (sp/transform [sp/ALL]
                 #(update % 0 underscores->dashes)
                 m))
+
+(defmacro with-timeout [timeout-ms default & body]
+  `(let [f# (future (do ~@body))
+         result# (deref f# ~timeout-ms ~default)]
+     result#))

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -185,6 +185,12 @@
   (-> (URL. protocol host port "")
       .toURI .toASCIIString))
 
+(defn base-url->str-with-prefix
+  [{:keys [protocol host port prefix] :as base-url}]
+  (-> (java.net.URL. protocol host port prefix)
+      .toURI
+      .toASCIIString))
+
 (defn describe-bad-base-url
   "If a problem is detected with `base-url`, returns a string
   describing the issue. For example {:host \"x:y\" ...}."

--- a/test/puppetlabs/puppetdb/dashboard_test.clj
+++ b/test/puppetlabs/puppetdb/dashboard_test.clj
@@ -6,7 +6,7 @@
             [puppetlabs.puppetdb.testutils.services :as svc-utils]
             [clojure.java.io :refer [file]]
             [clj-http.client :as client]
-            [puppetlabs.puppetdb.testutils.services :as svc-utils]
+            [puppetlabs.puppetdb.utils :refer [base-url->str-with-prefix]]
             [puppetlabs.puppetdb.testutils :as tu]
             [puppetlabs.puppetdb.testutils.dashboard :as dtu]))
 
@@ -19,6 +19,9 @@
 (deftest root-dashboard-routing
   (svc-utils/call-with-single-quiet-pdb-instance
    (fn []
-     (let [root-resp (client/get (dtu/dashboard-base-url->str (assoc svc-utils/*base-url* :prefix "/")))]
+     (let [root-resp (-> svc-utils/*base-url*
+                         (assoc :prefix "/")
+                         base-url->str-with-prefix
+                         client/get)]
        (tu/assert-success! root-resp)
        (is (dtu/dashboard-page? root-resp))))))

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -83,13 +83,13 @@
     (testing "logs projected"
       (is (= (query-result method endpoint ["extract" "logs"
                                             ["=" "certname" (:certname basic)]])
-             #{{:logs (merge {:href (utils/as-path "/v4/reports" report-hash "logs")}
+             #{{:logs (merge {:href (sutils/as-path "/v4/reports" report-hash "logs")}
                              (when (sutils/postgres?) {:data (get-in basic [:logs :data])}))}})))
 
     (testing "metrics projected"
       (is (= (query-result method endpoint ["extract" "metrics"
                                             ["=" "certname" (:certname basic)]])
-             #{{:metrics (merge {:href (utils/as-path "/v4/reports" report-hash "metrics")}
+             #{{:metrics (merge {:href (sutils/as-path "/v4/reports" report-hash "metrics")}
                                 (when (sutils/postgres?) {:data (get-in basic [:metrics :data])}))}})))
 
     (testing "one projected column with a not"

--- a/test/puppetlabs/puppetdb/pdb_routing_test.clj
+++ b/test/puppetlabs/puppetdb/pdb_routing_test.clj
@@ -40,8 +40,10 @@
 (deftest top-level-routes
   (svc-utils/call-with-puppetdb-instance
    (fn []
-     (let [pdb-resp (client/get (dtu/dashboard-base-url->str (assoc svc-utils/*base-url*
-                                                                    :prefix "/pdb")))]
+     (let [pdb-resp (-> svc-utils/*base-url*
+                        (assoc :prefix "/pdb")
+                        utils/base-url->str-with-prefix
+                        client/get)]
        (tu/assert-success! pdb-resp)
        (is (dtu/dashboard-page? pdb-resp))
 

--- a/test/puppetlabs/puppetdb/status_test.clj
+++ b/test/puppetlabs/puppetdb/status_test.clj
@@ -25,13 +25,13 @@
   (testing "status returns as expected when in maintenance mode"
     (with-redefs [puppetlabs.puppetdb.pdb-routing/maint-mode? (constantly true)]
       (svc-utils/with-puppetdb-instance
-        (let [{:keys [body] :as pdb-resp} (-> svc-utils/*base-url*
-                                              (assoc :prefix "/status/v1/services")
-                                              base-url->str-with-prefix
-                                              client/get)
+        (let [{:keys [body status]} (-> svc-utils/*base-url*
+                                        (assoc :prefix "/status/v1/services")
+                                        base-url->str-with-prefix
+                                        (client/get {:throw-exceptions false}))
               pdb-status (:puppetdb-status (json/parse-string body true))]
-          (tu/assert-success! pdb-resp)
-          (is (= "running" (:state pdb-status)))
+          (is (= 503 status))
+          (is (= "starting" (:state pdb-status)))
           (is (= {:maintenance_mode? true
                   :read_db_up? true
                   :write_db_up? true

--- a/test/puppetlabs/puppetdb/status_test.clj
+++ b/test/puppetlabs/puppetdb/status_test.clj
@@ -1,0 +1,39 @@
+(ns puppetlabs.puppetdb.status-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.puppetdb.testutils :as tu]
+            [puppetlabs.puppetdb.utils :refer [base-url->str-with-prefix]]
+            [puppetlabs.puppetdb.cheshire :as json]
+            [clj-http.client :as client]
+            [puppetlabs.puppetdb.testutils.services :as svc-utils]))
+
+(deftest status-test
+  (testing "status returns as expected on normal operation"
+    (svc-utils/call-with-puppetdb-instance
+      (fn []
+        (let [{:keys [body] :as pdb-resp} (-> svc-utils/*base-url*
+                                              (assoc :prefix "/status/v1/services")
+                                              base-url->str-with-prefix
+                                              client/get)
+              pdb-status (:puppetdb-status (json/parse-string body true))]
+          (tu/assert-success! pdb-resp)
+          (is (= "running" (:state pdb-status)))
+          (is (= {:maintenance_mode? false
+                  :read_db_up? true
+                  :write_db_up? true}
+                 (:status pdb-status)))))))
+
+  (testing "status returns as expected when in maintenance mode"
+    (with-redefs [puppetlabs.puppetdb.pdb-routing/maint-mode? (constantly true)]
+      (svc-utils/call-with-puppetdb-instance
+        (fn []
+          (let [{:keys [body] :as pdb-resp} (-> svc-utils/*base-url*
+                                                (assoc :prefix "/status/v1/services")
+                                                base-url->str-with-prefix
+                                                client/get)
+                pdb-status (:puppetdb-status (json/parse-string body true))]
+            (tu/assert-success! pdb-resp)
+            (is (= "running" (:state pdb-status)))
+            (is (= {:maintenance_mode? true
+                    :read_db_up? true
+                    :write_db_up? true}
+                   (:status pdb-status)))))))))

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -11,6 +11,7 @@
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tkbs]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :refer [webrouting-service]]
+            [puppetlabs.trapperkeeper.services.status.status-service :refer [status-service]]
             [puppetlabs.puppetdb.client :as pdb-client]
             [puppetlabs.puppetdb.cli.services :as svcs]
             [puppetlabs.puppetdb.metrics :as metrics]
@@ -68,6 +69,7 @@
    #'message-listener-service
    #'command-service
    #'metrics/metrics-service
+   #'status-service
    #'dashboard-redirect-service
    #'pdb-routing-service
    #'maint-mode-service


### PR DESCRIPTION
This cherry picks the status-service commits from master, changes our status implementation's maintenance mode response from "running" to "starting", and upgrades our tk-status version to enable the change.