### PR TITLE
(maint) change maint-mode state of status implementation to :starting

### DIFF
--- a/documentation/api/status/v1/status.markdown
+++ b/documentation/api/status/v1/status.markdown
@@ -36,7 +36,10 @@ following:
 * `detail_level`: info is currently the only level
 * `service_status_version`: version of the status API
 * `service_version`: version of PuppetDB
-* `state`: "running" if read and write databases are up, "error" if down
+* `state`: short description of PuppetDB's current state:
+    * "starting" if PuppetDB is in maintenance mode
+    * "running" if not in maintenance mode and read and write databases are up
+    * "error" if the read or write databases are down.
 * `status`:
     * `maintenance_mode?`: indicates whether PuppetDB is in maintenance mode.
     PuppetDB enters maintenance mode at startup and exits it after completing any
@@ -44,4 +47,5 @@ following:
     While in maintenance mode PuppetDB will not respond to queries.
     * `read_db_up?`: indicates whether the read database is responding to queries
     * `write_db_up?`: indicates whether the write database is responding to queries
-    * `queue_depth`: depth of the command queue
+    * `queue_depth`: depth of the command queue. If the queue is not yet
+      initialized, this field will be null.

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
 (def tk-version "1.1.1")
 (def tk-jetty9-version "1.3.1")
 (def ks-version "1.1.0")
-(def tk-status-version "0.2.0")
+(def tk-status-version "0.2.1")
 
 (def pdb-jvm-opts
   (case (System/getProperty "java.specification.version")

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -242,9 +242,10 @@
 (defn db-up?
   [db-spec]
   (utils/with-timeout 1000 false
-    (jdbc/with-transacted-connection db-spec
-      (try (let [select-42 "SELECT (a - b) AS answer FROM (VALUES ((7 * 7), 7)) AS x(a, b)"
-                 [{:keys [answer]}] (jdbc/query [select-42])]
-             (= answer 42))
-           (catch Exception _
-             false)))))
+    (try
+      (jdbc/with-transacted-connection db-spec
+        (let [select-42 "SELECT (a - b) AS answer FROM (VALUES ((7 * 7), 7)) AS x(a, b)"
+              [{:keys [answer]}] (jdbc/query [select-42])]
+          (= answer 42)))
+      (catch Exception _
+        false))))

--- a/test/puppetlabs/puppetdb/status_test.clj
+++ b/test/puppetlabs/puppetdb/status_test.clj
@@ -25,13 +25,13 @@
   (testing "status returns as expected when in maintenance mode"
     (with-redefs [puppetlabs.puppetdb.pdb-routing/maint-mode? (constantly true)]
       (svc-utils/with-puppetdb-instance
-        (let [{:keys [body] :as pdb-resp} (-> svc-utils/*base-url*
-                                              (assoc :prefix "/status/v1/services")
-                                              base-url->str-with-prefix
-                                              client/get)
+        (let [{:keys [body status]} (-> svc-utils/*base-url*
+                                        (assoc :prefix "/status/v1/services")
+                                        base-url->str-with-prefix
+                                        (client/get {:throw-exceptions false}))
               pdb-status (:puppetdb-status (json/parse-string body true))]
-          (tu/assert-success! pdb-resp)
-          (is (= "running" (:state pdb-status)))
+          (is (= 503 status))
+          (is (= "starting" (:state pdb-status)))
           (is (= {:maintenance_mode? true
                   :read_db_up? true
                   :write_db_up? true


### PR DESCRIPTION
This changes our status implementation to return :starting while in maint mode,
and bumps to the status-service version that enables the change.