### PR TITLE
(QENG-3111) Make use of the PUPPETDB_DBTYPE CI variable.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ RAKE_ROOT = File.dirname(__FILE__)
 
 def run_beaker(test_files)
   config = ENV["BEAKER_CONFIG"] || "ec2-west-dev"
-  options = ENV["BEAKER_OPTIONS"] || "postgres"
+  options = ENV["BEAKER_OPTIONS"] || "acceptance/options/postgres.rb"
   preserve_hosts = ENV["BEAKER_PRESERVE_HOSTS"] || "never"
   no_provision = ENV["BEAKER_NO_PROVISION"] == "true" ? true : false
   color = ENV["BEAKER_COLOR"] == "false" ? false : true
@@ -17,7 +17,7 @@ def run_beaker(test_files)
      "--type #{type} " +
      "--debug " +
      "--tests " + test_files + " " +
-     "--options-file 'acceptance/options/#{options}.rb' " +
+     "--options-file " + options + " " +
      "--root-keys " +
      "--preserve-hosts #{preserve_hosts}"
 

--- a/ext/jenkins/beaker-tests.sh
+++ b/ext/jenkins/beaker-tests.sh
@@ -20,6 +20,10 @@ export BEAKER_project=PuppetDB
 export BEAKER_department=eso-dept
 export BEAKER_PRESERVE_HOSTS=onfail
 
+if [ "$PUPPETDB_DBTYPE" = "hsqldb" ] ;then
+  export BEAKER_OPTIONS="acceptance/options/embedded_db.rb"
+fi
+
 # S3 params
 export PUPPETDB_PACKAGE_REPO_HOST="puppetdb-prerelease.s3.amazonaws.com"
 export PUPPETDB_PACKAGE_REPO_URL="http://puppetdb-prerelease.s3.amazonaws.com/puppetdb/${PACKAGE_BUILD_VERSION}"


### PR DESCRIPTION
Without this patch the acceptance tests just always use `postgres` even if PUPPETDB_DBTYPE is set to something else.

Previously the name `embedded_db` was the alternative to `postgres` despite the fact that the unit test jobs actually used `hsqldb` vs `postgres` as the distinction. In https://github.com/puppetlabs/ci-job-configs/pull/715 I removed the use of `embedded_db` entirely to be replaced with `hsqldb` where appropriate.