### PR TITLE
(maint) Tests: fix info level count due to new agent

### DIFF
--- a/acceptance/tests/reports/report_storage.rb
+++ b/acceptance/tests/reports/report_storage.rb
@@ -87,7 +87,7 @@ test_name "basic validation of puppet report submission" do
       assert(line_change["tags"].to_set == ["notice", "notify", "hi", "class"].to_set,
             "tags of logs do not match!")
       assert(notice_level.count == 3, "notice level count does not match!")
-      assert(info_level.count == 4, "info level count does not match!")
+      assert(info_level.count == 5, "info level count does not match!")
     end
   end
 end


### PR DESCRIPTION
The new puppet agent (4.3.0) drops 5 info level events, instead of just 4.

Signed-off-by: Ken Barber <ken@bob.sh>