### PR TITLE
(PDB-2206) indexes not getting used for hash/uuid queries

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1465,6 +1465,29 @@
       (format "ALTER TABLE reports ADD COLUMN logs %s DEFAULT NULL" jsonb-type)
       (format "ALTER TABLE reports ADD COLUMN resources %s DEFAULT NULL" jsonb-type))))
 
+(defn add-expression-indexes-for-bytea-queries
+  []
+  (if (sutils/postgres?)
+    (jdbc/do-commands
+      "CREATE UNIQUE INDEX reports_hash_expr_idx ON reports(trim(leading '\\x' from hash::text))"
+      "ALTER TABLE REPORTS DROP CONSTRAINT reports_hash_key"
+      "DROP INDEX reports_transaction_uuid_idx"
+      "CREATE INDEX reports_tx_uuid_expr_idx ON reports(CAST(transaction_uuid AS text))"
+
+      ;; leave the existing resources/rpc indices for resources-query join
+      "CREATE INDEX resources_hash_expr_idx ON catalog_resources(trim(leading '\\x' from resource::text))"
+      "CREATE INDEX rpc_hash_expr_idx ON resource_params_cache(trim(leading '\\x' from resource::text))"
+      "CREATE INDEX resource_params_hash_expr_idx ON resource_params(trim(leading '\\x' from resource::text))"
+
+      "CREATE UNIQUE INDEX catalogs_hash_expr_idx ON catalogs(trim(leading '\\x' from hash::text))"
+      "ALTER TABLE catalogs DROP CONSTRAINT catalogs_hash_key"
+      "DROP INDEX idx_catalogs_transaction_uuid"
+      "CREATE INDEX catalogs_tx_uuid_expr_idx ON catalogs(CAST(transaction_uuid AS text))"
+
+      "CREATE UNIQUE INDEX factsets_hash_expr_idx ON factsets(trim(leading '\\x' from hash::text))"
+      "ALTER TABLE factsets DROP CONSTRAINT factsets_hash_key")
+    nil))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {1 initialize-store
@@ -1508,7 +1531,7 @@
    36 rename-environments-name-to-environment
    37 add-jsonb-columns-for-metrics-and-logs
    38 add-code-id-to-catalogs
-   })
+   39 add-expression-indexes-for-bytea-queries})
 
 (def desired-schema-version (apply max (keys migrations)))
 


### PR DESCRIPTION
Without this patch, equality queries on our bytea fields trigger full table
scans because we're doing type coercion on the left hand side of the
comparison. This adds expression indexes for those coercions to enable fast
queries.