### PR TITLE
(PDB-2122) New 'root' single query endpoint and 'from' operator

### DIFF
--- a/documentation/_puppetdb_nav.html
+++ b/documentation/_puppetdb_nav.html
@@ -58,8 +58,10 @@
     <ul>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/upgrading-from-v3.html">Upgrading from Version 3</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/query.html">Query Structure</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/entities.html">Entities</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/operators.html">Available Operators</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/paging.html">Query Paging</a></li>
+      <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/index.html">Root Endpoint (Experimental)</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/nodes.html">Nodes Endpoint</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/environments.html">Environments Endpoint</a></li>
       <li><a href="/puppetdb/{{ puppetdb_version }}/api/query/v4/factsets.html">Factsets Endpoint</a></li>

--- a/documentation/api/index.markdown
+++ b/documentation/api/index.markdown
@@ -41,20 +41,8 @@ The available query endpoints are documented in the pages linked below.
 
 This is the current stable API.
 
-* [Nodes Endpoint](./query/v4/nodes.html)
-* [Environments Endpoint](./query/v4/environments.html)
-* [Factsets Endpoint](./query/v4/factsets.html)
-* [Facts Endpoint](./query/v4/facts.html)
-* [Fact-Names Endpoint](./query/v4/fact-names.html)
-* [Fact-Paths Endpoint](./query/v4/fact-paths.html)
-* [Fact-Contents Endpoint](./query/v4/fact-contents.html)
-* [Catalogs Endpoint](./query/v4/catalogs.html)
-* [Edges Endpoint](./query/v4/edges.html)
-* [Resources Endpoint](./query/v4/resources.html)
-* [Reports Endpoint](./query/v4/reports.html)
-* [Events Endpoint](./query/v4/events.html)
-* [Event Counts Endpoint](./query/v4/event-counts.html)
-* [Aggregate Event Counts Endpoint](./query/v4/aggregate-event-counts.html)
+* [Root Endpoint](./query/v4/index.html)
+* [Entity Endpoints](./query/v4/entities.html)
 * [Metrics Endpoint](./metrics/v1/mbeans.html)
 * [Server Time Endpoint](./meta/v1/server-time.html)
 * [Version Endpoint](./meta/v1/version.html)

--- a/documentation/api/query/v4/entities.markdown
+++ b/documentation/api/query/v4/entities.markdown
@@ -1,0 +1,53 @@
+---
+title: "PuppetDB 3.2 » API » v4 » Entities"
+layout: default
+canonical: "/puppetdb/latest/api/query/v4/entities.html"
+---
+
+[aggregate-event-counts]: ./aggregate-event-counts.html
+[catalogs]: ./catalogs.html
+[edges]: ./edges.html
+[environments]: ./environments.html
+[event-counts]: ./event-counts.html
+[events]: ./events.html
+[fact-names]: ./fact-names.html
+[facts]: ./facts.html
+[fact-contents]: ./fact-contents.html
+[fact-paths]: ./fact-paths.html
+[nodes]: ./nodes.html
+[query]: ./query.html
+[reports]: ./reports.html
+[resources]: ./resources.html
+[root]: ./index.html
+[from]: ./operators.html#context-operators
+[subquery]: ./operators.html#subquery-operators
+
+The PuppetDB API provides access to a series of data entities that map to the Puppet eco-system
+and the data that PuppetDB stores.
+
+## Entity Types
+
+The following table shows the list of entities available, and their respective REST endpoints for
+direct querying.
+
+The entity name is utilised within queries themselves, in particular within the [`from`][from]
+and [`subquery`][subquery] operators.
+
+Entity Name                                        | REST Endpoint
+---------------------------------------------------|---------------------------------------------------------------
+[`aggregate_event_counts`][aggregate-event-counts] | [/pdb/query/v4/aggregate-event-counts][aggregate-event-counts]
+[`catalogs`][catalogs]                             | [/pdb/query/v4/catalogs][catalogs]
+[`edges`][edges]                                   | [/pdb/query/v4/edges][edges]
+[`environments`][environments]                     | [/pdb/query/v4/environments][environments]
+[`event_counts`][event-counts]                     | [/pdb/query/v4/event-counts][event-counts]
+[`events`][events]                                 | [/pdb/query/v4/events][events]
+[`facts`][facts]                                   | [/pdb/query/v4/facts][facts]
+[`fact_contents`][fact-contents]                   | [/pdb/query/v4/fact-contents][fact-contents]
+[`fact_names`][fact-names]                         | [/pdb/query/v4/fact-names][fact-names]
+[`fact_paths`][fact-paths]                         | [/pdb/query/v4/fact-paths][fact-paths]
+[`nodes`][nodes]                                   | [/pdb/query/v4/nodes][nodes]
+[`reports`][reports]                               | [/pdb/query/v4/reports][reports]
+[`resources`][resources]                           | [/pdb/query/v4/resources][resources]
+
+You can also query a particular entity using the [root endpoint][root] by using a top-level [`from`][from]
+operator.

--- a/documentation/api/query/v4/index.markdown
+++ b/documentation/api/query/v4/index.markdown
@@ -1,0 +1,63 @@
+---
+title: "PuppetDB 3.2 » API » v4 » Root Endpoint"
+layout: default
+canonical: "/puppetdb/latest/api/query/v4/index.html"
+---
+
+[curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
+[paging]: ./paging.html
+[query]: ./query.html
+[from]: ./operators.html#context-operators
+[entities]: ./entities.html
+
+*Note:* This endpoint is experimental. It may be altered or removed in a future release.
+
+The root query endpoint can be used to retrieve any known entities, from a
+single endpoint.
+
+## `/pdb/query/v4`
+
+This will return any known entity based on the required `query` field. Unlike
+other endpoints, the [entity][entities] must be supplied using a query with the [`from`][from]
+operator.
+
+### URL Parameters
+
+* `query`: Required. A JSON array containing the query in prefix notation
+(`["from", "<ENTITY>", ["<OPERATOR>", "<FIELD>", "<VALUE>"]]`). Unlike other endpoints,
+a query with a [`from`][from] is required to choose the [entity][entities] to query for. For
+general info about queries, see [the page on query structure.][query]
+
+### Response Format
+
+The response will be in `application/json`, and will contain a list of JSON
+object results based on the [entity][entities] provided in the top-level [`from`][from] query.
+
+### Examples
+
+[Using `curl` from localhost][curl]:
+
+    curl -X GET http://localhost:8080/pdb/query/v4 --data-urlencode 'query=["from","nodes",["=","certname","macbook-pro.local"]]'
+
+    [
+      {
+        "catalog_environment": "production",
+        "catalog_timestamp": "2015-11-23T19:25:25.561Z",
+        "certname": "macbook-pro.local",
+        "deactivated": null,
+        "expired": null,
+        "facts_environment": "production",
+        "facts_timestamp": "2015-11-23T19:25:25.079Z",
+        "latest_report_hash": "0b2aa3bbb1deb71a5328c1d934eadbba5f52d733",
+        "latest_report_status": "unchanged",
+        "report_environment": "production",
+        "report_timestamp": "2015-11-23T19:25:23.394Z"
+      }
+    ]
+
+## Paging
+
+This query endpoint supports paged results via the common PuppetDB paging
+URL parameters.  For more information, please see the documentation
+on [paging][paging].
+

--- a/documentation/api/query/v4/query.markdown
+++ b/documentation/api/query/v4/query.markdown
@@ -6,12 +6,13 @@ canonical: "/puppetdb/latest/api/query/v4/query.html"
 
 [prefix]: http://en.wikipedia.org/wiki/Polish_notation
 [jetty]: ../../../configure.html#jetty-http-settings
-[index]: ../../index.html
 [urlencode]: http://en.wikipedia.org/wiki/Percent-encoding
 [operators]: ./operators.html
 [tutorial]: ../tutorial.html
 [curl]: ../curl.html
 [paging]: ./paging.html
+[entities]: ./entities.html
+[root]: ./index.html
 
 ## Summary
 
@@ -35,6 +36,12 @@ That is, most queries will look like a GET request to a URL that resembles the f
 
     https://puppetdb:8081/pdb/query/v4/<ENDPOINT>?query=<QUERY STRING>
 
+Alternatively, you can provide the entity context instead of using the `<ENDPOINT>` suffix with the following:
+
+    https://puppetdb:8081/pdb/query/v4?query=<QUERY STRING>
+
+Consult the [root] endpoint documentation for more details.
+
 ### API URLs
 
 API URLs generally look like this:
@@ -49,13 +56,13 @@ After the `/pdb/query/` prefix, the first part of an API URL is the
 **API version,** written as `v4`, etc. This section describes version
 4 of the API, so every URL will begin with `/pdb/query/v4`.
 
-### Endpoints
+### Entity Endpoints
 
-After the version, URLs are organized into a number of **endpoints.**
+After the version, URLs are organized into a number of **endpoints.** that express the entity you wish to query on.
 
-Conceptually, an endpoint represents a reservoir of some type of PuppetDB object. Each version of the PuppetDB API defines a set number of endpoints.
+Conceptually, an entity endpoint represents a PuppetDB entity. Each version of the PuppetDB API defines a set number of endpoints.
 
-See the [API index][index] for a list of the available endpoints. Each endpoint may have additional sub-endpoints under it; these are generally just shortcuts for the most common types of query, so that you can write terser and simpler query strings.
+See the [entities documentation][entities] for a list of the available endpoints. Each endpoint may have additional sub-endpoints under it; these are generally just shortcuts for the most common types of query, so that you can write terser and simpler query strings.
 
 ### URL Parameters
 

--- a/src/puppetlabs/puppetdb/export.clj
+++ b/src/puppetlabs/puppetdb/export.clj
@@ -45,9 +45,9 @@
   [entity datum]
   (let [file-suffix
         (case entity
-          :factsets ["facts" (str (:certname datum) ".json")]
-          :catalogs ["catalogs" (str (:certname datum) ".json")]
-          :reports ["reports" (export-report-filename datum)])]
+          "factsets" ["facts" (str (:certname datum) ".json")]
+          "catalogs" ["catalogs" (str (:certname datum) ".json")]
+          "reports" ["reports" (export-report-filename datum)])]
     {:file-suffix file-suffix
      :contents (if (= entity :reports)
                  (-> datum (dissoc :hash) json/generate-pretty-string)
@@ -58,13 +58,13 @@
   (map #(export-datum->tar-item entity %) data))
 
 (def export-info
-  {:catalogs {:query->wire-fn catalogs/catalogs-query->wire-v7
+  {"catalogs" {:query->wire-fn catalogs/catalogs-query->wire-v7
               :anonymize-fn anon/anonymize-catalog
               :json-encoded-fields [:edges :resources]}
-   :reports {:query->wire-fn reports/reports-query->wire-v6
+   "reports" {:query->wire-fn reports/reports-query->wire-v6
              :anonymize-fn anon/anonymize-report
              :json-encoded-fields [:metrics :logs :resource_events]}
-   :factsets {:query->wire-fn factsets/factsets-query->wire-v4
+   "factsets" {:query->wire-fn factsets/factsets-query->wire-v4
               :anonymize-fn anon/anonymize-facts
               :json-encoded-fields [:facts]}})
 
@@ -93,7 +93,7 @@
                                            (maybe-anonymize anonymize-fn anon-config)
                                            (export-data->tar-items entity)
                                            (add-tar-entries tar-writer)))]]
-      (query-fn entity query-api-version nil nil query-callback-fn))))
+      (query-fn query-api-version ["from" entity] nil query-callback-fn))))
 
 (defn export!
   ([outfile query-fn] (export! outfile query-fn nil))

--- a/src/puppetlabs/puppetdb/http.clj
+++ b/src/puppetlabs/puppetdb/http.clj
@@ -283,3 +283,17 @@
   "Produce a json 400 response with an :error key holding message."
   [message]
   (json-response {:error message} status-bad-request))
+
+(defn deprecated-app
+  "Add an X-Deprecation warning for deprecated endpoints"
+  [app msg request]
+  (let [result (app request)]
+    (log/warn msg)
+    (rr/header result "X-Deprecation" msg)))
+
+(defn experimental-warning
+  "Add a Warning: header for experimental endpoints"
+  [app msg request]
+  (let [result (app request)]
+    (log/warn msg)
+    (rr/header result "Warning" msg)))

--- a/src/puppetlabs/puppetdb/http/aggregate_event_counts.clj
+++ b/src/puppetlabs/puppetdb/http/aggregate_event_counts.clj
@@ -8,12 +8,10 @@
   (let [param-spec {:required ["summarize_by"]
                     :optional ["query" "counts_filter" "count_by"
                                "distinct_resources" "distinct_start_time"
-                               "distinct_end_time"]}
-        query-route #(apply (partial http-q/query-route :aggregate-event-counts
-                                     version param-spec) %)]
+                               "distinct_end_time"]}]
     (app
       []
-      (query-route optional-handlers))))
+      (http-q/query-route-from "aggregate_event_counts" version param-spec optional-handlers))))
 
 (defn aggregate-event-counts-app
   "Ring app for querying for aggregated summary information about resource events."

--- a/src/puppetlabs/puppetdb/http/edges.clj
+++ b/src/puppetlabs/puppetdb/http/edges.clj
@@ -12,11 +12,10 @@
                    http-q/restrict-query-to-active-nodes
                    identity)
          handlers (cons handler optional-handlers)
-         param-spec {:optional paging/query-params}
-         query-route #(apply (partial http-q/query-route :edges version param-spec) %)]
+         param-spec {:optional paging/query-params}]
      (app
        [""]
-       (query-route handlers)))))
+       (http-q/query-route-from "edges" version param-spec handlers)))))
 
 (defn edges-app
   ([version] (edges-app version true))

--- a/src/puppetlabs/puppetdb/http/event_counts.clj
+++ b/src/puppetlabs/puppetdb/http/event_counts.clj
@@ -11,11 +11,10 @@
                     :optional (concat ["counts_filter" "count_by"
                                        "distinct_resources" "distinct_start_time"
                                        "distinct_end_time"]
-                                      paging/query-params)}
-        query-route #(apply (partial http-q/query-route :event-counts version param-spec) %)]
+                                      paging/query-params)}]
     (app
       []
-      (query-route optional-handlers))))
+      (http-q/query-route-from "event_counts" version param-spec optional-handlers))))
 
 (defn event-counts-app
   "Ring app for querying for summary information about resource events."

--- a/src/puppetlabs/puppetdb/http/events.clj
+++ b/src/puppetlabs/puppetdb/http/events.clj
@@ -11,11 +11,10 @@
                                  "distinct_resources"
                                  "distinct_start_time"
                                  "distinct_end_time"]
-                                paging/query-params)}
-        query-route #(apply (partial http-q/query-route :events version param-spec) %)]
+                                paging/query-params)}]
     (app
       []
-      (query-route optional-handlers))))
+      (http-q/query-route-from "events" version param-spec optional-handlers))))
 
 (defn events-app
   "Ring app for querying events"

--- a/src/puppetlabs/puppetdb/http/fact_contents.clj
+++ b/src/puppetlabs/puppetdb/http/fact_contents.clj
@@ -9,8 +9,8 @@
   (let [param-spec {:optional paging/query-params}]
     (app
       []
-      (http-q/query-route :fact-contents version param-spec
-                          http-q/restrict-query-to-active-nodes))))
+      (http-q/query-route-from "fact_contents" version param-spec
+                               [http-q/restrict-query-to-active-nodes]))))
 
 (defn fact-contents-app
   [version]

--- a/src/puppetlabs/puppetdb/http/fact_paths.clj
+++ b/src/puppetlabs/puppetdb/http/fact_paths.clj
@@ -11,7 +11,7 @@
   (let [param-spec {:optional paging/query-params}]
     (app
       []
-      (http-q/query-route :fact-paths version param-spec))))
+      (http-q/query-route-from "fact_paths" version param-spec))))
 
 (defn fact-paths-app
   [version]

--- a/src/puppetlabs/puppetdb/http/facts.clj
+++ b/src/puppetlabs/puppetdb/http/facts.clj
@@ -2,8 +2,7 @@
   (:require [puppetlabs.puppetdb.http.query :as http-q]
             [puppetlabs.puppetdb.query.paging :as paging]
             [net.cgrand.moustache :refer [app]]
-            [puppetlabs.puppetdb.middleware :refer [verify-accepts-json
-                                                    wrap-with-paging-options]]))
+            [puppetlabs.puppetdb.middleware :refer [wrap-with-paging-options]]))
 
 (defn routes
   [version restrict-to-active-nodes optional-handlers]
@@ -12,7 +11,7 @@
                   identity)
         handlers (cons handler optional-handlers)
         param-spec {:optional paging/query-params}
-        query-route #(apply (partial http-q/query-route :facts version param-spec) %)]
+        query-route (partial http-q/query-route-from "facts" version param-spec)]
   (app
     []
     (query-route handlers)

--- a/src/puppetlabs/puppetdb/http/index.clj
+++ b/src/puppetlabs/puppetdb/http/index.clj
@@ -1,0 +1,18 @@
+(ns puppetlabs.puppetdb.http.index
+  (:require [net.cgrand.moustache :refer [app]]
+            [puppetlabs.puppetdb.http.query :as http-q]
+            [puppetlabs.puppetdb.middleware :refer [wrap-with-paging-options]]
+            [puppetlabs.puppetdb.query.paging :as paging]))
+
+(defn routes
+  [version optional-handlers]
+  (let [param-spec {:optional paging/query-params
+                    :required ["query"]}]
+    (app
+     []
+     (http-q/query-route version param-spec optional-handlers))))
+
+(defn index-app
+  [version & optional-handlers]
+  (-> (routes version optional-handlers)
+      wrap-with-paging-options))

--- a/src/puppetlabs/puppetdb/http/resources.clj
+++ b/src/puppetlabs/puppetdb/http/resources.clj
@@ -12,7 +12,7 @@
                   identity)
         handlers (cons handler optional-handlers)
         param-spec {:optional paging/query-params}
-        query-route #(apply (partial http-q/query-route :resources version param-spec) %)]
+        query-route (partial http-q/query-route-from "resources" version param-spec)]
     (app
       []
       (query-route handlers)

--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -11,18 +11,6 @@
             [net.cgrand.moustache :refer [app]]
             [ring.util.response :as rr]))
 
-(defn deprecated-app
-  [app msg request]
-  (let [result (app request)]
-    (log/warn msg)
-    (rr/header result "X-Deprecation" msg)))
-
-(defn experimental-warning
-  [app msg request]
-  (let [result (app request)]
-    (log/warn msg)
-    (rr/header result "Warning" msg)))
-
 (defn- refuse-retired-api
   [version]
   (constantly

--- a/src/puppetlabs/puppetdb/http/v4.clj
+++ b/src/puppetlabs/puppetdb/http/v4.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.puppetdb.http.v4
-  (:require [puppetlabs.puppetdb.http.aggregate-event-counts :as aec]
+  (:require [puppetlabs.puppetdb.http :as http]
+            [puppetlabs.puppetdb.http.aggregate-event-counts :as aec]
             [puppetlabs.puppetdb.http.event-counts :as ec]
             [puppetlabs.puppetdb.http.catalogs :as catalogs]
             [puppetlabs.puppetdb.http.reports :as reports]
@@ -13,12 +14,24 @@
             [puppetlabs.puppetdb.http.resources :as resources]
             [puppetlabs.puppetdb.http.nodes :as nodes]
             [puppetlabs.puppetdb.http.environments :as envs]
+            [puppetlabs.puppetdb.http.index :as index]
             [net.cgrand.moustache :as moustache]))
 
 (def version :v4)
 
+(defn experimental-index-app
+  [version]
+  (fn [request]
+    (http/experimental-warning
+     (index/index-app version)
+     "The root endpoint is experimental"
+     request)))
+
 (def v4-app
   (moustache/app
+   []
+   {:any (experimental-index-app version)}
+
    ["facts" &]
    {:any (facts/facts-app version)}
 

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -33,12 +33,12 @@
         (is (= 1 (count (logs-matching #"Skipping update check on Puppet Enterprise" @log-output))))))))
 
 (defn- check-service-query
-  [endpoint version q pagination check-result]
+  [version q pagination check-result]
   (let [pdb-service (get-service svc-utils/*server* :PuppetDBServer)
         results (atom nil)
         before-slurp? (atom nil)
         after-slurp? (atom nil)]
-    (query pdb-service endpoint version q pagination
+    (query pdb-service version q pagination
            (fn [result-set]
              ;; We evaluate the first element from lazy-seq just to check if DB query was successful or not
              ;; so we have to ensure the first element and the rest have been realized, not just the first
@@ -65,7 +65,7 @@
       @(block-until-results 100 (first (get-factsets "foo.local")))
 
       (check-service-query
-       :facts :v4 ["=" "certname" "foo.local"]
+       :v4 ["from" "facts" ["=" "certname" "foo.local"]]
        nil
        (fn [result]
          (is (= #{{:value "the baz",
@@ -101,7 +101,7 @@
           (let [expected (take limit
                                (drop offset (if (= order :ascending) exp rexp)))]
             (check-service-query
-             :facts :v4 ["=" "certname" "foo.local"]
+             :v4 ["from" "facts" ["=" "certname" "foo.local"]]
              {:order_by [[:name order]]
               :offset offset
               :limit limit}

--- a/test/puppetlabs/puppetdb/http/catalogs_test.clj
+++ b/test/puppetlabs/puppetdb/http/catalogs_test.clj
@@ -158,11 +158,20 @@
     ;; Resources
     ;;;;;;;;;;
 
-    ;; In syntax
+    ;; In syntax: select_resources
     ["extract" "certname"
      ["in" "certname"
       ["extract" "certname"
        ["select_resources"
+        ["=" "type" "Apt::Pin"]]]]]
+    #{{:certname "myhost.localdomain"}
+      {:certname "host2.localdomain"}}
+
+    ;; In syntax: from
+    ["extract" "certname"
+     ["in" "certname"
+      ["from" "resources"
+       ["extract" "certname"
         ["=" "type" "Apt::Pin"]]]]]
     #{{:certname "myhost.localdomain"}
       {:certname "host2.localdomain"}}
@@ -178,11 +187,20 @@
     ;; Edges subqueries
     ;;;;;;;;;
 
-    ;; In operator
+    ;; In operator: select_edges
     ["extract" "certname"
      ["in" "certname"
       ["extract" "certname"
        ["select_edges"
+        ["=" "target_type" "File"]]]]]
+    #{{:certname "host2.localdomain"}
+      {:certname "myhost.localdomain"}}
+
+    ;; In operator: from edges
+    ["extract" "certname"
+     ["in" "certname"
+      ["from" "edges"
+       ["extract" "certname"
         ["=" "target_type" "File"]]]]]
     #{{:certname "host2.localdomain"}
       {:certname "myhost.localdomain"}}

--- a/test/puppetlabs/puppetdb/http/environments_test.clj
+++ b/test/puppetlabs/puppetdb/http/environments_test.clj
@@ -86,10 +86,19 @@
          ;; Basic facts subquery examples
          ;;;;;;;;;;;;
 
-         ;; In syntax
+         ;; In syntax: select_facts
          ["in" "name"
           ["extract" "environment"
            ["select_facts"
+            ["and"
+             ["=" "name" "operatingsystem"]
+             ["=" "value" "Debian"]]]]]
+         #{{:name "DEV"}}
+
+         ;; In syntax: from
+         ["in" "name"
+          ["from" "facts"
+           ["extract" "environment"
             ["and"
              ["=" "name" "operatingsystem"]
              ["=" "value" "Debian"]]]]]
@@ -106,11 +115,23 @@
          ;; Not-wrapped subquery syntax
          ;;;;;;;;;;;;;
 
-         ;; In syntax
+         ;; In syntax: select_facts
          ["not"
           ["in" "name"
            ["extract" "environment"
             ["select_facts"
+             ["and"
+              ["=" "name" "operatingsystem"]
+              ["=" "value" "Debian"]]]]]]
+         #{{:name "foo"}
+           {:name "bar"}
+           {:name "baz"}}
+
+         ;; In syntax: from
+         ["not"
+          ["in" "name"
+           ["from" "facts"
+            ["extract" "environment"
              ["and"
               ["=" "name" "operatingsystem"]
               ["=" "value" "Debian"]]]]]]
@@ -132,7 +153,7 @@
          ;; Complex subquery example
          ;;;;;;;;
 
-         ;; In syntax
+         ;; In syntax: select_<entity>
          ["in" "name"
           ["extract" "environment"
            ["select_facts"
@@ -143,6 +164,19 @@
                ["select_resources"
                 ["=" "type" "Class"]]]]]]]]
          #{{:name "DEV"}}
+
+         ;; In syntax: from
+         ["in" "name"
+          ["from" "facts"
+           ["extract" "environment"
+            ["and"
+             ["=" "name" "hostname"]
+             ["in" "value"
+              ["from" "resources"
+               ["extract" "title"
+                ["=" "type" "Class"]]]]]]]]
+         #{{:name "DEV"}}
+
 
          ;; Note: fact/resource comparison isn't a natural
          ;; join, so there is no implicit syntax here.

--- a/test/puppetlabs/puppetdb/http/fact_names_test.clj
+++ b/test/puppetlabs/puppetdb/http/fact_names_test.clj
@@ -212,15 +212,24 @@
 
     (testing "subqueries"
       (are [query expected]
-          (is (= expected
-                 (query-result method endpoint query)))
+        (is (= expected
+               (query-result method endpoint query)))
 
+        ;; In: select_fact_contents
         ["in" "path"
          ["extract" "path"
           ["select_fact_contents"
            ["=" "path" ["kernel"]]]]]
         #{{:path ["kernel"] :type "string"}}
 
+        ;; In: from fact_contents
+        ["in" "path"
+         ["from" "fact_contents"
+          ["extract" "path"
+           ["=" "path" ["kernel"]]]]]
+        #{{:path ["kernel"] :type "string"}}
+
+        ;; Subquery syntax
         ["subquery" "fact_contents"
          ["=" "path" ["kernel"]]]
         #{{:path ["kernel"] :type "string"}}))))

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -492,7 +492,8 @@
    (mid/wrap-with-puppetdb-middleware
     (server/build-app #(hash-map :scf-read-db read-db
                                  :scf-write-db write-db
-                                 :product-name "puppetdb"))
+                                 :product-name "puppetdb"
+                                 :url-prefix "/pdb"))
     nil)))
 
 (deftest-http-app fact-queries
@@ -1406,11 +1407,21 @@
     ;; Facts subqueries
     ;;;;;;;;;;;;;;
 
-    ;; In format
+    ;; In: select_facts
     ["extract" "certname"
      ["in" "certname"
       ["extract" "certname"
        ["select_facts"
+        ["and"
+         ["=" "name" "uptime_seconds"]
+         ["=" "value" "4000"]]]]]]
+    #{{:certname "foo1"}}
+
+    ;; In: from facts
+    ["extract" "certname"
+     ["in" "certname"
+      ["from" "facts"
+       ["extract" "certname"
         ["and"
          ["=" "name" "uptime_seconds"]
          ["=" "value" "4000"]]]]]]
@@ -1428,11 +1439,21 @@
     ;; Fact content subqueries
     ;;;;;;;;;;;;;
 
-    ;; In format
+    ;; In: select_fact_contents
     ["extract" "certname"
      ["in" "certname"
       ["extract" "certname"
        ["select_fact_contents"
+        ["and"
+         ["=" "name" "uptime_seconds"]
+         ["=" "value" "4000"]]]]]]
+    #{{:certname "foo1"}}
+
+    ;; In: from fact_contents
+    ["extract" "certname"
+     ["in" "certname"
+      ["from" "fact_contents"
+       ["extract" "certname"
         ["and"
          ["=" "name" "uptime_seconds"]
          ["=" "value" "4000"]]]]]]

--- a/test/puppetlabs/puppetdb/http/index_test.clj
+++ b/test/puppetlabs/puppetdb/http/index_test.clj
@@ -1,0 +1,141 @@
+(ns puppetlabs.puppetdb.http.index-test
+  (:require [clj-time.core :refer [now]]
+            [clojure.test :refer :all]
+            [puppetlabs.puppetdb.examples :refer :all]
+            [puppetlabs.puppetdb.http :as http]
+            [puppetlabs.puppetdb.scf.storage :as scf-store]
+            [puppetlabs.puppetdb.testutils.http :refer [deftest-http-app
+                                                        ordered-query-result
+                                                        query-response
+                                                        query-result
+                                                        vector-param]]))
+
+(def endpoints [[:v4 "/v4"]])
+
+(deftest-http-app index-queries
+  [[version endpoint] endpoints
+   method [:get :post]]
+  (let [catalog (:basic catalogs)
+        facts   {"kernel"          "Linux"
+                 "operatingsystem" "Debian"}
+        facts1  (assoc facts "fqdn" "host1")
+        facts2  (assoc facts "fqdn" "host2")
+        facts3  (assoc facts "fqdn" "host3")
+        cat1    (assoc catalog :certname "host1")
+        cat2    (assoc catalog :certname "host2")
+        cat3    (assoc catalog :certname "host3")]
+    (scf-store/add-certname! "host1")
+    (scf-store/add-certname! "host2")
+    (scf-store/add-certname! "host3")
+    (scf-store/replace-catalog! cat1 (now))
+    (scf-store/replace-catalog! cat2 (now))
+    (scf-store/replace-catalog! cat3 (now))
+    (scf-store/add-facts! {:certname "host1"
+                           :values facts1
+                           :timestamp (now)
+                           :environment "DEV"
+                           :producer_timestamp (now)})
+    (scf-store/add-facts! {:certname "host2"
+                           :values facts2
+                           :timestamp (now)
+                           :environment "DEV"
+                           :producer_timestamp (now)})
+    (scf-store/add-facts! {:certname "host3"
+                           :values facts3
+                           :timestamp (now)
+                           :environment "DEV"
+                           :producer_timestamp (now)})
+    (scf-store/deactivate-node! "host3")
+
+    (testing "invalid from query"
+      (let [{:keys [status body]} (query-response method endpoint ["from" "foobar"])]
+        (is (re-find #"Invalid entity" body))
+        (is (= status http/status-bad-request))))
+
+    (testing "pagination"
+      (testing "with order_by only"
+        (let [results (ordered-query-result method endpoint ["from" "nodes"]
+                                            {:order_by
+                                             (vector-param method
+                                                           [{"field" "certname"
+                                                             "order" "ASC"}])})]
+          (is (= "host1" (:certname (first results))))
+          (is (= 3 (count results)))))
+
+      (testing "with all options"
+        (let [results (ordered-query-result method endpoint ["from" "nodes"]
+                                            {:order_by
+                                             (vector-param method
+                                                           [{"field" "certname"
+                                                             "order" "DESC"}])
+                                             :limit 2
+                                             :offset 1})]
+          (is (= "host2" (:certname (first results))))
+          (is (= 2 (count results))))))
+
+    (testing "extract parameters"
+      (let [results (query-result method endpoint ["from" "nodes"
+                                                   ["extract" "certname"
+                                                    ["=" "certname" "host2"]]])]
+        (is (= results #{{:certname "host2"}}))))
+
+    (testing "nodes"
+      (testing "query should return all nodes (including deactivated ones)"
+        (is (= (set (mapv :certname (query-result method endpoint ["from" "nodes"] {})))
+               #{"host1" "host2" "host3"})))
+
+      (testing "query should return single node info"
+        (doseq [host ["host1" "host2" "host3"]]
+          (let [results (query-result method endpoint ["from" "nodes" ["=" "certname" host]])
+                result (first results)]
+            (is (= host (:certname result)))
+            (if (= host "host3")
+              (is (:deactivated result))
+              (is (nil? (:deactivated result))))))))
+
+    (testing "resources"
+      (testing "query should return the resources just for that node"
+        (doseq [host ["host1" "host2"]]
+          (let [results (query-result method endpoint ["from" "resources" ["=" "certname" host]])]
+            (is (= (set (map :certname results)) #{host})))))
+
+      (testing "query should return the resources just for that node matching the supplied type"
+        (doseq [host ["host1" "host2"]]
+          (let [results (query-result method endpoint ["from" "resources"
+                                                       ["and"
+                                                        ["=" "certname" host]
+                                                        ["=" "type" "File"]]])]
+            (is (= (set (map :certname results)) #{host}))
+            (is (= (set (map :type results)) #{"File"}))
+            (is (= (count results) 2)))))
+
+      (testing "query should return all resources matching the supplied type"
+        (let [results (query-result method endpoint ["from" "resources" ["=" "type" "File"]])]
+          (is (= (set (map :certname results)) #{"host1" "host2" "host3"}))
+          (is (= (set (map :type results)) #{"File"}))
+          (is (= (count results) 6))))
+
+      (testing "query should return [] if the <type> doesn't match anything"
+        (let [results (query-result method endpoint ["from" "resources" ["=" "type" "Foobar"]])]
+          (is (= results #{})))))
+
+    (testing "facts"
+      (testing "query should return all instances of the given fact"
+        (let [results (query-result method endpoint ["from" "facts" ["=" "name" "kernel"]])]
+          (is (= (set (map :name results)) #{"kernel"}))
+          (is (= (count results) 3))))
+
+      (testing "query should return all instances of the given fact with the given value"
+        (let [results (query-result method endpoint ["from" "facts" ["and" ["=" "name" "kernel"] ["=" "value" "Linux"]]])]
+          (is (= (set (map :name results)) #{"kernel"}))
+          (is (= (set (map :value results)) #{"Linux"}))
+          (is (= (count results) 3))))
+
+      (testing "query should return [] if the fact doesn't match anything"
+        (let [results (query-result method endpoint ["from" "facts" ["=" "name" "blah"]])]
+          (is (= results #{})))))
+
+    (testing "fact_contents query should match expected results"
+      (let [results (query-result method endpoint ["from" "fact_contents" ["=" "certname" "host1"]])]
+        (is (= (set (mapv :name results))
+               #{"kernel" "operatingsystem" "fqdn"}))))))

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -138,10 +138,19 @@
       ;; Fact subqueries
       ;;;;;;;;;;;;
 
-      ;; In format
+      ;; In: select_facts
       ["in" "certname"
        ["extract" "certname"
         ["select_facts"
+         ["and"
+          ["=" "name" "operatingsystem"]
+          ["=" "value" "Debian"]]]]]
+      [db web1 web2]
+
+      ;; In: from facts
+      ["in" "certname"
+       ["from" "facts"
+        ["extract" "certname"
          ["and"
           ["=" "name" "operatingsystem"]
           ["=" "value" "Debian"]]]]]
@@ -158,10 +167,19 @@
       ;; Fact_contents subqueries
       ;;;;;;;;;;;
 
-      ;; In format
+      ;; In: select_facts
       ["in" "certname"
        ["extract" "certname"
         ["select_fact_contents"
+         ["and"
+          ["=" "name" "operatingsystem"]
+          ["=" "value" "Debian"]]]]]
+      [db web1 web2]
+
+      ;; In: from facts
+      ["in" "certname"
+       ["from" "fact_contents"
+        ["extract" "certname"
          ["and"
           ["=" "name" "operatingsystem"]
           ["=" "value" "Debian"]]]]]
@@ -178,10 +196,23 @@
       ;; Nodes with a class matching their hostname
       ;;;;;;;;;;;;;
 
-      ;; In format
+      ;; In: select_<entity>
       ["in" "certname"
        ["extract" "certname"
         ["select_facts"
+         ["and"
+          ["=" "name" "hostname"]
+          ["in" "value"
+           ["extract" "title"
+            ["select_resources"
+             ["and"
+              ["=" "type" "Class"]]]]]]]]]
+      [web1]
+
+      ;; In: from <entity>
+      ["in" "certname"
+       ["from" "facts"
+        ["extract" "certname"
          ["and"
           ["=" "name" "hostname"]
           ["in" "value"
@@ -206,7 +237,7 @@
       ;; Nodes with matching select-resources for file/line
       ;;;;;;;;;;;;
 
-      ;; In format
+      ;; In: select_resources
       ["in" "certname"
        ["extract" "certname"
         ["select_resources"
@@ -215,11 +246,14 @@
           ["=" "line" 1]]]]]
       [db puppet web1]
 
+      ;; In: from resources
       ["in" "certname"
-       ["extract" "certname"
-        ["select_resources"
-         ["=" "certname" web1]]]]
-      [web1]
+       ["from" "resources"
+        ["extract" "certname"
+         ["and"
+          ["=" "file" "/etc/puppet/modules/settings/manifests/init.pp"]
+          ["=" "line" 1]]]]]
+      [db puppet web1]
 
       ;; Implicit subquery
       ["subquery" "resources"
@@ -232,10 +266,17 @@
       ;; Reports subquery
       ;;;;;;;;;;;;
 
-      ;; In format
+      ;; In: select_reports
       ["in" "certname"
        ["extract" "certname"
         ["select_reports"
+         ["=" "certname" db]]]]
+      [db]
+
+      ;; In: from reports
+      ["in" "certname"
+       ["from" "reports"
+        ["extract" "certname"
          ["=" "certname" db]]]]
       [db]
 
@@ -248,10 +289,17 @@
       ;; Catalogs subquery
       ;;;;;;;;;;;;;;
 
-      ;; In format
+      ;; In: select_catalogs
       ["in" "certname"
        ["extract" "certname"
         ["select_catalogs"
+         ["=" "certname" web1]]]]
+      [web1]
+
+      ;; In: from catalogs
+      ["in" "certname"
+       ["from" "catalogs"
+        ["extract" "certname"
          ["=" "certname" web1]]]]
       [web1]
 
@@ -264,10 +312,17 @@
       ;; Factsets subquery
       ;;;;;;;;;;;;;;
 
-      ;; In format
+      ;; In: select_factsets
       ["in" "certname"
        ["extract" "certname"
         ["select_factsets"
+         ["=" "certname" web2]]]]
+      [web2]
+
+      ;; In: from factsets
+      ["in" "certname"
+       ["from" "factsets"
+        ["extract" "certname"
          ["=" "certname" web2]]]]
       [web2]
 
@@ -280,10 +335,17 @@
       ;; Events subquery
       ;;;;;;;;;;;;;
 
-      ;; In format
+      ;; In: select_events
       ["in" "certname"
        ["extract" "certname"
         ["select_events"
+         ["=" "certname" db]]]]
+      [db]
+
+      ;; In: from events
+      ["in" "certname"
+       ["from" "events"
+        ["extract" "certname"
          ["=" "certname" db]]]]
       [db]
 
@@ -296,10 +358,17 @@
       ;; Resource subquery
       ;;;;;;;;;;;;;
 
-      ;; In format
+      ;; In: select_resources
       ["in" "certname"
        ["extract" "certname"
         ["select_resources"
+         ["=" "certname" web1]]]]
+      [web1]
+
+      ;; In: from resources
+      ["in" "certname"
+       ["from" "resources"
+        ["extract" "certname"
          ["=" "certname" web1]]]]
       [web1]
 

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -595,11 +595,19 @@
     ;; Event subqueries
     ;;;;;;;;;;;;;;;
 
-    ;; In format
+    ;; In: select_events
     ["extract" "certname"
      ["in" "hash"
       ["extract" "report"
        ["select_events"
+        ["=" "file" "bar"]]]]]
+    #{{:certname "foo.local"}}
+
+    ;; In: from events
+    ["extract" "certname"
+     ["in" "hash"
+      ["from" "events"
+       ["extract" "report"
         ["=" "file" "bar"]]]]]
     #{{:certname "foo.local"}}
 

--- a/test/puppetlabs/puppetdb/testutils/events.clj
+++ b/test/puppetlabs/puppetdb/testutils/events.clj
@@ -58,9 +58,8 @@
   ([version query]
    (query-resource-events version query {}))
   ([version query query-options]
-   (eng/stream-query-result :events
-                            version
-                            query
+   (eng/stream-query-result version
+                            ["from" "events" query]
                             query-options
-                            *db*
-                            "")))
+                            {:scf-read-db *db*
+                             :url-prefix "/pdb"})))

--- a/test/puppetlabs/puppetdb/testutils/reports.clj
+++ b/test/puppetlabs/puppetdb/testutils/reports.clj
@@ -25,12 +25,11 @@
    :post [(or (nil? %)
               (map? %))]}
   (first
-   (eng/stream-query-result :reports
-                            version
-                            ["=" "hash" hash]
+   (eng/stream-query-result version
+                            ["from" "reports" ["=" "hash" hash]]
                             {}
-                            *db*
-                            "")))
+                            {:scf-read-db *db*
+                             :url-prefix "/pdb"})))
 
 (defn store-example-report!
   "Store an example report (from examples/report.clj) for use in tests.  Params:


### PR DESCRIPTION
This patch introduces the new 'root' endpoint that allows for querying any
entity inside a single query by providing a context query.

Here I've included this new feature all the way back to produce-streaming-body,
stream-query-result and the query API. This patch means that all the HTTP
endpoints are required to wrap their queries in from, so that this concept
of a single query for all endpoints exists all the way back to the query engine
API.

For cleanup, I've modified the produce-streaming-body and stream-query-results
to take an options map instead of a list of ordered arguments as we seem to change
this frequently and some validation is desired. Plus this simplifies argument
passing as most of the data is already available in `globals`.

As a side-effect of adding the from operator, I've added a new format for
subqueries that uses the same syntax at this level, as it does on the top-level.
This is provided for consistency, and it will hopefully remove the need for
the select_<entity> operator which was always a bit special.

Signed-off-by: Ken Barber <ken@bob.sh>