### PR TITLE
(PDB-2112) fix benchmark -A flag

### DIFF
--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -303,9 +303,9 @@
                            archive/read-entry-content
                            json/parse-string)]
       (condp re-find (.getName entry)
-        #"catalogs.*\\.json$" (update acc :catalogs conj parsed-entry)
-        #"reports.*\\.json$" (update acc :reports conj parsed-entry)
-        #"facts.*\\.json$" (update acc :facts conj parsed-entry)
+        #"catalogs.*\.json$" (update acc :catalogs conj parsed-entry)
+        #"reports.*\.json$" (update acc :reports conj parsed-entry)
+        #"facts.*\.json$" (update acc :facts conj parsed-entry)
         acc))))
 
 (def default-data-paths


### PR DESCRIPTION
This removes some unwarranted slashes from our benchmark code, and implements a
test for the -A flag.