### PR TITLE
(maint) Update Debian 7 & 8, Centos 7 and Ubuntu 14.04 ami's from latest packer builds

### DIFF
--- a/acceptance/config/ec2-west-ubuntu1404-64mda.cfg
+++ b/acceptance/config/ec2-west-ubuntu1404-64mda.cfg
@@ -1,0 +1,28 @@
+HOSTS:
+  ubuntu-1404-64-1:
+    roles:
+      - master
+      - database
+      - dashboard
+      - agent
+    vmname: ubuntu-14.04-amd64-west
+    platform: ubuntu-14.04-amd64
+    amisize: c3.large
+    hypervisor: ec2
+    snapshot: foss
+  ubuntu-1204-64-2:
+    roles:
+      - agent
+    vmname: ubuntu-14.04-amd64-west
+    platform: ubuntu-14.04-amd64
+    amisize: c3.large
+    hypervisor: ec2
+    snapshot: foss
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  vpc_id: vpc-cc4aeda9
+  subnet_ids:
+    - subnet-4a74d73d
+    - subnet-6169e404
+    - subnet-5870b101

--- a/config/image_templates/ec2.yaml
+++ b/config/image_templates/ec2.yaml
@@ -1,8 +1,8 @@
 AMI:
   el-7-x86_64-west:
     :image:
-      :pe: ami-d5c2e8e5
-      :foss: ami-d5c2e8e5
+      :pe: ami-c25448a3
+      :foss: ami-c25448a3
     :region: us-west-2
 
   el-6-x86_64-west:
@@ -15,6 +15,18 @@ AMI:
     :image:
       :pe: ami-85693fb5
       :foss: ami-85693fb5
+    :region: us-west-2
+
+  fedora-20-x86_64-west:
+    :image:
+      :pe: ami-c0b9daf0
+      :foss: ami-c0b9daf0
+    :region: us-west-2
+
+  ubuntu-14.04-amd64-west:
+    :image:
+      :pe: ami-be524edf
+      :foss: ami-be524edf
     :region: us-west-2
 
   ubuntu-12.04-amd64-west:
@@ -31,12 +43,6 @@ AMI:
 
   debian-7-amd64-west:
     :image:
-      :pe: ami-99e0ada9
-      :foss: ami-99e0ada9
-    :region: us-west-2
-
-  fedora-20-x86_64-west:
-    :image:
-      :pe: ami-c0b9daf0
-      :foss: ami-c0b9daf0
+      :pe: ami-6a574b0b
+      :foss: ami-6a574b0b
     :region: us-west-2


### PR DESCRIPTION
The packer builds for Centos 7 and Debian 7 have been updated, this PR
switches to the new AMI's.

Signed-off-by: Ken Barber <ken@bob.sh>