### PR TITLE
(PDB-992) Move to HikariCP instead of BoneCP

### DIFF
--- a/documentation/api/metrics/v1/mbeans.markdown
+++ b/documentation/api/metrics/v1/mbeans.markdown
@@ -57,9 +57,9 @@ Responses return a JSON Object mapping strings to (strings/numbers/booleans).
 
 ### Database metrics
 
-* `com.jolbox.bonecp:type=BoneCP`: Database connection pool
-  metrics. How long it takes to get a free connection, average
-  execution times, number of free connections, etc.
+* See
+  [the HikariCP documentation](https://github.com/brettwooldridge/HikariCP/wiki/Dropwizard-Metrics)
+  for the metric names and descriptions.
 
 ### Command-processing metrics
 

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -305,17 +305,6 @@ runs every `gc-interval` minutes.
 
 If unset, the default value is 14 days.
 
-### `classname`
-
-This sets the JDBC class to use.  It should be
-`org.postgresql.Driver`, which is the default.  You should not need to
-change it.
-
-### `subprotocol`
-
-This should be `postgresql`, which is the default.  You should not
-need to change it.
-
 ### `subname`
 
 This describes where to find the database. It should be something like
@@ -332,23 +321,26 @@ This is the username to use when connecting. Only used with PostgreSQL.
 
 This is the password to use when connecting. Only used with PostgreSQL.
 
-### `log-slow-statements`
+### `maximum-pool-size`
 
-This sets the number of seconds before an SQL query is considered "slow." Slow SQL queries are logged as warnings, to assist in debugging and tuning. Note PuppetDB does not interrupt slow queries; it simply reports them after they complete.
+From the HikariCP documentation:
 
-The default value is 10 seconds. A value of 0 will disable logging of slow queries.
+> This property controls the maximum size that the pool is allowed to reach,
+> including both idle and in-use connections. Basically this value will
+> determine the maximum number of actual connections to the database backend. A
+> reasonable value for this is best determined by your execution environment.
+
+When the pool reaches this size, and no idle connections are available, attempts
+to get a connection will wait for `connection-timeout` milliseconds before timing
+out.
+
+The default value is 10.
 
 ### `conn-max-age`
 
 The maximum time (in minutes), for a pooled connection to remain unused before it is closed off.
 
 If not supplied, we default to 60 minutes.
-
-### `conn-keep-alive`
-
-This sets the time (in minutes), for a connection to remain idle before sending a test query to the DB. This is useful to prevent a DB from timing out connections on its end.
-
-If not supplied, we default to 45 minutes.
 
 ### `conn-lifetime`
 
@@ -360,7 +352,47 @@ If not supplied, we won't terminate connections based on their age alone.
 
 The maximum time to wait (in milliseconds) to acquire a connection from the pool of database connections. If not supplied, defaults to 1000.
 
+## Deprecated settings
+
+### `classname`
+
+**Note**: This setting is deprecated and ignored by PuppetDB. It will be removed
+from PuppetDB in a future release.
+
+This sets the JDBC class to use.  It should be
+`org.postgresql.Driver`, which is the default.  You should not need to
+change it.
+
+### `subprotocol`
+
+**Note**: This setting is deprecated and ignored by PuppetDB. It will be removed
+from PuppetDB in a future release.
+
+This should be `postgresql`, which is the default.  You should not
+need to change it.
+
+### `log-slow-statements`
+
+**Note**: This setting is deprecated and ignored by PuppetDB. It will be removed
+from PuppetDB in a future release.
+
+This sets the number of seconds before an SQL query is considered "slow." Slow SQL queries are logged as warnings, to assist in debugging and tuning. Note PuppetDB does not interrupt slow queries; it simply reports them after they complete.
+
+The default value is 10 seconds. A value of 0 will disable logging of slow queries.
+
+### `conn-keep-alive`
+
+**Note**: This setting is deprecated and ignored by PuppetDB. It will be removed
+from PuppetDB in a future release.
+
+This sets the time (in minutes), for a connection to remain idle before sending a test query to the DB. This is useful to prevent a DB from timing out connections on its end.
+
+If not supplied, we default to 45 minutes.
+
 ###`statements-cache-size`
+
+**Note**: This setting is deprecated and ignored by PuppetDB. It will be removed
+from PuppetDB in a future release.
 
 This setting defines how many prepared statements are cached automatically. For a large amount of dynamic queries this number could be increased to increase performance, at the cost of memory consumption and database resources.
 
@@ -390,14 +422,6 @@ The main difference in the config file is that you must be sure to add `?ssl=tru
 
     subname = //<HOST>:<PORT>/<DATABASE>?ssl=true
 
-### `classname`
-
-This sets the JDBC class to use. This should be `org.postgresql.Driver`.
-
-### `subprotocol`
-
-Set this to `postgresql`.
-
 ### `subname`
 
 This describes where to find the database. Set this to:
@@ -413,23 +437,26 @@ This is the username to use when connecting.
 
 This is the password to use when connecting.
 
-### `log-slow-statements`
+### `maximum-pool-size`
 
-This sets the number of seconds before an SQL query is considered "slow." Slow SQL queries are logged as warnings, to assist in debugging and tuning. Note PuppetDB does not interrupt slow queries; it simply reports them after they complete.
+From the HikariCP documentation:
 
-The default value is 10 seconds. A value of 0 will disable logging of slow queries.
+> This property controls the maximum size that the pool is allowed to reach,
+> including both idle and in-use connections. Basically this value will
+> determine the maximum number of actual connections to the database backend. A
+> reasonable value for this is best determined by your execution environment.
+
+When the pool reaches this size, and no idle connections are available, attempts
+to get a connection will wait for `connection-timeout` milliseconds before timing
+out.
+
+The default value is 10.
 
 ### `conn-max-age`
 
 The maximum time (in minutes), for a pooled connection to remain unused before it is closed off.
 
 If not supplied, we default to 60 minutes.
-
-### `conn-keep-alive`
-
-This sets the time (in minutes), for a connection to remain idle before sending a test query to the DB. This is useful to prevent a DB from timing out connections on its end.
-
-If not supplied, we default to 45 minutes.
 
 ### `conn-lifetime`
 
@@ -440,6 +467,53 @@ If not supplied, we won't terminate connections based on their age alone.
 ### `connection-timeout`
 
 The maximum time to wait (in milliseconds) to acquire a connection from the pool of database connections. If not supplied, defaults to 500.
+
+## Deprecated settings
+
+### `classname`
+
+**Note**: This setting is deprecated and ignored by PuppetDB. It will be removed
+from PuppetDB in a future release.
+
+This sets the JDBC class to use.  It should be
+`org.postgresql.Driver`, which is the default.  You should not need to
+change it.
+
+### `subprotocol`
+
+**Note**: This setting is deprecated and ignored by PuppetDB. It will be removed
+from PuppetDB in a future release.
+
+This should be `postgresql`, which is the default.  You should not
+need to change it.
+
+
+### `log-slow-statements`
+
+**Note**: This setting is deprecated and ignored by PuppetDB. It will be removed
+from PuppetDB in a future release.
+
+This sets the number of seconds before an SQL query is considered "slow." Slow SQL queries are logged as warnings, to assist in debugging and tuning. Note PuppetDB does not interrupt slow queries; it simply reports them after they complete.
+
+The default value is 10 seconds. A value of 0 will disable logging of slow queries.
+
+### `conn-keep-alive`
+
+**Note**: This setting is deprecated and ignored by PuppetDB. It will be removed
+from PuppetDB in a future release.
+
+This sets the time (in minutes), for a connection to remain idle before sending a test query to the DB. This is useful to prevent a DB from timing out connections on its end.
+
+If not supplied, we default to 45 minutes.
+
+###`statements-cache-size`
+
+**Note**: This setting is deprecated and ignored by PuppetDB. It will be removed
+from PuppetDB in a future release.
+
+This setting defines how many prepared statements are cached automatically. For a large amount of dynamic queries this number could be increased to increase performance, at the cost of memory consumption and database resources.
+
+If not supplied, we default to 1000.
 
 
 `[command-processing]` Settings

--- a/project.clj
+++ b/project.clj
@@ -53,9 +53,9 @@
                  [slingshot "0.12.2"]
 
                  ;; Database connectivity
-                 [com.jolbox/bonecp "0.7.1.RELEASE" :exclusions [org.slf4j/slf4j-api]]
+                 [com.zaxxer/HikariCP "2.4.1"]
                  [org.clojure/java.jdbc "0.3.7"]
-                 [org.postgresql/postgresql "9.2-1003-jdbc4"]
+                 [org.postgresql/postgresql "9.4-1206-jdbc4"]
 
                  ;; MQ connectivity
                  [org.apache.activemq/activemq-broker "5.11.1"]

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -211,9 +211,7 @@
   (with-open [init-db-pool (jdbc/make-connection-pool
                             (assoc write-db-config
                                    ;; Block waiting to grab a connection
-                                   :connection-timeout 0
-                                   ;; Only allocate connections when needed
-                                   :pool-availability-threshold 0))]
+                                   :connection-timeout 0))]
     (let [db-pool-map {:datasource init-db-pool}]
       (initialize-schema db-pool-map config))))
 

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -208,12 +208,20 @@
   being fully started when PuppetDB starts. This connection pool will
   be opened and closed within the body of this function."
   [write-db-config config]
-  (with-open [init-db-pool (jdbc/make-connection-pool
-                            (assoc write-db-config
-                                   ;; Block waiting to grab a connection
-                                   :connection-timeout 0))]
-    (let [db-pool-map {:datasource init-db-pool}]
-      (initialize-schema db-pool-map config))))
+  (loop [db-spec (assoc write-db-config
+                        ;; Block waiting to grab a connection
+                        :connection-timeout 15000
+                        :pool-name "PDBMigrationsPool")]
+    (if-let [result
+             (try
+               (with-open [init-db-pool (jdbc/make-connection-pool db-spec)]
+                 (let [db-pool-map {:datasource init-db-pool}]
+                   (initialize-schema db-pool-map config)
+                   ::success))
+               (catch java.sql.SQLTransientConnectionException e
+                 (log/error e "Error while attempting to create connection pool")))]
+      result
+      (recur db-spec))))
 
 (defn start-puppetdb
   [context config service get-registered-endpoints]
@@ -230,8 +238,8 @@
         {:keys [dlo-compression-threshold]} command-processing
         {:keys [disable-update-checking]} puppetdb
 
-        write-db (jdbc/pooled-datasource database)
-        read-db (jdbc/pooled-datasource (assoc read-database :read-only? true))
+        write-db (jdbc/pooled-datasource (assoc database :pool-name "PDBWritePool"))
+        read-db (jdbc/pooled-datasource (assoc read-database :read-only? true :pool-name "PDBReadPool"))
         discard-dir (io/file (conf/mq-discard-dir config))]
 
     (when-let [v (version/version)]

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -54,6 +54,7 @@
      :conn-max-age (pls/defaulted-maybe s/Int 60)
      :conn-keep-alive (pls/defaulted-maybe s/Int 45)
      :conn-lifetime (s/maybe s/Int)
+     :maximum-pool-size (pls/defaulted-maybe s/Int 10)
      :classname (pls/defaulted-maybe String "org.postgresql.Driver")
      :subprotocol (pls/defaulted-maybe String "postgresql")
      :subname (s/maybe String)
@@ -96,6 +97,7 @@
    :log-statements Boolean
    :statements-cache-size s/Int
    :connection-timeout s/Int
+   :maximum-pool-size s/Int
    (s/optional-key :conn-lifetime) (s/maybe Minutes)
    (s/optional-key :username) String
    (s/optional-key :user) String

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -68,7 +68,7 @@
      :stats (pls/defaulted-maybe String "true")
      :log-statements (pls/defaulted-maybe String "true")
      :statements-cache-size (pls/defaulted-maybe s/Int 1000)
-     :connection-timeout (pls/defaulted-maybe s/Int 500)}))
+     :connection-timeout (pls/defaulted-maybe s/Int 3000)}))
 
 (def write-database-config-in
   "Includes the common database config params, also the write-db specific ones"
@@ -78,8 +78,7 @@
             :dlo-compression-interval s/Int
             :report-ttl (pls/defaulted-maybe String "14d")
             :node-purge-ttl (pls/defaulted-maybe String "0s")
-            :node-ttl (pls/defaulted-maybe String "0s")
-            :connection-timeout (pls/defaulted-maybe s/Int 1000)})))
+            :node-ttl (pls/defaulted-maybe String "0s")})))
 
 (def database-config-out
   "Schema for parsed/processed database config"

--- a/src/puppetlabs/puppetdb/jdbc/internal.clj
+++ b/src/puppetlabs/puppetdb/jdbc/internal.clj
@@ -2,56 +2,7 @@
   "JDBC helper functions
 
    *External code should not call any of these functions directly, as they are*
-   *subject to change without notice.*"
-  (:import (com.jolbox.bonecp.hooks AbstractConnectionHook ConnectionState)
-           (com.jolbox.bonecp PreparedStatementHandle))
-  (:require [clojure.tools.logging :as log]
-            [clojure.string :as str]))
-
-(defn query-param->str
-  "Helper method for converting a single parameter from a prepared statement
-  to a human-eradable string, including the java type of the param value."
-  [param]
-  (let [val (.getValue param)]
-    (format "(%s - %s)"
-            (if (string? val) (str "'" val "'") val)
-            (pr-str (type val)))))
-
-(defn query-params->str
-  "Helper method for converting a list of parameters from a prepared statement
-  to a human-readable string.  Our current connection pool library does not
-  make these available unless we've enabled SQL statement logging, so we have
-  to check first to see whether that is enabled.  If it's not, we print out
-  a message letting the user know how they can enable it."
-  [log-statements? params]
-  (if log-statements?
-    (format "Query Params: %s"
-            (str/join ", " (map query-param->str params)))
-    (str "(Query params unavailable: to enable logging of query params, please set "
-         "'log-statements' to true in the [database] section of your config file.)")))
-
-(defn on-query-execute-time-limit-exceeded
-  "Called *after* a query completes, if the elapsed time of a query exceeds
-   the configure timeout."
-  [conn stmt sql params time-elapsed log-statements? query-execution-limit]
-  (log/warnf (str "Query slower than %ss threshold:  "
-                  "actual execution time: %.4f seconds; Query: %s; "
-                  (query-params->str log-statements? params))
-             query-execution-limit
-             (/ time-elapsed 1000000000.0)
-             sql))
-
-(defn connection-hook
-  "Helper method for building up a `ConnectionHook` for our connection pool.
-  Currently only defines behavior for `onQueryExecuteTimeLimitExceeded`, which
-  is called for slow queries.  There are several other hooks available that we
-  could provide handlers for in the future."
-  [log-statements? query-execution-limit]
-  (proxy [AbstractConnectionHook] []
-    (onQueryExecuteTimeLimitExceeded
-      [conn stmt sql params time-elapsed]
-      (on-query-execute-time-limit-exceeded conn stmt sql params time-elapsed
-                                            log-statements? query-execution-limit))))
+   *subject to change without notice.*")
 
 (defn limit-exception
   "Helper method; simply throws an exception with a message explaining


### PR DESCRIPTION
This commit moves our connection pooling to use HikariCP instead of
BoneCP. This means we lose our pool metrics for now, until we update our
codehale metrics dependency.