### PR TITLE
[BKR-643] [DO NOT MERGE] Introduce and use Beaker::DSL.register

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :acceptance do
     gem 'beaker', *location_for(beaker_version)
   else
     # use the pinned version
-    gem 'beaker', '2.29.1'
+    gem 'beaker', '~2.11'
   end
   # This forces google-api-client to not download retirable 2.0.0 which lacks
   # ruby 1.9.x support.

--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -967,4 +967,12 @@ PP
 end
 
 # oh dear.
-Beaker::TestCase.send(:include, PuppetDBExtensions)
+module Beaker
+  module DSL
+    def self.register(helper_module)
+      include helper_module
+    end
+  end
+end
+
+Beaker::DSL.register(PuppetDBExtensions)


### PR DESCRIPTION
![](http://1.bp.blogspot.com/-MvRxTCZpbEM/U9RUKv1W4VI/AAAAAAAADBE/4E9DNuKcx9M/s1600/Fingers-crossed1.jpg)

This is a spike to see if we can get this part of the acceptance suite green using the most recent Beaker. Changes to support BKR-623, introduced via https://github.com/puppetlabs/beaker/pull/1013 result in relocation of `Beaker::TestCase`-specific code (as the `Beaker::TestSuite` and `Beaker::TestCase` modules are test-runner specific, and the nature of BKR-623 is to lay the groundwork to support multiple test runners).

Test suites which are overly familiar with the `Beaker::Test*` hierarchy are seeing scoping issues, where injection of methods into the `Beaker::TestCase` module ends up not providing the right scope.

There are a few ways to go about fixing this; this commit introduces one. The registration method was already developed for a later stage of the test runner refactorings (see: https://github.com/puppetlabs/beaker/pull/1023). We wish to gradually remove uses of `Beaker::TestCase` from non-Beaker code, and exposing a regisration facility on `Beaker::DSL` is our preferred method.

Backporting this registration facility here to see if it allows us to go green.

/cc @puppetlabs/puppetdb @puppetlabs/beaker 
