### PR TITLE
(PDB-2239) Use encode for handling bytea data

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1488,6 +1488,24 @@
       "ALTER TABLE factsets DROP CONSTRAINT factsets_hash_key")
     nil))
 
+
+(defn fix-bytea-expression-indexes-to-use-encode
+  []
+  (if (sutils/postgres?)
+    (jdbc/do-commands
+     "DROP INDEX reports_hash_expr_idx"
+     "CREATE UNIQUE INDEX reports_hash_expr_idx ON reports(encode(hash::bytea, 'hex'))"
+     "DROP INDEX resources_hash_expr_idx"
+     "CREATE INDEX resources_hash_expr_idx ON catalog_resources(encode(resource::bytea, 'hex'))"
+     "DROP INDEX rpc_hash_expr_idx"
+     "CREATE INDEX rpc_hash_expr_idx ON resource_params_cache(encode(resource::bytea, 'hex'))"
+     "DROP INDEX resource_params_hash_expr_idx"
+     "CREATE INDEX resource_params_hash_expr_idx ON resource_params(encode(resource::bytea, 'hex'))"
+     "DROP INDEX catalogs_hash_expr_idx"
+     "CREATE UNIQUE INDEX catalogs_hash_expr_idx ON catalogs(encode(hash::bytea, 'hex'))"
+     "DROP INDEX factsets_hash_expr_idx"
+     "CREATE UNIQUE INDEX factsets_hash_expr_idx ON factsets(encode(hash::bytea, 'hex'))")))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {1 initialize-store
@@ -1531,7 +1549,8 @@
    36 rename-environments-name-to-environment
    37 add-jsonb-columns-for-metrics-and-logs
    38 add-code-id-to-catalogs
-   39 add-expression-indexes-for-bytea-queries})
+   39 add-expression-indexes-for-bytea-queries
+   40 fix-bytea-expression-indexes-to-use-encode})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -278,7 +278,7 @@ must be supplied as the value to be matched."
 (defn sql-hash-as-str
   [column]
   (if (postgres?)
-    (format "trim(leading '\\x' from %s::text)" column)
+    (format "encode(%s::bytea, 'hex')" column)
     column))
 
 (defn sql-uuid-as-str


### PR DESCRIPTION
This commit changes our handling of bytea from using `trim` (which
relies implicitly on `bytea_output` being set to `'hex'` in PostgreSQL)
to instead use `encode(...,'hex')`. This allows our `bytea` usage to be
database setting independent.

This commit also cleans up some of the `fact_values` code in storage.clj
which was using `parse-db-hash` which is also not `bytea_output`
independent.