### PR TITLE
(PDB-2246) Add trivial system info to Jenkins log

### DIFF
--- a/ext/jenkins/lein-test.sh
+++ b/ext/jenkins/lein-test.sh
@@ -3,6 +3,8 @@
 set -e
 set -x
 
+(top -b -n 1 | head 5) || true
+
 DBNAME=$(echo "puppetdb_${PUPPETDB_BRANCH}_${BUILD_ID}_${BUILD_NUMBER}_${PUPPETDB_DBTYPE}_${JDK}" | tr - _)
 DBUSER="puppetdb"
 DBHOST="fixture-pg94.delivery.puppetlabs.net"


### PR DESCRIPTION
...in case it's handy when diagnosing failures.