### PR TITLE
(PDB-163) Add the `in`-`array` operator to the query language

### DIFF
--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -306,6 +306,8 @@ An `in` statement constitutes a full query string, which can be used alone or as
    the subquery for matching against the **fields** in the `in` clause.
 ** a **`from` statement,** which sets the context, and allows for an extract
    statement to be provided. *Note:* this syntax is new and experimental.
+** an **`array` statement,** which acts as a list of values to match against the
+   **field** in the `in` clause.
 
 **Matches if:** the field values are included in the list of values created by the `extract` or `from` statement.
 
@@ -332,8 +334,8 @@ which is equivalent to the following query:
      ["=","certname","bar.local"],
      ["=","certname","baz.local"]]
 
-The in operator support much of the same syntax as the `=` operator. For
-example, the following query on the `/nodes` endpoint is valid:
+The `in`-`array` operators support much of the same syntax as the `=` operator.
+For example, the following query on the `/nodes` endpoint is valid:
 
     ["in", ["fact", "uptime_seconds"], 
      ["array",

--- a/documentation/api/query/v4/operators.markdown
+++ b/documentation/api/query/v4/operators.markdown
@@ -299,19 +299,57 @@ An `in` statement constitutes a full query string, which can be used alone or as
 
 "In" statements are **non-transitive** and take two arguments:
 
-* The first argument **must** consist of one or more **fields** for the endpoint or entity **being queried.**. This is a string or vector of strings.
+* The first argument **must** consist of one or more **fields** for the endpoint
+  or entity **being queried.**. This is a string or vector of strings.
 * The second argument **must** be either:
-** an **`extract` statement,** which acts as a list of fields to extract during the subquery for matching against the **fields** in the `in` clause.
-** a **`from` statement,** which sets the context, and allows for an extract statement to be provided. *Note:* this syntax is new and experimental.
+** an **`extract` statement,** which acts as a list of fields to extract during
+   the subquery for matching against the **fields** in the `in` clause.
+** a **`from` statement,** which sets the context, and allows for an extract
+   statement to be provided. *Note:* this syntax is new and experimental.
 
 **Matches if:** the field values are included in the list of values created by the `extract` or `from` statement.
 
+##### `array`
+
+An `in` statement also accepts an `array` statement as a second argument.
+
+"Array" statements take a single vector argument of values to match the first
+argument of `in` against.
+
+The following query filters for the nodes, `foo.local`, `bar.local`, and
+`baz.local`:
+
+    ["in", "certname",
+     ["array",
+      ["foo.local",
+       "bar.local",
+       "baz.local"]]]
+
+which is equivalent to the following query:
+
+    ["or",
+     ["=","certname","foo.local"],
+     ["=","certname","bar.local"],
+     ["=","certname","baz.local"]]
+
+The in operator support much of the same syntax as the `=` operator. For
+example, the following query on the `/nodes` endpoint is valid:
+
+    ["in", ["fact", "uptime_seconds"], 
+     ["array",
+      [20000.0,
+       150.0,
+       300000]]]
+
 #### `from`
 
-*Note:* the use of `from` in a subquery is experimental. It may change or be removed in the future.
+*Note:* the use of `from` in a subquery is experimental. It may change or be
+ removed in the future.
 
-This statement works like the top-level [`from`](#context-operators) operator, and expects an [entity][entities] as the first argument and an optional query in the second
-argument, however when used within an `in` clause an `extract` statement is expected to choose the fields like so:
+This statement works like the top-level [`from`](#context-operators) operator,
+and expects an [entity][entities] as the first argument and an optional query in
+the second argument, however when used within an `in` clause an `extract`
+statement is expected to choose the fields like so:
 
     ["in", "certname",
      ["from", "facts",
@@ -322,12 +360,16 @@ argument, however when used within an `in` clause an `extract` statement is expe
 
 "Extract" statements are **non-transitive** and take two arguments:
 
-* The first argument **must** be a valid set of **fields** for the endpoint **being subqueried** (see second argument). This is a string or vector of strings.
+* The first argument **must** be a valid set of **fields** for the endpoint
+  **being subqueried** (see second argument). This is a string or vector of
+  strings.
 * The second argument:
 ** **must** contain a **subquery statement**
 ** or when used with the new `from` operator, **may** contain an optional query.
 
-As the second argument of an `in` statement, an `extract` statement acts as a list of possible values. This list is compiled by extracting the value of the requested field from every result of the subquery.
+As the second argument of an `in` statement, an `extract` statement acts as a
+list of possible values. This list is compiled by extracting the value of the
+requested field from every result of the subquery.
 
 #### `select_<ENTITY>` Subquery Statements
 

--- a/project.clj
+++ b/project.clj
@@ -79,7 +79,7 @@
                  [com.novemberain/pantomime "2.1.0"]
                  [fast-zip-visit "1.0.2"]
                  [robert/hooke "1.3.0"]
-                 [honeysql "0.5.2"]
+                 [honeysql "0.6.2"]
                  [org.clojure/data.xml "0.0.8"]
                  [com.rpl/specter "0.5.7"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -112,8 +112,7 @@
   [q]
   (and
    (vector? q)
-   (string? (first q))
-   (every? (complement coll?) (rest q))))
+   (string? (first q))))
 
 (def valid-results-query-schema
   "Schema type for compiled query-eng queries"

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -473,9 +473,7 @@
   (match [path]
          ["tag"]
          {:where (h/sqlraw->str
-                   (sql-regexp-array-match "catalog_resources"
-                                           "catalog_resources"
-                                           "tags"))
+                   (sql-regexp-array-match "tags"))
           :params [value]}
 
          ;; node join.

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.puppetdb.query-eng.engine
   (:require [clojure.core.match :as cm]
-            [clojure.string :as string]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [honeysql.core :as hcore]
             [honeysql.helpers :as hsql]
@@ -25,8 +25,9 @@
 (defrecord Query [projections selection source-table alias where
                   subquery? entity call group-by])
 (defrecord BinaryExpression [operator column value])
+(defrecord InArrayExpression [table column value])
 (defrecord RegexExpression [column value])
-(defrecord ArrayRegexExpression [table alias column value])
+(defrecord ArrayRegexExpression [column value])
 (defrecord NullExpression [column null?])
 (defrecord ArrayBinaryExpression [column value])
 (defrecord InExpression [column subquery])
@@ -218,11 +219,11 @@
                              "environment" {:type :string
                                             :queryable? true
                                             :field :env.environment}
-                             "value_integer" {:type :number
+                             "value_integer" {:type :integer
                                               :query-only? true
                                               :queryable? false
                                               :field :fv.value_integer}
-                             "value_float" {:type :number
+                             "value_float" {:type :float
                                             :query-only? true
                                             :queryable? false
                                             :field :fv.value_float}
@@ -291,11 +292,11 @@
                              "environment" {:type :string
                                             :queryable? true
                                             :field :env.environment}
-                             "value_integer" {:type :number
+                             "value_integer" {:type :integer
                                               :queryable? false
                                               :field :fv.value_integer
                                               :query-only? true}
-                             "value_float" {:type :number
+                             "value_float" {:type :float
                                             :queryable? false
                                             :field :fv.value_float
                                             :query-only? true}
@@ -390,7 +391,7 @@
       "puppet_version"  {:type :string
                          :queryable? true
                          :field :reports.puppet_version}
-      "report_format"   {:type :number
+      "report_format"   {:type :integer
                          :queryable? true
                          :field :reports.report_format}
       "configuration_version" {:type :string
@@ -639,7 +640,7 @@
                              "file" {:type :string
                                      :queryable? true
                                      :field :file}
-                             "line" {:type :number
+                             "line" {:type :integer
                                      :queryable? true
                                      :field :line}
                              "parameters" {:type :json
@@ -716,7 +717,7 @@
                              "file" {:type :string
                                      :queryable? true
                                      :field :file}
-                             "line" {:type :number
+                             "line" {:type :integer
                                      :queryable? true
                                      :field :line}
                              "containment_path" {:type :array
@@ -937,6 +938,10 @@
                     (utils/vector-maybe (:column expr))
                     (utils/vector-maybe (:value expr)))))
 
+  InArrayExpression
+  (-plan->sql [expr]
+    (su/sql-in-array (:column expr)))
+
   ArrayBinaryExpression
   (-plan->sql [expr]
     (su/sql-array-query-string (:column expr)))
@@ -947,7 +952,7 @@
 
   ArrayRegexExpression
   (-plan->sql [expr]
-    (su/sql-regexp-array-match (:table expr) (:alias expr) (:column expr)))
+    (su/sql-regexp-array-match (:column expr)))
 
   NullExpression
   (-plan->sql [expr]
@@ -982,6 +987,7 @@
   [node]
   (or (instance? BinaryExpression node)
       (instance? RegexExpression node)
+      (instance? InArrayExpression node)
       (instance? ArrayBinaryExpression node)
       (instance? ArrayRegexExpression node)))
 
@@ -1080,6 +1086,29 @@
                   ["=" "name" fact-name]
                   [op value-column fact-value]]]]])
 
+            [["in" ["fact" fact-name] ["array" fact-values]]]
+            (let [clause (cond
+                           (every? string? fact-values)
+                           ["in" "value_string" ["array" fact-values]]
+
+                           (every? ks/boolean? fact-values)
+                           ["in" "value_boolean" ["array" fact-values]]
+
+                           (every? number? fact-values)
+                           ["or"
+                            ["in" "value_float" ["array" fact-values]]
+                            ["in" "value_integer" ["array" fact-values]]]
+
+                           :else (throw (IllegalArgumentException.
+                                         "All values in 'array' must be the same type.")))]
+              ["in" "certname"
+               ["extract" "certname"
+                ["select_facts"
+                 ["and"
+                  ["=" "name" fact-name]
+                  clause]]]])
+
+
             [[(op :guard #{"=" ">" "<" "<=" ">="}) ["fact" fact-name] fact-value]]
             (if-not (number? fact-value)
               (throw (IllegalArgumentException. (format "Operator '%s' not allowed on value '%s'" op fact-value)))
@@ -1131,7 +1160,7 @@
             ["null?" (utils/dashes->underscores field) true]
 
             [[op "tag" array-value]]
-            [op "tags" (string/lower-case array-value)]
+            [op "tags" (str/lower-case array-value)]
 
             :else nil))
 
@@ -1162,7 +1191,8 @@
 
               [["=" field value]]
               (let [col-type (get-in query-context [:projections field :type])]
-                (when (and (= :number col-type) (string? value))
+                (when (and (or (= :integer col-type)
+                               (= :float col-type)) (string? value))
                   (throw
                     (IllegalArgumentException.
                       (format "Argument \"%s\" is incompatible with numeric field \"%s\"."
@@ -1171,7 +1201,7 @@
               [[(:or ">" ">=" "<" "<=") field _]]
               (let [col-type (get-in query-context [:projections field :type])]
                 (when-not (or (vec? field)
-                              (contains? #{:number :timestamp :multi}
+                              (contains? #{:float :integer :timestamp :multi}
                                          col-type))
                   (throw (IllegalArgumentException. (format "Query operators >,>=,<,<= are not allowed on field %s" field)))))
 
@@ -1277,7 +1307,7 @@
 
 (defn replace-numeric-args
   [fargs]
-  (mapv #(string/replace % #"value" "COALESCE(value_integer,value_float)") fargs))
+  (mapv #(str/replace % #"value" "COALESCE(value_integer,value_float)") fargs))
 
 (defn user-node->plan-node
   "Create a query plan for `node` in the context of the given query (as `query-rec`)"
@@ -1295,11 +1325,6 @@
                (map->ArrayBinaryExpression {:column field
                                             :value value})
 
-               :number
-               (map->BinaryExpression {:operator :=
-                                       :column field
-                                       :value value})
-
                :path
                (map->BinaryExpression {:operator :=
                                        :column field
@@ -1309,9 +1334,46 @@
                                        :column field
                                        :value value})))
 
+            [["in" column ["array" value]]]
+            (let [{:keys [type field]} (get-in query-rec [:projections column])]
+              (when-not (coll? value)
+                (throw (IllegalArgumentException. "Operator 'array' requires a vector argument")))
+              (case type
+                :array
+                (throw (IllegalArgumentException. "Operator 'in'...'array' is not supported on array types"))
+
+                :timestamp
+                (map->InArrayExpression {:column field
+                                         :value (su/array-to-param "timestamp"
+                                                                   java.sql.Timestamp
+                                                                   (map to-timestamp value))})
+
+                :float
+                (map->InArrayExpression {:column field
+                                         :value (su/array-to-param "float4"
+                                                                   java.lang.Double
+                                                                   (map double value))})
+                :integer
+                (map->InArrayExpression {:column field
+                                         :value (su/array-to-param "bigint"
+                                                                   java.lang.Integer
+                                                                   (map int value))})
+
+                :path
+                (map->InArrayExpression {:column field
+                                         :value (su/array-to-param "text"
+                                                                   String
+                                                                   (map facts/factpath-to-string value))})
+
+                (map->InArrayExpression {:column field
+                                         :value (su/array-to-param "text"
+                                                                   String
+                                                                   (map str value))})))
+
             [[(op :guard #{">" "<" ">=" "<="}) column value]]
             (let [{:keys [type field]} (get-in query-rec [:projections column])]
-              (if (or (= :timestamp type) (and (= :number type) (number? value)))
+              (if (or (= :timestamp type) (and (or (= :float type)
+                                                   (= :integer type)) (number? value)))
                 (map->BinaryExpression {:operator (keyword op)
                                         :column field
                                         :value  (if (= :timestamp type)
@@ -1331,9 +1393,7 @@
             (let [{:keys [type field]} (get-in query-rec [:projections column])]
               (case type
                 :array
-                (map->ArrayRegexExpression {:table (:source-table query-rec)
-                                            :alias (:alias query-rec)
-                                            :column field
+                (map->ArrayRegexExpression {:column field
                                             :value value})
 
                 :multi
@@ -1431,7 +1491,7 @@
               error-action
               query-name
               (if (> (count invalid-fields) 1) "fields:" "field")
-              (string/join "', '" invalid-fields)
+              (str/join "', '" invalid-fields)
               (if (empty? error-context) "" (str " " error-context))
               (json/generate-string allowed-fields)))))
 
@@ -1523,6 +1583,9 @@
                 {:node node
                  :state (conj state column-validation-message)}))
 
+            [["in" _ ["array" _]]]
+            nil
+
             [["in" field & _]]
             (let [query-context (:query-context (meta node))
                   column-validation-message (validate-query-operation-fields
@@ -1546,19 +1609,19 @@
              :state state}
             :else {:node node :state state}))
 
-(pls/defn-validated op-to-string
-  "Convert an operator to a lowercase string or vector of such."
-  [op]
-  (if (vector? op)
-    (mapv string/lower-case op)
-    (string/lower-case op)))
+(defn valid-operator?
+  [operator]
+  (or (contains? #{"from" "in" "extract" "subquery" "and"
+                   "or" "not" "function" "group_by" "null?"} operator)
+      (contains? binary-operators operator)
+      (contains? (ks/keyset user-name->query-rec-name) operator)))
 
 (defn ops-to-lower
   "Lower cases operators (such as and/or)."
   [node state]
   (cm/match [node]
-            [[op & stmt-rest]]
-            {:node (with-meta (vec (cons (op-to-string op) stmt-rest))
+            [[(op :guard (comp valid-operator? str/lower-case)) & stmt-rest]]
+            {:node (with-meta (vec (apply vector (str/lower-case op) stmt-rest))
                               (meta node))
              :state state}
             :else {:node node :state state}))
@@ -1574,7 +1637,7 @@
                                               validate-query-fields
                                               dashes-to-underscores ops-to-lower])]
     (when (seq errors)
-      (throw (IllegalArgumentException. (string/join \newline errors))))
+      (throw (IllegalArgumentException. (str/join \newline errors))))
 
     annotated-query))
 

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.puppetdb.scf.storage-utils
   (:require [clojure.java.jdbc :as sql]
             [honeysql.core :as hcore]
+            [honeysql.format :as hfmt]
             [clojure.string :as str]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.honeysql :as h]
@@ -195,7 +196,7 @@
 (defn sql-in-array
   [column]
   (hcore/raw
-   (format "EXISTS(SELECT 1 from UNNEST(?) WHERE unnest = %s)" (name column))))
+   (format "%s = ANY(?)" (first (hfmt/format column)))))
 
 (defn db-serialize
   "Serialize `value` into a form appropriate for querying against a

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.puppetdb.scf.storage-utils
   (:require [clojure.java.jdbc :as sql]
             [honeysql.core :as hcore]
+            [clojure.string :as str]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.honeysql :as h]
             [puppetlabs.puppetdb.jdbc :as jdbc]
@@ -187,9 +188,14 @@
   "Returns SQL for performing a regexp match against the contents of
   an array. If any of the array's items match the supplied regexp,
   then that satisfies the match."
-  [orig-table _ column]
+  [column]
   (hcore/raw
    (format "EXISTS(SELECT 1 FROM UNNEST(%s) WHERE UNNEST ~ ?)" (name column))))
+
+(defn sql-in-array
+  [column]
+  (hcore/raw
+   (format "EXISTS(SELECT 1 from UNNEST(?) WHERE unnest = %s)" (name column))))
 
 (defn db-serialize
   "Serialize `value` into a form appropriate for querying against a

--- a/test/puppetlabs/puppetdb/http/catalogs_test.clj
+++ b/test/puppetlabs/puppetdb/http/catalogs_test.clj
@@ -151,8 +151,8 @@
   (testcat/replace-catalog (json/generate-string catalog2))
 
   (are [query expected]
-      (is (= (query-result method endpoint query {} strip-hash)
-             expected))
+      (= expected
+         (query-result method endpoint query {} strip-hash))
 
     ;;;;;;;;;;
     ;; Resources
@@ -164,6 +164,14 @@
       ["extract" "certname"
        ["select_resources"
         ["=" "type" "Apt::Pin"]]]]]
+    #{{:certname "myhost.localdomain"}
+      {:certname "host2.localdomain"}}
+
+    ["extract" "certname"
+     ["in" "certname"
+      ["extract" "certname"
+       ["select_resources"
+        ["in" "type" ["array" ["Apt::Pin"]]]]]]]
     #{{:certname "myhost.localdomain"}
       {:certname "host2.localdomain"}}
 
@@ -180,6 +188,12 @@
     ["extract" "certname"
      ["subquery" "resources"
       ["=" "type" "Apt::Pin"]]]
+    #{{:certname "myhost.localdomain"}
+      {:certname "host2.localdomain"}}
+
+    ["extract" "certname"
+     ["subquery" "resources"
+      ["in" "type" ["array" ["Apt::Pin"]]]]]
     #{{:certname "myhost.localdomain"}
       {:certname "host2.localdomain"}}
 
@@ -209,6 +223,12 @@
     ["extract" "certname"
      ["subquery" "edges"
       ["=" "target_type" "File"]]]
+    #{{:certname "host2.localdomain"}
+      {:certname "myhost.localdomain"}}
+
+    ["extract" "certname"
+     ["subquery" "edges"
+      ["in" "target_type" ["array" ["File"]]]]]
     #{{:certname "host2.localdomain"}
       {:certname "myhost.localdomain"}}))
 

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -36,8 +36,8 @@
                  (catch com.fasterxml.jackson.core.JsonParseException e
                    body))]
 
-    (is (= (count result)
-           (count expected))
+    (is (= (count expected)
+           (count result))
         (str "Query was: " query))
 
     (doseq [res result]
@@ -101,11 +101,14 @@
       (is-query-result' ["=" ["fact" "uptime_seconds"] 10000] [web1])
       (is-query-result' ["=" ["fact" "uptime_seconds"] "10000"] [])
       (is-query-result' ["=" ["fact" "uptime_seconds"] 10000.0] [web1])
+      (is-query-result' ["in" ["fact" "uptime_seconds"] ["array" [10000.0]]] [web1])
+      (is-query-result' ["in" ["fact" "uptime_seconds"] ["array" [10000]]] [web1])
       (is-query-result' ["=" ["fact" "uptime_seconds"] true] [])
       (is-query-result' ["=" ["fact" "uptime_seconds"] 0] []))
 
     (testing "missing facts are not equal to anything"
       (is-query-result' ["=" ["fact" "fake_fact"] "something"] [])
+      (is-query-result' ["in" ["fact" "fake_fact"] ["array" ["something"]]] [])
       (is-query-result' ["not" ["=" ["fact" "fake_fact"] "something"]] [db puppet web1 web2]))
 
     (testing "arithmetic works on facts"

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -108,6 +108,20 @@
                                             ["group_by" "status"]])
              #{{:status "unchanged", :sum 8}})))
 
+    (testing "using the `in`-`array` operator"
+      (is (= (query-result method endpoint ["extract" [["function" "count"] "status" "certname"]
+                                            ["in" "certname" ["array" ["bar.local" "foo.local"]]]
+                                            ["group_by" "status" "certname"]])
+             #{{:certname "bar.local" :status "unchanged" :count 1}
+               {:certname "foo.local" :status "unchanged" :count 1}}))
+      (is (= (query-result method endpoint ["extract" [["function" "count"] "status" "certname"]
+                                            ["or"
+                                             ["in" "status" ["array" ["unchanged"]]]
+                                             ["in" "certname" ["array" ["baz.local"]]]]
+                                            ["group_by" "status" "certname"]])
+             #{{:certname "bar.local" :status "unchanged" :count 1}
+               {:certname "foo.local" :status "unchanged" :count 1}})))
+
     (testing "projected aggregate function call with two column groupings"
       (is (= (query-result method endpoint ["extract" [["function" "count"] "status" "certname"]
                                             ["~" "certname" ".*"]

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -114,6 +114,12 @@
                                             ["group_by" "status" "certname"]])
              #{{:certname "bar.local" :status "unchanged" :count 1}
                {:certname "foo.local" :status "unchanged" :count 1}}))
+      (is (= (query-result method endpoint ["extract" ["hash"]
+                                            ["in" "hash"
+                                             ["array" ["572d1e89a4075170938f4e960b26d8f63ad705f8"
+                                                       "b437558374bf9d6e21cb880c22409f42f743de9b"]]]])
+             #{{:hash "572d1e89a4075170938f4e960b26d8f63ad705f8"}
+               {:hash "b437558374bf9d6e21cb880c22409f42f743de9b"}}))
       (is (= (query-result method endpoint ["extract" [["function" "count"] "status" "certname"]
                                             ["or"
                                              ["in" "status" ["array" ["unchanged"]]]


### PR DESCRIPTION
This commit adds the `in`-`array` operator to the query language.

For example:

```json

        ["from", "nodes",
            ["subquery", "resources",
                ["in", "type",
                    ["array",
                      ["File",
                       "Apache::Mode",
                       "Apt::Pin"]]]]]

```