### PR TITLE
Revert "Revert "(maint) default statement cache size to 0""

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -393,7 +393,7 @@ The maximum time to wait (in milliseconds) to acquire a connection from the pool
 
 This setting defines how many prepared statements are cached automatically. For a large amount of dynamic queries this number could be increased to increase performance, at the cost of memory consumption and database resources.
 
-If not supplied, we default to 1000.
+If not supplied, we default to 0.
 
 `[read-database]` Settings
 -----

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -67,7 +67,7 @@
      :partition-count (pls/defaulted-maybe s/Int 1)
      :stats (pls/defaulted-maybe String "true")
      :log-statements (pls/defaulted-maybe String "true")
-     :statements-cache-size (pls/defaulted-maybe s/Int 1000)
+     :statements-cache-size (pls/defaulted-maybe s/Int 0)
      :connection-timeout (pls/defaulted-maybe s/Int 500)}))
 
 (def write-database-config-in


### PR DESCRIPTION
This reverts commit 8a70a5d3416a89c45cf70c1b1c9e58f7e82ce19b.