### PR TITLE
(PDB-156) reject-large-commands should be enabled by default

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -655,7 +655,7 @@ commands that are too large to process. An example of this would be a
 catalog that is too large and would cause PuppetDB to run out of
 memory. This setting can be used along with `max-command-size`.
 
-This setting is false by default.
+This setting is true by default.
 
 ### `max-command-size`
 

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -147,7 +147,7 @@
      :max-frame-size (pls/defaulted-maybe s/Int 209715200)
      :temp-usage s/Int
      :max-command-size (pls/defaulted-maybe s/Int (default-max-command-size))
-     :reject-large-commands (pls/defaulted-maybe String "false")}))
+     :reject-large-commands (pls/defaulted-maybe String "true")}))
 
 (def command-processing-out
   "Schema for parsed/processed command processing config - currently incomplete"

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -201,9 +201,9 @@
                  (warn-retirements {:database {param "foo"}}))))))))
 
 (deftest test-default-max-command-size
-  (testing "default is disabled"
+  (testing "default is enabled"
     (let [default-config (:command-processing (configure-command-processing {}))]
-      (is (false? (:reject-large-commands default-config)))
+      (is (true? (:reject-large-commands default-config)))
       (is (= (long (default-max-command-size))
              (:max-command-size default-config)))))
 


### PR DESCRIPTION
This commit enables `reject-large-commands` by default. It can still be
disabled and the size of commands to reject can still be set via
`max-command-size`.