### PR TITLE
(PDB-2255) Make notable-pdb-event? configurable

### DIFF
--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -143,13 +143,15 @@
       (fn []
         ~@body))))
 
+(def ^:dynamic *notable-log-event?* notable-pdb-event?)
+
 (defn call-with-single-quiet-pdb-instance
   "Calls the call-with-puppetdb-instance with args after suppressing
   all log events.  If there's an error or worse, prints the log to
   *err*.  Should not be nested, nor nested with calls to
   with-log-suppressed-unless-notable."
   [& args]
-  (with-log-suppressed-unless-notable notable-pdb-event?
+  (with-log-suppressed-unless-notable *notable-log-event?*
     (apply call-with-puppetdb-instance args)))
 
 (defmacro with-single-quiet-pdb-instance


### PR DESCRIPTION
Originally notable-pdb-event? wasn't set up to be customized, but now we
want that (i.e. PDB-2215), so make it configurable by
adding *notable-pdb-event?* to testutils.services.