### PR TITLE
(maint) log command sizes at debug level

### DIFF
--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -319,7 +319,7 @@
       (let [length-in-bytes (request/content-length req)]
 
         (if length-in-bytes
-          (log/infof "Processing command with a content-length of %s bytes" length-in-bytes )
+          (log/debugf "Processing command with a content-length of %s bytes" length-in-bytes)
           (log/warn (str "No content length found for POST. "
                          "POST bodies that are too large could cause memory-related failures.")))
 


### PR DESCRIPTION
This changes our logging of command sizes from info to debug level.