### PR TITLE
(PDB-2262) Don't assume group-by needs function calls

### DIFF
--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -95,13 +95,14 @@
                                             ["not" ["=" "certname" (:certname basic)]]])
              #{{:hash bar-report-hash}})))
 
-    (testing "projected aggregate count call"
-      (is (= (query-result method endpoint ["extract" [["function" "count"] "status"]
-                                            ["~" "certname" ".*"]
-                                            ["group_by" "status"]])
-             #{{:status "unchanged", :count 2}})))
-
     (testing "projected aggregate sum call"
+      (is (= (query-result method endpoint ["extract" ["status"]
+                                            ["group_by" "status"]])
+             #{{:status "unchanged"}}))
+      (is (= (query-result method endpoint ["extract"
+                                            [["function" "sum" "report_format"] "status"]
+                                            ["group_by" "status"]])
+             #{{:status "unchanged", :sum 8}}))
       (is (= (query-result method endpoint ["extract"
                                             [["function" "sum" "report_format"] "status"]
                                             ["~" "certname" ".*"]


### PR DESCRIPTION
This commit fixes an issue in the query language where the group-by
operator assumed a function operator in the columns of the extract.
This was causing `NullPointerException`s for valid queries. This commit
also adds some more tests around this behavior.