### PR TITLE
(PDB-2256) Fix performance regression in puppetdb-termini

### DIFF
--- a/puppet/lib/puppet/util/puppetdb/char_encoding.rb
+++ b/puppet/lib/puppet/util/puppetdb/char_encoding.rb
@@ -34,11 +34,6 @@ module CharEncoding
   DEFAULT_INVALID_CHAR = "\ufffd"
 
   # @api private
-  def self.all_indexes_of_char(str, char)
-    (0..str.length).find_all{ |i| str[i] == char}
-  end
-
-  # @api private
   #
   # Takes an array and returns a sub-array without the last element
   #
@@ -104,13 +99,13 @@ module CharEncoding
   # @param error_context_str information about where this string came from for use in error messages
   # @return String
   def self.warn_if_invalid_chars(str, error_context_str)
-    bad_char_indexes = all_indexes_of_char(str, DEFAULT_INVALID_CHAR)
-    if bad_char_indexes.empty?
+    first_bad_char_index = str.index(DEFAULT_INVALID_CHAR)
+    if first_bad_char_index.nil?
       str
     else
       Puppet.warning "#{error_context_str} ignoring invalid UTF-8 byte sequences in data to be sent to PuppetDB, see debug logging for more info"
       if Puppet.settings[:log_level] == "debug"
-        Puppet.debug error_context_str + "\n" + error_char_context(str, bad_char_indexes).join("\n")
+        Puppet.debug error_context_str + "\n" + error_char_context(str, [first_bad_char_index]).join("\n")
       end
 
       str

--- a/puppet/spec/unit/util/puppetdb/char_encoding_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/char_encoding_spec.rb
@@ -89,10 +89,6 @@ describe Puppet::Util::Puppetdb::CharEncoding do
   end
 
   describe "on ruby >= 1.9" do
-    it "finds all index of a given character" do
-      described_class.all_indexes_of_char("a\u2192b\u2192c\u2192d\u2192", "\u2192").should == [1, 3, 5, 7]
-      described_class.all_indexes_of_char("abcd", "\u2192").should == []
-    end
 
     it "should collapse consecutive integers into ranges" do
       described_class.collapse_ranges((1..5).to_a).should == [1..5]


### PR DESCRIPTION
Show only the first index of non-utf8 characters in the warning.

Performance of the all_indexes_of_char drops non-linearly with larger
strings. The benchmark is available at:

https://gist.github.com/vzctl/3f86e72feab5bca98b06