### PR TITLE
(PDB-2264) Add setting for toggling historical-catalogs storage

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -229,10 +229,18 @@ If not supplied, PuppetDB uses standard HTTPS without any additional
 authorization. All HTTPS clients must still supply valid, verifiable
 SSL client certificates.
 
+### `include-historical-catalogs` (PE only)
+
+> **Warning:** This setting is intended for use only in Puppet Enterprise (PE).
+> This this setting will be ignored without a PE PuppetDB package.
+
+Setting this to `false` disables the storage of historical catalogs. Defaults to
+`true`.
+
 ### `disable-update-checking`
 
-Optional.  Setting this to `true` disables checking for updated
-versions of PuppetDB.  Defaults to `false`.
+Setting this to `true` disables checking for updated versions of PuppetDB.
+Defaults to `false`.
 
 
 `[database]` Settings

--- a/documentation/puppetdb_connection.markdown
+++ b/documentation/puppetdb_connection.markdown
@@ -78,7 +78,7 @@ The default value is false.
 ### `include_unchanged_resources` (PE only)
 
 > **Warning:** This setting is intended for use only in Puppet Enterprise (PE).
-> Using this setting with a PE PuppetDB package will only result in degraded
+> Using this setting without a PE PuppetDB package will only result in degraded
 > PuppetDB performance and PuppetDB will not store the unchanged resources data.
 
 This setting tells the PuppetDB terminus whether or not it should include

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -155,7 +155,7 @@
    :threads s/Int
    :max-frame-size s/Int
    :max-command-size s/Int
-   :reject-large-commands s/Bool
+   :reject-large-commands Boolean
    (s/optional-key :store-usage) s/Int
    (s/optional-key :temp-usage) s/Int})
 
@@ -163,11 +163,14 @@
   "Schema for validating the incoming [puppetdb] block"
   (all-optional
     {:certificate-whitelist s/Str
+     ;; The `include-historical-catalogs` setting is only used by `pe-puppetdb`
+     :include-historical-catalogs (pls/defaulted-maybe String "true")
      :disable-update-checking (pls/defaulted-maybe String "false")}))
 
 (def puppetdb-config-out
   "Schema for validating the parsed/processed [puppetdb] block"
   {(s/optional-key :certificate-whitelist) s/Str
+   :include-historical-catalogs Boolean
    :disable-update-checking Boolean})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -218,9 +221,7 @@
 (defn configure-puppetdb
   "Validates the [puppetdb] section of the config"
   [{:keys [puppetdb] :as config :or {puppetdb {}}}]
-  (->> puppetdb
-       (s/validate puppetdb-config-in)
-       (assoc config :puppetdb)))
+  (configure-section config :puppetdb puppetdb-config-in puppetdb-config-out))
 
 (defn configure-command-processing
   [config]

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -15,22 +15,27 @@
 
 (deftest puppetdb-configuration
   (testing "puppetdb-configuration"
-    (let [configure-puppetdb (fn [config] (configure-section config :puppetdb puppetdb-config-in puppetdb-config-out))]
-      (testing "should convert disable-update-checking value to boolean, if it is specified"
-        (let [config (configure-puppetdb {:puppetdb {:disable-update-checking "true"}})]
-          (is (= (get-in config [:puppetdb :disable-update-checking]) true)))
-        (let [config (configure-puppetdb {:puppetdb {:disable-update-checking "false"}})]
-          (is (= (get-in config [:puppetdb :disable-update-checking]) false)))
-        (let [config (configure-puppetdb {:puppetdb {:disable-update-checking "some-string"}})]
-          (is (= (get-in config [:puppetdb :disable-update-checking]) false))))
+    (testing "should convert disable-update-checking value to boolean, if it is specified"
+      (let [config (configure-puppetdb {:puppetdb {:disable-update-checking "true"}})]
+        (is (= (get-in config [:puppetdb :disable-update-checking]) true)))
+      (let [config (configure-puppetdb {:puppetdb {:disable-update-checking "false"}})]
+        (is (= (get-in config [:puppetdb :disable-update-checking]) false)))
+      (let [config (configure-puppetdb {:puppetdb {:disable-update-checking "some-string"}})]
+        (is (= (get-in config [:puppetdb :disable-update-checking]) false))))
 
-      (testing "should throw exception if disable-update-checking cannot be converted to boolean"
-        (is (thrown? clojure.lang.ExceptionInfo
-                     (configure-puppetdb {:puppetdb {:disable-update-checking 1337}}))))
+    (testing "should throw exception if disable-update-checking cannot be converted to boolean"
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (configure-puppetdb {:puppetdb {:disable-update-checking 1337}}))))
 
-      (testing "disable-update-checking should default to 'false' if left unspecified"
-        (let [config (configure-puppetdb {})]
-          (is (= (get-in config [:puppetdb :disable-update-checking]) false)))))))
+    (testing "should allow for `pe-puppetdb`'s include-historical-catalogs setting"
+      (let [config (configure-puppetdb {})]
+        (is (= (get-in config [:puppetdb :include-historical-catalogs]) true)))
+      (let [config (configure-puppetdb {:puppetdb {:include-historical-catalogs "false"}})]
+        (is (= (get-in config [:puppetdb :include-historical-catalogs]) false))))
+
+    (testing "disable-update-checking should default to 'false' if left unspecified"
+      (let [config (configure-puppetdb {})]
+        (is (= (get-in config [:puppetdb :disable-update-checking]) false))))))
 
 (deftest commandproc-configuration
   (let [configure-command-params (fn [config] (configure-section config :command-processing command-processing-in command-processing-out))]


### PR DESCRIPTION
This commit adds a setting for toggling the storage of
historical-catalogs (to be used in PE) to the `puppetdb` section of the
PuppetDB config.