### PR TITLE
(PDB-2259) Fix initial migration for non-english postgresql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,10 @@ addons:
   postgresql: "9.4"
 
 services: postgresql
+
+# workaround for buffer overflow issue, ref https://github.com/travis-ci/travis-ci/issues/5227
+before_install:
+  - cat /etc/hosts # optionally check the content *before*
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - cat /etc/hosts # optionally check the content *after*


### PR DESCRIPTION
Instead of parsing the error message to determine if the schema_migrations
table already exists, use the error code embedded in the exception.