### PR TITLE
(maint) Improve memory usage in benchmark tool

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -82,7 +82,8 @@
                  [honeysql "0.6.2"]
                  [com.rpl/specter "0.5.7"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [puppetlabs/http-client "0.4.4"]]
+                 [puppetlabs/http-client "0.4.4"]
+                 [com.taoensso/nippy "2.10.0" :exclusions [org.clojure/tools.reader]]]
 
   :jvm-opts ~pdb-jvm-opts
 


### PR DESCRIPTION
Use ActiveMQ for on-disk intermediate storage when doing a
simulation-style (--runinterval) benchmark.