### PR TITLE
(PDB-2276) Remove usage of robert.hooke library

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
    :password :env/nexus_jenkins_password
    :sign-releases false})
 
-(def tk-version "1.1.1")
+(def tk-version "1.1.2-SNAPSHOT")
 (def tk-jetty9-version "1.3.1")
 (def ks-version "1.1.0")
 (def tk-status-version "0.2.1")
@@ -17,6 +17,7 @@
 (def pdb-jvm-opts
   (case (System/getProperty "java.specification.version")
     "1.7" ["-XX:MaxPermSize=200M"]
+    "1.8" ["-Dclojure.compiler.direct-linking=true"]
     []))
 
 (defproject puppetlabs/puppetdb pdb-version
@@ -32,7 +33,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.8.0-RC3"]
+  :dependencies [[org.clojure/clojure "1.8.0-RC4"]
                  [cheshire "5.4.0"]
                  [org.clojure/core.match "0.2.2"]
                  [org.clojure/math.combinatorics "0.0.4"]
@@ -78,7 +79,6 @@
                  [org.clojure/tools.macro "0.1.5"]
                  [com.novemberain/pantomime "2.1.0"]
                  [fast-zip-visit "1.0.2"]
-                 [robert/hooke "1.3.0"]
                  [honeysql "0.6.2"]
                  [com.rpl/specter "0.5.7"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -66,7 +66,6 @@
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.trapperkeeper.core :refer [defservice] :as tk]
             [puppetlabs.trapperkeeper.services :refer [service-id service-context]]
-            [robert.hooke :as rh]
             [slingshot.slingshot :refer [throw+ try+]])
   (:import [javax.jms ExceptionListener]))
 
@@ -337,6 +336,4 @@
         customization."}
   -main
   (fn [& args]
-    (rh/add-hook #'puppetlabs.trapperkeeper.config/parse-config-data
-                 #'conf/hook-tk-parse-config-data)
-    (apply tk/main args)))
+    (tk/main-with-config-hook args conf/adjust-and-validate-tk-config)))

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -353,13 +353,6 @@
         warn-retirements
         validate-db-settings))
 
-(defn hook-tk-parse-config-data
-  "This is a robert.hooke compatible hook that is designed to intercept
-   trapperkeeper configuration before it is used, so that we may munge &
-   customize it.  It may throw {:type ::cli-error :message m}."
-  [f args]
-  (adjust-and-validate-tk-config (f args)))
-
 (defn process-config!
   "Accepts a map containing all of the user-provided configuration values
   and configures the various PuppetDB subsystems."


### PR DESCRIPTION
Use the new tk main-with-config-hook entry point instead

Depends on https://github.com/puppetlabs/trapperkeeper/pull/200