### PR TITLE
(maint) Enable sudo again to allow workaround for java bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: clojure
 lein: lein2
-sudo: false
+# Disabled due to buffer overflow issue below
+#sudo: false
 
 jdk:
   - openjdk7


### PR DESCRIPTION
The bug described here: https://github.com/travis-ci/travis-ci/issues/5227

... and its work-around requires sudo, so we need to remove the sudo:false setting
for this to work. This is temporary until the bug is fixed upstream.

Signed-off-by: Ken Barber <ken@bob.sh>