### PR TITLE
(PDB-2286) Add ability to always store catalog jsonb fields, (PDB-2290) Munge edges and resources jsonb for storage

### DIFF
--- a/src/puppetlabs/puppetdb/catalogs.clj
+++ b/src/puppetlabs/puppetdb/catalogs.clj
@@ -158,7 +158,9 @@
    :file (s/maybe s/Str)
    :line (s/maybe s/Int)
    :parameters {s/Any s/Any}
-   :resource s/Str
+   ;; On historical-catalogs this is an optional-key but this is required on
+   ;; "normal" catalogs
+   (s/optional-key :resource) s/Str
    :tags [(s/maybe s/Str)]
    :title s/Str
    :type s/Str})

--- a/src/puppetlabs/puppetdb/reports.clj
+++ b/src/puppetlabs/puppetdb/reports.clj
@@ -129,7 +129,7 @@
    (s/optional-key :noop) (s/maybe s/Bool)
    (s/optional-key :report_format) s/Int
    (s/optional-key :configuration_version) s/Str
-   (s/optional-key :resources) resources-expanded-query-schema
+   (s/optional-key :resources) (s/maybe resources-expanded-query-schema)
    (s/optional-key :metrics) metrics-expanded-query-schema
    (s/optional-key :logs) logs-expanded-query-schema
    (s/optional-key :resource_events) resource-events-expanded-query-schema

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -351,16 +351,17 @@
    (comp first sql/result-set-seq)))
 
 (def store-catalogs-historically? (atom false))
+(def store-catalogs-jsonb-columns? (atom false))
 
 (pls/defn-validated catalog-row-map
   "Creates a row map for the catalogs table, optionally adding envrionment when it was found"
   [hash
    {:keys [edges resources version code_id transaction_uuid environment producer_timestamp]} :- catalog-schema
    received-timestamp :- pls/Timestamp]
-  (let [historical-catalogs? @store-catalogs-historically?]
+  (let [catalogs-jsonb? @store-catalogs-jsonb-columns?]
     {:hash (sutils/munge-hash-for-storage hash)
-     :edges (when historical-catalogs? (sutils/munge-jsonb-for-storage edges))
-     :resources (when historical-catalogs? (sutils/munge-jsonb-for-storage (vals resources)))
+     :edges (when catalogs-jsonb? (sutils/munge-jsonb-for-storage edges))
+     :resources (when catalogs-jsonb? (sutils/munge-jsonb-for-storage (vals resources)))
      :catalog_version  version
      :transaction_uuid (sutils/munge-uuid-for-storage transaction_uuid)
      :timestamp (to-timestamp received-timestamp)

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -350,7 +350,15 @@
     certname]
    (comp first sql/result-set-seq)))
 
+;; `store-catalogs-historically?` is used for toggling historical catalog
+;; storage, this is configurable and PE only.
 (def store-catalogs-historically? (atom false))
+
+;; `store-catalogs-jsonb-columns?` is used for toggling storage of the resources
+;; and edges jsonb blobs for catalogs. These blobs are used in PE only and this
+;; variable is meant to only be set to true in PE. This exists so that we can
+;; store the jsonb columns idependently from storing historical catalogs. This
+;; way a user can turn off historical catalogs and the PE only views still work.
 (def store-catalogs-jsonb-columns? (atom false))
 
 (defn munge-edges-for-storage [edges]

--- a/test/puppetlabs/puppetdb/acceptance/cli.clj
+++ b/test/puppetlabs/puppetdb/acceptance/cli.clj
@@ -49,7 +49,7 @@
 
       (svc-utils/call-with-single-quiet-pdb-instance
        (let [anon-out-map (tar->map anon-out-file)
-             anon-certname (-> anon-out-map (get "reports") first val (get "certname"))]
+             anon-certname (some-> anon-out-map (get "reports") first val (get "certname"))]
          (fn []
            (is (empty? (get-nodes)))
 

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -463,6 +463,7 @@
   (add-certname! "basic.catalogs.com")
 
   (reset! store-catalogs-historically? true)
+  (reset! store-catalogs-jsonb-columns? true)
   (testing "stores JSONB resources and edges fields"
     (store-catalog! (assoc catalog :producer_timestamp (-> 2 days ago)) (now))
     (is (= [{:count 1}]

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -469,12 +469,27 @@
     (is (= [{:count 1}]
            (query-to-vec [(str "SELECT COUNT(*) FROM catalogs WHERE resources IS NOT NULL"
                                " AND edges IS NOT NULL")])))
-    (is (= (set (map #(update % :relationship name)
-                     (:edges catalog)))
+    (is (= #{{:source_type "Class" :source_title "foobar"
+              :target_type "File" :target_title "/etc/foobar"
+              :relationship "contains"}
+             {:source_type "Class" :source_title "foobar"
+              :target_type "File" :target_title "/etc/foobar/baz"
+              :relationship "contains"}
+             {:source_type "File" :source_title "/etc/foobar"
+              :target_type "File" :target_title "/etc/foobar/baz"
+              :relationship "required-by"}}
            (->> (query-to-vec [(str "SELECT edges FROM catalogs")])
                 (mapcat (comp sutils/parse-db-json :edges))
                 set)))
-    (is (= (set (vals (:resources catalog)))
+    (is (= #{{:type "Class" :title "foobar" :exported false
+              :tags #{"class" "foobar"} :file nil :line nil :parameters {}}
+             {:type "File" :title "/etc/foobar" :exported false
+              :file "/tmp/foo" :line 10 :tags #{"file" "class" "foobar"}
+              :parameters {:ensure "directory" :group "root" :user "root"}}
+             {:type "File" :title "/etc/foobar/baz" :exported false
+              :file "/tmp/bar" :line 20 :tags #{"file" "class" "foobar"}
+              :parameters {:ensure "directory" :group "root" :user "root"
+                           :require "File[/etc/foobar]"}}}
            (->> (query-to-vec [(str "SELECT resources FROM catalogs")])
                 (mapcat (comp sutils/parse-db-json :resources))
                 (map #(update % :tags set))


### PR DESCRIPTION
This PR fixes a bug with historical catalogs where a user could turn
off historical catalogs and break some of the PE views because the JSONB
column storage was also turned off. This new atom will always be set to
true in PE (as opposed to the historical-catalogs' atom which is config
dependent).

This PR aligns the edges and resources jsonb format with the return
format from querying the catalogs endpoint, this means we do not have to
parse and munge jsonb in export, the new endpoints and sync.