### PR TITLE
(PDB-2290) Align edges and resources formats with query formats

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -352,6 +352,21 @@
 
 (def store-catalogs-historically? (atom false))
 
+(defn munge-edges-for-storage [edges]
+  (->> edges
+       (map (fn [{:keys [source target relationship]}]
+              {:source_type (:type source)
+               :source_title (:title source)
+               :target_type (:type target)
+               :target_title (:title target)
+               :relationship relationship}))
+       sutils/munge-jsonb-for-storage))
+
+(defn munge-resources-for-storage [resources]
+  (->> resources
+       (map (partial merge {:file nil :line nil}))
+       sutils/munge-jsonb-for-storage))
+
 (pls/defn-validated catalog-row-map
   "Creates a row map for the catalogs table, optionally adding envrionment when it was found"
   [hash
@@ -359,8 +374,8 @@
    received-timestamp :- pls/Timestamp]
   (let [historical-catalogs? @store-catalogs-historically?]
     {:hash (sutils/munge-hash-for-storage hash)
-     :edges (when historical-catalogs? (sutils/munge-jsonb-for-storage edges))
-     :resources (when historical-catalogs? (sutils/munge-jsonb-for-storage (vals resources)))
+     :edges (when historical-catalogs? (munge-edges-for-storage edges))
+     :resources (when historical-catalogs? (munge-resources-for-storage (vals resources)))
      :catalog_version  version
      :transaction_uuid (sutils/munge-uuid-for-storage transaction_uuid)
      :timestamp (to-timestamp received-timestamp)

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -467,12 +467,27 @@
     (is (= [{:count 1}]
            (query-to-vec [(str "SELECT COUNT(*) FROM catalogs WHERE resources IS NOT NULL"
                                " AND edges IS NOT NULL")])))
-    (is (= (set (map #(update % :relationship name)
-                     (:edges catalog)))
+    (is (= #{{:source_type "Class" :source_title "foobar"
+              :target_type "File" :target_title "/etc/foobar"
+              :relationship "contains"}
+             {:source_type "Class" :source_title "foobar"
+              :target_type "File" :target_title "/etc/foobar/baz"
+              :relationship "contains"}
+             {:source_type "File" :source_title "/etc/foobar"
+              :target_type "File" :target_title "/etc/foobar/baz"
+              :relationship "required-by"}}
            (->> (query-to-vec [(str "SELECT edges FROM catalogs")])
                 (mapcat (comp sutils/parse-db-json :edges))
                 set)))
-    (is (= (set (vals (:resources catalog)))
+    (is (= #{{:type "Class" :title "foobar" :exported false
+              :tags #{"class" "foobar"} :file nil :line nil :parameters {}}
+             {:type "File" :title "/etc/foobar" :exported false
+              :file "/tmp/foo" :line 10 :tags #{"file" "class" "foobar"}
+              :parameters {:ensure "directory" :group "root" :user "root"}}
+             {:type "File" :title "/etc/foobar/baz" :exported false
+              :file "/tmp/bar" :line 20 :tags #{"file" "class" "foobar"}
+              :parameters {:ensure "directory" :group "root" :user "root"
+                           :require "File[/etc/foobar]"}}}
            (->> (query-to-vec [(str "SELECT resources FROM catalogs")])
                 (mapcat (comp sutils/parse-db-json :resources))
                 (map #(update % :tags set))


### PR DESCRIPTION
This commit aligns the edges and resources jsonb format with the return
format from querying the catalogs endpoint, this means we do not have to
parse and munge jsonb in export, the new endpoints and sync.