### PR TITLE
(PDB-2230) support multipart/form-data command posting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ end
 
 gem 'facter'
 gem 'rake'
+gem 'multipart-post', '~> 2.0'
 
 group :test do
   # Pinning to work-around an incompatiblity with 2.14 in puppetlabs_spec_helper

--- a/puppet/lib/puppet/util/puppetdb/char_encoding.rb
+++ b/puppet/lib/puppet/util/puppetdb/char_encoding.rb
@@ -65,7 +65,7 @@ module CharEncoding
   # @param bad_char_range a range indicating a block of invalid characters
   # @return String
   def self.error_char_context(str, bad_char_range)
-    
+
     gap = bad_char_range.to_a.length
 
     start_char = [0, bad_char_range.begin-100].max
@@ -106,9 +106,10 @@ module CharEncoding
   # information using error_context_str
   #
   # @param str A string coming from to_pson, likely a command to be submitted to PDB
-  # @param error_context_str information about where this string came from for use in error messages
+  # @param error_context_str information about where this string came from for
+  # use in error messages. Defaults to nil, in which case no error is reported.
   # @return Str
-  def self.coerce_to_utf8(str, error_context_str)
+  def self.coerce_to_utf8(str, error_context_str=nil)
     str_copy = str.dup
     # This code is passed in a string that was created by
     # to_pson. to_pson calls force_encoding('ASCII-8BIT') on the
@@ -127,11 +128,17 @@ module CharEncoding
       # byte related issues that could arise from mis-interpreting a
       # random extra byte as part of a multi-byte UTF-8 character
       str_copy.force_encoding("US-ASCII")
-      warn_if_invalid_chars(str_copy.encode!("UTF-8",
-                                             :invalid => :replace,
-                                             :undef => :replace,
-                                             :replace => DEFAULT_INVALID_CHAR),
-                            error_context_str)
+
+      str_lossy = str_copy.encode!("UTF-8",
+                                   :invalid => :replace,
+                                   :undef => :replace,
+                                   :replace => DEFAULT_INVALID_CHAR)
+
+      if !error_context_str.nil?
+        warn_if_invalid_chars(str_lossy, error_context_str)
+      else
+        str_lossy
+      end
     end
   end
 

--- a/src/puppetlabs/puppetdb/cheshire.clj
+++ b/src/puppetlabs/puppetdb/cheshire.clj
@@ -19,23 +19,29 @@
             [clojure.java.io :as io]
             [clojure.set :as set]))
 
+(defrecord EncodedPayload [data])
+
 ;; Alias coerce/to-string to avoid reflection
 (def ^String to-string coerce/to-string)
 (defn add-common-json-encoders!*
   "Non-memoize version of add-common-json-encoders!"
   []
   (generate/add-encoder
-   org.postgresql.util.PGobject
-   (fn [^PGobject data ^JsonGenerator jsonGenerator]
-     ;; The .getPrettyPrinter method on the Jackson jsonGenerator will return
-     ;; nil if `:pretty` is not set as a cheshire option
-     (if (.getPrettyPrinter jsonGenerator)
-       (generate/encode-map (core/parse-string (.getValue data)) jsonGenerator)
-       (.writeRawValue jsonGenerator (.getValue data)))))
+    org.postgresql.util.PGobject
+    (fn [^PGobject data ^JsonGenerator jsonGenerator]
+      ;; The .getPrettyPrinter method on the Jackson jsonGenerator will return
+      ;; nil if `:pretty` is not set as a cheshire option
+      (if (.getPrettyPrinter jsonGenerator)
+        (generate/encode-map (core/parse-string (.getValue data)) jsonGenerator)
+        (.writeRawValue jsonGenerator (.getValue data)))))
   (generate/add-encoder
-   org.joda.time.DateTime
-   (fn [data ^JsonGenerator jsonGenerator]
-     (.writeString jsonGenerator (to-string data)))))
+    org.joda.time.DateTime
+    (fn [data ^JsonGenerator jsonGenerator]
+      (.writeString jsonGenerator (to-string data))))
+  (generate/add-encoder
+    EncodedPayload
+    (fn [data ^JsonGenerator jsonGenerator]
+      (.writeRawValue jsonGenerator (:data data)))))
 
 (def
   ^{:doc "Registers some common encoders for cheshire JSON encoding.

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -10,10 +10,12 @@
             [clojure.java.io :as io]
             [puppetlabs.puppetdb.cheshire :as json]
             [clojure.walk :as walk]
+            [clojure.edn :as edn]
             [slingshot.slingshot :refer [try+ throw+]]
             [com.rpl.specter :as sp])
   (:import [java.net MalformedURLException URISyntaxException URL]
-           [org.postgresql.util PGobject]))
+           [org.postgresql.util PGobject]
+           [puppetlabs.puppetdb.cheshire EncodedPayload]))
 
 (defn jdk6?
   "Returns true when the current JDK version is 1.6"
@@ -309,6 +311,12 @@
   (sp/transform [sp/ALL]
                 #(update % 0 underscores->dashes)
                 m))
+
+(defn synthesize-body-str
+  [{:strs [command version certname payload]}]
+  (json/generate-string
+    {:command command :version (edn/read-string version)
+     :certname certname :payload (EncodedPayload. payload)}))
 
 (defmacro with-timeout [timeout-ms default & body]
   `(let [f# (future (do ~@body))


### PR DESCRIPTION
This will allow more granular logging at the wire without parsing the
command payload itself.