### PR TITLE
(PDB-2230) support submission of certname/command/version via post params

### DIFF
--- a/puppet/lib/puppet/util/puppetdb/char_encoding.rb
+++ b/puppet/lib/puppet/util/puppetdb/char_encoding.rb
@@ -65,7 +65,7 @@ module CharEncoding
   # @param bad_char_range a range indicating a block of invalid characters
   # @return String
   def self.error_char_context(str, bad_char_range)
-    
+
     gap = bad_char_range.to_a.length
 
     start_char = [0, bad_char_range.begin-100].max
@@ -106,9 +106,10 @@ module CharEncoding
   # information using error_context_str
   #
   # @param str A string coming from to_pson, likely a command to be submitted to PDB
-  # @param error_context_str information about where this string came from for use in error messages
+  # @param error_context_str information about where this string came from for
+  # use in error messages. Defaults to nil, in which case no error is reported.
   # @return Str
-  def self.coerce_to_utf8(str, error_context_str)
+  def self.coerce_to_utf8(str, error_context_str=nil)
     str_copy = str.dup
     # This code is passed in a string that was created by
     # to_pson. to_pson calls force_encoding('ASCII-8BIT') on the
@@ -127,11 +128,16 @@ module CharEncoding
       # byte related issues that could arise from mis-interpreting a
       # random extra byte as part of a multi-byte UTF-8 character
       str_copy.force_encoding("US-ASCII")
-      warn_if_invalid_chars(str_copy.encode!("UTF-8",
-                                             :invalid => :replace,
-                                             :undef => :replace,
-                                             :replace => DEFAULT_INVALID_CHAR),
-                            error_context_str)
+
+      str_lossy = str_copy.encode!("UTF-8",
+                                   :invalid => :replace,
+                                   :undef => :replace,
+                                   :replace => DEFAULT_INVALID_CHAR)
+      if !error_context_str.nil?
+        warn_if_invalid_chars(str_lossy, error_context_str)
+      else
+        str_lossy
+      end
     end
   end
 

--- a/puppet/lib/puppet/util/puppetdb/command.rb
+++ b/puppet/lib/puppet/util/puppetdb/command.rb
@@ -24,13 +24,11 @@ class Puppet::Util::Puppetdb::Command
   #   primitive (numeric type, string, array, or hash) that is natively supported
   #   by JSON serialization / deserialization libraries.
   def initialize(command, version, certname, payload)
-    @command = command
-    @version = version
-    @certname = certname
     profile("Format payload", [:puppetdb, :payload, :format]) do
-      @payload = Puppet::Util::Puppetdb::CharEncoding.utf8_string({
+      @checksum_payload = Puppet::Util::Puppetdb::CharEncoding.utf8_string({
         :command => command,
         :version => version,
+        :certname => certname,
         :payload => payload,
       # We use to_pson still here, to work around the support for shifting
       # binary data from a catalog to PuppetDB. Attempting to use to_json
@@ -44,21 +42,25 @@ class Puppet::Util::Puppetdb::Command
       # Puppet 4.1.0. We need a better answer to non-utf8 data end-to-end.
       }.to_pson, "Error encoding a '#{command}' command for host '#{certname}'")
     end
+    @command = Puppet::Util::Puppetdb::CharEncoding.coerce_to_utf8(command).gsub(" ", "_")
+    @version = version
+    @certname = Puppet::Util::Puppetdb::CharEncoding.coerce_to_utf8(certname)
+    @payload = Puppet::Util::Puppetdb::CharEncoding.coerce_to_utf8(payload.to_pson)
   end
 
-  attr_reader :command, :version, :certname, :payload
+  attr_reader :command, :version, :certname, :payload, :checksum_payload
 
   # Submit the command, returning the result hash.
   #
   # @return [Hash <String, String>]
   def submit
-    checksum = Digest::SHA1.hexdigest(payload)
+    checksum = Digest::SHA1.hexdigest(checksum_payload)
 
     for_whom = " for #{certname}" if certname
-
+    params = "checksum=#{checksum}&version=#{version}&certname=#{certname}&command=#{command}"
     begin
       response = profile("Submit command HTTP post", [:puppetdb, :command, :submit]) do
-        Http.action("#{CommandsUrl}?checksum=#{checksum}", :command) do |http_instance, path|
+        Http.action("#{CommandsUrl}?#{params}", :command) do |http_instance, path|
           http_instance.post(path, payload, headers)
         end
       end

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -38,15 +38,10 @@ describe Puppet::Resource::Catalog::Puppetdb do
     end
 
     it "should POST the catalog command as a JSON string" do
-      command_payload = subject.munge_catalog(catalog, options)
-      payload = {
-        :command => Puppet::Util::Puppetdb::CommandNames::CommandReplaceCatalog,
-        :version => 7,
-        :payload => command_payload,
-      }.to_json
+      command_payload = subject.munge_catalog(catalog, options).to_json
 
       http.expects(:post).with do |uri, body, headers|
-        expect(body).to eq(payload)
+        expect(body).to eq(command_payload)
       end.returns response
 
       save

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -43,17 +43,11 @@ describe Puppet::Node::Facts::Puppetdb do
       trusted_data = {"foo" => "foobar", "certname" => "testing_posting"}
       subject.stubs(:get_trusted_info).returns trusted_data
 
-      f = {
+      payload = {
         "certname" => facts.name,
         "values" => facts.values.merge({"trusted" => trusted_data}),
         "environment" => "my_environment",
         "producer_timestamp" => "a test",
-      }
-
-      payload = {
-        :command => CommandReplaceFacts,
-        :version => 4,
-        :payload => f,
       }.to_pson
 
       http.expects(:post).with do |uri, body, headers|
@@ -75,11 +69,10 @@ describe Puppet::Node::Facts::Puppetdb do
       save
 
       message = JSON.parse(sent_payload)
-      sent_facts = message['payload']
 
       # We shouldn't modify the original instance
       facts.values['something'].should == 100
-      sent_facts['values']['something'].should == 100
+      message['values']['something'].should == 100
     end
   end
 

--- a/puppet/spec/unit/indirector/node/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/node/puppetdb_spec.rb
@@ -31,12 +31,8 @@ describe Puppet::Node::Puppetdb do
     it "should POST a '#{CommandDeactivateNode}' command" do
       response.stubs(:body).returns '{"uuid": "a UUID"}'
 
-      payload = {
-        :command => CommandDeactivateNode,
-        :version => 3,
-        :payload => { :certname => node,
-                      :producer_timestamp => producer_timestamp },
-      }.to_json
+      payload = { :certname => node,
+                  :producer_timestamp => producer_timestamp }.to_json
 
       http.expects(:post).with do |uri,body,headers|
         expect(body).to eq(payload)

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -26,7 +26,7 @@ describe processor do
 
     def without_producer_timestamp(json_body)
       parsed = JSON.parse(json_body)
-      parsed["payload"].delete("producer_timestamp")
+      parsed.delete("producer_timestamp")
       parsed.to_json
     end
 
@@ -34,11 +34,7 @@ describe processor do
       httpok.stubs(:body).returns '{"uuid": "a UUID"}'
       subject.stubs(:run_duration).returns(10)
 
-      expected_body = {
-        :command => Puppet::Util::Puppetdb::CommandNames::CommandStoreReport,
-        :version => 6,
-        :payload => subject.send(:report_to_hash)
-      }.to_json
+      expected_body = subject.send(:report_to_hash).to_json
 
       Puppet::Network::HttpPool.expects(:http_instance).returns(http)
       http.expects(:post).with {|path, body, headers|

--- a/puppet/spec/unit/util/puppetdb/command_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/command_spec.rb
@@ -87,7 +87,7 @@ describe Puppet::Util::Puppetdb::Command do
         end
         Puppet.expects(:debug).with do |msg|
           msg =~ /Error encoding a 'command-1' command for host 'foo.localdomain'/ &&
-            msg =~ Regexp.new(Regexp.quote('"command":"command-1","version":1,"payload":{"foo"')) &&
+            msg =~ Regexp.new(Regexp.quote('"command":"command-1","version":1,"certname":"foo.localdomain","payload":{"foo"')) &&
             msg =~ /1 invalid\/undefined/
         end
         cmd = described_class.new("command-1", 1, "foo.localdomain", {"foo" => [192].pack('c*')})

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -310,6 +310,12 @@
                 #(update % 0 underscores->dashes)
                 m))
 
+(defn cmd-params->json-str
+  [{:strs [command version certname payload]}]
+  (json/generate-string
+    {:command command :version (Integer. version)
+     :certname certname :payload (json/->RawJsonString payload)}))
+
 (defmacro with-timeout [timeout-ms default & body]
   `(let [f# (future (do ~@body))
          result# (deref f# ~timeout-ms ~default)]


### PR DESCRIPTION
This allows us to do more granular logging at the wire without parsing the
command payload itself.