### PR TITLE
(PDB-2234) Add ability for sync tests to disable metrics

### DIFF
--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -350,6 +350,14 @@
            (.cancel stmt)
            (throw e)))))))
 
+(defn ^:dynamic enable-jmx
+  "This function exists to enable starting multiple PuppetDB instances
+  inside a single JVM. Starting up a second instance results in a
+  collision exception between JMX beans from the two
+  instances. Disabling JMX from the broker avoids that issue"
+  [^HikariConfig config metrics-registry]
+  (.setMetricRegistry config metrics-registry))
+
 (defn make-connection-pool
   "Given a DB spec map containing :subprotocol, :subname, :user, and :password
   keys, return a pooled DB spec map (one containing just the :datasource key
@@ -383,7 +391,7 @@
      (some->> read-only? (.setReadOnly config))
      (some->> (or user username) str (.setUsername config))
      (some->> password str (.setPassword config))
-     (some->> metrics-registry (.setMetricRegistry config))
+     (some->> metrics-registry (enable-jmx config))
      (HikariDataSource. config))))
 
 (defn pooled-datasource

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -42,7 +42,8 @@
   allow them both to be started."
   [& body]
   `(with-redefs [puppetlabs.puppetdb.mq/enable-jmx (fn [broker# _#]
-                                                     (.setUseJmx broker# false))]
+                                                     (.setUseJmx broker# false))
+                 puppetlabs.puppetdb.jdbc/enable-jmx (fn [config# _#] nil)]
      (do ~@body)))
 
 (defmacro with-test-broker


### PR DESCRIPTION
This commit adds a similar mechanism to HikariCP that we have for
ActiveMQ to disable JMX reporting. This is because JMX is per JVM which
means our sync tests' metrics will collide by trying to start 2 PDB's in
the same JVM.