### PR TITLE
(PDB-2252) Try to avoid parsing a POSTed cmd

### DIFF
--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -96,7 +96,7 @@
           (string? (:command %))
           (number? (:version %))
           (map? (:annotations %))]}
-  (let [message (if (= (class body) (class (byte-array 0)))
+  (let [message (if (instance? utils/byte-array-class body)
                       (json/parse-string (String. body "UTF-8") true)
                       (json/parse-string body true))
         default-annotations {:received (kitchensink/timestamp)

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -77,6 +77,21 @@
             [clojure.set :as set]
             [clojure.core.async :as async]))
 
+(defn fatality
+  "Create an object representing a fatal command-processing exception
+
+  cause - object representing the cause of the failure
+  "
+  [cause]
+  {:fatal true :cause cause})
+
+(defmacro upon-error-throw-fatality
+  [& body]
+  `(try+
+    ~@body
+    (catch Throwable e#
+      (throw+ (fatality e#)))))
+
 (defn version-range [min-version max-version]
   (set (range min-version (inc max-version))))
 
@@ -86,23 +101,102 @@
    "store report" (version-range 3 6)
    "deactivate node" (version-range 1 3)})
 
-;; ## Command parsing
+(defn- die-on-header-payload-mismatch
+  [name in-header in-body]
+  (when (and in-header in-body (not= in-header in-body))
+    (throw+
+     (fatality
+      (Exception.
+       (format "%s mismatch between message properties and payload (%s != %s)"
+               name in-header in-body))))))
+
+(def new-message-schema
+  {:headers {:command s/Str
+             :version s/Str
+             :certname s/Str
+             :received s/Str
+             :id s/Str}
+   :body (s/cond-pre s/Str utils/byte-array-class)})
+
+(def queue-message-schema
+  ;; Perhaps eventually require :id and :received
+  {(s/optional-key :headers) {(s/optional-key :id) s/Str
+                              (s/optional-key :received) s/Str
+                              (s/optional-key :scheduledJobId) s/Str
+                              (s/optional-key :JMSXDeliveryCount) s/Str
+                              s/Any s/Any}
+   :body (s/cond-pre s/Str utils/byte-array-class)})
+
+(def new-command-schema ;; This could probably be stricter
+  {:command s/Str
+   :version s/Int
+   :certname s/Str
+   :payload {s/Any s/Any}
+   :annotations
+   (s/pred
+    (fn [x]
+      (and (map? x)
+           (some-> x :id string?)
+           (some-> x :received string?)
+           (empty? (select-keys x [:command :version :certname])))))})
+
+(def queue-command-schema
+  ;; Created to match existing test behavior, but is that
+  ;; comprehensive? i.e. if we're wrong, and this is too strict, then
+  ;; it could break on outside queue content on release.  Adding a
+  ;; schema here could change our effectively public queue API.
+  (-> new-command-schema
+      (dissoc :certname)
+      (assoc (s/optional-key :certname) s/Str)
+      (dissoc :payload)
+      (assoc (s/optional-key :payload) (s/cond-pre s/Str {s/Any s/Any}))))
+
+(defn-validated ^:private parse-new-command :- new-command-schema
+  "Parses a new-format queue command and returns it in the traditional
+  format (see parse-queue-command).  New-style messages must have all
+  5 headers (command, version, certname, received, and id), and the
+  body must be the bare command content (i.e. the payload).  So for a
+  \"deactivate node\" command, a string like
+  {\"certname\":\"test1\",\"producer_timestamp\":\"2015-01-01\"}."
+  [{:keys [headers body]} :- new-message-schema]
+  (let [{:keys [command version certname received id]} headers
+        version (Integer/parseInt version)]
+    (let [message (json/parse body true)]
+      (die-on-header-payload-mismatch "certname"
+                                      certname
+                                      (get-in message ["payload" "certname"]))
+      ;; Since new commands aren't the queue retry format, we expect
+      ;; no annotations.
+      (assert (not (:annotations message)))
+      {:command command
+       :version version
+       :certname certname ;; Duplicated with respect to payload for now.
+       :payload message
+       :annotations (dissoc headers :command :version :certname)})))
+
+(defn-validated ^:private parse-queue-command :- queue-command-schema
+  "Parses a traditional queue command (also the current format for
+  failed, re-queued messages).  See parse-new-command for the handling
+  of newly received messages.  These messages must not have command,
+  version, or certname headers, and the body must be a JSON map like
+  this: {\"command\":\"deactivate node\",\"version\":3,\"payload\":{\"certname\":...}}."
+  [{:keys [headers body]} :- queue-message-schema]
+  (let [{:keys [command version certname]} headers]
+    (update (json/parse-strict body true) :annotations merge
+            {:received (kitchensink/timestamp) :id (kitchensink/uuid)}
+            headers)))
 
 (defn parse-command
-  "Take a wire-format command and parse it into a command object."
-  [{:keys [headers body]}]
+  "Parses a queue message and returns it as a command map."
+  [{:keys [headers body] :as message}]
   {:post [(map? %)
           (:payload %)
           (string? (:command %))
           (number? (:version %))
           (map? (:annotations %))]}
-  (let [message (if (instance? utils/byte-array-class body)
-                      (json/parse-string (String. body "UTF-8") true)
-                      (json/parse-string body true))
-        default-annotations {:received (kitchensink/timestamp)
-                             :id (kitchensink/uuid)}]
-    (update message :annotations
-            merge default-annotations headers)))
+  (if (:command headers)
+    (parse-new-command message)
+    (parse-queue-command message)))
 
 ;; ## Command submission
 
@@ -111,7 +205,7 @@
   its id."
   [mq-connection :- mq/connection-schema
    mq-endpoint :- s/Str
-   raw-command :- s/Str
+   raw-command :- (s/cond-pre s/Str utils/byte-array-class)
    uuid :- (s/maybe s/Str)
    properties :- (s/maybe {s/Str s/Str})] ;; For now stick with str -> str
   (let [uuid (or uuid (kitchensink/uuid))]
@@ -139,23 +233,6 @@
                             (json/generate-string command-map)
                             uuid
                             properties)))
-
-;; ## Command processing exception classes
-
-(defn fatality
-  "Create an object representing a fatal command-processing exception
-
-  cause - object representing the cause of the failure
-  "
-  [cause]
-  {:fatal true :cause cause})
-
-(defmacro upon-error-throw-fatality
-  [& body]
-  `(try+
-    ~@body
-    (catch Throwable e#
-      (throw+ (fatality e#)))))
 
 ;; Catalog replacement
 

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -107,6 +107,11 @@
           (do-submit)
           (http/json-response {:uuid uuid}))))))
 
+(defn- add-received-param
+  [handle]
+  (fn [req]
+    (handle (assoc-in req [:params "received"] (kitchensink/timestamp)))))
+
 (defn routes [enqueue-fn get-response-pub]
   (cmdi/context "/v1"
                 (cmdi/ANY "" []
@@ -126,6 +131,7 @@
       (mid/fail-when-payload-too-large reject-large-commands? max-command-size)
       mid/verify-accepts-json
       mid/verify-checksum
+      add-received-param ;; must be (temporally) after validate-query-params
       (mid/validate-query-params {:optional ["checksum" "secondsToWaitForCompletion"
                                              "certname" "command" "version"]})
       mid/payload-to-body-string

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -128,12 +128,12 @@
   (-> (routes enqueue-fn get-response-pub)
       mid/make-pdb-handler
       validate-command-version
-      mid/verify-accepts-json
       add-received-param ;; must be (temporally) after validate-query-params
       ;; The checksum here is vestigial.  It is no longer checked
       (mid/validate-query-params {:optional ["checksum" "secondsToWaitForCompletion"
                                              "certname" "command" "version"]})
       mid/payload-to-body-string
+      mid/verify-accepts-json
       (mid/verify-content-type ["application/json"])
       (mid/fail-when-payload-too-large reject-large-commands? max-command-size)
       (mid/wrap-with-metrics (atom {}) http/leading-uris)

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -67,6 +67,22 @@
        (finally
          (async/unsub p# t# c#)))))
 
+(defn- restrained-drained-stream [stream max-size]
+  "Returns a stream that will throw ::body-stream-overflow and drain
+  the rest of the stream if more than max-size-data is read."
+  ;; The drain is because ruby.  i.e. if we closed the connection
+  ;; without that, one of the ruby clients wouldn't handle the broken
+  ;; pipe in a friendly way.
+  (proxy [LimitedInputStream] [stream max-size]
+    (raiseError [max-size count]
+      ;; We don't trust skip; it appears to just invoke InputStream
+      ;; skip which claims to allocate at least one buffer (of
+      ;; unspecified size) per request.
+      (loop [buf (byte-array (* 64 1024))]
+        (when (pos? (.read ^java.io.InputStream this buf))
+          (recur buf)))
+      (throw+ ::body-stream-overflow))))
+
 (defn- blocking-submit-command
   "Submit a command by calling do-submit-fn and block until it completes.
   Subscribes to response-pub on the topic of the commands uuid, waiting up to
@@ -80,19 +96,20 @@
           timeout-chan (http/json-response {:uuid uuid
                                             :processed false
                                             :timed_out true}
-                                           503)
+                                           http/status-unavailable)
           response-chan ([{:keys [command exception]}]
                          (let [base-response {:uuid uuid
                                               :processed true}]
                            (if exception
-                             (http/json-response (assoc base-response
-                                                        :timed_out false
-                                                        :error (str exception)
-                                                        :stack_trace (map str (.getStackTrace exception)))
-                                                 503)
+                             (http/json-response
+                              (assoc base-response
+                                     :timed_out false
+                                     :error (str exception)
+                                     :stack_trace (map str (.getStackTrace exception)))
+                              http/status-unavailable)
                              (http/json-response (assoc base-response
                                                         :timed_out false)
-                                                 200)))))))))
+                                                 http/status-ok)))))))))
 
 (def new-request-schema
   {:params {(s/required-key "command") s/Str
@@ -151,43 +168,69 @@
               (normalize-new-request req)
               (normalize-old-request req)))))
 
+(defn- realize-body [body max-command-size]
+  "Returns the body as an in-memory string or byte-array, reading it
+  if necessary.  Throws ::body-stream-overflow if the max-command-size
+  is not false and not respected."
+  (if-not max-command-size
+    (if (instance? java.io.InputStream body)
+      (IOUtils/toByteArray body)
+      body)
+    (cond
+      (instance? java.io.InputStream body)
+      (IOUtils/toByteArray
+       (restrained-drained-stream body (long max-command-size)))
+
+      (string? body)
+      ;; Given Java's (UCS-2) encoding, the size should be effectively
+      ;; two bytes per character.
+      (if (> (* 2 (count body)) max-command-size)
+        (throw+ ::body-stream-overflow)
+        body)
+
+      :else
+      (throw (Exception. (str "Unexpected body type: " (class body)))))))
+
 (defn- enqueue-command-handler
   "Enqueues the command in request and returns a UUID"
-  [enqueue-fn get-response-pub]
+  [enqueue-fn get-response-pub max-command-size]
   (fn [{:keys [body params] :as request}]
     ;; For now body will be in-memory, but eventually may be a stream.
-    (let [uuid (kitchensink/uuid)
-          completion-timeout-ms (some-> params
-                                        (get "secondsToWaitForCompletion")
-                                        Double/parseDouble
-                                        (* 1000))
-          submit-params (select-keys params ["certname" "command" "version"])
-          submit-params (if-let [v (submit-params "version")]
-                          (update submit-params "version" str)
-                          submit-params)
-          ;; Replace read-body when our queue supports streaming
-          do-submit #(enqueue-fn (if (instance? java.io.InputStream body)
-                                   (IOUtils/toByteArray body)
-                                   body)
-                                 uuid
-                                 submit-params)]
-      (if (some-> completion-timeout-ms pos?)
-        (blocking-submit-command do-submit (get-response-pub)
-                                 uuid
-                                 completion-timeout-ms)
-        (do
-          (do-submit)
-          (http/json-response {:uuid uuid}))))))
+    (try+
+     (let [uuid (kitchensink/uuid)
+           completion-timeout-ms (some-> params
+                                         (get "secondsToWaitForCompletion")
+                                         Double/parseDouble
+                                         (* 1000))
+           submit-params (select-keys params ["certname" "command" "version"])
+           submit-params (if-let [v (submit-params "version")]
+                           (update submit-params "version" str)
+                           submit-params)
+           ;; Replace read-body when our queue supports streaming
+           do-submit #(enqueue-fn (realize-body body max-command-size)
+                                  uuid
+                                  submit-params)]
+       (if (some-> completion-timeout-ms pos?)
+         (blocking-submit-command do-submit (get-response-pub)
+                                  uuid
+                                  completion-timeout-ms)
+         (do
+           (do-submit)
+           (http/json-response {:uuid uuid}))))
+     (catch (= ::body-stream-overflow %) _
+       (http/error-response "Command size exceeds max-command-size"
+                            http/status-entity-too-large)))))
 
 (defn- add-received-param
   [handle]
   (fn [req]
     (handle (assoc-in req [:params "received"] (kitchensink/timestamp)))))
 
-(defn routes [enqueue-fn get-response-pub]
+(defn routes [enqueue-fn get-response-pub max-command-size]
   (cmdi/context "/v1"
                 (cmdi/ANY "" []
-                          (enqueue-command-handler enqueue-fn get-response-pub))))
+                          (enqueue-command-handler enqueue-fn get-response-pub
+                                                   max-command-size))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
@@ -196,8 +239,10 @@
 ;; return functions that accept a ring request map
 
 (defn command-app
-  [get-shared-globals enqueue-fn get-response-pub reject-large-commands? max-command-size]
-  (-> (routes enqueue-fn get-response-pub)
+  [get-shared-globals enqueue-fn get-response-pub
+   reject-large-commands? max-command-size]
+  (-> (routes enqueue-fn get-response-pub
+              (when reject-large-commands? max-command-size))
       mid/make-pdb-handler
       validate-command-version
       wrap-with-request-normalization

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -129,8 +129,8 @@
       mid/make-pdb-handler
       validate-command-version
       mid/verify-accepts-json
-      mid/verify-checksum
       add-received-param ;; must be (temporally) after validate-query-params
+      ;; The checksum here is vestigial.  It is no longer checked
       (mid/validate-query-params {:optional ["checksum" "secondsToWaitForCompletion"
                                              "certname" "command" "version"]})
       mid/payload-to-body-string

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -100,7 +100,7 @@
                                         (get "secondsToWaitForCompletion")
                                         Double/parseDouble
                                         (* 1000))
-          do-submit #(enqueue-fn body-string uuid)]
+          do-submit #(enqueue-fn body-string uuid nil)] ;; nil is properties
       (if (some-> completion-timeout-ms pos?)
         (blocking-submit-command do-submit (get-response-pub) uuid completion-timeout-ms)
         (do

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -128,7 +128,6 @@
   (-> (routes enqueue-fn get-response-pub)
       mid/make-pdb-handler
       validate-command-version
-      (mid/fail-when-payload-too-large reject-large-commands? max-command-size)
       mid/verify-accepts-json
       mid/verify-checksum
       add-received-param ;; must be (temporally) after validate-query-params
@@ -136,5 +135,6 @@
                                              "certname" "command" "version"]})
       mid/payload-to-body-string
       (mid/verify-content-type ["application/json"])
+      (mid/fail-when-payload-too-large reject-large-commands? max-command-size)
       (mid/wrap-with-metrics (atom {}) http/leading-uris)
       (mid/wrap-with-globals get-shared-globals)))

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -128,11 +128,11 @@
   (-> (routes enqueue-fn get-response-pub)
       mid/make-pdb-handler
       validate-command-version
+      mid/payload-to-body-string
       add-received-param ;; must be (temporally) after validate-query-params
       ;; The checksum here is vestigial.  It is no longer checked
       (mid/validate-query-params {:optional ["checksum" "secondsToWaitForCompletion"
                                              "certname" "command" "version"]})
-      mid/payload-to-body-string
       mid/verify-accepts-json
       (mid/verify-content-type ["application/json"])
       (mid/fail-when-payload-too-large reject-large-commands? max-command-size)

--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -200,20 +200,6 @@
   (fn [app]
     (verify-accepts-content-type app "application/json")))
 
-(defn verify-checksum
-  "Ring middleware which will verify that the content of the body-string
-  has the checksum specified in the `checksum` parameter. If no checksum is
-  provided, this check will be skipped. If the checksum doesn't match, a 400
-  Bad Request error is returned."
-  [app]
-  (fn [{:keys [params body-string] :as req}]
-    (let [expected-checksum (params "checksum")
-          payload           body-string]
-      (if (and expected-checksum
-               (not= expected-checksum (kitchensink/utf8-string->sha1 payload)))
-        (http/error-response "checksums don't match")
-        (app req)))))
-
 (def http-metrics-registry (get-in metrics/metrics-registries [:http :registry]))
 
 (defn wrap-with-metrics

--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -294,9 +294,9 @@
                        length-in-bytes
                        max-command-size)
             (consume-and-close (:body req) length-in-bytes)
-            {:status 413
-             :headers {}
-             :body "Command rejected due to size exceeding max-command-size"})
+            (http/error-response
+             "Command rejected due to size exceeding max-command-size"
+             http/status-entity-too-large))
           (app req)))
       (app req))))
 

--- a/src/puppetlabs/puppetdb/mq.clj
+++ b/src/puppetlabs/puppetdb/mq.clj
@@ -7,6 +7,7 @@
            [org.apache.activemq.pool PooledConnectionFactory])
   (:require [clojure.java.jmx :as jmx]
             [clojure.tools.logging :as log]
+            [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.schema :refer [defn-validated]]
             [schema.core :as s]
             [slingshot.slingshot :refer [throw+]]))
@@ -209,7 +210,7 @@
                           (-set-jms-property! value name msg))
                         msg))})
 
-(extend (Class/forName "[B")
+(extend utils/byte-array-class
   ToJmsMessage
   {:-to-jms-message (fn [x properties session]
                       (let [msg (.createBytesMessage session)]

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -320,3 +320,5 @@
   `(let [f# (future (do ~@body))
          result# (deref f# ~timeout-ms ~default)]
      result#))
+
+(def byte-array-class (Class/forName "[B"))

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -55,18 +55,38 @@
           (is (map? (:annotations parsed))))))
 
     (testing "should reject invalid input"
-      (is (thrown? AssertionError (parse-command {:body ""})))
-      (is (thrown? AssertionError (parse-command {:body "{}"})))
+      (is (thrown-with-msg?
+           RuntimeException
+           #"Output of parse-queue-command does not match schema"
+           (parse-command {:body ""})))
+      (is (thrown-with-msg?
+           RuntimeException
+           #"Output of parse-queue-command does not match schema"
+           (parse-command {:body "{}"})))
 
       ;; Missing required attributes
-      (is (thrown? AssertionError (parse-command {:body "{\"version\": 2, \"payload\": \"meh\"}"})))
-      (is (thrown? AssertionError (parse-command {:body "{\"version\": 2}"})))
+      (is (thrown-with-msg?
+           RuntimeException
+           #"Output of parse-queue-command does not match schema"
+           (parse-command {:body "{\"version\": 2, \"payload\": \"meh\"}"})))
+      (is (thrown-with-msg?
+           RuntimeException
+           #"Output of parse-queue-command does not match schema"
+           (parse-command {:body "{\"version\": 2}"})))
 
       ;; Non-numeric version
-      (is (thrown? AssertionError (parse-command {:body "{\"version\": \"2\", \"payload\": \"meh\"}"})))
+      (is (thrown-with-msg?
+           RuntimeException
+           #"Output of parse-queue-command does not match schema"
+           (parse-command
+            {:body "{\"version\": \"2\", \"payload\": \"meh\"}"})))
 
       ;; Non-string command
-      (is (thrown? AssertionError (parse-command {:body "{\"command\": 123, \"version\": 2, \"payload\": \"meh\"}"})))
+      (is (thrown-with-msg?
+           RuntimeException
+           #"Output of parse-queue-command does not match schema"
+           (parse-command
+            {:body "{\"command\": 3, \"version\": 2, \"payload\": \"meh\"}"})))
 
       ;; Non-JSON payload
       (is (thrown? Exception (parse-command {:body "{\"command\": \"foo\", \"version\": 2, \"payload\": #{}"})))

--- a/test/puppetlabs/puppetdb/http/command_test.clj
+++ b/test/puppetlabs/puppetdb/http/command_test.clj
@@ -72,13 +72,6 @@
             response (*command-app* (post-request* endpoint nil payload))]
         (assert-success! response)))
 
-    (testing "should return 400 when checksums don't match"
-      (let [response (*command-app* (post-request* endpoint
-                                                   {"checksum" "something bad"}
-                                                   "Testing"))]
-        (is (= (:status response)
-               http/status-bad-request))))
-
     (testing "should 400 when the command is invalid"
       (let [invalid-command (form-command "foo" 100 "{}")
             invalid-checksum (kitchensink/utf8-string->sha1 invalid-command)

--- a/test/puppetlabs/puppetdb/http/command_test.clj
+++ b/test/puppetlabs/puppetdb/http/command_test.clj
@@ -1,8 +1,10 @@
 (ns puppetlabs.puppetdb.http.command-test
-  (:import [java.io ByteArrayInputStream])
-  (:require [puppetlabs.puppetdb.cheshire :as json]
-            [puppetlabs.puppetdb.http.command :refer [min-supported-commands
-                                                      valid-commands-str]]
+  (:require [clojure.math.combinatorics :refer [combinations]]
+            [clojure.set :as set]
+            [clojure.string :as str]
+            [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.http.command :as tgt
+             :refer [min-supported-commands valid-commands-str]]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.testutils
              :refer [*command-app*
@@ -16,7 +18,9 @@
             [puppetlabs.puppetdb.config :as conf]
             [puppetlabs.puppetdb.http :as http]
             [puppetlabs.puppetdb.mq :as mq]
-            [clj-time.format :as time]))
+            [clj-time.format :as time])
+  (:import [clojure.lang ExceptionInfo]
+           [java.io ByteArrayInputStream]))
 
 (def endpoints [[:v1 "/v1"]])
 
@@ -48,7 +52,7 @@
     (testing "should work when well-formed"
       (let [payload (form-command "replace facts"
                                   (get min-supported-commands "replace facts")
-                                  "{}")
+                                  {})
             checksum (kitchensink/utf8-string->sha1 payload)
             req (internal-request {"payload" payload "checksum" checksum})
             response (*command-app* (post-request* endpoint
@@ -68,12 +72,12 @@
     (testing "should not do checksum verification if no checksum is provided"
       (let [payload (form-command "deactivate node"
                                   (get min-supported-commands "deactivate node")
-                                  "{}")
+                                  {})
             response (*command-app* (post-request* endpoint nil payload))]
         (assert-success! response)))
 
     (testing "should 400 when the command is invalid"
-      (let [invalid-command (form-command "foo" 100 "{}")
+      (let [invalid-command (form-command "foo" 100 {})
             invalid-checksum (kitchensink/utf8-string->sha1 invalid-command)
             {:keys [status body]} (*command-app*
                                    (post-request* endpoint
@@ -90,7 +94,7 @@
       (let [min-supported-version (get min-supported-commands "replace facts")
             misversioned-command (form-command "replace facts"
                                                (dec min-supported-version)
-                                               "{}")
+                                               {})
             misversioned-checksum (kitchensink/utf8-string->sha1 misversioned-command)
             {:keys [status body]} (*command-app*
                                    (post-request* endpoint
@@ -117,7 +121,7 @@
 
   (let [good-payload  (form-command "replace facts"
                                     (get min-supported-commands "replace facts")
-                                    "{}")
+                                    {})
         good-checksum (kitchensink/utf8-string->sha1 good-payload)
         request       (fn [payload checksum]
                         (post-request* endpoint {"checksum" checksum} payload))]
@@ -132,3 +136,72 @@
         (let [timestamp (get-in good-msg [:headers :received])]
           (time/parse (time/formatters :date-time) timestamp))))))
 
+(deftest wrap-with-request-normalization-all-params
+  (let [normalize (#'tgt/wrap-with-request-normalization identity)]
+    ;; Make sure that when all three params are present, the body is passed on.
+    (let [before-params {"certname" "x" "command" "y_z" "version" "1"
+                         "received" (kitchensink/timestamp)}
+          before {:params before-params
+                  :body (ByteArrayInputStream. (byte-array 0))}
+          after (normalize before)
+          after-params (:params after)]
+      ;; Accomodate the fact that command and version will be transformed.
+      (is (identical? (:body before) (:body after)))
+      (is (= (dissoc before :params) (dissoc after :params)))
+      (is (= (before-params "version") (str (after-params "version"))))
+      (is (= (str/replace (before-params "command") "_" " ")
+             (after-params "command")))
+      (is (= (dissoc before-params "version" "command")
+             (dissoc after-params "version" "command"))))))
+
+(deftest wrap-with-request-normalization-no-params
+  (let [normalize (#'tgt/wrap-with-request-normalization identity)]
+    ;; Check that when there are no parameters, they're extracted from the body
+    ;; and returned in :params.
+    (let [body-str (json/generate-string
+                    {"command" "x y"
+                     "version" 1
+                     "payload" {"certname" "z"}})
+          body-stream  (ByteArrayInputStream. (.getBytes body-str "UTF-8"))
+          body-parsed (json/parse-string body-str)]
+      (doseq [body [body-str body-stream]]
+        (let [before {:params {} :body body}
+              after (normalize before)
+              after-params (:params after)]
+          (is (= (body-parsed "payload")
+                 (json/parse-string (:body after))))
+          (is (= {"command" "x y" "version" 1 "certname" "z"}
+                 (:params after))))))))
+
+(deftest wrap-with-request-normalization-some-params
+  (let [normalize (#'tgt/wrap-with-request-normalization identity)]
+    ;; Check for an error if some but not all params are present
+    (doseq [items (apply concat
+                         (map #(combinations ["command" "version" "certname"] %)
+                              [1 2]))]
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Input to normalize-(old|new)-request does not match schema"
+           (normalize {:body ::ignored
+                       :params (into {} (for [k items] [k "1"]))}))))))
+
+;; Right now, this is the only unit test that tests the (eventually
+;; streaming) command/version/certname params POST.  The acceptance
+;; tests test it via the altered terminus.
+(deftest-command-app almost-streaming-post
+  [[version endpoint] endpoints]
+  (let [replace-ver (get min-supported-commands "replace facts")
+        payload (form-command "replace facts" replace-ver {})
+        checksum (kitchensink/utf8-string->sha1 payload)
+        req (internal-request {"payload" payload "checksum" checksum})
+        preq (post-request* endpoint
+                            {"command" "replace_facts"
+                             "certname" "foo"
+                             "version" (str replace-ver)
+                             "checksum" checksum}
+                            payload)
+        response (*command-app* preq)]
+    (assert-success! response)
+    (is (= (content-type response)
+           http/json-response-content-type))
+    (is (uuid-in-response? response))))

--- a/test/puppetlabs/puppetdb/middleware_test.clj
+++ b/test/puppetlabs/puppetdb/middleware_test.clj
@@ -139,24 +139,6 @@
                                        utils/cmd-params->json-str)
                       :param-post? true)))))))
 
-(deftest verify-checksum-test
-  (let [test-content "test content"
-        checksum     "1eebdf4fdc9fc7bf283031b93f9aef3338de9052"
-        wrapped-fn   (verify-checksum identity)]
-
-    (testing "ensure fn succeeds with matching checksum"
-      (let [test-req {:body-string test-content
-                      :params {"checksum" checksum}}]
-        (is (= (wrapped-fn test-req)
-               {:body-string test-content
-                :params {"checksum" checksum}}))))
-
-    (testing "ensure fn call with mismatching checksum fails"
-      (let [test-req {:body-string test-content
-                      :params {"checksum" "asdf"}}]
-        (is (= (wrapped-fn test-req)
-               {:status 400 :headers {} :body "checksums don't match"}))))))
-
 (deftest verify-content-type-test
   (testing "with content-type of application/json"
     (let [test-req {:content-type "application/json"

--- a/test/puppetlabs/puppetdb/middleware_test.clj
+++ b/test/puppetlabs/puppetdb/middleware_test.clj
@@ -108,37 +108,6 @@
         (is (= http/status-bad-request status))
         (is (= "Unsupported query parameter 'wazzup'" body))))))
 
-(deftest payload-to-body-string-test
-  (let [test-content "test content"
-        test-stream  #(ByteArrayInputStream. (.getBytes test-content "UTF-8"))
-        wrapped-fn   (payload-to-body-string identity)]
-
-    (doseq [mt ["application/json" "application/json;charset=UTF8"]]
-      (testing (str "for content-type " mt " body should populate body-string"
-                    (let [test-req {:body    (test-stream)
-                                    :headers {"content-type" "application/json"}}]
-                      (is (= (wrapped-fn test-req)
-                             (assoc test-req :body-string test-content :param-post? false)))))))
-
-    (testing "url encoded payload should populate body-string"
-      (let [test-req {:params {"payload" test-content}
-                      :headers {"content-type" "application/x-www-form-urlencoded"}}]
-        (is (= (wrapped-fn test-req)
-               (assoc test-req :body-string test-content)))))
-
-    (testing "param-post? is true when params are included"
-      (let [test-req {:params {"certname" "foo.com"
-                               "command" "fix drywall"
-                               "version" "307"}
-                      :body (test-stream)
-                      :headers {"content-type" "application/json"}}]
-        (is (= (wrapped-fn test-req)
-               (assoc test-req
-                      :body-string (-> (:params test-req)
-                                       (assoc "payload" test-content)
-                                       utils/cmd-params->json-str)
-                      :param-post? true)))))))
-
 (deftest verify-content-type-test
   (testing "with content-type of application/json"
     (let [test-req {:content-type "application/json"


### PR DESCRIPTION
Don't parse the incoming command body when it has command and version
parameters (which should now be the common case).  Instead, validate the
parameters, and pass the body directly to the queue, uninterpreted.
Otherwise, warn if body has to be parsed into RAM.

Attach the command, version, and if available, certname, to the queue
message as JMS properties, extracting them from the body (after
parsing), if they weren't available in the incoming request.

As before, reject incoming commands that don't have both command and
version when they have either.
