### PR TITLE
(maint) stop deleting unassociated report statuses

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -846,13 +846,6 @@
            UNION SELECT environment_id FROM factsets
                    WHERE environment_id IS NOT NULL)"])))
 
-(defn delete-unassociated-statuses!
-  "Remove any statuses that aren't associated with a report"
-  []
-  (time! (:gc-report-statuses performance-metrics)
-         (jdbc/delete! :report_statuses
-                       ["ID NOT IN (SELECT status_id FROM reports)"])))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Facts
 
@@ -1411,8 +1404,7 @@
    (:gc performance-metrics)
    (jdbc/with-transacted-connection db
      (delete-unassociated-params!)
-     (delete-unassociated-environments!)
-     (delete-unassociated-statuses!))
+     (delete-unassociated-environments!))
    ;; These require serializable because they make the decision to
    ;; delete based on row counts in another table.
    (jdbc/with-transacted-connection' db :serializable

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -746,22 +746,6 @@
     (is (= (:c (first (query-to-vec ["SELECT count(id) as c FROM fact_values"]))) 0))
     (is (= (:c (first (query-to-vec ["SELECT count(id) as c FROM fact_paths"]))) 0))))
 
-(deftest-db delete-with-gc-report-statuses
-  (add-certname! certname)
-
-  (let [timestamp     (now)
-        report        (:basic reports)
-        certname      (:certname report)]
-    (store-example-report! report timestamp)
-
-    (is (= [{:c 1}] (query-to-vec ["SELECT COUNT(*) as c FROM report_statuses"])))
-
-    (delete-reports-older-than! (-> 2 days ago))
-
-    (is (= [{:c 1}] (query-to-vec ["SELECT COUNT(*) as c FROM report_statuses"])))
-    (garbage-collect! *db*)
-    (is (= [{:c 0}] (query-to-vec ["SELECT COUNT(*) as c FROM report_statuses"])))))
-
 (deftest-db catalog-bad-input
   (testing "should noop"
     (testing "on bad input"


### PR DESCRIPTION
This removes a gc operation that can become expensive on large environments.
Since report_statuses has 3 rows max, there's no reason to clean the table.