### PR TITLE
(tests) Don't install rubygems package on Ubuntu 14.04 Trusty

### DIFF
--- a/acceptance/config/ec2-west-ubuntu1404-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1404-64mda-64a.cfg
@@ -10,7 +10,7 @@ HOSTS:
     amisize: c3.large
     hypervisor: ec2
     snapshot: foss
-  ubuntu-1204-64-2:
+  ubuntu-1404-64-2:
     roles:
       - agent
     vmname: ubuntu-14.04-amd64-west

--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -67,6 +67,13 @@ unless (test_config[:skip_presuite_provisioning])
         when /^ubuntu-10.04/
           # Ubuntu 10.04 has rubygems 1.3.5 which is known to not be reliable, so therefore
           # we skip.
+        when /^ubuntue-14.04/
+          on master, "apt-get install -y ruby ruby-dev libsqlite3-dev build-essential"
+          # this is to get around the activesupport dependency on Ruby 1.9.3 for
+          # Ubuntu 12.04. We can remove it when we drop support for 1.8.7.
+          on master, "gem install i18n -v 0.6.11"
+          on master, "gem install activerecord -v 3.2.17 --no-ri --no-rdoc -V --backtrace"
+          on master, "gem install sqlite3 -v 1.3.9 --no-ri --no-rdoc -V --backtrace"
         else
           on master, "apt-get install -y rubygems ruby-dev libsqlite3-dev build-essential"
           # this is to get around the activesupport dependency on Ruby 1.9.3 for

--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -67,7 +67,7 @@ unless (test_config[:skip_presuite_provisioning])
         when /^ubuntu-10.04/
           # Ubuntu 10.04 has rubygems 1.3.5 which is known to not be reliable, so therefore
           # we skip.
-        when /^ubuntue-14.04/
+        when /^ubuntu-14.04/
           on master, "apt-get install -y ruby ruby-dev libsqlite3-dev build-essential"
           # this is to get around the activesupport dependency on Ruby 1.9.3 for
           # Ubuntu 12.04. We can remove it when we drop support for 1.8.7.


### PR DESCRIPTION
On trusty (and later?), the gem command is packaged with the ruby package instead. Work done in support of PDB-997.