### PR TITLE
(tests) Don't try to install rubygems package on Ubuntu 14.04

### DIFF
--- a/acceptance/config/ec2-west-ubuntu1404-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1404-64mda-64a.cfg
@@ -1,0 +1,28 @@
+HOSTS:
+  ubuntu-1404-64-1:
+    roles:
+      - master
+      - database
+      - dashboard
+      - agent
+    vmname: ubuntu-14.04-amd64-west
+    platform: ubuntu-14.04-amd64
+    amisize: c3.large
+    hypervisor: ec2
+    snapshot: foss
+  ubuntu-1404-64-2:
+    roles:
+      - agent
+    vmname: ubuntu-14.04-amd64-west
+    platform: ubuntu-14.04-amd64
+    amisize: c3.large
+    hypervisor: ec2
+    snapshot: foss
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  vpc_id: vpc-cc4aeda9
+  subnet_ids:
+    - subnet-4a74d73d
+    - subnet-6169e404
+    - subnet-5870b101

--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -67,6 +67,13 @@ unless (test_config[:skip_presuite_provisioning])
         when /^ubuntu-10.04/
           # Ubuntu 10.04 has rubygems 1.3.5 which is known to not be reliable, so therefore
           # we skip.
+        when /^ubuntu-14.04/
+          on master, "apt-get install -y ruby ruby-dev libsqlite3-dev build-essential"
+          # this is to get around the activesupport dependency on Ruby 1.9.3 for
+          # Ubuntu 12.04. We can remove it when we drop support for 1.8.7.
+          on master, "gem install i18n -v 0.6.11"
+          on master, "gem install activerecord -v 3.2.17 --no-ri --no-rdoc -V --backtrace"
+          on master, "gem install sqlite3 -v 1.3.9 --no-ri --no-rdoc -V --backtrace"
         else
           on master, "apt-get install -y rubygems ruby-dev libsqlite3-dev build-essential"
           # this is to get around the activesupport dependency on Ruby 1.9.3 for

--- a/ext/jenkins/packaging.sh
+++ b/ext/jenkins/packaging.sh
@@ -60,7 +60,7 @@ echo "BUCKET_NAME IS: ${BUCKET_NAME}"
 
 time s3cmd --verbose --acl-public --delete-removed  sync ${REPO_CONFIGS}/*  ${S3_BRANCH_PATH}/repo_configs/
 
-time s3cmd --verbose --acl-public --delete-removed  sync ${REPO_DIR}/apt/{jessie,lucid,precise,squeeze,wheezy,stable,testing}  ${S3_BRANCH_PATH}/repos/apt/
+time s3cmd --verbose --acl-public --delete-removed  sync ${REPO_DIR}/apt/{jessie,lucid,precise,squeeze,trusty,wheezy,stable,testing}  ${S3_BRANCH_PATH}/repos/apt/
 
 time s3cmd --verbose --acl-public --delete-removed  sync ${REPO_DIR}/el/{5,6,7}  ${S3_BRANCH_PATH}/repos/el/
 


### PR DESCRIPTION
Rubygems on Ubuntu 14.04 Trusty is now part of the ruby package.

Change name of new config file for Ubuntu 14.04 Trusty.

Work done in support of PDB-997.