### PR TITLE
(maint) Fix nodes query for historical catalogs

### DIFF
--- a/documentation/api/ext/v1/resource-graphs.markdown
+++ b/documentation/api/ext/v1/resource-graphs.markdown
@@ -87,7 +87,6 @@ the form:
 The `<resources>` object is of the following form:
 
     {
-      "certname": <string>,
       "resource": <string>,
       "type": <string>,
       "title": <sttring>,

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -117,8 +117,11 @@
                                "resources" {:columns ["certname"]}}
 
                :selection {:from [:certnames]
-                           :left-join [:catalogs
-                                       [:= :certnames.certname :catalogs.certname]
+                           :left-join [:latest_catalogs
+                                       [:= :latest_catalogs.certname_id :certnames.id]
+
+                                       :catalogs
+                                       [:= :catalogs.id :latest_catalogs.catalog_id]
 
                                        [:factsets :fs]
                                        [:= :certnames.certname :fs.certname]


### PR DESCRIPTION
This commit fixes the nodes query to left join on only the latest
catalog and not all (historical catalogs) and fixes the documentation
for resource-graphs.