### PR TITLE
(maint) Use join on `id` for nodes-query with reports

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -120,10 +120,7 @@
                                        [:= :certnames.certname :fs.certname]
 
                                        :reports
-                                       [:and
-                                        [:= :certnames.certname :reports.certname]
-                                        [:in :reports.id {:select [:latest_report_id]
-                                                          :from [:certnames]}]]
+                                       [:= :certnames.latest_report_id :reports.id]
 
                                        [:environments :catalog_environment]
                                        [:= :catalog_environment.id :catalogs.environment_id]


### PR DESCRIPTION
This commit changes the nodes query to use a "regular" left join from
certnames to reports using the `latest_report_id` instead of using an
`in` expression.