### PR TITLE
(PDB-2271) support relative path to vardir

### DIFF
--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -245,7 +245,10 @@
   "Checks that `vardir` is specified, exists, and is writeable, throwing
   appropriate exceptions if any condition is unmet."
   [config]
-  (let [vardir (io/file (get-in config [:global :vardir]))]
+  (let [vardir (some-> (get-in config [:global :vardir])
+                       io/file
+                       fs/absolute-path
+                       fs/file)]
     (cond
      (nil? vardir)
      (throw (IllegalArgumentException.

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -143,10 +143,6 @@
     (is (thrown-with-msg? IllegalArgumentException #"is not specified"
                           (validate-vardir {:global {:vardir nil}}))))
 
-  (testing "should fail if it's not an absolute path"
-    (is (thrown-with-msg? IllegalArgumentException #"must be an absolute path"
-                          (validate-vardir (vardir "foo/bar/baz")))))
-
   (testing "should fail if it doesn't exist"
     (is (thrown-with-msg? java.io.FileNotFoundException #"does not exist"
                           (validate-vardir (vardir "/abc/def/ghi")))))
@@ -172,6 +168,15 @@
                      (.delete)
                      (.mkdir)
                      (.setWritable true))]
+      (is (= (validate-vardir (vardir filename))
+             (vardir filename)))))
+
+  (testing "should support relative paths"
+    (let [filename "./target/totally/okay"]
+      (doto (fs/file filename)
+        (.deleteOnExit)
+        (.mkdirs)
+        (.setWritable true))
       (is (= (validate-vardir (vardir filename))
              (vardir filename))))))
 


### PR DESCRIPTION
This commit modifies the configuration validation to support
specifying a relative path, which is necessary in order to
support a portable development environment where users
can run the system "out-of-the-box" (e.g., by including
a developer config file that has a hard-coded vardir path
of "./target/puppetdb-vardir".)

This is a requirement for the PE-AIO dev environment and tests
to work properly, at least based on their current implementation.