### PR TITLE
(PDB-2186) Add PuppetDB utility function for querying PuppetDB

### DIFF
--- a/puppet/lib/puppet/util/puppetdb/http.rb
+++ b/puppet/lib/puppet/util/puppetdb/http.rb
@@ -147,7 +147,7 @@ module Puppet::Util::Puppetdb
         request_exception = with_http_error_logging(server_url, route) {
           http = Puppet::Network::HttpPool.http_instance(server_url.host, server_url.port)
 
-          response = timeout(config.server_url_timeout) do
+          response = Timeout.timeout(config.server_url_timeout) do
             http_callback.call(http, route)
           end
         }
@@ -182,7 +182,7 @@ module Puppet::Util::Puppetdb
         request_exception = with_http_error_logging(server_url, route) {
           http = Puppet::Network::HttpPool.http_instance(server_url.host, server_url.port)
 
-          response = timeout(config.server_url_timeout) do
+          response = Timeout.timeout(config.server_url_timeout) do
             http_callback.call(http, route)
           end
         }

--- a/puppet/spec/unit/util/puppetdb_spec.rb
+++ b/puppet/spec/unit/util/puppetdb_spec.rb
@@ -5,27 +5,47 @@ require 'spec_helper'
 require 'digest/sha1'
 require 'puppet/util/puppetdb'
 require 'puppet/util/puppetdb/command_names'
+require 'puppet/util/puppetdb/http'
+require 'json'
 
-Command                 = Puppet::Util::Puppetdb::Command
 
+class FakeHttpResponse
+  def initialize(body)
+    @body = body
+  end
+  attr_reader :body
+end
 
 describe Puppet::Util::Puppetdb do
   subject { Object.new.extend described_class }
 
   describe "#submit_command" do
-    let(:payload)        { {'resistance' =>  'futile', 'opinion' => 'irrelevant'} }
-    let(:command1)  { Command.new("OPEN SESAME", 1, 'foo.localdomain',
-                                  payload.merge(:uniqueprop => "command1")) }
+    let(:payload) { {'resistance' =>  'futile', 'opinion' => 'irrelevant'} }
+    let(:command1) { Puppet::Util::Puppetdb::Command.new("OPEN SESAME", 1, 'foo.localdomain',
+                                                         payload.merge(:uniqueprop => "command1")) }
 
     it "should submit the command" do
       # careful here... since we're going to stub Command.new, we need to
       # make sure we reference command1 first, because it calls Command.new.
       command1.expects(:submit).once
-      Command.expects(:new).once.returns(command1)
+      Puppet::Util::Puppetdb::Command.expects(:new).once.returns(command1)
       subject.submit_command(command1.certname,
                              command1.payload,
                              command1.command,
                              command1.version)
+    end
+
+  end
+
+  describe "#query_puppetdb" do
+    let(:response) { JSON.generate({'certname' => 'futile', 'status' => 'irrelevant'}) }
+    let(:query) { ["=", "type", "Foo"] }
+    let(:http_response) { FakeHttpResponse.new(response) }
+    it "should query PuppetDB" do
+      # careful here... since we're going to stub Command.new, we need to
+      # make sure we reference command1 first, because it calls Command.new.
+      Puppet::Util::Puppetdb::Http.expects(:action).once.returns(http_response)
+      subject.query_puppetdb(query)
     end
 
   end


### PR DESCRIPTION
This commit adds a PuppetDB terminus utility function to query PuppetDB at the `root`
endpoint.