### PR TITLE
(maint) use table stats to compute the number of resources

### DIFF
--- a/resources/public/dashboard/index.html
+++ b/resources/public/dashboard/index.html
@@ -108,6 +108,19 @@ body {
     };
   };
 
+  function merge(a, b){
+      // merge objects a and b, giving b's contents precedence and returning
+      // a new object
+      var result = {};
+      for (item in a) {
+          result[item] = a[item];
+      }
+      for (item in b) {
+          result[item] = b[item];
+      }
+      return result;
+  };
+
   // Parse URL arguments
   function getParameter(paramName) {
     var searchString = window.location.search.substring(1),
@@ -177,9 +190,14 @@ body {
        url: "/metrics/v1/mbeans/java.lang:type=Memory",
        format: d3.format(",.3s"),
        snag: function(res) { return res["HeapMemoryUsage"]["used"]; }},
-      {description: "Nodes",
+      {description: "Active Nodes",
        addendum: "in the population",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.query.population:type=default,name=num-nodes",
+       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.query.population:type=default,name=num-active-nodes",
+       format: d3.format(","),
+       snag: getValueSnag},
+      {description: "Inactive Nodes",
+       addendum: "in the population",
+       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.query.population:type=default,name=num-inactive-nodes",
        format: d3.format(","),
        snag: getValueSnag},
       {description: "Resources",
@@ -188,6 +206,7 @@ body {
        format: d3.format(","),
        snag: getValueSnag},
       {description: "Resource duplication",
+       options: {pollingInterval: 1000 * 30},
        addendum: "% of resources stored",
        url: "/metrics/v1/mbeans/puppetlabs.puppetdb.query.population:type=default,name=pct-resource-dupes",
        format: d3.format(",.1%"),
@@ -265,12 +284,13 @@ body {
 
   for (i = 0; i < metrics.length; i++) {
       var metric = metrics[i];
+      var local_options = metric["options"] || {};
       counterAndSparkline(metric.description,
                           metric.addendum,
                           metric.url,
                           metric.format,
                           metric.snag,
-                          options);
+                          merge(options, local_options));
   }
 
   // Check the current version and for updates now, and then every 5 minutes

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -281,6 +281,14 @@ must be supplied as the value to be matched."
     (format "encode(%s::bytea, 'hex')" column)
     column))
 
+(defn vacuum-analyze
+  "Must call within a db connection"
+  [db]
+  (sql/with-db-connection [conn db]
+    (-> (doto (:connection conn) (.setAutoCommit true))
+        .createStatement
+        (.execute "vacuum (analyze)"))))
+
 (defn sql-uuid-as-str
   [column]
   (if (postgres?)

--- a/test/puppetlabs/puppetdb/query/population_test.clj
+++ b/test/puppetlabs/puppetdb/query/population_test.clj
@@ -14,6 +14,7 @@
 (deftest resource-count
   (testing "Counting resources"
     (testing "should return 0 when no resources present"
+      (sutils/vacuum-analyze *db*)
       (is (= 0 (pop/num-resources))))
 
     (testing "should only count current resources"
@@ -45,31 +46,29 @@
        {:catalog_id 1 :resource (sutils/munge-hash-for-storage "02") :type "Foo" :title "Boo" :exported true :tags (to-jdbc-varchar-array [])}
        {:catalog_id 1 :resource (sutils/munge-hash-for-storage "03") :type "Foo" :title "Goo" :exported true :tags (to-jdbc-varchar-array [])})
 
-      (is (= 3 (pop/num-resources))))
-
-    (testing "should only count resources for active nodes"
-      ;; Remove the node from the previous block
-      (deactivate-node! "h1")
-      (is (= 0 (pop/num-resources))))))
+      (sutils/vacuum-analyze *db*)
+      (is (= 4 (pop/num-resources))))))
 
 (deftest node-count
   (testing "Counting nodes"
     (testing "should return 0 when no resources present"
-      (is (= 0 (pop/num-nodes))))
+      (is (= 0 (pop/num-active-nodes))))
 
     (testing "should only count active nodes"
       (jdbc/insert! :certnames
                     {:certname "h1"}
                     {:certname "h2"})
 
-      (is (= 2 (pop/num-nodes)))
+      (is (= 2 (pop/num-active-nodes)))
 
       (deactivate-node! "h1")
-      (is (= 1 (pop/num-nodes))))))
+      (is (= 1 (pop/num-active-nodes)))
+      (is (= 1 (pop/num-inactive-nodes))))))
 
 (deftest resource-dupes
   (testing "Computing resource duplication"
     (testing "should return 0 when no resources present"
+      (sutils/vacuum-analyze *db*)
       (is (= 0 (pop/pct-resource-duplication))))
 
     (testing "should equal (total-unique) / total"
@@ -102,9 +101,5 @@
       (let [total  4
             unique 3
             dupes  (/ (- total unique) total)]
-        (is (= dupes (pop/pct-resource-duplication))))
-
-      ;; If we remove h2's resources, the only resources left are all
-      ;; unique and should result in a duplicate percentage of zero
-      (deactivate-node! "h2")
-      (is (= 0 (pop/pct-resource-duplication))))))
+        (sutils/vacuum-analyze *db*)
+        (is (= dupes (pop/pct-resource-duplication)))))))


### PR DESCRIPTION
This commit changes one of our population metrics to use table stats to compute
the number of resources. It also eliminates a restriction to active nodes for
the metric, and splits the num-nodes metric into num-active-nodes and
num-inactive-nodes in the dashboard to make things clearer. num-nodes is left
around for backward compatibility. Lastly it adds a mechanism for independent
specification of chart options for our metrics, and changes the
percent-resource-duplication query to run every 30 seconds instead of 5. This
may or may not be the right number.