### PR TITLE
(PDB-2186) Add puppetdb_query function for querying PuppetDB via Puppet

### DIFF
--- a/acceptance/tests/storeconfigs/puppetdb_query.rb
+++ b/acceptance/tests/storeconfigs/puppetdb_query.rb
@@ -1,0 +1,47 @@
+test_name "puppetdb_query should work" do
+  step "clear puppetdb database" do
+    clear_and_restart_puppetdb(database)
+  end
+
+  names = hosts.map(&:hostname)
+
+  manifest = <<-CONTENT
+node default {
+  $counts = puppetdb_query(["from", "catalogs",
+                            ["extract", [["function", "count"]]]])
+  $count = $counts[0]['count']
+  file { '/tmp/test_puppetdb_query.txt':
+    ensure  => present,
+    content => "${count}"
+  }
+}
+    CONTENT
+
+
+  manifest_path = create_remote_site_pp(master, manifest)
+  with_puppet_running_on master, {
+    'master' => {
+      'autosign' => 'true',
+    },
+    'main' => {
+      'environmentpath' => manifest_path
+    }
+  } do
+
+    step "Run agent once to populate database" do
+      run_agent_on hosts, "--test --server #{master}", :acceptable_exit_codes => [0,2]
+    end
+    # Wait until all the commands have been processed
+    sleep_until_queue_empty database
+
+    step "Run agent second time to populate test files" do
+      run_agent_on hosts, "--test --server #{master}", :acceptable_exit_codes => [0,2]
+    end
+
+    step "Check that the puppetdb_query() call was a success" do
+      on hosts[0], "cat /tmp/test_puppetdb_query.txt"
+      created = stdout.split.map(&:strip).sort[0]
+      assert_equal("#{hosts.length}", "#{created}", "expected '#{hosts.length}' nodes but got '#{created}'")
+    end
+  end
+end

--- a/puppet/lib/puppet/functions/puppetdb_query.rb
+++ b/puppet/lib/puppet/functions/puppetdb_query.rb
@@ -1,0 +1,6 @@
+require 'puppet/util/puppetdb'
+Puppet::Functions.create_function(:puppetdb_query) do
+  def puppetdb_query(query)
+    Puppet::Util::Puppetdb.query_puppetdb(query)
+  end
+end

--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -69,8 +69,8 @@ module Puppet::Util::Puppetdb
   #
   # @param query [String, Array] The PQL or AST query for PuppetDB
   # @return [Array<Hash>]
-  def query_puppetdb(query)
-    profile("Submitted query '#{query}'", [:puppetdb, :query, query]) do
+  def self.query_puppetdb(query)
+    Puppet::Util::Profiler.profile("Submitted query '#{query}'", [:puppetdb, :query, query]) do
       headers = { "Accept" => "application/json",
                   "Content-Type" => "application/json; charset=UTF-8" }
       response = Puppet::Util::Puppetdb::Http.action("/pdb/query/v4", :query) do |http_instance, path|

--- a/puppet/spec/unit/util/puppetdb_spec.rb
+++ b/puppet/spec/unit/util/puppetdb_spec.rb
@@ -37,7 +37,7 @@ describe Puppet::Util::Puppetdb do
 
   end
 
-  describe "#query_puppetdb" do
+  describe ".query_puppetdb" do
     let(:response) { JSON.generate({'certname' => 'futile', 'status' => 'irrelevant'}) }
     let(:query) { ["=", "type", "Foo"] }
     let(:http_response) { FakeHttpResponse.new(response) }
@@ -45,7 +45,7 @@ describe Puppet::Util::Puppetdb do
       # careful here... since we're going to stub Command.new, we need to
       # make sure we reference command1 first, because it calls Command.new.
       Puppet::Util::Puppetdb::Http.expects(:action).once.returns(http_response)
-      subject.query_puppetdb(query)
+      Puppet::Util::Puppetdb.query_puppetdb(query)
     end
 
   end


### PR DESCRIPTION
This commit adds a puppetdb_query function for querying PuppetDB with
either AST of PQL syntax in a Puppet manifest.