### PR TITLE
(PDB-2332) use params for submit-command-via-http

### DIFF
--- a/src/puppetlabs/puppetdb/client.clj
+++ b/src/puppetlabs/puppetdb/client.clj
@@ -3,6 +3,7 @@
             [clojure.tools.logging :as log]
             [puppetlabs.puppetdb.reports :as reports]
             [clj-http.client :as http-client]
+            [clojure.string :as str]
             [puppetlabs.puppetdb.command.constants :refer [command-names]]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.schema :refer [defn-validated]]
@@ -12,80 +13,77 @@
 
 (defn-validated submit-command-via-http!
   "Submits `payload` as a valid command of type `command` and
-  `version` to the PuppetDB instance specified by `host` and
-  `port`. The `payload` will be converted to JSON before
-  submission. Alternately accepts a command-map object (such as those
-  returned by `parse-command`). Returns the server response."
+   `version` to the PuppetDB instance specified by `host` and
+   `port`. The `payload` will be converted to JSON before
+   submission. Alternately accepts a command-map object (such as those
+   returned by `parse-command`). Returns the server response."
   ([base-url
+    certname :- s/Str
     command :- s/Str
     version :- s/Int
     payload]
-   (submit-command-via-http! base-url
-                             {:command command :version version :payload payload}
-                             nil))
-
+   (submit-command-via-http! base-url certname command version payload nil))
   ([base-url
+    certname :- s/Str
     command :- s/Str
     version :- s/Int
-    payload
+    payload :- {s/Any s/Any}
     timeout]
-   (submit-command-via-http! base-url
-                             {:command command :version version :payload payload}
-                             timeout))
-
-  ([base-url :- utils/base-url-schema
-    command-map :- {s/Any s/Any}]
-   (submit-command-via-http! base-url command-map nil))
-
-  ([base-url :- utils/base-url-schema
-    command-map :- {s/Any s/Any}
-    timeout]
-     (let [message (json/generate-string command-map)
-           checksum (kitchensink/utf8-string->sha1 message)
-           url (str (utils/base-url->str base-url)
-                    (format "?checksum=%s" checksum)
-                    (when timeout (format "&secondsToWaitForCompletion=%s" timeout)))]
-       (http-client/post url {:body               message
-                              :throw-exceptions   false
-                              :content-type       :json
-                              :character-encoding "UTF-8"
-                              :accept             :json}))))
+   (let [body (json/generate-string payload)
+         url (str (utils/base-url->str base-url)
+                  (format "?command=%s&version=%s&certname=%s"
+                          (str/replace command #" " "_") version certname)
+                  (when timeout (format "&secondsToWaitForCompletion=%s" timeout)))]
+     (http-client/post url {:body body
+                            :throw-exceptions false
+                            :content-type :json
+                            :character-encoding "UTF-8"
+                            :accept :json}))))
 
 (defn-validated submit-catalog
   "Send the given wire-format `catalog` (associated with `host`) to a
   command-processing endpoint located at `puppetdb-host`:`puppetdb-port`."
   [base-url :- utils/base-url-schema
+   certname :- s/Str
    command-version :- s/Int
    catalog-payload]
   (let [result (submit-command-via-http!
-                base-url
-                (command-names :replace-catalog) command-version
-                catalog-payload)]
+                 base-url
+                 certname
+                 (command-names :replace-catalog)
+                 command-version
+                 catalog-payload)]
     (when-not (= http/status-ok (:status result))
       (log/error result))))
 
 (defn-validated submit-report
   "Send the given wire-format `report` (associated with `host`) to a
-  command-processing endpoint located at `puppetdb-host`:`puppetdb-port`."
+   command-processing endpoint located at `puppetdb-host`:`puppetdb-port`."
   [base-url :- utils/base-url-schema
+   certname :- s/Str
    command-version :- s/Int
    report-payload]
   (let [result (submit-command-via-http!
-                base-url
-                (command-names :store-report) command-version
-                report-payload)]
+                 base-url
+                 certname
+                 (command-names :store-report)
+                 command-version
+                 report-payload)]
     (when-not (= http/status-ok (:status result))
       (log/error result))))
 
 (defn-validated submit-facts
   "Send the given wire-format `facts` (associated with `host`) to a
-  command-processing endpoint located at `puppetdb-host`:`puppetdb-port`."
+   command-processing endpoint located at `puppetdb-host`:`puppetdb-port`."
   [base-url :- utils/base-url-schema
+   certname :- s/Str
    facts-version :- s/Int
    fact-payload]
   (let [result  (submit-command-via-http!
-                 base-url
-                 (command-names :replace-facts) facts-version
-                 fact-payload)]
+                  base-url
+                  certname
+                  (command-names :replace-facts)
+                  facts-version
+                  fact-payload)]
     (when-not (= http/status-ok (:status result))
       (log/error result))))

--- a/test/puppetlabs/puppetdb/acceptance/cli.clj
+++ b/test/puppetlabs/puppetdb/acceptance/cli.clj
@@ -22,9 +22,12 @@
        (fn []
          (is (empty? (get-nodes)))
 
-         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "replace catalog" 7 example-catalog)
-         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "store report" 6 example-report)
-         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "replace facts" 4 example-facts)
+         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
+                                      "replace catalog" 7 example-catalog)
+         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
+                                      "store report" 6 example-report)
+         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
+                                      "replace facts" 4 example-facts)
 
          (is (= (tuc/munge-catalog example-catalog)
                 (tuc/munge-catalog (get-catalogs example-certname))))

--- a/test/puppetlabs/puppetdb/acceptance/node_ttl.clj
+++ b/test/puppetlabs/puppetdb/acceptance/node_ttl.clj
@@ -24,7 +24,8 @@
                  catalog (-> (get-in wire-catalogs [7 :empty])
                              (assoc :certname certname
                                     :producer_timestamp (now)))]
-             (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "replace catalog" 7 catalog)
+             (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) certname
+                                          "replace catalog" 7 catalog)
 
              (is (= 1 (count (:body (tuhttp/pdb-get (svc-utils/pdb-query-url) "/nodes")))))
              (is (nil? (:expired (:body (tuhttp/pdb-get (svc-utils/pdb-query-url) "/nodes/foo.com")))))

--- a/test/puppetlabs/puppetdb/admin_test.clj
+++ b/test/puppetlabs/puppetdb/admin_test.clj
@@ -26,9 +26,12 @@
      (fn []
        (is (empty? (get-nodes)))
 
-       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "replace catalog" 7 example-catalog)
-       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "store report" 6 example-report)
-       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "replace facts" 4 example-facts)
+       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
+                                    "replace catalog" 7 example-catalog)
+       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
+                                    "store report" 6 example-report)
+       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
+                                    "replace facts" 4 example-facts)
 
        (is (= (tuc/munge-catalog example-catalog)
               (tuc/munge-catalog (get-catalogs example-certname))))
@@ -69,9 +72,12 @@
        (fn []
          (is (empty? (get-nodes)))
 
-         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "replace catalog" 7 example-catalog)
-         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "store report" 6 example-report)
-         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "replace facts" 4 example-facts)
+         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
+                                      "replace catalog" 7 example-catalog)
+         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
+                                      "store report" 6 example-report)
+         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
+                                      "replace facts" 4 example-facts)
 
 
          (is (= (tuc/munge-catalog example-catalog)

--- a/test/puppetlabs/puppetdb/cli/benchmark_test.clj
+++ b/test/puppetlabs/puppetdb/cli/benchmark_test.clj
@@ -8,7 +8,8 @@
             [puppetlabs.puppetdb.testutils :as tu]
             [puppetlabs.puppetdb.cli.export :as cli-export]
             [puppetlabs.puppetdb.testutils.cli :refer [get-nodes example-catalog
-                                                       example-report example-facts]]
+                                                       example-report example-facts
+                                                       example-certname]]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.kitchensink.core :as ks]
             [slingshot.test]
@@ -16,7 +17,7 @@
 
 
 (defn mock-submit-record-fn [submitted-records entity]
-  (fn [base-url version payload-string]
+  (fn [base-url certname version payload-string]
     (swap! submitted-records conj
            {:entity entity
             :base-url base-url
@@ -79,9 +80,9 @@
      (fn []
        (is (empty? (get-nodes)))
 
-       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "replace catalog" 7 example-catalog)
-       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "store report" 6 example-report)
-       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "replace facts" 4 example-facts)
+       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname "replace catalog" 7 example-catalog)
+       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname "store report" 6 example-report)
+       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname "replace facts" 4 example-facts)
        (#'cli-export/-main "--outfile" export-out-file
                            "--host" (:host svc-utils/*base-url*)
                            "--port" (str (:port svc-utils/*base-url*)))))

--- a/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
+++ b/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
@@ -23,9 +23,12 @@
      (fn []
        (is (empty? (get-nodes)))
 
-       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "replace catalog" 7 example-catalog)
-       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "store report" 6 example-report)
-       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "replace facts" 4 example-facts)
+       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
+                                    "replace catalog" 7 example-catalog)
+       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
+                                    "store report" 6 example-report)
+       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
+                                    "replace facts" 4 example-facts)
 
        (is (= (tuc/munge-catalog example-catalog)
               (tuc/munge-catalog (get-catalogs example-certname))))
@@ -61,7 +64,7 @@
      (fn []
        (is (empty? (get-nodes)))
 
-       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "replace facts" 4 example-facts)
+       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname "replace facts" 4 example-facts)
 
        (is (empty? (get-catalogs example-certname)))
        (is (empty? (get-reports example-certname)))
@@ -100,7 +103,11 @@
      (fn []
        (is (empty? (get-nodes)))
 
-       (pdb-client/submit-command-via-http! (svc-utils/pdb-cmd-url) "replace catalog" 7 example-catalog)
+       (pdb-client/submit-command-via-http! (svc-utils/pdb-cmd-url)
+                                            example-certname
+                                            "replace catalog"
+                                            7
+                                            example-catalog)
 
        (is (thrown-with-msg?
             java.util.concurrent.ExecutionException #"Results not found"

--- a/test/puppetlabs/puppetdb/pdb_routing_test.clj
+++ b/test/puppetlabs/puppetdb/pdb_routing_test.clj
@@ -15,8 +15,8 @@
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.puppetdb.testutils.http :as tuhttp]))
 
-(defn submit-facts [base-url facts]
-  (svc-utils/sync-command-post base-url "replace facts" 4 facts))
+(defn submit-facts [base-url certname facts]
+  (svc-utils/sync-command-post base-url certname "replace facts" 4 facts))
 
 (defn query-fact-names [{:keys [host port]}]
   (tuhttp/pdb-get (utils/pdb-query-base-url host port :v4)
@@ -58,7 +58,7 @@
 (deftest maintenance-mode
   (svc-utils/with-puppetdb-instance
     (let [maint-mode-service (tk-app/get-service svc-utils/*server* :MaintenanceMode)]
-      (is (= 200 (:status (submit-facts (svc-utils/pdb-cmd-url) test-facts))))
+      (is (= 200 (:status (submit-facts (svc-utils/pdb-cmd-url) "foo.com" test-facts))))
       (is (= #{"foo" "bar" "baz"}
              (-> (query-fact-names svc-utils/*base-url*)
                  :body

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -316,9 +316,10 @@
 (defn sync-command-post
   "Syncronously post a command to PDB by blocking until the message is consumed
    off the queue."
-  [base-url cmd version payload]
+  [base-url certname cmd version payload]
   (let [timeout-seconds 10]
-    (let [response (pdb-client/submit-command-via-http! base-url cmd version payload timeout-seconds)]
+    (let [response (pdb-client/submit-command-via-http!
+                     base-url certname cmd version payload timeout-seconds)]
       (if (>= (:status response) 400)
         (throw (ex-info "Command processing failed" {:response response}))
         response))))


### PR DESCRIPTION
This changes our tests and benchmark tool to use form params in accordance with
the new command submission style.