### PR TITLE
(PDB-2214) anonymize words independently

### DIFF
--- a/test/puppetlabs/puppetdb/anonymizer_test.clj
+++ b/test/puppetlabs/puppetdb/anonymizer_test.clj
@@ -161,8 +161,8 @@
 
 (deftest test-anonymize-leaf-message
   (testing "should return a string of equal length"
-    (is (string? (anonymize-leaf-memoize :message "good old string")))
-    (is (= 15 (count (anonymize-leaf-memoize :message "good old string"))))))
+    (is (string? (anonymize-leaf-memoize :text "good old string")))
+    (is (= 15 (count (anonymize-leaf-memoize :text "good old string"))))))
 
 (deftest test-memoized-vector-elements
   (testing "should memoize individual vector elements"


### PR DESCRIPTION
This fixes an anonymization bug where we would anonymize text blobs as
completely different, sometimes long random strings even if they only differed
by a word. This prevented any reasonable compression of report logs/messages,
which meant that the tool produced unmanagably large tarballs on big installs.