### PR TITLE
(PDB-2214) anonymize words as ?????

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,6 +44,7 @@
                  [org.clojure/java.jmx "0.3.1"]
                  ;; Filesystem utilities
                  [me.raynes/fs "1.4.5"]
+                 [org.apache.commons/commons-lang3 "3.3.1"]
                  ;; Version information
                  [puppetlabs/dujour-version-check "0.1.3"]
                  ;; Job scheduling

--- a/test/puppetlabs/puppetdb/anonymizer_test.clj
+++ b/test/puppetlabs/puppetdb/anonymizer_test.clj
@@ -162,7 +162,9 @@
 (deftest test-anonymize-leaf-message
   (testing "should return a string of equal length"
     (is (string? (anonymize-leaf-memoize :message "good old string")))
-    (is (= 15 (count (anonymize-leaf-memoize :message "good old string"))))))
+    (is (= 15 (count (anonymize-leaf-memoize :message "good old string"))))
+    (is (= "???????????????" (anonymize-leaf-memoize :text "good old string")))
+    (is (= 15 (count (anonymize-leaf-memoize :text "good old string"))))))
 
 (deftest test-memoized-vector-elements
   (testing "should memoize individual vector elements"


### PR DESCRIPTION
This fixes an anonymization bug where we would anonymize text blobs as
completely different, sometimes long random strings even if they only differed
by a word. This prevented any reasonable compression of report logs/messages,
which meant that the tool produced unmanagebly large tarballs on big installs.

With this patch a text blob is replaced by a string of question marks of the
same length.