### PR TITLE
(PE-13485) Implement a consistent request logging format

### DIFF
--- a/resources/ext/config/request-logging.xml
+++ b/resources/ext/config/request-logging.xml
@@ -2,13 +2,7 @@
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>/var/log/puppetlabs/puppetdb/puppetdb-access.log</file>
         <encoder>
-            <pattern>combined</pattern>
-            <!-- To have the same "combined" pattern with elapsedTime ('%D')
-                 appended use the following line:
-
             <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D</pattern>
-
-            -->
         </encoder>
     </appender>
     <appender-ref ref="FILE" />


### PR DESCRIPTION
Prior to this commit puppetdb used a different request
logging format than console-services and puppetserver.

After this commit the request logging will be of the suggested
formatting for all trapper-keeper projects.