### PR TITLE
(PDB-2380) Limit the storage of historical-catalogs

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -225,13 +225,14 @@ If not supplied, PuppetDB uses standard HTTPS without any additional
 authorization. All HTTPS clients must still supply valid, verifiable
 SSL client certificates.
 
-### `include-historical-catalogs` (PE only)
+### `historical-catalogs-limit` (PE only)
 
 > **Warning:** This setting is intended for use only in Puppet Enterprise (PE).
 > This setting will be ignored without a PE PuppetDB package.
 
-Setting this to `false` disables the storage of historical catalogs. Defaults to
-`true`.
+This settings controls how many historical catalogs are stored in PuppetDB per
+node. Setting this to `0` disables the storage of historical catalogs. Defaults
+to `3`.
 
 ### `disable-update-checking`
 

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -122,8 +122,7 @@
      (format "sweep of stale reports (threshold: %s)"
              (format-period report-ttl))
      (jdbc/with-transacted-connection db
-       (scf-store/delete-reports-older-than! (ago report-ttl))
-       (scf-store/delete-old-unassociated-catalogs! (ago report-ttl))))
+       (scf-store/delete-reports-older-than! (ago report-ttl))))
     (catch Exception e
       (log/error e "Error while sweeping reports"))))
 

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -163,14 +163,14 @@
   "Schema for validating the incoming [puppetdb] block"
   (all-optional
     {:certificate-whitelist s/Str
-     ;; The `include-historical-catalogs` setting is only used by `pe-puppetdb`
-     :include-historical-catalogs (pls/defaulted-maybe String "true")
+     ;; The `historical-catalogs-limit` setting is only used by `pe-puppetdb`
+     :historical-catalogs-limit (pls/defaulted-maybe s/Int 3)
      :disable-update-checking (pls/defaulted-maybe String "false")}))
 
 (def puppetdb-config-out
   "Schema for validating the parsed/processed [puppetdb] block"
   {(s/optional-key :certificate-whitelist) s/Str
-   :include-historical-catalogs Boolean
+   :historical-catalogs-limit s/Int
    :disable-update-checking Boolean})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -27,11 +27,11 @@
       (is (thrown? clojure.lang.ExceptionInfo
                    (configure-puppetdb {:puppetdb {:disable-update-checking 1337}}))))
 
-    (testing "should allow for `pe-puppetdb`'s include-historical-catalogs setting"
+    (testing "should allow for `pe-puppetdb`'s historical-catalogs-limit setting"
       (let [config (configure-puppetdb {})]
-        (is (= (get-in config [:puppetdb :include-historical-catalogs]) true)))
-      (let [config (configure-puppetdb {:puppetdb {:include-historical-catalogs "false"}})]
-        (is (= (get-in config [:puppetdb :include-historical-catalogs]) false))))
+        (is (= (get-in config [:puppetdb :historical-catalogs-limit]) 3)))
+      (let [config (configure-puppetdb {:puppetdb {:historical-catalogs-limit 5}})]
+        (is (= (get-in config [:puppetdb :historical-catalogs-limit]) 5))))
 
     (testing "disable-update-checking should default to 'false' if left unspecified"
       (let [config (configure-puppetdb {})]


### PR DESCRIPTION
This commit limits the storage of historical catalogs to only the latest
three catalogs for a node. This commit limits the storage because for
our benchmarking data with 5000 nodes (~3 million catalogs) we were
seeing the catalogs table take up around 140GB of space.