### PR TITLE
(maint) test upgrades from 2.3.8

### DIFF
--- a/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
+++ b/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
@@ -1,5 +1,5 @@
 # We skip this step entirely unless we are running in :upgrade mode.
-OLDEST_SUPPORTED_UPGRADE="2.3.2"
+OLDEST_SUPPORTED_UPGRADE="2.3.8"
 
 if ([:upgrade_oldest, :upgrade_latest].include? test_config[:install_mode] and not test_config[:skip_presuite_provisioning])
   install_target = test_config[:install_mode] == :upgrade_latest ? 'latest' : OLDEST_SUPPORTED_UPGRADE

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -59,7 +59,7 @@
             [puppetlabs.puppetdb.jdbc :as jdbc :refer [query-to-vec]]
             [puppetlabs.puppetdb.config :as conf]))
 
-(defn init-through-2-3-2
+(defn init-through-2-3-8
   []
 
   (jdbc/do-commands
@@ -1018,7 +1018,7 @@
 
 (def migrations
   "The available migrations, as a map from migration version to migration function."
-  {28 init-through-2-3-2
+  {28 init-through-2-3-8
    29 version-2yz-to-300-migration
    30 add-expired-to-certnames
    31 coalesce-fact-values


### PR DESCRIPTION
This changes our oldest supported upgrade branch to 2.3.8, from 2.3.2