### PR TITLE
(maint) maybe fix upgrade tests

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -337,7 +337,8 @@ module PuppetDBExtensions
     end
   end
 
-  def install_puppetdb_termini(host, databases, version=nil)
+  def install_puppetdb_termini(host, databases, version=nil,
+                              terminus_package='puppetdb-termini')
     # We pass 'restart_puppet' => false to prevent the module from trying to
     # manage the puppet master service, which isn't actually installed on the
     # acceptance nodes (they run puppet master from the CLI).
@@ -352,6 +353,7 @@ module PuppetDBExtensions
       enable_reports           => true,
       strict_validation        => true,
       restart_puppet           => false,
+      terminus_package         => #{terminus_package},
     }
     ini_setting {'server_urls':
       ensure  => present,

--- a/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
+++ b/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
@@ -2,13 +2,19 @@
 OLDEST_SUPPORTED_UPGRADE="2.3.8"
 
 if ([:upgrade_oldest, :upgrade_latest].include? test_config[:install_mode] and not test_config[:skip_presuite_provisioning])
-  install_target = test_config[:install_mode] == :upgrade_latest ? 'latest' : OLDEST_SUPPORTED_UPGRADE
+  if test_config[:install_mode] == :upgrade_latest
+    install_target = 'latest'
+    terminus_package = 'puppetdb-termini'
+  else
+    install_target = OLDEST_SUPPORTED_UPGRADE
+    terminus_package = 'puppetdb-terminus'
+  end
   step "Install most recent released PuppetDB on the PuppetDB server for upgrade test" do
     databases.each do |database|
       install_puppetdb(database, install_target)
       start_puppetdb(database)
     end
-    install_puppetdb_termini(master, databases, install_target)
+    install_puppetdb_termini(master, databases, install_target, terminus_package)
     databases.each do |database|
       stop_puppetdb(database)
     end

--- a/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
+++ b/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
@@ -33,7 +33,6 @@ step "Install development build of PuppetDB on the PuppetDB server" do
         # make sure it got started by the package install/upgrade
         sleep_until_started(database)
       end
-
     end
   end
 
@@ -41,6 +40,11 @@ step "Install development build of PuppetDB on the PuppetDB server" do
   when :git
     install_puppetdb_termini_via_rake(master, databases)
   when :package
-    install_puppetdb_termini(master, databases)
+    os = PuppetDBExtensions.config[:os_families][master.name]
+    if test_config[:install_mode] == :upgrade_oldest && ([:redhat, :fedora].include? os)
+      install_puppetdb_termini(master, databases, nil, 'puppetdb-terminus')
+    else
+      install_puppetdb_termini(master, databases)
+    end
   end
 end


### PR DESCRIPTION
This will cause the terminus to be installed with package 'puppetdb-terminus'
when upgrading from 2.3.x. The puppetdb-terminus is a dummy package that points
to the latest puppetdb-termini, but it's needed to obsolete the legacy terminus
package.