### PR TITLE
(maint) Don't 500 on malformed AST queries

### DIFF
--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -279,13 +279,15 @@
   "Query handler that converts the incoming request (GET or POST)
   parameters/body to a pdb query map"
   ([handler param-spec]
-   (extract-query handler param-spec #(json/parse-strict-string % true)))
+   (extract-query handler param-spec pql/parse-json-query))
   ([handler param-spec parse-fn]
    (fn [{:keys [request-method body params puppetdb-query] :as req}]
      (handler
       (if puppetdb-query
         req
-        (assoc req :puppetdb-query (create-query-map req param-spec parse-fn)))))))
+        (assoc req
+               :puppetdb-query
+               (create-query-map req param-spec parse-fn)))))))
 
 (defn extract-query-pql
   [handler param-spec]

--- a/src/puppetlabs/puppetdb/query/paging.clj
+++ b/src/puppetlabs/puppetdb/query/paging.clj
@@ -63,7 +63,8 @@
     (catch JsonParseException e
       (throw (IllegalArgumentException.
               (str "Illegal value '" order_by "' for :order_by; expected a JSON "
-                   "array of maps."))))))
+                   "array of maps.")
+              e)))))
 
 (defn parse-order-str
   "Given an 'order' string, returns either :ascending or :descending"

--- a/test/puppetlabs/puppetdb/http/command_test.clj
+++ b/test/puppetlabs/puppetdb/http/command_test.clj
@@ -35,8 +35,8 @@
   [path params payload]
   (let [body (when-not (nil? payload)
                (ByteArrayInputStream. (.getBytes payload "UTF-8")))]
-    (post-request path nil params {"content-type" "application/json"
-                                   "accept" "application/json"} body)))
+    (post-request path params {"content-type" "application/json"
+                               "accept" "application/json"} body)))
 
 (defn form-command
   [command version payload]

--- a/test/puppetlabs/puppetdb/http/index_test.clj
+++ b/test/puppetlabs/puppetdb/http/index_test.clj
@@ -53,8 +53,9 @@
         (is (= status http/status-bad-request)))
 
       ;; Ensure we parse anything that looks like AST/JSON as JSON not PQL
-      (is (thrown-with-msg? com.fasterxml.jackson.core.JsonParseException #"Unexpected end-of-input"
-                            (query-response method endpoint "[\"from\",\"foobar\"")))
+      (let [{:keys [status body]} (query-response method endpoint "[\"from\",\"foobar\"")]
+        (is (= "Malformed JSON for query: [\"from\",\"foobar\"" body))
+        (is (= http/status-bad-request status)))
 
       (let [{:keys [status body]} (query-response method endpoint "foobar {}")]
         (is (re-find #"PQL parse error at line 1, column 1" body))

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -146,6 +146,15 @@
                                             ["=" "certname" (:certname basic)]])
              #{(select-keys basic [:hash :certname :transaction_uuid])})))))
 
+(deftest-http-app query-report-with-malformed-json
+  [version [:v4]]
+  (let [report-hash (:hash (store-example-report! (:basic reports) (now)))
+        basic (assoc (:basic reports) :hash report-hash)
+        {:keys [status body]} (query-response :get "/v4/reports" "[\"=\"")]
+    (testing "malformed json queries don't return status 500 responses"
+      (is (= 400 status))
+      (is (= "Malformed JSON for query: [\"=\"" body)))))
+
 (deftest-http-app query-report-data
   [[version field] [[:v4 :logs] [:v4 :metrics]]
    method [:get :post]]

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -160,11 +160,10 @@
 (defn post-request
   "Submit a POST request against path, suitable as an argument to a ring
   app."
-  ([path] (post-request path nil))
-  ([path query] (post-request path query {}))
-  ([path query params] (post-request path query params {"accept" c-t "content-type" c-t}))
-  ([path query params headers] (post-request path query params headers nil))
-  ([path query params headers body]
+  ([path] (post-request path {}))
+  ([path params] (post-request path params {"accept" c-t "content-type" c-t}))
+  ([path params headers] (post-request path params headers nil))
+  ([path params headers body]
      (let [request (mock/request :post path)
            orig-headers (:headers request)]
        (assoc request :headers (merge orig-headers headers)
@@ -180,7 +179,7 @@
   ([http-method path query {:keys [params headers]}]
    (if (= :get http-method)
      (get-request path query params headers)
-     (post-request path nil nil headers
+     (post-request path nil headers
                    (-> params
                        (assoc :query query)
                        json/generate-string


### PR DESCRIPTION
This commit fixes an issue where PuppetDB was return HTTP 500 responses
for requests with malformed JSON in an AST query because our middleware
only catches IllegalArguementExceptions.