### PR TITLE
(RE-6278) Update lein-ezbake pin to 0.3.22

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -134,7 +134,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "0.3.21"
+                      :plugins [[puppetlabs/lein-ezbake "0.3.22"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}


### PR DESCRIPTION
This updates the pinned lein-ezbake version
to 0.3.22.