### PR TITLE
(PDB-2434) PDB status missing in PE

### DIFF
--- a/resources/puppetlabs/puppetdb/bootstrap.cfg
+++ b/resources/puppetlabs/puppetdb/bootstrap.cfg
@@ -18,6 +18,7 @@ puppetlabs.puppetdb.metrics/metrics-service
 puppetlabs.puppetdb.mq-listener/message-listener-service
 puppetlabs.puppetdb.command/command-service
 puppetlabs.puppetdb.pdb-routing/maint-mode-service
+puppetlabs.puppetdb.pdb-routing/pdb-status-service
 puppetlabs.puppetdb.pdb-routing/pdb-routing-service
 puppetlabs.puppetdb.config/config-service
 

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -29,7 +29,9 @@
             [slingshot.slingshot :refer [throw+]]
             [clojure.tools.logging :as log]
             [puppetlabs.puppetdb.dashboard :refer [dashboard-redirect-service]]
-            [puppetlabs.puppetdb.pdb-routing :refer [pdb-routing-service maint-mode-service]]
+            [puppetlabs.puppetdb.pdb-routing :refer [pdb-routing-service
+                                                     maint-mode-service
+                                                     pdb-status-service]]
             [puppetlabs.puppetdb.config :refer [config-service]]))
 
 ;; See utils.clj for more information about base-urls.
@@ -70,6 +72,7 @@
    #'dashboard-redirect-service
    #'pdb-routing-service
    #'maint-mode-service
+   #'pdb-status-service
    #'config-service])
 
 (defn call-with-puppetdb-instance


### PR DESCRIPTION
This splits the status functionality out into its own TK service so it can be
shared with PE routing.