### PR TITLE
(PDB-2435) Use read-db for population metrics

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -242,7 +242,7 @@
       (log/infof "PuppetDB version %s" v))
 
     (init-with-db database config)
-    (pop/initialize-metrics write-db)
+    (pop/initialize-metrics read-db)
 
     (when (.exists discard-dir)
       (dlo/create-metrics-for-dlo! discard-dir))


### PR DESCRIPTION
This commit changes our population metrics to use the read-db and not
the write-db so that we leverage read replica's when they are available.