### PR TITLE
(PDB-2380) Only delete historical-catalogs for the given node

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -776,9 +776,11 @@
                             (jdbc/update! :latest_catalogs {:catalog_id catalog-id} ["certname_id=?" certname-id]))
                           (update-catalog-associations! certname-id catalog refs-to-hashes)))
                       (jdbc/delete! :catalogs
-                                    [(str "id NOT IN (SELECT id FROM catalogs "
+                                    [(str "certname = ? AND "
+                                          "id NOT IN (SELECT id FROM catalogs "
                                           "           WHERE certname=?"
                                           "           ORDER BY producer_timestamp DESC LIMIT ?)")
+                                     certname
                                      certname
                                      historical-catalogs-limit])))
              hash))))

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -515,7 +515,15 @@
     (store-catalog! (assoc catalog :producer_timestamp (-> 3 days ago)) (now))
     (store-catalog! (assoc catalog :producer_timestamp (-> 4 days ago)) (now))
     (store-catalog! (assoc catalog :producer_timestamp (-> 5 days ago)) (now))
-    (is (= [{:count 3}] (query-to-vec ["SELECT COUNT(*) FROM catalogs"])))))
+    (store-catalog! (assoc catalog :producer_timestamp (-> 6 days ago)) (now))
+    (is (= [{:count 3}] (query-to-vec ["SELECT COUNT(*) FROM catalogs"]))))
+
+  (testing "storing a new certname doesn't delete other certname's catalogs"
+    (add-certname! "bar.bazz.com")
+    (store-catalog! (assoc catalog
+                           :certname "bar.bazz.com"
+                           :producer_timestamp (-> 1 days ago)) (now))
+    (is (= [{:count 4}] (query-to-vec ["SELECT COUNT(*) FROM catalogs"])))))
 
 (deftest-db catalog-persistence
   (testing "Persisted catalogs"


### PR DESCRIPTION
Prior to this commit when historical catalogs was turned on, storing a
catalog for a given certname would delete all the other catalogs for the
other certnames in the database. This commit fixes the issue.