### PR TITLE
(PDB-2425) use table stats to compute the number of resources

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,6 +37,7 @@
                  [org.clojure/math.combinatorics "0.0.4"]
                  [org.clojure/math.numeric-tower "0.0.4"]
                  [org.clojure/tools.logging "0.3.1"]
+                 [org.clojure/core.memoize "0.5.8"]
                  [puppetlabs/tools.namespace "0.2.4.1"]
                  [clj-stacktrace "0.2.8"]
                  [metrics-clojure "0.7.0" :exclusions [org.clojure/clojure org.slf4j/slf4j-api]]

--- a/src/puppetlabs/puppetdb/query/population.clj
+++ b/src/puppetlabs/puppetdb/query/population.clj
@@ -5,68 +5,57 @@
   (:require [puppetlabs.puppetdb.jdbc :refer [query-to-vec
                                               table-count
                                               with-transacted-connection]]
+            [puppetlabs.puppetdb.metrics.core :as metrics]
+            [clojure.core.memoize :as mem]
             [puppetlabs.kitchensink.core :refer [quotient]]
             [metrics.gauges :refer [gauge]]
             [honeysql.core :as hcore]
             [honeysql.helpers :as hh]))
 
-;;; Query library
-
-(def ^:private from-all-resources-and-their-nodes
-  (hcore/build :from [:catalogs :catalog_resources :certnames]
-               :merge-where [:and
-                             [:= :catalogs.id :catalog_resources.catalog_id]
-                             [:= :certnames.certname :catalogs.certname]]))
-
-(defn- where-nodes-are-active [q]
-  (hh/merge-where q [:and
-                     [:= :certnames.deactivated nil]
-                     [:= :certnames.expired nil]]))
-
-(defn- select-count [q]
-  (-> q
-      (hh/select [:%count.* :c])
-      hcore/format
+(defn first-query-result
+  "Pick a key out of the first result of a query."
+  [query k]
+  (-> query
       query-to-vec
       first
-      :c))
-
-;;; Public
+      k))
 
 (defn num-resources
   "The number of resources in the population"
   []
   {:post [(number? %)]}
-  (-> from-all-resources-and-their-nodes
-      where-nodes-are-active
-      select-count))
+  (-> "select reltuples::bigint as c from pg_class where relname='catalog_resources'"
+      (first-query-result :c)))
 
-(defn num-nodes
+(defn num-active-nodes
   "The number of unique certnames in the population"
   []
   {:post [(number? %)]}
-  (-> (hh/from :certnames)
-      where-nodes-are-active
-      select-count))
+  (-> "select count(*) as c from certnames where deactivated is null and expired is null"
+      (first-query-result :c)))
 
 (defn avg-resource-per-node
   "The average number of resources per node"
   []
   {:post [(number? %)]}
-  (quotient (num-resources) (num-nodes)))
+  (let [nresources (num-resources)
+        nnodes (first-query-result "select count(*) as c from certnames" :c)]
+    (/ nresources nnodes)))
 
-(defn pct-resource-duplication
+(defn pct-resource-duplication*
   "What percentage of resources in the population are duplicates"
   []
   {:post [(number? %)]}
-  (let [distinct-resources-q (-> from-all-resources-and-their-nodes
-                                 where-nodes-are-active
-                                 (hh/select :catalog_resources.resource)
-                                 (hh/modifiers :distinct))
-        num-unique (-> (hh/from [distinct-resources-q :r])
-                       select-count)
-        num-total (num-resources)]
-    (quotient (- num-total num-unique) num-total)))
+  (let [nresources (num-resources)
+        ndistinct (-> "select count(*) as c from
+                       (select distinct resource from catalog_resources) dist"
+                      (first-query-result :c))]
+    (if (zero? nresources)
+      0
+      (/ (- nresources ndistinct) nresources))))
+
+(def pct-resource-duplication
+  (mem/ttl pct-resource-duplication* :ttl/threshold 60000))
 
 ;; ## Population-wide metrics
 
@@ -82,7 +71,7 @@
                                     (num-resources)))
    :num-nodes              (gauge [ns-str "default" "num-nodes"]
                                   (with-transacted-connection db
-                                    (num-nodes)))
+                                    (num-active-nodes)))
    :avg-resources-per-node (gauge [ns-str "default" "avg-resources-per-node"]
                                   (with-transacted-connection db
                                     (avg-resource-per-node)))
@@ -94,3 +83,4 @@
   "Initializes the set of population-wide metrics"
   [db]
   (compare-and-set! metrics nil (population-gauges db)))
+

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -287,6 +287,10 @@ must be supplied as the value to be matched."
     (format "%s::text" column)
     column))
 
+(defn vacuum-analyze
+  [db]
+  (jdbc/do-commands false "vacuum analyze"))
+
 (defn parse-db-hash
   [db-hash]
   (if (postgres?)

--- a/test/puppetlabs/puppetdb/query/population_test.clj
+++ b/test/puppetlabs/puppetdb/query/population_test.clj
@@ -3,9 +3,11 @@
             [clojure.java.jdbc :as sql]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.jdbc :as jdbc]
+            [clojure.core.memoize :as mem]
             [puppetlabs.puppetdb.scf.storage :refer [deactivate-node!]]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils :refer [to-jdbc-varchar-array]]
-            [puppetlabs.puppetdb.fixtures :refer :all]
+            [puppetlabs.puppetdb.fixtures :refer [*db* with-test-db]]
+            [puppetlabs.puppetdb.testutils :refer [with-fixtures]]
             [clj-time.coerce :refer [to-timestamp]]
             [clj-time.core :refer [now]]))
 
@@ -14,12 +16,13 @@
 (deftest resource-count
   (testing "Counting resources"
     (testing "should return 0 when no resources present"
+      (sutils/vacuum-analyze *db*)
       (is (= 0 (pop/num-resources))))
 
     (testing "should only count current resources"
       (jdbc/insert! :certnames
-                    {:certname "h1"}
-                    {:certname "h2"})
+                    {:certname "h1" :id 1}
+                    {:certname "h2" :id 2})
 
       (deactivate-node! "h2")
 
@@ -45,31 +48,28 @@
        {:catalog_id 1 :resource (sutils/munge-hash-for-storage "02") :type "Foo" :title "Boo" :exported true :tags (to-jdbc-varchar-array [])}
        {:catalog_id 1 :resource (sutils/munge-hash-for-storage "03") :type "Foo" :title "Goo" :exported true :tags (to-jdbc-varchar-array [])})
 
-      (is (= 3 (pop/num-resources))))
-
-    (testing "should only count resources for active nodes"
-      ;; Remove the node from the previous block
-      (deactivate-node! "h1")
-      (is (= 0 (pop/num-resources))))))
+      (sutils/vacuum-analyze *db*)
+      (is (= 4 (pop/num-resources))))))
 
 (deftest node-count
   (testing "Counting nodes"
     (testing "should return 0 when no resources present"
-      (is (= 0 (pop/num-nodes))))
+      (is (= 0 (pop/num-active-nodes))))
 
     (testing "should only count active nodes"
       (jdbc/insert! :certnames
                     {:certname "h1"}
                     {:certname "h2"})
 
-      (is (= 2 (pop/num-nodes)))
+      (is (= 2 (pop/num-active-nodes)))
 
       (deactivate-node! "h1")
-      (is (= 1 (pop/num-nodes))))))
+      (is (= 1 (pop/num-active-nodes))))))
 
 (deftest resource-dupes
   (testing "Computing resource duplication"
     (testing "should return 0 when no resources present"
+      (sutils/vacuum-analyze *db*)
       (is (= 0 (pop/pct-resource-duplication))))
 
     (testing "should equal (total-unique) / total"
@@ -102,9 +102,6 @@
       (let [total  4
             unique 3
             dupes  (/ (- total unique) total)]
-        (is (= dupes (pop/pct-resource-duplication))))
-
-      ;; If we remove h2's resources, the only resources left are all
-      ;; unique and should result in a duplicate percentage of zero
-      (deactivate-node! "h2")
-      (is (= 0 (pop/pct-resource-duplication))))))
+        (sutils/vacuum-analyze *db*)
+        (is (= dupes (pop/pct-resource-duplication*)))
+        (is (not (= dupes (pop/pct-resource-duplication))))))))


### PR DESCRIPTION
This is a stable backport of
1b79d8158698a01cefe791f8f8cc0031e62950e3. This switches the metrics
calls that query for number of nodes and resources per node to use table
stats rather than a full table scan for each call. This isn't an exact
backport as some things are different in master right now (java.jdbc
usage, metrics, fixtures are different etc). This does preserve the
behavior of caching the resources per node calls though. Number of
inactive nodes was not backported as it's a new metric and will need a
non-bugfix release.