### PR TITLE
(maint) Bump EZbake version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -134,7 +134,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "0.3.22"
+                      :plugins [[puppetlabs/lein-ezbake "0.3.23"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}


### PR DESCRIPTION
This bumps the EZBake version due
to a new release of EZBake