### PR TITLE
(PDB-2357) angle bracket group by

### DIFF
--- a/documentation/api/query/v4/pql.markdown
+++ b/documentation/api/query/v4/pql.markdown
@@ -392,17 +392,25 @@ query combined everything before, but with a `resource` subquery for `Package[to
 ## Group By
 
 As explained above in the `projections` section, a `group by` clause is
-effected by surrounding a projection in angle brackets.
+effected by surrounding a projection in angle brackets. When a function is
+supplied in the projection, however, angle brackets are assumed on the other
+fields. In other words,
 
-For example, to only show a list of fact names, you can group by the `name` field:
+    facts[<name>, count(value)] {certname ~ 'web.*'}
 
-    facts[<name>] {}
+and
 
-In addition, you may apply an aggregate function to results grouped along a
-chosen axis. For example, to return the number of facts that exist for each
-fact name across all nodes with certnames matching a regex, you can use:
+    facts[name, count(value)] {certname ~ 'web.*'}
 
-    facts[<name>, count(value)] { certname ~ 'web.*'}
+are equivalent, whereas
+
+    facts[<name>]{}
+
+and
+   
+    facts[name]{}
+
+are not, since the first will only return a list of distinct fact names.
 
 ## Paging
 PQL supports restriction of the result set via the SQL-like paging clauses

--- a/documentation/api/query/v4/pql.markdown
+++ b/documentation/api/query/v4/pql.markdown
@@ -35,7 +35,7 @@ And the following example shows how to execute a `POST` request:
 
 A PQL query has the following structure:
 
-    <entity> [<projection>] { <filter> <modifiers> }
+    entity [projection] { filter modifiers }
 
 Which is broken up into the following parts:
 
@@ -71,15 +71,31 @@ The entity context can also be used within a subquery, see the [subquery] sectio
 ## Projection
 
 The projection part of a query provides a mechanism to choose a subset of fields that are returned
-or to modify the way those fields are displayed with the usage of functions.
+or to modify the way those fields are displayed with the usage of functions
 
 The projection lives within the brackets of a query:
 
-    nodes[<projection>] {}
+    nodes[projection] {}
 
-And is a comma separated list of fields and functions:
+Projections are a comma-separated list of fields and functions. When a field is
+surrounded in angle brackets (`<`, `>`), the results will be grouped by that
+field. When angle brackets are used without a function, the result will be a
+list of distinct combinations of the bracketed field(s). When a function is
+supplied, the function will be applied to the results of the filter expression
+grouped by the specified fields.
 
-    facts[name, count()] { group by name }
+For example,
+
+    facts[<name>] {}
+
+will return a list of all unique fact names stored in PuppetDB. Alternatively,
+
+    facts[<name>, count()] {}
+
+will return a list of all unique fact names and the number of times they occur.
+In SQL terms, the latter is conceptually equivalent to
+
+    select name, count(*) from facts group by name;
 
 If you provide a projection with no fields or functions, then all fields will be displayed. So
 the following two examples are equivalent:
@@ -131,19 +147,19 @@ There are only a few functions that are supported today by PQL, see the list bel
 
 Returns the number of objects returned by the query, instead of returning the actual results.
 
-#### `avg(<field>)`
+#### `avg(field)`
 
 Returns the average value for the values held in the `<field>` argument.
 
-#### `sum(<field>)`
+#### `sum(field)`
 
 Returns the sum of values for the values held in the `<field>` argument.
 
-#### `min(<field>)`
+#### `min(field)`
 
 Returns the minimum value for all the values held in the `<field>` argument.
 
-#### `max(<field>)`
+#### `max(field)`
 
 Returns the maximum value for all the values held in the `<field>` argument.
 
@@ -151,7 +167,7 @@ Returns the maximum value for all the values held in the `<field>` argument.
 
 Filtering a query allows you to reduce the number of responses from PuppetDB based on a filter.
 
-In a basic query, a filter is optional, and is provided in the `<filter>` area as a set of boolean
+In a basic query, a filter is optional, and is provided in the `filter` area as a set of boolean
 and conditional operators that make up a filter. For example:
 
     entity { field1 = 'mystring' and field2 < 3 }
@@ -375,17 +391,18 @@ query combined everything before, but with a `resource` subquery for `Package[to
 
 ## Group By
 
-A `group by` clause will condense into a single row all selected rows that share the same values for the grouped expressions.
+As explained above in the `projections` section, a `group by` clause is
+effected by surrounding a projection in angle brackets.
 
 For example, to only show a list of fact names, you can group by the `name` field:
 
-    facts[name] { group by name }
+    facts[<name>] {}
 
-Combined with aggregate functions, you can effectively rollup of results and aggregate the rolled
-up values, for example to return how many facts exist for each fact name across all facts, where the certame
-starts with `web`:
+In addition, you may apply an aggregate function to results grouped along a
+chosen axis. For example, to return the number of facts that exist for each
+fact name across all nodes with certnames matching a regex, you can use:
 
-    facts[name, count(value)] { certname ~ "^web.*" group by name }
+    facts[<name>, count(value)] { certname ~ 'web.*'}
 
 ## Paging
 PQL supports restriction of the result set via the SQL-like paging clauses

--- a/resources/puppetlabs/puppetdb/pql/pql-grammar-experimental.ebnf
+++ b/resources/puppetlabs/puppetdb/pql/pql-grammar-experimental.ebnf
@@ -28,7 +28,7 @@ extract = <lbracket>, [<whitespace>], [extractfields], [<whitespace>], <rbracket
 <extractfields> = fieldlist;
 
 (* Filtering *)
-<where> = <lbrace>, [<whitespace>], [expression], [<whitespace>], [groupbyclause | {pagingclause, [<whitespace>]}], {<whitespace>}, <rbrace>;
+<where> = <lbrace>, [<whitespace>], [expression], [<whitespace>], [{pagingclause, [<whitespace>]}], {<whitespace>}, <rbrace>;
 
 (* Static list of entity types *)
 <entity> = 'facts' |
@@ -72,7 +72,7 @@ condisnotnull = <'is not null'>;
 
 (* Conditional expression parts *)
 groupedfieldlist = <lbracket>, [<whitespace>], fieldlist, [<whitespace>], <rbracket>;
-<fieldlist>      = (field | function), [ [<whitespace>], <','>, [<whitespace>], fieldlist ];
+<fieldlist>      = (field | function | groupedfield), [ [<whitespace>], <','>, [<whitespace>], fieldlist ];
 function         = functionname, [<whitespace>], groupedarglist;
 <functionname>   = 'count' | 'avg' | 'sum' | 'min' | 'max';
 
@@ -80,6 +80,7 @@ groupedarglist = <lparens>, [<whitespace>], [arglist], [<whitespace>], <rparens>
 <arglist>      = field, [ [<whitespace>], <','>, [<whitespace>], arglist ];
 
 (* Represents a field from an entity *)
+groupedfield = <langle>, field, <rangle>;
 <field> = #'[a-zA-Z_]+\??';
 
 <condregexp>      = '~';
@@ -119,10 +120,6 @@ sqstring = (<singlequote>, stringwithoutsinglequotes, <singlequote>);
 <stringwithoutsinglequotes> = #'(?:[^\'\\]|\\.)*';
 <singlequote> = "'";
 
-(* Group By *)
-<groupbyclause> = groupby;
-groupby  = <'group by'>, <whitespace>, fieldlist;
-
 (* Paging *)
 <pagingclause> = limit | offset | orderby;
 limit = <'limit'>, <whitespace>, integer;
@@ -143,6 +140,10 @@ orderparam = !('asc' | 'desc') field, [<whitespace> direction], [<whitespace>];
 (* Bracket *)
 <lbracket> = '[';
 <rbracket> = ']';
+
+(* Angle Brackets *)
+<langle> = '<';
+<rangle> = '>';
 
 (* Booleans *)
 boolean = true | false;

--- a/src/puppetlabs/puppetdb/pql/transform.clj
+++ b/src/puppetlabs/puppetdb/pql/transform.clj
@@ -1,19 +1,44 @@
 (ns puppetlabs.puppetdb.pql.transform
   (:require [clojure.string :as str]
-            [puppetlabs.puppetdb.cheshire :as json]))
+            [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.zip :as zip]
+            [clojure.core.match :as cm]))
 
 (defn paging-clause?
   [v]
   (contains? #{"limit" "offset" "order_by"} (first v)))
 
+(defn strip-and-move-groupedfields
+  [v]
+  (let [result (zip/post-order-visit
+                 (zip/tree-zipper v)
+                 #{}
+                 [(fn [node state]
+                    (cm/match node
+                              [:groupedfield field]
+                              {:node field :state (conj state field)}
+
+                              :else nil))
+                  (fn  [node state]
+                    (when (not (empty? state))
+                      (cm/match node
+                                ["extract" & _]
+                                {:node (conj node (vec (cons "group_by" state)))}
+
+                                :else nil)))])]
+    (vec (:node result))))
+
 (defn slurp-expr->extract
   [clauses]
   (let [paging-groups (group-by paging-clause? clauses)
         paging-clauses (get paging-groups true)
-        other-clauses (get paging-groups false)]
-    (if (and (= (ffirst other-clauses) "extract") (second other-clauses))
-      (cons (vec (concat (first other-clauses) (rest other-clauses))) (vec paging-clauses))
-      clauses)))
+        other-clauses (get paging-groups false)
+        result (if (and (= (ffirst other-clauses) "extract") (second other-clauses))
+                 (cons (vec (concat (first other-clauses) (rest other-clauses)))
+                       (vec paging-clauses))
+                 clauses)]
+    (-> result
+        strip-and-move-groupedfields)))
 
 (defn transform-from
   [entity & args]
@@ -103,10 +128,6 @@
   ([mod int]
    (str "E" mod int)))
 
-(defn transform-groupby
-  [& args]
-  (vec (concat ["group_by"] args)))
-
 (defn transform-limit
   [arg]
   ["limit" arg])
@@ -143,7 +164,6 @@
    :integer            transform-integer
    :real               transform-real
    :exp                transform-exp
-   :groupby            transform-groupby
    :limit              transform-limit
    :offset             transform-offset
    :orderby            transform-orderby})

--- a/src/puppetlabs/puppetdb/pql/transform.clj
+++ b/src/puppetlabs/puppetdb/pql/transform.clj
@@ -20,7 +20,7 @@
 
                               :else nil))
                   (fn  [node state]
-                    (when (not (empty? state))
+                    (when (seq state)
                       (cm/match node
                                 ["extract" & _]
                                 {:node (conj node (vec (cons "group_by" state)))}
@@ -50,9 +50,18 @@
   ([entity arg2]
    ["subquery" entity arg2]))
 
+(defn assume-groupedfield-in-function-case
+  [args]
+  (if (some #(= (first %) "function") args)
+    (for [arg args]
+      (if (not (contains? #{"function" :groupedfield} (first arg)))
+        [:groupedfield arg]
+        arg))
+    args))
+
 (defn transform-extract
   [& args]
-  ["extract" (vec args)])
+  ["extract" (vec (assume-groupedfield-in-function-case args))])
 
 (defn transform-expr-or
   ;; Single arg? collapse

--- a/test/puppetlabs/puppetdb/http/index_test.clj
+++ b/test/puppetlabs/puppetdb/http/index_test.clj
@@ -225,7 +225,7 @@
                       ["extract"
                        ["name" ["function" "count"]]
                        ["group_by" "name"]]]
-                     "facts [name, count()] { group by name }"]]
+                     "facts [<name>, count()] {}"]]
         (let [results (query-result method endpoint query)]
           (is (= results
                  #{{:name "fqdn" :count 3}

--- a/test/puppetlabs/puppetdb/pql/parser_test.clj
+++ b/test/puppetlabs/puppetdb/pql/parser_test.clj
@@ -37,6 +37,25 @@
      "nodes"
      [:extract "a" "b" "c"]]
 
+    "nodes [a, <b>, c] {}"
+    [:from
+     "nodes"
+     [:extract "a" [:groupedfield "b"] "c"]]
+
+    "nodes [a, <b>, <c>] {}"
+    [:from
+     "nodes"
+     [:extract "a" [:groupedfield "b"] [:groupedfield "c"]]]
+
+    "nodes [a, <b>, <c>] { a = 1 }"
+    [:from
+     "nodes"
+     [:extract "a" [:groupedfield "b"] [:groupedfield "c"]]
+     [:expr-or
+      [:expr-and
+       [:expr-not
+        [:condexpression "a" "=" [:integer "1"]]]]]]
+
     "nodes [a, b, c] { a = 1 }"
     [:from
      "nodes"
@@ -113,7 +132,7 @@
 
     "fact_contents"
     ["fact_contents"])
- 
+
   (are [in] (insta/failure? (insta/parse parse in :start :entity))
     "foobar"
     "hyphen-ated"
@@ -126,7 +145,7 @@
     "[ a ]" [:extract "a"]
     "[a]" [:extract "a"]
     "[]" [:extract])
- 
+
   (are [in] (insta/failure? (insta/parse parse in :start :extract))
     "[a b]"
     "[ab.cd]"
@@ -719,34 +738,15 @@
       "'"
       "")))
 
-(deftest test-groupbyclause
-  (testing "groupbyclause"
-    (are [in expected] (= (parse in :start :groupbyclause) expected)
-      "group by name" [[:groupby "name"]]
-      "group by name, value" [[:groupby "name" "value"]])
-
-    (are [in] (insta/failure? (insta/parse parse in :start :groupbyclause))
-      "group by 'name'"
-      ""))
-
-  (testing "groupby"
-    (are [in expected] (= (parse in :start :groupby) expected)
-      "group by name" [:groupby "name"]
-      "group by name, value" [:groupby "name" "value"])
-
-    (are [in] (insta/failure? (insta/parse parse in :start :groupby))
-      "group by 'name'"
-      "")))
-
 (deftest test-paging
   (testing "offset"
     (are [in expected] (= (parse in :start :pagingclause) expected)
          "offset 1" [[:offset [:integer "1"]]]))
-  
+
   (testing "limit"
     (are [in expected] (= (parse in :start :pagingclause) expected)
          "limit 1" [[:limit [:integer "1"]]]))
-  
+
   (testing "order by"
     (are [in expected] (= (parse in :start :pagingclause) expected)
          "order by name" [[:orderby [:orderparam "name"]]]

--- a/test/puppetlabs/puppetdb/pql/transform_test.clj
+++ b/test/puppetlabs/puppetdb/pql/transform_test.clj
@@ -40,7 +40,6 @@
         ["=" "a" 1]]
        ["order_by" [["certname" "desc"]]]]
 
-
       ["nodes" ["extract" [[:groupedfield "a"]] ["=" "a" 1]]]
       ["from" "nodes" ["extract" ["a"] ["=" "a" 1] ["group_by" "a"]]]
 
@@ -143,7 +142,16 @@
   (testing "function"
     (are [in expected] (= (apply transform-extract in) expected)
       ["a" "b" "c"]
-      ["extract" ["a" "b" "c"]]))
+      ["extract" ["a" "b" "c"]]
+      
+      [[:groupedfield "a"] ["function" "count"]]
+      ["extract" [[:groupedfield "a"] ["function" "count"]]]
+      
+      ["a" ["function" "count"]]
+      ["extract" [[:groupedfield "a"] ["function" "count"]]]
+
+      [[:groupedfield "b"] "a" ["function" "count"]]
+      ["extract" [[:groupedfield "b"] [:groupedfield "a"] ["function" "count"]]]))
 
   (testing "transform"
     (are [in expected] (= (transform in) expected)

--- a/test/puppetlabs/puppetdb/pql/transform_test.clj
+++ b/test/puppetlabs/puppetdb/pql/transform_test.clj
@@ -22,12 +22,6 @@
        ["extract" ["a" "b" "c"]
         ["=" "a" 1]]]
 
-      ["nodes" ["extract" ["a" "b" "c"]] ["=" "a" 1] ["group_by" "a"]]
-      ["from" "nodes"
-       ["extract" ["a" "b" "c"]
-        ["=" "a" 1]
-        ["group_by" "a"]]]
-
       ["nodes" ["extract" ["a" "b" "c"]] ["=" "a" 1] ["limit" 1]]
       ["from" "nodes"
        ["extract" ["a" "b" "c"]
@@ -44,7 +38,23 @@
       ["from" "nodes"
        ["extract" ["a" "b" "c"]
         ["=" "a" 1]]
-       ["order_by" [["certname" "desc"]]]]))
+       ["order_by" [["certname" "desc"]]]]
+
+
+      ["nodes" ["extract" [[:groupedfield "a"]] ["=" "a" 1]]]
+      ["from" "nodes" ["extract" ["a"] ["=" "a" 1] ["group_by" "a"]]]
+
+      ["nodes" ["extract" [[:groupedfield "a"] "b"] ["=" "a" 1]]]
+      ["from" "nodes" ["extract" ["a" "b"] ["=" "a" 1] ["group_by" "a"]]]
+
+      ["nodes" ["extract" [[:groupedfield "a"] "b"] ["=" "a" 1]]]
+      ["from" "nodes" ["extract" ["a" "b"] ["=" "a" 1] ["group_by" "a"]]]
+
+      ["nodes" ["extract" [[:groupedfield "a"] "b"] ["=" "a" 1]] ["limit" 1]]
+      ["from" "nodes" ["extract" ["a" "b"] ["=" "a" 1] ["group_by" "a"]] ["limit" 1]]
+
+      ["nodes" ["extract" [[:groupedfield "a"] [:groupedfield "b"]] ["=" "a" 1]] ["limit" 1]]
+      ["from" "nodes" ["extract" ["a" "b"] ["=" "a" 1] ["group_by" "a" "b"]] ["limit" 1]]))
 
   (testing "transform"
     (are [in expected] (= (transform in) expected)
@@ -390,13 +400,3 @@
       [:real "1" "." "1" [:exp "-" "45"]] 1.1E-45
       [:real "1" "." "1" [:exp "+" "45"]] 1.1E45
       [:real "-" "1" "." "1"] -1.1)))
-
-(deftest test-groupby
-  (testing "function"
-    (are [in expected] (= (apply transform-groupby in) expected)
-      ["a"] ["group_by" "a"]
-      ["a" "b"] ["group_by" "a" "b"]))
-
-  (testing "transform"
-    (are [in expected] (= (transform in) expected)
-      [:groupby "a"] ["group_by" "a"])))

--- a/test/puppetlabs/puppetdb/pql_test.clj
+++ b/test/puppetlabs/puppetdb/pql_test.clj
@@ -200,23 +200,23 @@
        ["<" "value" 100]]]]
 
     ;; Modifiers
-    "facts[name, count()] { group by name }"
+    "facts[<name>, count()] {}"
     ["from" "facts"
      ["extract"
       ["name" ["function" "count"]]
       ["group_by" "name"]]]
 
-    "facts[name, count(value)] { certname ~ 'web.*' group by name }"
+    "facts[<name>, count(value)] { certname ~ 'web.*'}"
     ["from" "facts"
      ["extract" ["name" ["function" "count" "value"]]
       ["~" "certname" "web.*"]
       ["group_by" "name"]]]
 
-    "events[count(), status, certname] { certname ~ 'web.*' group by status, certname }"
+    "events[count(), <status>, <certname>] { certname ~ 'web.*'}"
     ["from" "events"
      ["extract", [["function" "count"] "status" "certname"],
       ["~" "certname" "web.*"]
-      ["group_by" "status" "certname"]]]
+      ["group_by" "certname" "status"]]]
 
 
     ;; Paging


### PR DESCRIPTION
This changes the PQL syntax from "group by" supplied in the braced section to
angle-bracketed fields within the bracketed (extract) section.