### PR TITLE
(maint) PQL fixes & corrections from Scott Walker

### DIFF
--- a/resources/puppetlabs/puppetdb/pql/pql-grammar-experimental.ebnf
+++ b/resources/puppetlabs/puppetdb/pql/pql-grammar-experimental.ebnf
@@ -80,7 +80,7 @@ groupedarglist = <lparens>, [<whitespace>], [arglist], [<whitespace>], <rparens>
 <arglist>      = field, [ [<whitespace>], <','>, [<whitespace>], arglist ];
 
 (* Represents a field from an entity *)
-<field> = #'[a-zA-Z_]+';
+<field> = #'[a-zA-Z_]+\??';
 
 <condregexp>      = '~';
 <condregexparray> = '~>';

--- a/src/puppetlabs/puppetdb/pql/transform.clj
+++ b/src/puppetlabs/puppetdb/pql/transform.clj
@@ -65,7 +65,7 @@
 
 (defn transform-groupedlist
   [& args]
-  args)
+  (vec args))
 
 (defn transform-groupedliterallist
   [& args]

--- a/test/puppetlabs/puppetdb/pql/parser_test.clj
+++ b/test/puppetlabs/puppetdb/pql/parser_test.clj
@@ -483,11 +483,14 @@
     (are [in] (= (parse in :start :field) [in])
       "certname"
       "value"
-      "field_underscore")
+      "field_underscore"
+      "latest_report?")
 
     (are [in] (insta/failure? (insta/parse parse in :start :field))
       "'asdf'"
       "field-hyphen"
+      "foo?bar"
+      "?"
       ""))
 
   (testing "condregexp"

--- a/test/puppetlabs/puppetdb/pql/transform_test.clj
+++ b/test/puppetlabs/puppetdb/pql/transform_test.clj
@@ -281,7 +281,7 @@
   (testing "function"
     (are [in expected] (= (apply transform-groupedlist in) expected)
       []
-      nil
+      []
 
       ["a"]
       ["a"]


### PR DESCRIPTION
* Convert examples to double quotes, so they can be cut & paste using the curl example
* Show better path and array regexp examples that actually work
* Use a better explicit subquery example for multiple fields
* Allow question marks in a field
* Add more tests for the above bugs/problems

Signed-off-by: Ken Barber <ken@bob.sh>