### PR TITLE
(PDB-2424) Fix delete-edges! to hit unique index

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -324,10 +324,13 @@ must be supplied as the value to be matched."
     (str->pgobject "uuid" value)
     value))
 
+(defn bytea-escape [s]
+  (format "\\x%s" s))
+
 (defn munge-hash-for-storage
   [hash]
   (if (postgres?)
-    (str->pgobject "bytea" (format "\\x%s" hash))
+    (str->pgobject "bytea" (bytea-escape hash))
     hash))
 
 (defn munge-json-for-storage

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -608,14 +608,21 @@
                        "before"] nil})))
 
           (testing "should only delete the 1 edge"
-            (is (= [[:edges [(format "certname=? and %s=? and %s=? and type=?"
-                                     (sutils/sql-hash-as-str "source")
-                                     (sutils/sql-hash-as-str "target"))
-                             "basic.catalogs.com"
-                             "ff0702ba8a7dc69d3fb17f9d151bf9bd265a9ed9"
-                             "57495b553981551c5194a21b9a26554cd93db3d9"
-                             "contains"]]]
-                   (map rest @deletes))))
+            (let [source-hash "ff0702ba8a7dc69d3fb17f9d151bf9bd265a9ed9"
+                  target-hash "57495b553981551c5194a21b9a26554cd93db3d9"]
+              (is (= [[:edges [(str "certname=?"
+                                    " and source=?" (when (sutils/postgres?) "::bytea")
+                                    " and target=?" (when (sutils/postgres?) "::bytea")
+                                    " and type=?")
+                               "basic.catalogs.com"
+                               (if (sutils/postgres?)
+                                 (sutils/bytea-escape source-hash)
+                                 source-hash)
+                               (if (sutils/postgres?)
+                                 (sutils/bytea-escape target-hash)
+                                 target-hash)
+                               "contains"]]]
+                     (map rest @deletes)))))
           (testing "should only insert the 1 edge"
             (is (= [[:edges {:certname "basic.catalogs.com"
                              :source (sutils/munge-hash-for-storage "57495b553981551c5194a21b9a26554cd93db3d9")


### PR DESCRIPTION
Currently delete-edges coerces the column and compares it with the data
passed in. This cause ALL source/target column values to be
decoded. This is slow and doesn't hit the unique index that is in
place. Instead this patch converts the source/target being deleted to
bytea and compares it with what is stored. This hits the index and will
be much faster as only 1 conversion is done, not one for each row + column.