### PR TITLE
(PDB-2454) reject-large-commands false by default

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -658,14 +658,17 @@ commands that are too large to process, such as a
 catalog that is too large, causing PuppetDB to run out of
 memory. This setting can be used along with `max-command-size`.
 
-This setting is true by default.
+This setting is false by default.
 
 ### `max-command-size`
 
 This is an integer that specifies (in bytes) which commands are "too
 large" to process with PuppetDB. By default this setting is a fraction
-of the total heap space, but can be specified manually for users who
-want to support larger catalog sizes. This setting has no effect when
+of the total heap space. It is strongly recommended that users set
+this manually as the default is probably too conservative. To help
+determine the current size of commands being processed, enable debug
+logging for the `puppetlabs.puppetdb.middleware` appender in the
+[logback.xml](#logging-config). This setting has no effect when
 `reject-large-commands` is set to false.
 
 

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -147,7 +147,7 @@
      :max-frame-size (pls/defaulted-maybe s/Int 209715200)
      :temp-usage s/Int
      :max-command-size (pls/defaulted-maybe s/Int (default-max-command-size))
-     :reject-large-commands (pls/defaulted-maybe String "true")}))
+     :reject-large-commands (pls/defaulted-maybe String "false")}))
 
 (def command-processing-out
   "Schema for parsed/processed command processing config - currently incomplete"

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -211,11 +211,9 @@
                  (warn-retirements {:database {param "foo"}}))))))))
 
 (deftest test-default-max-command-size
-  (testing "default is enabled"
+  (testing "default is disabled"
     (let [default-config (:command-processing (configure-command-processing {}))]
-      (is (true? (:reject-large-commands default-config)))
-      (is (= (long (default-max-command-size))
-             (:max-command-size default-config)))))
+      (is (false? (:reject-large-commands default-config)))))
 
   (testing "enabled but with default size"
     (let [default-config (:command-processing (configure-command-processing {:command-processing {:reject-large-commands "true"}}))]


### PR DESCRIPTION
Attempting to set a command size that is "too large" is difficult as
it's very dependent on environment. Having this enabled by default was
causing commands that were able to be processed before to be rejected as
they were considered too large by this setting. With the potential
impact of these false positives, the setting should be false by default.

Users wanting to set a max-command-size still can. We also output debug
logging to help users get a feel for their current command sizes, using
that users should better be able to determine their typical command
sizes and find a better default than our current (overly conservative)
estimate.