### PR TITLE
(PDB-2407) PQL- Allow inequalities on date fields

### DIFF
--- a/resources/puppetlabs/puppetdb/pql/pql-grammar-experimental.ebnf
+++ b/resources/puppetlabs/puppetdb/pql/pql-grammar-experimental.ebnf
@@ -58,10 +58,10 @@ expr-not     = ( not, [<whitespace>], expr-not ) | expr-rest;
 subquery = entity, [<whitespace>], where;
 
 (* Conditional expression *)
-condexpression  = (condexpregexp | condexpregexparray | condexpnumber | condexpmatch | condexpin);
+condexpression  = (condexpregexp | condexpregexparray | condexpinequality | condexpmatch | condexpin);
 <condexpregexp> = field, [<whitespace>], condregexp, [<whitespace>], valueregexp;
 <condexpregexparray> = field, [<whitespace>], condregexparray, [<whitespace>], valueregexparray;
-<condexpnumber> = field, [<whitespace>], condnumber, [<whitespace>], valuenumber;
+<condexpinequality> = field, [<whitespace>], condinequality, [<whitespace>], valueordered;
 <condexpmatch>  = field, [<whitespace>], condmatch, [<whitespace>], valuematch;
 <condexpin>     = (field | groupedfieldlist), [<whitespace>], condin, [<whitespace>], valuein;
 
@@ -84,13 +84,13 @@ groupedarglist = <lparens>, [<whitespace>], [arglist], [<whitespace>], <rparens>
 
 <condregexp>      = '~';
 <condregexparray> = '~>';
-<condnumber>      = '>=' | '<=' | '<' | '>';
+<condinequality>      = '>=' | '<=' | '<' | '>';
 <condmatch>       = '=';
 <condin>          = 'in';
 
 <valueregexp>      = string;
 <valueregexparray> = groupedregexplist;
-<valuenumber>      = integer | real;
+<valueordered>      = integer | real | string; (* Dates are parsed as strings *)
 <valuematch>       = string | integer | real | boolean;
 <valuein>          = query | groupedliterallist;
 

--- a/test/puppetlabs/puppetdb/pql/parser_test.clj
+++ b/test/puppetlabs/puppetdb/pql/parser_test.clj
@@ -303,11 +303,8 @@
       [:condexpression "a" "in" [:from "nodes" [:extract "a"]]])
 
     (are [in] (insta/failure? (insta/parse parse in :start :condexpression))
-      "foo >= 'bar'"
       "foo >= true"
-      "foo <= 'bar'"
       "foo <= true"
-      "foo > 'bar'"
       "foo < true"
       "foo ~ /bar/"
       "foo = bar"
@@ -336,16 +333,13 @@
       "a ~> true"
       ""))
 
-  (testing "condexpnumber"
-    (are [in expected] (= (parse in :start :condexpnumber) expected)
+  (testing "condexpinequality"
+    (are [in expected] (= (parse in :start :condexpinequality) expected)
       "a >= 4" ["a" ">=" [:integer "4"]])
 
-    (are [in] (insta/failure? (insta/parse parse in :start :condexpnumber))
-      "a >= 'bar'"
+    (are [in] (insta/failure? (insta/parse parse in :start :condexpinequality))
       "a >= true"
-      "a <= 'bar'"
       "a <= true"
-      "a > 'bar'"
       "a < true"
       ""))
 
@@ -505,14 +499,14 @@
       "="
       ""))
 
-  (testing "condnumber"
-    (are [in] (= (parse in :start :condnumber) [in])
+  (testing "condinequality"
+    (are [in] (= (parse in :start :condinequality) [in])
       ">="
       "<="
       ">"
       "<")
 
-    (are [in] (insta/failure? (insta/parse parse in :start :condnumber))
+    (are [in] (insta/failure? (insta/parse parse in :start :condinequality))
       "="
       "~>"
       "~"
@@ -554,15 +548,14 @@
       "/as/df/"
       ""))
 
-  (testing "valuenumber"
-    (are [in expected] (= (parse in :start :valuenumber) expected)
+  (testing "valueordered"
+    (are [in expected] (= (parse in :start :valueordered) expected)
       "1" [[:integer "1"]]
       "-1" [[:integer "-" "1"]]
-      "1.1" [[:real "1" "." "1"]])
+      "1.1" [[:real "1" "." "1"]]
+      "'2016-02-25'" [[:sqstring "2016-02-25"]])
 
-    (are [in] (insta/failure? (insta/parse parse in :start :valuenumber))
-      "'asdf'"
-      "\"asdf\""
+    (are [in] (insta/failure? (insta/parse parse in :start :valueordered))
       "true"
       "/asdf/"
       ""))

--- a/test/puppetlabs/puppetdb/pql_test.clj
+++ b/test/puppetlabs/puppetdb/pql_test.clj
@@ -261,4 +261,21 @@
     "reports[certname]{certname = 'foo' order by certname desc, receive_time asc limit 10}"
     ["from" "reports"
      ["extract" ["certname"] ["=" "certname" "foo"]]
-     ["order_by" [["certname" "desc"] ["receive_time" "asc"]]] ["limit" 10]]))
+     ["order_by" [["certname" "desc"] ["receive_time" "asc"]]] ["limit" 10]]
+
+    ;;Inequality on dates
+    "reports{receive_time > '2016-02-07T08:45:42.170687300Z'}"
+    ["from" "reports"
+     [">" "receive_time" "2016-02-07T08:45:42.170687300Z"]]
+
+    "reports{receive_time >= '2016-02-07T08:45:42.170687300Z'}"
+    ["from" "reports"
+     [">=" "receive_time" "2016-02-07T08:45:42.170687300Z"]]
+
+    "reports{receive_time <= '2016-02-07T08:45:42.170687300Z'}"
+    ["from" "reports"
+     ["<=" "receive_time" "2016-02-07T08:45:42.170687300Z"]]
+
+    "reports{receive_time < '2016-02-07T08:45:42.170687300Z'}"
+    ["from" "reports"
+     ["<" "receive_time" "2016-02-07T08:45:42.170687300Z"]]))


### PR DESCRIPTION
This patch allows inequality operators (>,>=,<,<=) to be used on date
fields similar to how they are allowed in the AST language. There is
currently no validation to ensure correct format of the date
strings (similar to AST).