### PR TITLE
(PDB-2438) Fix pretty-printing parameter for POST

### DIFF
--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -100,21 +100,6 @@
         response
         (assoc response :body (http/default-body req response))))))
 
-(defn wrap-pretty-printing-opts
-  [app]
-  (fn [{:keys [params] :as req}]
-    (if-let [pretty (get params "pretty")]
-      (if-not (or (= "false" pretty)
-                  (= "true" pretty))
-        (http/error-response (str "Parameter 'pretty' must be either 'true' or 'false' not '"
-                                  pretty
-                                  "'"))
-        (let [new-req (-> req
-                          (update :params dissoc "pretty")
-                          (assoc-in [:globals :pretty-print] (= "true" pretty)))]
-          (app new-req)))
-      (app req))))
-
 (defn wrap-with-globals
   "Ring middleware that adds a :globals attribute to each request that
    contains a map of the current shared-global settings."
@@ -305,7 +290,6 @@
   "Default middleware for puppetdb webservers."
   [app cert-whitelist]
   (-> app
-      wrap-pretty-printing-opts
       wrap-params
       (wrap-with-authorization cert-whitelist)
       wrap-with-certificate-cn

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -110,7 +110,7 @@
   {:scf-read-db s/Any
    :url-prefix String
    (s/optional-key :warn-experimental) Boolean
-   (s/optional-key :pretty-print) Boolean})
+   (s/optional-key :pretty-print) (s/maybe Boolean)})
 
 (pls/defn-validated stream-query-result
   "Given a query, and database connection, return a Ring response with the query

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -397,6 +397,17 @@
           (is (= status http/status-bad-request))
           (is (re-find msg body)))))))
 
+(deftest-http-app query-with-pretty-printing
+  [[version endpoint] endpoints
+   method [:get :post]]
+  (let [expected (store-example-nodes)]
+    (testing "should support pretty printing in reports"
+      (let [results (slurp (:body (query-response method endpoint nil {:pretty true})))
+            normal-results (slurp (:body (query-response method endpoint nil {:pretty false})))]
+        (is (not (empty? (json/parse-string results))))
+        (is (> (count (clojure.string/split-lines results))
+               (count (clojure.string/split-lines normal-results))))))))
+
 (deftest-http-app paging-results
   [[version endpoint] endpoints
    method [:get :post]]

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -170,12 +170,26 @@
   [[version field] [[:v4 :logs] [:v4 :metrics]]
    method [:get :post]]
   (let [report-hash (:hash (store-example-report! (:basic reports) (now)))
-        basic (assoc (:basic reports) :hash report-hash)
+        basic (assoc (:basic reports)
+                     :hash report-hash)
         get-data (fn [hash field]
-                   (query-result method (format "/v4/reports/%s/%s?pretty=true" hash field)))]
+                   (query-result method
+                                 (format "/v4/reports/%s/%s" hash field)
+                                 nil
+                                 {:pretty true}))]
     (testing (format "%s endpoint returns the proper data" (name field))
       (is (= (get-data report-hash (name field))
              (-> basic field :data set))))))
+
+(deftest-http-app query-with-pretty-printing
+  [[version endpoint] endpoints
+   method [:get :post]]
+  (let [basic1 (:basic reports)]
+    (store-example-report! basic1 (now))
+
+    (testing "should support pretty printing in reports"
+      (let [results (query-result method endpoint nil {:pretty true})]
+        (is (not (empty? results)))))))
 
 (deftest-http-app query-with-paging
   [[version endpoint] endpoints

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -225,7 +225,7 @@
   ([method {:keys [app-fn path query params limit total include_total] :as paged-test-params}]
    {:pre [(= #{} (difference
                   (keyset paged-test-params)
-                  #{:app-fn :path :query :params :limit :total :include_total}))]}
+                  #{:app-fn :path :query :pretty :params :limit :total :include_total}))]}
    (reduce
     (fn [coll n]
       (let [{:keys [status body headers] :as resp} (paged-results* method (assoc paged-test-params :offset (* limit n)))]


### PR DESCRIPTION
This commit fixes our `pretty` parameter for query POSTs, before this
commit we weren't properly passing the param from the POST body to the
produce-streaming-body function and weren't allowing the parameter
through validation.