### PR TITLE
(PDB-2360) Fix aliasing in aggregates and group-by

### DIFF
--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -86,7 +86,9 @@
     ["extract" columns crit]
 
     [["extract" columns subquery]]
-    ["extract" columns ["and" subquery crit]]
+    (if (= "group_by" (first subquery))
+      ["extract" columns crit subquery]
+      ["extract" columns ["and" subquery crit]])
 
     [["extract" columns subquery clauses]]
     ["extract" columns ["and" subquery crit] clauses]

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -330,6 +330,24 @@
           (is (= status http/status-bad-request))
           (is (re-find msg body)))))))
 
+(deftestseq aggregate-functions-on-nodes
+  [[version endpoint] endpoints
+   method [:get :post]]
+
+  (let [expected (store-example-nodes)]
+
+    (testing "ambiguous function column args"
+      (is (= (query-result method endpoint ["extract" [["function" "count" "certname"]]])
+             #{{:count 4}})))
+
+    (testing "ambiguous group by column args"
+      (is (= (query-result method endpoint ["extract" [["function" "count"] "certname"]
+                                            ["group_by" "certname"]])
+             #{{:certname "web2.example.com" :count 1}
+               {:certname "web1.example.com" :count 1}
+               {:certname "db.example.com" :count 1}
+               {:certname "puppet.example.com" :count 1}})))))
+
 (deftestseq paging-results
   [[version endpoint] endpoints
    method [:get :post]]

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -103,6 +103,12 @@
                                             ["group_by" "status"]])
              #{{:status "unchanged", :count 2}})))
 
+    (testing "projected aggregate count call"
+      (is (= (query-result method endpoint ["extract" [["function" "count" "certname"]
+                                                       ["function" "min" "producer_timestamp"]]])
+             #{{:count 2
+                :min "2011-01-01T15:11:00.000Z"}})))
+
     (testing "projected aggregate sum call"
       (is (= (query-result method endpoint ["extract"
                                             [["function" "sum" "report_format"] "status"]

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -137,7 +137,9 @@
                     (compile-user-query->sql reports-query)
                     :results-query
                     first)))
-  (is (re-find #"SELECT count\(certname\) AS \"count\" FROM reports"
+  (is (re-find (if (su/postgres?)
+                 #"SELECT count\(reports.certname\) AS count FROM reports"
+                 #"SELECT count\(reports.certname\) AS \"count\" FROM reports")
                (->> ["extract" [["function" "count" "certname"]]]
                     (compile-user-query->sql reports-query)
                     :results-query


### PR DESCRIPTION
This commit fixes a bug with aggregates and group-by where the fields
used as arguments to those operators (`function` and `group_by`) weren't
being converted to our `fields` (honeysql) constructs which have the
table disambiguation and correct names for certain query API fields
(e.g. queries to `/nodes` grouping by certname now work instead of
erroring with an ambiguous column message, and queries to `/reports`
with `["function","min","report_timestamp"]` will now properly rename
`report_timestamp` to `reports.end_time` in the SQL).