### PR TITLE
(PDB-1960) This commit unblocks startup on the post migration vacuum

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -57,7 +57,7 @@
                  ;; Database connectivity
                  [com.zaxxer/HikariCP "2.4.3"]
                  [org.clojure/java.jdbc "0.4.2"]
-                 [org.postgresql/postgresql "9.4-1206-jdbc4"]
+                 [org.postgresql/postgresql "9.4.1208"]
 
                  ;; MQ connectivity
                  [org.apache.activemq/activemq-broker "5.13.1" :exclusions [org.slf4j/slf4j-api]]

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1089,9 +1089,10 @@
     (into (sorted-map)
           (select-keys migrations pending))))
 
-(defn- sql-or-die [f]
+(defn- sql-or-die
   "Calls (f) and returns its result.  If f throws an SQLException,
   logs the exception and its parent and then calls (System/exit 1)"
+  [f]
   ;; Here we've preserved existing behavior, but this may warrant
   ;; further consideration later.  If possible, we might want to
   ;; avoid System/exit in favor of careful exception
@@ -1157,10 +1158,14 @@
         ;; Make sure we're creating a new connection (the new
         ;; clojure.jdbc API will re-use an existing one).
         (assert (not (:connection db-connection-pool)))
-        (jdbc/with-db-connection db-connection-pool
-          (log/info "Analyzing database")
-          (sql-or-die
-           (fn [] (jdbc/do-commands-outside-txn "vacuum (analyze, verbose)")))))
+        ;; We don't want to stay in maintenance mode while we vaccum analyze,
+        ;; i.e. refuse http requests as this can take quite some time on large
+        ;; databases
+        (future
+          (jdbc/with-db-connection db-connection-pool
+           (log/info "Analyzing database")
+           (fn []
+             (jdbc/do-commands-outside-txn "vacuum (analyze, verbose)")))))
       (log/info "There are no pending migrations"))))
 
 ;; SPECIAL INDEX HANDLING


### PR DESCRIPTION
This commit moves the post migration vacuum analyze to a future so that
we don't block startup on the analyze which can take a while on large
databases.