### PR TITLE
(PDB-1960) Don't block startup on the post migration vacuum

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1594,9 +1594,10 @@
     (into (sorted-map)
           (select-keys migrations pending))))
 
-(defn- sql-or-die [f]
+(defn- sql-or-die
   "Calls (f) and returns its result.  If f throws an SQLException,
   logs the exception and its parent and then calls (System/exit 1)"
+  [f]
   ;; Here we've preserved existing behavior, but this may warrant
   ;; further consideration later.  If possible, we might want to
   ;; avoid System/exit in favor of careful exception
@@ -1605,9 +1606,8 @@
     (f)
     (catch java.sql.SQLException e
       (log/error e "Caught SQLException during migration")
-      (let [next (.getNextException e)]
-        (when-not (nil? next)
-          (log/error next "Unravelled exception")))
+      (when-let [next (.getNextException e)]
+        (log/error next "Unravelled exception"))
       (binding [*out* *err*] (flush)) (flush)
       (System/exit 1))))
 
@@ -1634,13 +1634,21 @@
         ;; Make sure we're creating a new connection (the new
         ;; clojure.jdbc API will re-use an existing one).
         (assert (not (:connection db-connection-pool)))
-        (jdbc/with-db-connection db-connection-pool
-          (log/info "Analyzing database")
-          (sql-or-die (fn []
-                        (-> (doto (:connection (jdbc/db)) (.setAutoCommit true))
-                            .createStatement
-                            (.execute "vacuum (analyze, verbose)")))))))
-    (log/info "There are no pending migrations")))
+        ;; We don't want to stay in maintenance mode while we vaccum analyze,
+        ;; i.e. refuse http requests as this can take quite some time on large
+        ;; databases
+        (future
+          (jdbc/with-db-connection db-connection-pool
+            (log/info "Analyzing database")
+            (try
+              (-> (doto (:connection (jdbc/db)) (.setAutoCommit true))
+                  .createStatement
+                  (.execute "vacuum (analyze, verbose)"))
+              (catch java.sql.SQLException e
+                (log/error e "Caught SQLException during migration")
+                (when-let [next (.getNextException e)]
+                  (log/error next "Unravelled exception")))))))
+      (log/info "There are no pending migrations"))))
 
 ;; SPECIAL INDEX HANDLING
 


### PR DESCRIPTION
This commit moves the post migration vacuum analyze to a future so that
we don't block startup on the analyze which can take a while on large
databases.