### PR TITLE
(maint) Fix flaky reports test

### DIFF
--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -141,22 +141,24 @@
 (deftestseq query-with-paging
   [[version endpoint] endpoints
    method [:get :post]]
-
   (let [basic1 (:basic reports)
-        _      (store-example-report! basic1 (now))
+        _ (store-example-report! basic1 (now))
         basic2 (:basic2 reports)
-        _      (store-example-report! basic2 (now))]
+        _ (store-example-report! basic2 (now))]
 
     (doseq [[label count?] [["without" false]
                             ["with" true]]]
       (testing (str "should support paging through reports " label " counts")
-        (let [results       (paged-results
-                             {:app-fn  fixt/*app*
-                              :path    endpoint
-                              :query   ["=" "certname" (:certname basic1)]
-                              :limit   1
-                              :total   2
-                              :include_total  count?})]
+        (let [results (paged-results
+                       {:app-fn fixt/*app*
+                        :path endpoint
+                        :query ["=" "certname" (:certname basic1)]
+                        :limit 1
+                        :total 2
+                        :params {:order_by (json/generate-string
+                                            [{:field :transaction_uuid
+                                              :order :desc}])}
+                        :include_total count?})]
           (is (= 2 (count results)))
           (is (= (munge-reports-for-comparison [basic1 basic2])
                  (munge-reports-for-comparison results))))))))


### PR DESCRIPTION
Now that we do the post-migration vacuum in the background, it can
race with test execution (especially in the 3.x series, where we are
still running db migration once per test case). In this case, we are
testing pagination. If we do the first paginated query, then vacuum
executes, and then we do the second paginated query, the underlying
table can be rewritten to have a different natural order.

Fix this by supplying an order_by to the paginated query, ensuring
its stability across storage change.