### PR TITLE
(PDB-1960) Remove race condition with initial vacuum analyze

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.puppetdb.scf.storage-utils
   (:require [clojure.java.jdbc :as sql]
+            [clojure.tools.logging :as log]
             [honeysql.core :as hcore]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.honeysql :as h]
@@ -349,3 +350,20 @@ must be supplied as the value to be matched."
       (str->pgobject "jsonb" json-str)
       json-str)))
 
+
+(defn async-vacuum-analyze [db-connection-pool]
+  (when (postgres?)
+    ;; We don't want to stay in maintenance mode while we vaccum analyze,
+    ;; i.e. refuse http requests as this can take quite some time on large
+    ;; databases
+    (future
+      (jdbc/with-db-connection db-connection-pool
+        (log/info "Analyzing database")
+        (try
+          (-> (doto (:connection (jdbc/db)) (.setAutoCommit true))
+              .createStatement
+              (.execute "vacuum (analyze, verbose)"))
+          (catch java.sql.SQLException e
+            (log/error e "Caught SQLException during migration")
+            (when-let [next (.getNextException e)]
+              (log/error next "Unravelled exception"))))))))


### PR DESCRIPTION
This commit move the asynchronous vacuum analyze to use the write-db
connection pool instead of the temporary one we use for migrations so
that we know the connection will still be around while we attempt to
execute the vacuum.