### PR TITLE
(PDB-2596) Respect [developer] pretty-print

### DIFF
--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -290,7 +290,8 @@
         req
         (let [param-spec (update param-spec :optional conj "pretty")
               query-map (create-query-map req param-spec parse-fn)
-              pretty-print (:pretty query-map)]
+              pretty-print (:pretty query-map
+                                    (get-in req [:globals :pretty-print]))]
           (-> req
               (assoc :puppetdb-query query-map)
               (assoc-in [:globals :pretty-print] pretty-print))))))))

--- a/test/puppetlabs/puppetdb/testutils/http.clj
+++ b/test/puppetlabs/puppetdb/testutils/http.clj
@@ -97,15 +97,17 @@
 
 (defn call-with-http-app
   "Builds an HTTP app and make it available as *app* during the
-  execution of (f)."
-  [f]
-  (let [get-shared-globals (constantly {:scf-read-db *db*
-                                        :scf-write-db *db*
-                                        :url-prefix ""})]
-    (binding [*app* (wrap-with-puppetdb-middleware
-                     (server/build-app get-shared-globals)
-                     nil)]
-      (f))))
+  execution of (f).  Calls (adjust-globals default-globals) if
+  adjust-globals is provided."
+  ([f] (call-with-http-app f identity))
+  ([f adjust-globals]
+   (let [get-shared-globals #(adjust-globals {:scf-read-db *db*
+                                              :scf-write-db *db*
+                                              :url-prefix ""})]
+     (binding [*app* (wrap-with-puppetdb-middleware
+                      (server/build-app get-shared-globals)
+                      nil)]
+       (f)))))
 
 (defmacro with-http-app
   [& body]


### PR DESCRIPTION
Don't clobber the [developer] pretty-print (config) value that's in
shared-globals with nil when there's no pretty parameter in the query
map, and add a trivial test for the effect of :pretty-print in
shared-globals.