### PR TITLE
(PDB-2390) Upgrade to ActiveMQ 5.13.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -60,9 +60,9 @@
                  [org.postgresql/postgresql "9.2-1003-jdbc4"]
 
                  ;; MQ connectivity
-                 [org.apache.activemq/activemq-broker "5.13.0"]
-                 [org.apache.activemq/activemq-kahadb-store "5.13.0"]
-                 [org.apache.activemq/activemq-pool "5.13.0"]
+                 [org.apache.activemq/activemq-broker "5.13.2"]
+                 [org.apache.activemq/activemq-kahadb-store "5.13.2"]
+                 [org.apache.activemq/activemq-pool "5.13.2"]
 
                  ;; bridge to allow some spring/activemq stuff to log over slf4j
                  [org.slf4j/jcl-over-slf4j "1.7.10"]


### PR DESCRIPTION
This fixes an issue with ever-growing scheduler logs for failed
commands.

Changelog for 5.13.1: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12334251
Changelog for 5.13.2: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12334774

I've been through these and nothing aside from the relevant fix looks to impact features we use. 