### PR TITLE
(maint) Remove some potential ordering issues from tests

### DIFF
--- a/test/puppetlabs/puppetdb/http/event_counts_test.clj
+++ b/test/puppetlabs/puppetdb/http/event_counts_test.clj
@@ -8,7 +8,7 @@
             [clojure.walk :refer [keywordize-keys]]
             [puppetlabs.puppetdb.examples.reports :refer :all]
             [puppetlabs.puppetdb.testutils.catalogs :as testcat]
-            [puppetlabs.puppetdb.testutils :refer [paged-results deftestseq]]
+            [puppetlabs.puppetdb.testutils :refer [deftestseq]]
             [puppetlabs.puppetdb.testutils.http :refer [query-response query-result
                                                         vector-param
                                                         ordered-query-result]]

--- a/test/puppetlabs/puppetdb/http/fact_names_test.clj
+++ b/test/puppetlabs/puppetdb/http/fact_names_test.clj
@@ -5,7 +5,7 @@
             [puppetlabs.puppetdb.fixtures :as fixt]
             [clojure.test :refer :all]
             [clj-time.core :refer [now]]
-            [puppetlabs.puppetdb.testutils :refer [paged-results deftestseq
+            [puppetlabs.puppetdb.testutils :refer [deftestseq
                                                    parse-result]]
             [puppetlabs.puppetdb.testutils.http :refer [query-response
                                                         query-result

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -696,6 +696,11 @@
     :query   query
     :limit   limit
     :total   total
+    :params {:order_by (json/generate-string
+                        [{:field :certname
+                          :order :desc}
+                         {:field :name
+                          :order :desc}])}
     :include_total include_total}))
 
 (deftestseq fact-query-paging

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -173,11 +173,12 @@
   [[version endpoint] endpoints
   method [:get :post]]
 
-  (let [basic1 (:basic reports)
+  (let [munge (fn [d] (set (map #(update-in % [:resource_events :data] set) d)))
+        basic1 (:basic reports)
         _ (store-example-report! basic1 (now))
         basic2 (assoc (:basic2 reports) :certname "bar.local")
         _ (store-example-report! basic2 (now))
-        initial-response (query-result method endpoint)
+        initial-response (munge (query-result method endpoint))
         json-type (if (sutils/postgres?) "::json" "")]
 
     (testing "response is the same with logs split between json and jsonb"
@@ -189,7 +190,7 @@
         "update reports
          set logs=null where certname='foo.local'")
 
-      (is (= (query-result method endpoint) initial-response)))
+      (is (= (munge (query-result method endpoint)) initial-response)))
 
     (testing "response is the same with all logs in json column"
       (jdbc/do-commands
@@ -200,7 +201,7 @@
         "update reports
          set logs=null where certname='bar.local'")
 
-      (is (= (query-result method endpoint) initial-response)))))
+      (is (= (munge (query-result method endpoint)) initial-response)))))
 
 (def my-reports
   (-> reports

--- a/test/puppetlabs/puppetdb/http/resources_test.clj
+++ b/test/puppetlabs/puppetdb/http/resources_test.clj
@@ -215,6 +215,13 @@ to the result of the form supplied to this method."
                           :path    endpoint
                           :limit   2
                           :total   (count expected)
+                          :params {:order_by (json/generate-string
+                                              [{:field :certname
+                                                :order :desc}
+                                               {:field :type
+                                                :order :desc}
+                                               {:field :title
+                                                :order :desc}])}
                           :include_total  count?})]
             (is (= (count results) (count expected)))
             (is (= (set (vals expected))

--- a/test/puppetlabs/puppetdb/testutils/cli.clj
+++ b/test/puppetlabs/puppetdb/testutils/cli.clj
@@ -80,8 +80,8 @@
   [tar-map]
   (-> tar-map
       (dissoc "export-metadata.json")
-      (update "facts" tuf/munge-facts)
-      (update "reports" (comp stringify-keys
-                              tur/munge-report
-                              keywordize-keys))
-      (update "catalogs" tuc/munge-catalog)))
+      (update "facts" #(kitchensink/mapvals tuf/munge-facts %))
+      (update "reports" #(kitchensink/mapvals (comp stringify-keys
+                                                   tur/munge-report
+                                                   keywordize-keys) %))
+      (update "catalogs" #(kitchensink/mapvals tuc/munge-catalog %))))


### PR DESCRIPTION
With the inclusion of the recent backgrounded 'analyze' it introduced some
flakiness to our tests due to ordering issues. This patch fixes two cases
where we are doing a limit without an order-by, and converts resource_events
for reports tests to a set so comparison always works.

Signed-off-by: Ken Barber <ken@bob.sh>