### PR TITLE
(docs) Fix typo in yaml frontmatter (pdb_support_guide)

### DIFF
--- a/documentation/pdb_support_guide.markdown
+++ b/documentation/pdb_support_guide.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 3.2: Support and Troublshooting Guide
+title: "PuppetDB 3.2: Support and Troublshooting Guide"
 layout: default
 ---
 


### PR DESCRIPTION
This file had an unclosed quote.

This affects master as well, but I think we're still merging stable to master occasionally, right? 