### PR TITLE
(docs) Fix typo in yaml frontmatter (summary-stats)

### DIFF
--- a/documentation/api/admin/v1/summary-stats.markdown
+++ b/documentation/api/admin/v1/summary-stats.markdown
@@ -1,7 +1,6 @@
 ---
 title: "PuppetDB 4.0: Summary-stats endpoint"
 layout: default
-canonical "/puppetdb/latest/api/admin/v1/summary-stats.markdown
 ---
 
 > **Experimental Endpoint**: The summary-stats endpoint is designated


### PR DESCRIPTION
This file had an unclosed quote. But since the "canonical:" key is now optional
and automatically detected, I just deleted it entirely instead of closing the quote.

This only affects master, afaict. 

For folk with confluence accounts, here's a link about "canonical" being optional now: https://confluence.puppetlabs.com/display/DOCS/YAML+Frontmatter#YAMLFrontmatter-canonical: