### PR TITLE
(PDB-2486) allow upgrades in different schemas with pg_trgm

### DIFF
--- a/ext/jenkins/lein-test.sh
+++ b/ext/jenkins/lein-test.sh
@@ -16,6 +16,9 @@ export PUPPETDB_DBPASSWORD="puppetdb137"
 export PGPASSWORD="puppetdb137"
 export PUPPETDB_DBSUBNAME="//${DBHOST}:${DBPORT}/${DBNAME}"
 
+export PDB_TEST_DB_ADMIN=pdb_test_admin
+export PDB_TEST_DB_USER_PASSWORD=optuwaeg6ujzo
+
 rm -f testreports.xml *.war *.jar
 
 export HTTP_CLIENT="wget --no-check-certificate -O"

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -11,6 +11,7 @@ case "$PDB_TEST_LANG" in
     case "$PDB_TEST_DB" in
       postgres)
         psql -c 'create database puppetdb_test;' -U postgres
+        export PDB_TEST_DB_ADMIN=postgres
         PUPPETDB_DBTYPE=postgres \
           PUPPETDB_DBUSER=postgres \
           PUPPETDB_DBSUBNAME=//127.0.0.1:5432/puppetdb_test \


### PR DESCRIPTION
This fixes an issue where our index-exists? function assumed the public schema.