### PR TITLE
(maint) use correct db test admin credentials in jenkins

### DIFF
--- a/ext/jenkins/lein-test.sh
+++ b/ext/jenkins/lein-test.sh
@@ -17,7 +17,7 @@ export PGPASSWORD="puppetdb137"
 export PUPPETDB_DBSUBNAME="//${DBHOST}:${DBPORT}/${DBNAME}"
 
 export PDB_TEST_DB_ADMIN=pdb_test_admin
-export PDB_TEST_DB_USER_PASSWORD=optuwaeg6ujzo
+export PDB_TEST_DB_ADMIN_PASSWORD=optuwaeg6ujzo
 
 rm -f testreports.xml *.war *.jar
 


### PR DESCRIPTION
This corrects a misnamed environment variable for db admin credentials in our
jenkins test.