### PR TITLE
(PDB-2565) Change =-after? to is-equal-after

### DIFF
--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -128,11 +128,11 @@
 (defn json-content-type? [response]
   (= http/json-response-content-type (get-in response [:headers "Content-Type"])))
 
-(defmacro =-after?
+(defmacro is-equal-after
   "Checks equality of `args` after
    the `func` has been applied to them"
   [func & args]
-  `(= ~@(map #(list func %) args)))
+  `(is (= ~@(map #(list func %) args))))
 
 (defn assert-success!
   "Given a Ring response, verify that the status


### PR DESCRIPTION
This wraps the entire macro in an `is` assertion. Since all cases where this was
used did this anyway, it provides more convenience. However, the main reason was
to ensure that the differential between the old and new values actually gets
printed during testing instead of simply returning the expectation of being true.

Signed-off-by: Ken Barber <ken@bob.sh>