### PR TITLE
(PDB-2482) Add ability to pass in token auth (RBAC auth) to PuppetDB

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -57,7 +57,7 @@
                  ;; Database connectivity
                  [com.zaxxer/HikariCP "2.4.3"]
                  [org.clojure/java.jdbc "0.4.2"]
-                 [org.postgresql/postgresql "9.4.1208"]
+                 [org.postgresql/postgresql "9.4.1208.jre7"]
 
                  ;; MQ connectivity
                  [org.apache.activemq/activemq-broker "5.13.2" :exclusions [org.slf4j/slf4j-api]]

--- a/project.clj
+++ b/project.clj
@@ -57,7 +57,7 @@
                  ;; Database connectivity
                  [com.zaxxer/HikariCP "2.4.3"]
                  [org.clojure/java.jdbc "0.4.2"]
-                 [org.postgresql/postgresql "9.4-1206-jdbc4"]
+                 [org.postgresql/postgresql "9.4.1208"]
 
                  ;; MQ connectivity
                  [org.apache.activemq/activemq-broker "5.13.2" :exclusions [org.slf4j/slf4j-api]]

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -334,9 +334,12 @@
 
 (defn add-web-routing-service-config
   [config-data]
-  (let [default-web-router-service {:puppetlabs.puppetdb.metrics/metrics-service "/metrics"
-                                    :puppetlabs.trapperkeeper.services.status.status-service/status-service "/status"
-                                    :puppetlabs.puppetdb.pdb-routing/pdb-routing-service "/pdb"}
+  (let [default-web-router-service {:puppetlabs.puppetdb.metrics/metrics-service
+                                    {:route "/metrics" :server "default"}
+                                    :puppetlabs.trapperkeeper.services.status.status-service/status-service
+                                    {:route "/status" :server "default"}
+                                    :puppetlabs.puppetdb.pdb-routing/pdb-routing-service
+                                    {:route "/pdb" :server "default"}}
         bootstrap-cfg (-> (find-bootstrap-config config-data)
                           slurp
                           str/split-lines)
@@ -349,7 +352,8 @@
     ;; We override the users settings as to make the above routes *not* configurable
     (update config-data :web-router-service merge default-web-router-service
             (when dashboard-redirect?
-              {:puppetlabs.puppetdb.dashboard/dashboard-redirect-service "/"}))))
+              {:puppetlabs.puppetdb.dashboard/dashboard-redirect-service
+               {:route "/" :server "default"}}))))
 
 (defn- add-mq-defaults
   [config-data]

--- a/src/puppetlabs/puppetdb/metrics/server.clj
+++ b/src/puppetlabs/puppetdb/metrics/server.clj
@@ -30,8 +30,8 @@
   should be a message describing the reason that access was denied."
   [cert-whitelist]
   (-> routes
-      mid/make-pdb-handler 
+      mid/make-pdb-handler
       mid/verify-accepts-json
       mid/validate-no-query-params
-      (mid/wrap-with-puppetdb-middleware cert-whitelist)))
+      (mid/wrap-with-puppetdb-middleware {:cert-whitelist cert-whitelist})))
 


### PR DESCRIPTION
This commit adds the ability to pass in token authorization functions to our PuppetDB middleware, these functions come from [clj-rbac-client](https://github.com/puppetlabs/clj-rbac-client) and will only be passed in to the authorization middleware in the PE
PuppetDB extensions repo, [see this PR](https://github.com/puppetlabs/pe-puppetdb-extensions/pull/175).

This commit allows us to pass in the rbac-client functions `valid-token->subject` and `is-permitted?`, [found here](https://github.com/puppetlabs/clj-rbac client/blob/master/src/puppetlabs/rbac_client/services/rbac.clj#L40) so that our cert-whitelist middleware can optionally fallback to checking for a [token](https://github.com/puppetlabs/clj-jwt) in a `X-Authentication` header in the request with which PuppetDB will use to talk to RBAC. If the subject of the token has the right permission, `puppetdb:use:*` (similar to what the Orchestrator uses for it's RBAC permission), the request is validated.

This will require us to use `client-auth: want` in our Jetty configuration for PuppetDB (by default Jetty uses `client-auth: need` which prevents requests which don't have a cert attached.

We do not cache the validity of the `token` because there is a hard requirement for revocation of permissions for tokens.

In summary:

1. Configuring PuppetDB to use a certificate-whitelist will add middleware to PuppetDB to validate requests.
2. Configuring `client-auth: want` in the Jetty config will allow SSL requests through to PuppetDB which do not have a `cert`.
3. PuppetDB will first attempt to authorize a request by checking if the ssl-client-cn is on the cert-whitelist.
4. If the ssl-client-cn is not on the whitelist, PuppetDB will check to see if the `X-Authentication` header has been set (i.e. the `token`), if it has been we query rbac for the subject of the `token`.
5. If the `token` corresponds to a valid subject, we query rbac again to see if the user has the permission `puppetdb:use:*`, and validate the request if they do.
6. If the `token` was invalid, the `subject` doesn't have the correct permissions, or no `token` was provided we respond with a `Permission denied`.