### PR TITLE
(PDB-2548) prepared statement array in resource-exists?

### DIFF
--- a/src/com/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage.clj
@@ -366,12 +366,19 @@
   {:pre  [(coll? resource-hashes)
           (every? string? resource-hashes)]
    :post [(set? %)]}
-  (let [qmarks     (str/join "," (repeat (count resource-hashes) "?"))
-        query      (format "SELECT DISTINCT resource FROM resource_params_cache WHERE resource IN (%s)" qmarks)
-        sql-params (vec (cons query resource-hashes))]
-    (sql/with-query-results result-set
-      sql-params
-      (set (map :resource result-set)))))
+  (if (sutils/postgres?)
+    (let [resource-array (sutils/array-to-param "text" String (vec resource-hashes))
+          query "SELECT DISTINCT resource FROM resource_params_cache WHERE resource=ANY(?)"
+          sql-params [query resource-array]]
+      (sql/with-query-results result-set
+        sql-params
+        (set (map :resource result-set))))
+    (let [qmarks     (str/join "," (repeat (count resource-hashes) "?"))
+          query      (format "SELECT DISTINCT resource FROM resource_params_cache WHERE resource IN (%s)" qmarks)
+          sql-params (vec (cons query resource-hashes))]
+      (sql/with-query-results result-set
+        sql-params
+        (set (map :resource result-set))))))
 
 ;;The schema definition of this function should be
 ;;resource-ref->resource-schema, but there are a lot of tests that

--- a/src/com/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/com/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -134,6 +134,12 @@
          (into-array Object)
          (.createArrayOf connection "varchar"))))
 
+(defn array-to-param
+  [col-type java-type values]
+  (.createArrayOf (sql/connection)
+                  col-type
+                  (into-array java-type values)))
+
 (defmulti sql-array-type-string
   "Returns a string representing the correct way to declare an array
   of the supplied base database type."

--- a/test/com/puppetlabs/puppetdb/test/scf/storage.clj
+++ b/test/com/puppetlabs/puppetdb/test/scf/storage.clj
@@ -1527,6 +1527,10 @@
          resources-1
          resources-2)))
 
+(deftest giant-resources-exist
+  (testing "resources-exist?"
+    (is (= #{} (resources-exist? (set (take 40000 (repeatedly random/random-string))))))))
+
 (deftest test-merge-resource-hash
   (let [ref->resource {{:type "File" :title "/tmp/foo"}
                        {:line 10}


### PR DESCRIPTION
This changes the resource-exists? function to use an array-valued prepared
statement parameter, rather than a list of parameters that could potentially
exceed max_short.