### PR TITLE
(PDB-2494) add to_string function and ability to group by function results

### DIFF
--- a/documentation/api/query/v4/ast.markdown
+++ b/documentation/api/query/v4/ast.markdown
@@ -19,6 +19,7 @@ canonical: "/puppetdb/latest/api/query/v4/ast.html"
 [entities]: ./entities.html
 [pql]: ./pql.html
 [urlencode]: http://en.wikipedia.org/wiki/Percent-encoding
+[to-char]: http://www.postgresql.org/docs/9.4/static/functions-formatting.html
 
 ## Summary
 
@@ -182,10 +183,23 @@ or
 ### `function`
 
 The **function** operator is used to call a function on the result of a
-subquery. Supported functions are `count`, `avg`, `sum`, `min`, and `max`. The
-function operator is applied within the first argument of an extract, as in
-the examples above. The `avg`, `sum`, `min`, and `max` functions will ignore
-non-numeric fact values.
+subquery. Supported functions are described below.
+
+#### `avg`, `sum`, `min`, `max`
+These functions will operator on any numeric column and take the column name as
+an argument, as in the examples above.
+
+#### `count`
+The `count` function can be used with or without a column. When no column is
+supplied, it will return the number of results in the associated subquery.
+Using the function with a column will return the number of results where the
+specified column is not null.
+
+#### `to_string`
+The `to_string` function operates on timestamps and integers, allowing them to
+be formatted in a user-defined manner before being returned from puppetdb.
+Available  formats are the same as those documented for [PostgreSQL's `to_char`
+function][to-char].
 
 ### `group_by`
 

--- a/documentation/api/query/v4/pql.markdown
+++ b/documentation/api/query/v4/pql.markdown
@@ -429,6 +429,10 @@ each fact name across all facts, where the certame starts with `web`:
 
     facts[name, count(value)] { certname ~ "^web.*" group by name }
 
+Grouping on function results is also supported:
+
+    reports[count(), to_string(receive_time, "DAY")]{group by to_string(receive_time, "DAY")}
+
 ## Paging
 
 PQL supports restriction of the result set via the SQL-like paging clauses

--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -385,6 +385,25 @@ Get counts of reports grouped by status:
       "count" : 20
     } ]
 
+Get counts of reports grouped by status and day of the week received:
+
+    curl -X GET http://localhost:8080/pdb/query/v4/reports -d
+    'query=["extract",["status", ["function", "count"], ["function", "to_string","receive_time", "FMDay"]],["group_by","status",["function","to_string","receive_time", "FMDay"]]]'
+
+    [ {
+      "status" : "failed",
+      "count" : 10,
+      "to_string" : "Thursday"
+    }, {
+      "status" : "changed",
+       "count" : 60,
+       "to_string" : "Thursday"
+    }, {
+      "status" : "unchanged",
+       "count" : 30,
+       "to_string" : "Thursday"
+    } ]
+
 ## `/pdb/query/v4/reports/<HASH>/events`
 
 Returns all events for a particular report, designated by its unique hash.

--- a/resources/puppetlabs/puppetdb/pql/pql-grammar-experimental.ebnf
+++ b/resources/puppetlabs/puppetdb/pql/pql-grammar-experimental.ebnf
@@ -74,13 +74,14 @@ condisnotnull = <'is not null'>;
 groupedfieldlist = <lbracket>, [<whitespace>], fieldlist, [<whitespace>], <rbracket>;
 <fieldlist>      = (field | function), [ [<whitespace>], <','>, [<whitespace>], fieldlist ];
 function         = functionname, [<whitespace>], groupedarglist;
-<functionname>   = 'count' | 'avg' | 'sum' | 'min' | 'max';
+<functionname>   = 'count' | 'avg' | 'sum' | 'min' | 'max' | 'to_string';
 
 groupedarglist = <lparens>, [<whitespace>], [arglist], [<whitespace>], <rparens>;
-<arglist>      = field, [ [<whitespace>], <','>, [<whitespace>], arglist ];
+<arglist>      = (field | string), [ [<whitespace>], <','>, [<whitespace>], stringlist ];
+<stringlist>   = string , [ [<whitespace>], <','>, [<whitespace>], stringlist ];
 
 (* Represents a field from an entity *)
-<field> = #'[a-zA-Z_]+\??';
+<field> = #'[a-zA-Z0-9_]+\??';
 
 <condregexp>      = '~';
 <condregexparray> = '~>';

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -107,6 +107,25 @@
              #{{:count 2
                 :min "2011-01-01T15:11:00.000Z"}})))
 
+    (testing "group by function result"
+      (is (= (query-result method endpoint
+                           ["extract" [["function" "to_string" "producer_timestamp" "FMDAY"]
+                                       ["function" "count"]]
+                            ["group_by" ["function" "to_string" "producer_timestamp" "FMDAY"]]])
+
+             #{{:to_string "SATURDAY" :count 2}})))
+
+    (testing "group by function result and a column"
+      (is (= (query-result method endpoint
+                           ["extract" ["certname"
+                                       ["function" "to_string" "producer_timestamp" "FMDAY"]
+                                       ["function" "count"]]
+                            ["group_by" "certname"
+                             ["function" "to_string" "producer_timestamp" "FMDAY"]]])
+
+             #{{:count 1 :certname "foo.local" :to_string "SATURDAY"}
+               {:count 1 :certname "bar.local" :to_string "SATURDAY"}})))
+
     (testing "projected aggregate sum call"
       (is (= (query-result method endpoint ["extract" ["status"]
                                             ["group_by" "status"]])

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -138,7 +138,7 @@
                     (compile-user-query->sql reports-query)
                     :results-query
                     first)))
-  (is (re-find #"SELECT.* count\(reports.certname\) AS count .*FROM reports"
+  (is (re-find #"SELECT count\(reports.certname\) count FROM reports"
                (->> ["extract" [["function" "count" "certname"]]]
                     (compile-user-query->sql reports-query)
                     :results-query


### PR DESCRIPTION
This adds a to_string function that wraps PG's to_char function, and also
allows consumers to group by the results of a function, allowing users to get
counts of events by hour and similar.