### PR TITLE
(PDB-2490) add latest_report_noop field to nodes

### DIFF
--- a/documentation/api/query/tutorial-pql.markdown
+++ b/documentation/api/query/tutorial-pql.markdown
@@ -305,6 +305,7 @@ The result of this query is:
         "certname" : "foo.example.com",
         "catalog_timestamp" : "2015-06-22T17:25:12.023Z",
         "latest_report_hash" : "754b0b87af9ee647507b5aa3001f44f8e8843216",
+        "latest_report_noop": true,
         "latest_report_status" : "unchanged"
     } ]
 
@@ -402,6 +403,7 @@ facts relating to the node:
         "certname" : "foo.example.com",
         "catalog_timestamp" : "2015-06-22T17:25:12.023Z",
         "latest_report_hash" : "754b0b87af9ee647507b5aa3001f44f8e8843216",
+        "latest_report_noop": true,
         "latest_report_status" : "unchanged"
     } ]
 

--- a/documentation/api/query/v4/index.markdown
+++ b/documentation/api/query/v4/index.markdown
@@ -52,6 +52,7 @@ object results based on the [entity][entities] provided in the top-level [`from`
         "facts_timestamp": "2015-11-23T19:25:25.079Z",
         "latest_report_hash": "0b2aa3bbb1deb71a5328c1d934eadbba5f52d733",
         "latest_report_status": "unchanged",
+        "latest_report_noop": true,
         "report_environment": "production",
         "report_timestamp": "2015-11-23T19:25:23.394Z"
       }
@@ -72,6 +73,7 @@ The same query can also be executed using [PQL][pql]:
         "facts_timestamp": "2015-11-23T19:25:25.079Z",
         "latest_report_hash": "0b2aa3bbb1deb71a5328c1d934eadbba5f52d733",
         "latest_report_status": "unchanged",
+        "latest_report_noop": true,
         "report_environment": "production",
         "report_timestamp": "2015-11-23T19:25:23.394Z"
       }

--- a/documentation/api/query/v4/nodes.markdown
+++ b/documentation/api/query/v4/nodes.markdown
@@ -61,6 +61,9 @@ The below fields are allowed as filter criteria and are returned in all response
 * `latest_report_status` (string): the status of the latest report. Possible values
   come from Puppet's report status, which can be found [here][statuses].
 
+* `latest_report_noop` (boolean): indicates whether the most recent report for
+  the node was a noop run.
+
 * `latest_report_hash` (string): a hash of the latest report for the node.
 
 * `["fact", <FACT NAME>]` (string, number, Boolean): the value of `<FACT NAME>` for a node. Inequality operators are allowed, and will skip non-numeric values.
@@ -97,6 +100,7 @@ The response is a JSON array of hashes, where each hash has the form:
      "facts_environment": <string or null>,
      "report_environment": <string or null>,
      "latest_report_status": <string>,
+     "latest_report_noop": <boolean>,
      "latest_report_hash": <string>
     }
 
@@ -144,6 +148,7 @@ of `["=", "certname", "<NODE>"]`.
         "certname" : "mbp.local",
         "catalog_timestamp" : "2015-06-19T23:03:43.007Z",
         "latest_report_status": "success",
+        "latest_report_noop": false,
         "latest_report_hash": "2625d1b601e98ed1e281ccd79ca8d16b9f74fea6"
     }
 

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -94,6 +94,9 @@
                                                    :queryable? true
                                                    :field (hsql-hash-as-str
                                                             :reports.hash)}
+                             "latest_report_noop" {:type :boolean
+                                                   :queryable? true
+                                                   :field :reports.noop}
                              "latest_report_status" {:type :string
                                                      :queryable? true
                                                      :field :report_statuses.status}

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -43,7 +43,7 @@
     (doseq [res result]
       (is (= #{:certname :deactivated :expired :catalog_timestamp :facts_timestamp :report_timestamp
                :catalog_environment :facts_environment :report_environment
-               :latest_report_status :latest_report_hash} (keyset res))
+               :latest_report_status :latest_report_hash :latest_report_noop} (keyset res))
           (str "Query was: " query))
       (is (= (set expected) (set (mapv :certname result)))
           (str "Query was: " query)))
@@ -95,6 +95,10 @@
       (is-query-result' ["=" "latest_report_status" "success"] [])
       (is-query-result' ["=" "latest_report_status" "failure"] [])
       (is-query-result' ["=" "latest_report_status" "unchanged"] [web1 db puppet]))
+
+    (testing "querying on latest report noop works"
+      (is-query-result' ["=" "latest_report_noop" true] [])
+      (is-query-result' ["=" "latest_report_noop" false] [web1 db puppet]))
 
     (testing "basic equality works for facts, and is based on string equality"
       (is-query-result' ["=" ["fact" "operatingsystem"] "Debian"] [db web1 web2])


### PR DESCRIPTION
This adds a latest_report_noop flag to the nodes response to indicate whether
the latest puppet run for a node was a noop.