### PR TITLE
(PDB-2577) Fix environment method stubbing for indirector tests

### DIFF
--- a/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
@@ -18,7 +18,7 @@ describe Puppet::Resource::Puppetdb do
       # The API for creating scope objects is different between Puppet 2.7 and
       # 3.0. The scope here isn't really used for anything relevant, so it's
       # easiest to make it a stub to run against both versions of Puppet.
-      scope = stub('scope', :source => nil)
+      scope = stub('scope', :source => nil, :environment => 'production')
       args = { :host => host, :filter => nil, :scope => scope }
       Puppet::Resource.indirection.search(type, args)
     end


### PR DESCRIPTION
Puppet master branch (4.5.0 in the future) has added extra expectation on the scope object
now, in that it expects to be able to call environment. This patch fixes our tests so the
stub included environment also.

Signed-off-by: Ken Barber <ken@bob.sh>