### PR TITLE
(PDB-2581) set max connection size

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -402,7 +402,7 @@ When the pool reaches this size, and no idle connections are available, attempts
 to get a connection will wait for `connection-timeout` milliseconds before timing
 out.
 
-The default value is 10.
+The default value is 20.
 
 ### `conn-max-age`
 

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -54,7 +54,7 @@
      :conn-max-age (pls/defaulted-maybe s/Int 60)
      :conn-keep-alive (pls/defaulted-maybe s/Int 45)
      :conn-lifetime (s/maybe s/Int)
-     :maximum-pool-size (pls/defaulted-maybe s/Int 10)
+     :maximum-pool-size (pls/defaulted-maybe s/Int 20)
      :classname (pls/defaulted-maybe String "org.postgresql.Driver")
      :subprotocol (pls/defaulted-maybe String "postgresql")
      :subname (s/maybe String)

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -373,7 +373,8 @@
             conn-max-age
             conn-lifetime
             read-only?
-            pool-name]
+            pool-name
+            maximum-pool-size]
      :as db-spec}
     metrics-registry]
    (let [conn-lifetime-ms (some-> conn-max-age pl-time/to-millis)
@@ -385,6 +386,7 @@
        (.setInitializationFailFast false))
      (some->> pool-name (.setPoolName config))
      (some->> connection-timeout (.setConnectionTimeout config))
+     (some->> maximum-pool-size (.setMaximumPoolSize config))
      (when (and conn-max-age-ms conn-lifetime-ms (> conn-max-age-ms conn-lifetime-ms))
        (some->> conn-max-age-ms (.setIdleTimeout config)))
      (some->> conn-lifetime-ms (.setMaxLifetime config))

--- a/test/puppetlabs/puppetdb/jdbc_test.clj
+++ b/test/puppetlabs/puppetdb/jdbc_test.clj
@@ -49,7 +49,24 @@
                          ""
                          (catch java.sql.SQLException ex
                            (full-sql-exception-msg ex)))]
-               (is (re-find #"read-only.*transaction" msg))))))))))
+               (is (re-find #"read-only.*transaction" msg)))))))))
+
+  (testing "max connections setting defaults to 20"
+    (call-with-antonym-test-database
+      (fn []
+        (let [pool (-> *db*
+                       defaulted-read-db-config
+                       subject/pooled-datasource)]
+          (is (= 20 (.getMaximumPoolSize (:datasource pool))))))))
+
+  (testing "max connections setting takes effect"
+    (call-with-antonym-test-database
+      (fn []
+        (let [pool (-> *db*
+                       defaulted-read-db-config
+                       (assoc :maximum-pool-size 5)
+                       subject/pooled-datasource)]
+          (is (= 5 (.getMaximumPoolSize (:datasource pool)))))))))
 
 (deftest-antonyms query-to-vec
   (testing "query string only"


### PR DESCRIPTION
This patch raises the default number of pool connections fro 10 to 20 (same as
in all previous PDB releases) and fixes a bug where the configuration option
was not actually being applied.