### PR TITLE
(maint) improve dotestseq macro

### DIFF
--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -33,7 +33,11 @@
     `(do ~@body)
     (let [case-versions (remove keyword? (take-nth 2 bindings))]
       `(doseq ~bindings
-         (testing (str "Testing case " '~case-versions)
+         (testing (str "Testing case: " (clojure.string/join
+                                          ", "
+                                          (map #(str %1 ": " %2)
+                                               '~case-versions
+                                               (list ~@case-versions))))
            ~@body)))))
 
 (defmacro without-jmx


### PR DESCRIPTION
Before this commit the ```dotestseq``` macro didn't show the values of the bindings per iteration in the test name, only the names of them.

    Testing case ([version endpoint] method)
    Testing case ([version endpoint] method)
    Testing case ([version endpoint] method)
    Testing case ([version endpoint] method)

This commit imoproves the macro such that it now produces better annotated test names like so:

    Testing case: [version endpoint]: [:v4 "/v4/catalogs/foo/edges"], method: :get
    Testing case: [version endpoint]: [:v4 "/v4/catalogs/foo/edges"], method: :post
    Testing case: [version endpoint]: [:v4 "/v4/catalogs/foo/resources"], method: :get
    Testing case: [version endpoint]: [:v4 "/v4/catalogs/foo/resources"], method: :post