### PR TITLE
(PDB-2625) Upgrade raynes.fs to 1.4.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,9 +9,9 @@
    :password :env/nexus_jenkins_password
    :sign-releases false})
 
-(def tk-version "1.2.0")
+(def tk-version "1.3.1")
 (def tk-jetty9-version "1.5.0")
-(def ks-version "1.2.0")
+(def ks-version "1.3.0")
 (def tk-status-version "0.3.1")
 (def i18n-version "0.2.1")
 
@@ -46,7 +46,7 @@
                  [metrics-clojure "2.6.1" :exclusions [org.clojure/clojure org.slf4j/slf4j-api]]
                  [clj-time "0.11.0"]
                  ;; Filesystem utilities
-                 [me.raynes/fs "1.4.5"]
+                 [me.raynes/fs "1.4.6"]
                  [org.apache.commons/commons-lang3 "3.3.1"]
                  ;; Version information
                  [puppetlabs/dujour-version-check "0.1.3"]

--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -412,7 +412,7 @@
   (count [this] @queue-count))
 
 (defn amq-broker-buffer [broker-name endpoint-name]
-  (let [dir (fs/absolute-path broker-name)
+  (let [dir (kitchensink/absolute-path broker-name)
         conn-str (str "vm://" broker-name
                       "?broker.useJmx=false"
                       "&broker.enableStatistics=false"

--- a/src/puppetlabs/puppetdb/cli/import.clj
+++ b/src/puppetlabs/puppetdb/cli/import.clj
@@ -63,7 +63,7 @@
 (defn -main
   [& args]
   (let [{:keys [infile base-url]} (validate-cli! args)
-        import-archive (fs/normalized-path infile)
+        import-archive (fs/normalized infile)
         command-versions (:command_versions (parse-metadata import-archive))]
     (try
       (println (str "[deprecated] The PuppetDB import command is deprecated in "

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -258,7 +258,7 @@
   [config]
   (let [vardir (some-> (get-in config [:global :vardir])
                        io/file
-                       fs/absolute-path
+                       kitchensink/absolute-path
                        fs/file)]
     (cond
      (nil? vardir)

--- a/test/puppetlabs/puppetdb/middleware_test.clj
+++ b/test/puppetlabs/puppetdb/middleware_test.clj
@@ -143,7 +143,7 @@
   (testing "should log on reject"
     (let [wl (temp-file "whitelist-log-reject")]
       (spit wl "foobar")
-      (let [authorizer-fn (build-whitelist-authorizer (fs/absolute-path wl))]
+      (let [authorizer-fn (build-whitelist-authorizer (kitchensink/absolute-path wl))]
         (is (= :authorized (authorizer-fn {:ssl-client-cn "foobar"})))
         (with-log-output logz
           (is (string? (authorizer-fn {:ssl-client-cn "badguy"})))

--- a/test/puppetlabs/puppetdb/mq_test.clj
+++ b/test/puppetlabs/puppetdb/mq_test.clj
@@ -2,6 +2,7 @@
   (:import [org.apache.activemq ScheduledMessage]
            [org.apache.activemq.broker BrokerService])
   (:require [me.raynes.fs :as fs]
+            [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.mq :refer :all :as mq]
             [puppetlabs.puppetdb.testutils :refer :all]
             [clojure.test :refer :all]
@@ -53,7 +54,7 @@
       ;; restarting the broker ourselves is still needed.
       ;;
       ;; Upstream bug is: https://issues.apache.org/jira/browse/AMQ-4339
-      (let [dir (fs/absolute-path (fs/temp-dir "corrupt-kahadb-handling"))
+      (let [dir (kitchensink/absolute-path (fs/temp-dir "corrupt-kahadb-handling"))
             broker-name  "test"]
         (try
           ;; Start and stop a broker, then corrupt the journal
@@ -71,7 +72,7 @@
       ;; Current work-around is to restart the broker upon this kind of
       ;; corruption. This test makes sure this continues to work for the
       ;; lifetime of this code.
-      (let [dir (fs/absolute-path (fs/temp-dir "ignore-kahadb-corruption"))
+      (let [dir (kitchensink/absolute-path (fs/temp-dir "ignore-kahadb-corruption"))
             broker-name "test"]
         (try
           ;; Start and stop a broker, then corrupt the journal

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -20,7 +20,7 @@
             [ring.mock.request :as mock]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.jdbc :as jdbc]
-            [puppetlabs.kitchensink.core :refer [parse-int excludes? keyset mapvals]]
+            [puppetlabs.kitchensink.core :refer [parse-int excludes? keyset mapvals absolute-path]]
             [environ.core :refer [env]]
             [clojure.test :refer :all]
             [clojure.set :refer [difference]]
@@ -52,7 +52,7 @@
   duration of the call.  Wrap with without-jmx to disable JMX."
   [name conn-var & body]
   `(with-log-output broker-logs#
-     (let [dir#                   (fs/absolute-path (fs/temp-dir "test-broker"))
+     (let [dir#                   (absolute-path (fs/temp-dir "test-broker"))
            broker-name#           ~name
            conn-str#              (str "vm://" ~name)
            size-megs#              50

--- a/test/puppetlabs/puppetdb/testutils/log.clj
+++ b/test/puppetlabs/puppetdb/testutils/log.clj
@@ -152,7 +152,7 @@
 
 (defn- call-with-log-suppressed-unless-notable [notable-event? f]
   (let [problem (atom false)
-        log-path (fs/absolute-path (temp-file "pdb-suppressed" ".log"))]
+        log-path (kitchensink/absolute-path (temp-file "pdb-suppressed" ".log"))]
     (try
       (with-started
         [appender (suppressing-file-appender log-path)

--- a/test/puppetlabs/puppetdb/testutils/repl.clj
+++ b/test/puppetlabs/puppetdb/testutils/repl.clj
@@ -26,7 +26,7 @@
          (string? config)
          (fs/exists? config)]}
   (let [new-config-file (testutils/temp-file "config" ".ini")
-        config-path (fs/absolute-path new-config-file)]
+        config-path (kitchensink/absolute-path new-config-file)]
     (println "Writing current config to" config-path)
     (kitchensink/spit-ini new-config-file (merge-with merge (kitchensink/ini-to-map config) config-overrides))
     (svcs/-main "--config" config-path)))


### PR DESCRIPTION
This harmonizes the version of raynes.fs with the one used in other
projects.

This requires upgrading kitchensink and trapperkeeper as well, because
raynes.fs 1.4.6 is backward-incompatible with 1.4.5. Specifically, the
absolute-path and normalized-path functions are removed. Those functions
have been added to kitchensink 1.3.0, so we now use the kitchensink
version. Because trapperkeeper 1.2.0 also depended on fs 1.4.5 (and is
thus broken by upgrading it), it's also now version 1.3.1.