### PR TITLE
(maint) Add puppet-agent libs to load path

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,8 @@
+# We need access to the ruby libraries installed via puppet-agent
+# More specifically, we need access to Facter to satisfy the
+# dependency on line 8
+$LOAD_PATH.push("/opt/puppetlabs/puppet/lib/ruby/vendor_ruby")
+
 require 'rake'
 require 'erb'
 require 'facter'


### PR DESCRIPTION
When we build puppetdb, we require access to the facter library.
Unfortunately, this is under the Ruby Lib path installed with
puppet-agent. System ruby, which we are currently using to build,
doesn't have access to this libdir. This appends the puppet-agent
vendor_lib path to the search path so system ruby can find Facter.