### PR TITLE
(PDB-2620) Remove runtime validation of reports in storage

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -132,7 +132,10 @@
                                   [org.clojure/test.check "0.5.9"]
                                   [environ "1.0.2"]
                                   [org.clojure/tools.cli "0.3.3"] ; prevents dependency clash caused by lein-cloverage
-                                  [riddley "0.1.12"]]}
+                                  [riddley "0.1.12"]]
+                   :injections [(do
+                                  (require 'schema.core)
+                                  (schema.core/set-fn-validation! true))]}
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1235,7 +1235,7 @@
                                    reports/resources->resource-events
                                    (map normalize-resource-event)))))
 
-(pls/defn-validated add-report!*
+(s/defn add-report!*
   "Helper function for adding a report.  Accepts an extra parameter, `update-latest-report?`, which
   is used to determine whether or not the `update-latest-report!` function will be called as part of
   the transaction.  This should always be set to `true`, except during some very specific testing
@@ -1393,7 +1393,7 @@
              (log/warnf "Not updating facts for certname %s because local data is newer." certname))
            (add-facts! fact-data))))
 
-(pls/defn-validated add-report!
+(s/defn add-report!
   "Add a report and all of the associated events to the database."
   [report :- reports/report-wireformat-schema
    received-timestamp :- pls/Timestamp]


### PR DESCRIPTION
We currently validate reports in puppetdb/command.clj and then
re-validate those reports twice in puppetdb/scf/storage.clj. This second
and third validation is very CPU intensive. Some load testing has
revealed as much as 30% of the CPU usage was dedicated to this purpose.

This inefficientcy is mainly spent on unchanged resources and would
likely only be observed on catalogs that have a large number of
unchanged resources.