### PR TITLE
(PDB-2527) allow latest-report? to be used in legacy events queries

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1024,6 +1024,11 @@
    "UPDATE catalogs SET catalog_uuid=catalogs.transaction_uuid WHERE hash is NULL"
    "UPDATE reports SET catalog_uuid=reports.transaction_uuid WHERE hash is NULL"))
 
+(defn index-certnames-latest-report-id
+  []
+  (jdbc/do-commands
+    "CREATE INDEX idx_certnames_latest_report_id on certnames(latest_report_id)"))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1045,7 +1050,8 @@
    41 factset-hash-field-not-nullable
    42 add-support-for-historical-catalogs
    43 add-indexes-for-reports-summary-query
-   44 add-catalog-uuid-to-reports-and-catalogs})
+   44 add-catalog-uuid-to-reports-and-catalogs
+   45 index-certnames-latest-report-id})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/test/puppetlabs/puppetdb/http/aggregate_event_counts_test.clj
+++ b/test/puppetlabs/puppetdb/http/aggregate_event_counts_test.clj
@@ -91,7 +91,48 @@
          ["=" "certname" "foo.local"]
          ["<=" "report_receive_time" current-time-str]
          ["<=" "run_start_time" current-time-str]
-         ["<=" "run_end_time" current-time-str])))
+         ["<=" "run_end_time" current-time-str]))
+
+  (store-example-report! (:basic2 reports) (coerce/to-string (now)))
+
+  (are [result query] (= result
+                         (query-result method endpoint query
+                                       {:summarize_by "resource"
+                                        :distinct_resources true
+                                        :distinct_start_time 0
+                                        :distinct_end_time (now)}))
+
+       #{{:summarize_by "resource"
+          :successes 3
+          :failures 0
+          :noops 0
+          :skips 0
+          :total 3}}
+       ["=" "latest_report?" true]
+
+       #{{:summarize_by "resource"
+          :successes 4
+          :failures 1
+          :noops 0
+          :skips 1
+          :total 6}}
+       []
+
+       #{{:summarize_by "resource"
+          :successes 1
+          :failures 1
+          :noops 0
+          :skips 1
+          :total 3}}
+       ["=" "latest_report?" false]
+
+       #{{:summarize_by "resource"
+          :successes 3
+          :failures 0
+          :noops 0
+          :skips 0
+          :total 3}}
+       ["and" ["=" "latest_report?" true] ["=" "certname" "foo.local"]]))
 
 (deftest-http-app query-with-environment
   [[version endpoint] endpoints
@@ -168,4 +209,12 @@
           :noops 0
           :total 0
           :summarize_by "resource"}}
-       ["<" "timestamp" 0]))
+       ["<" "timestamp" 0]
+
+       #{{:summarize_by "resource"
+          :successes 5
+          :failures 0
+          :noops 0
+          :skips 1
+          :total 6}}
+       ["=" "latest_report?" true]))

--- a/test/puppetlabs/puppetdb/http/event_counts_test.clj
+++ b/test/puppetlabs/puppetdb/http/event_counts_test.clj
@@ -268,6 +268,53 @@
                                :distinct_end_time (now)})
                 result))
 
+
+         ["=" "latest_report?" true]
+         #{{:failures 0
+            :successes 1
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify"
+                      :title "notify, yo"}}
+           {:failures 1
+            :successes 0
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify"
+                      :title "notify, yar"}}
+           {:failures 0
+            :successes 0
+            :noops 0
+            :skips 1
+            :subject_type "resource"
+            :subject {:type "Notify"
+                      :title "hi"}}}
+
+         ["=" "latest_report?" false]
+         #{{:failures 0
+            :successes 1
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify"
+                      :title "notify, yo"}}
+           {:failures 0
+            :successes 1
+            :noops 0
+            :skips 0
+            :subject_type "resource"
+            :subject {:type "Notify"
+                      :title "notify, yar"}}
+           {:failures 0
+            :successes 0
+            :noops 0
+            :skips 1
+            :subject_type "resource"
+            :subject {:type "Notify"
+                      :title "hi"}}}
+
          ["=" "certname" "foo.local"]
          #{{:subject_type "resource"
             :subject {:type "Notify" :title "notify, yo"}

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -260,6 +260,15 @@
                                     munge-event-values)]
         (is (= response expected))))
 
+    (testing "distinct resources should work with latest_report?"
+      (let [expected (expected-resource-events basic3-events basic3)
+            response (query-result method endpoint ["=" "latest_report?" true]
+                                   {:distinct_resources true
+                                    :distinct_start_time 0
+                                    :distinct_end_time (now)}
+                                   munge-event-values)]
+        (is (= response expected))))
+
     (testing "events should be contained within distinct resource timestamps"
       (let [expected  (expected-resource-events basic-events basic)
             response  (query-result method endpoint ["=" "certname" "foo.local"]

--- a/test/puppetlabs/puppetdb/query/events_test.clj
+++ b/test/puppetlabs/puppetdb/query/events_test.clj
@@ -22,7 +22,7 @@
         ops (query/resource-event-ops version)]
     (testing "should succesfully compile a valid equality query"
       (is (= (query/compile-term ops ["=" "report" "blah"])
-             {:where   (format "%s = ?" (sutils/sql-hash-as-str "latest_events.hash"))
+             {:where   (format "%s = ?" (sutils/sql-hash-as-str "reports.hash"))
               :params  ["blah"]})))
     (testing "should fail with an invalid equality query"
       (is (thrown-with-msg?


### PR DESCRIPTION
* adds an index on certnames(latest_report_id)
* fixes a bug preventing latest_report? usage with the distinct_resources parameter
* moves query logic for unioned aggregate-event-counts queries from the
  aggregations to the CTE