### PR TITLE
(PDB-2624) allow colons in routes

### DIFF
--- a/src/puppetlabs/puppetdb/http/handlers.clj
+++ b/src/puppetlabs/puppetdb/http/handlers.clj
@@ -70,7 +70,7 @@
                               (http-q/narrow-globals globals)))))
 
 (defn route-param [param-name]
-  [#"[\w%\.~-]*" param-name])
+  [#"[\w%\.~:-]*" param-name])
 
 ;; Handlers checking for a single entity
 
@@ -171,7 +171,7 @@
    (cmdi/routes
     (cmdi/ANY "" []
               (create-query-handler version "resources"  http-q/restrict-query-to-active-nodes))
-    
+
     (cmdi/context ["/" (route-param :type)]
                   (cmdi/ANY "" []
                             (create-query-handler version "resources"
@@ -204,10 +204,10 @@
                   (cmdi/context "/edges"
                                 (-> (edge-routes version)
                                     (wrap-with-parent-check version :catalog :node)))
-                                
+
                   (cmdi/context "/resources"
                                 (-> (resources-routes version)
-                                    (append-handler http-q/restrict-query-to-node) 
+                                    (append-handler http-q/restrict-query-to-node)
                                     (wrap-with-parent-check version :catalog :node)))))))
 
 (pls/defn-validated facts-routes :- bidi-schema/RoutePair
@@ -218,10 +218,10 @@
               (create-query-handler version "facts" http-q/restrict-query-to-active-nodes))
 
     (cmdi/context ["/" (route-param :fact)]
-                  
+
                   (cmdi/ANY "" []
                             (create-query-handler version "facts"
-                                            http-q/restrict-fact-query-to-name 
+                                            http-q/restrict-fact-query-to-name
                                             http-q/restrict-query-to-active-nodes))
 
                   (cmdi/ANY ["/" (route-param :value)] []

--- a/test/puppetlabs/puppetdb/http/explore_test.clj
+++ b/test/puppetlabs/puppetdb/http/explore_test.clj
@@ -138,6 +138,11 @@
          resources response (get-response "resources/Foobar")
          (is (= resources []))))
 
+      (testing "colon allowed in resource type param"
+        (check-json-response
+          resources response (get-response "resources/foo::bar")
+          (is (= resources []))))
+
       (testing "/resources/<type>/<title> should return all resources matching the supplied type/title"
         (check-json-response
          resources response (get-response "resources/File/%2Fetc%2Ffoobar")


### PR DESCRIPTION
Fixes a regex bug introduced in the switch to comidi, which disallowed colons
in routes (e.g resource types/titles, etc). Strips a bit of incidental trailing whitespace too.