### PR TITLE
Add a basic checking of the "query" parameter in the function puppetdb_query()

### DIFF
--- a/puppet/lib/puppet/functions/puppetdb_query.rb
+++ b/puppet/lib/puppet/functions/puppetdb_query.rb
@@ -1,5 +1,9 @@
 require 'puppet/util/puppetdb'
 Puppet::Functions.create_function(:puppetdb_query) do
+  dispatch :puppetdb_query do
+    required_param 'Variant[String[1], Array[Data, 1]]', :query
+  end
+
   def puppetdb_query(query)
     Puppet::Util::Puppetdb.query_puppetdb(query)
   end


### PR DESCRIPTION
To be compatible with Puppet 4.0.0 where recursive types
are not possible, the type checked here is not accurate.
Ideally, the type should be:

  Variant[String[1], StringTree]

where StringTree is defined (recursively) by:

  StringTree = Array[Variant[String, StringTree]]