### PR TITLE
(PDB-2477) Drop constraints while sweeping reports/nodes

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -439,9 +439,29 @@
     "ALTER TABLE ONLY resource_params
         ADD CONSTRAINT resource_params_resource_fkey FOREIGN KEY (resource) REFERENCES resource_params_cache(resource) ON DELETE CASCADE"))
 
+(def add-factset-id-fk-constraint-cmd
+  "alter table facts add constraint factset_id_fk
+     foreign key (factset_id) references factsets(id)
+     on update cascade on delete cascade")
+
 (def add-resource-events-report-id-fkey-constraint-cmd
   "alter table resource_events add constraint resource_events_report_id_fkey
      foreign key (report_id) references reports(id) on delete cascade")
+
+(def add-catalogs-certname-fkey-constraint-cmd
+  "alter table catalogs add constraint catalogs_certname_fkey
+     foreign key (certname) references certnames(certname)
+     on update no action on delete cascade")
+
+(def add-factsets-certname-fk-constraint-cmd
+  "alter table factsets add constraint factsets_certname_fk
+     foreign key (certname) references certnames(certname)
+     on update cascade on delete cascade")
+
+(def add-reports-certname-fk-constraint-cmd
+  "alter table reports add constraint reports_certname_fkey
+     foreign key (certname) references certnames(certname)
+     on delete cascade")
 
 (def add-certnames-reports-id-fkey-constraint-cmd
   "alter table certnames add constraint certnames_reports_id_fkey
@@ -745,9 +765,9 @@
       "ALTER TABLE factsets ADD CONSTRAINT factsets_environment_id_fk
        FOREIGN KEY (environment_id) REFERENCES environments(id)
        ON UPDATE RESTRICT ON DELETE RESTRICT"
-      "ALTER TABLE facts ADD CONSTRAINT factset_id_fk
-       FOREIGN KEY (factset_id) REFERENCES factsets(id)
-       ON UPDATE CASCADE ON DELETE CASCADE"
+
+      add-factset-id-fk-constraint-cmd
+
       "ALTER TABLE factsets ADD CONSTRAINT factsets_certname_idx
          UNIQUE (certname)"
       "ALTER TABLE factsets ADD CONSTRAINT factsets_hash_key UNIQUE (hash)"
@@ -764,16 +784,10 @@
       "ALTER TABLE edges ADD CONSTRAINT edges_certname_fkey
          FOREIGN KEY (certname) REFERENCES certnames(certname)
          ON UPDATE NO ACTION ON DELETE CASCADE"
-      "ALTER TABLE catalogs ADD CONSTRAINT catalogs_certname_fkey
-         FOREIGN KEY (certname) REFERENCES certnames(certname)
-         ON UPDATE NO ACTION ON DELETE CASCADE"
-      "ALTER TABLE factsets ADD CONSTRAINT factsets_certname_fk
-         FOREIGN KEY (certname) REFERENCES certnames(certname)
-         ON UPDATE CASCADE ON DELETE CASCADE"
-      "ALTER TABLE reports ADD CONSTRAINT reports_certname_fkey
-         FOREIGN KEY (certname) REFERENCES certnames(certname)
-         ON DELETE CASCADE"
 
+      add-catalogs-certname-fkey-constraint-cmd
+      add-factsets-certname-fk-constraint-cmd
+      add-reports-certname-fk-constraint-cmd
       add-certnames-reports-id-fkey-constraint-cmd)))
 
 (defn add-expired-to-certnames
@@ -867,8 +881,14 @@
    "ALTER TABLE catalog_resources RENAME TO catalog_resources_tmp"
    ;; CREATE certnames and catalog_resources transform tables
    "CREATE TABLE catalog_resources (LIKE catalog_resources_tmp INCLUDING ALL)"
+   ;; Make sure to update the constraints in
+   ;; purge-deactivated-and-expired-nodes-new! if you change
+   ;; the columns here.
    "CREATE TABLE latest_catalogs (catalog_id BIGINT NOT NULL UNIQUE REFERENCES catalogs(id) ON DELETE CASCADE, certname_id BIGINT PRIMARY KEY REFERENCES certnames(id) ON DELETE CASCADE)"
    "ALTER TABLE catalog_resources DROP COLUMN catalog_id"
+   ;; Make sure to update the constraint in
+   ;; purge-deactivated-and-expired-nodes-new! if you change
+   ;; the columns here.
    "ALTER TABLE catalog_resources ADD COLUMN certname_id BIGINT NOT NULL REFERENCES certnames(id) ON DELETE CASCADE"
    "ALTER TABLE catalog_resources ADD PRIMARY KEY (certname_id, type, title)"
 
@@ -958,19 +978,11 @@
    "ALTER TABLE certnames DROP CONSTRAINT certnames_pkey CASCADE"
    "DROP TABLE certnames"
    "ALTER TABLE certnames_transform RENAME to certnames"
-   "ALTER TABLE catalogs ADD CONSTRAINT catalogs_certname_fkey
-     FOREIGN KEY (certname) REFERENCES certnames(certname)
-     ON UPDATE NO ACTION ON DELETE CASCADE"
-   "ALTER TABLE factsets ADD CONSTRAINT factsets_certname_fk
-     FOREIGN KEY (certname) REFERENCES certnames(certname)
-     ON UPDATE CASCADE ON DELETE CASCADE"
-   "ALTER TABLE reports ADD CONSTRAINT reports_certname_fkey
-     FOREIGN KEY (certname)
-     REFERENCES certnames(certname) ON DELETE CASCADE"
 
-   "ALTER TABLE certnames ADD CONSTRAINT certnames_reports_id_fkey
-      FOREIGN KEY (latest_report_id)
-      REFERENCES reports(id) ON DELETE SET NULL"))
+   add-catalogs-certname-fkey-constraint-cmd
+   add-factsets-certname-fk-constraint-cmd
+   add-reports-certname-fk-constraint-cmd
+   add-certnames-reports-id-fkey-constraint-cmd))
 
 (defn add-certname-id-to-resource-events
   []
@@ -1020,8 +1032,8 @@
      ON resource_events(resource_title)"
    "CREATE INDEX resource_events_status_idx ON resource_events(status)"
    "CREATE INDEX resource_events_timestamp_idx ON resource_events(timestamp)"
-   "ALTER TABLE resource_events ADD CONSTRAINT resource_events_report_id_fkey
-     FOREIGN KEY (report_id) REFERENCES reports(id) ON DELETE CASCADE"))
+
+   add-resource-events-report-id-fkey-constraint-cmd))
 
 (defn add-catalog-uuid-to-reports-and-catalogs
   []

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -439,6 +439,15 @@
     "ALTER TABLE ONLY resource_params
         ADD CONSTRAINT resource_params_resource_fkey FOREIGN KEY (resource) REFERENCES resource_params_cache(resource) ON DELETE CASCADE"))
 
+(def add-resource-events-report-id-fkey-constraint-cmd
+  "alter table resource_events add constraint resource_events_report_id_fkey
+     foreign key (report_id) references reports(id) on delete cascade")
+
+(def add-certnames-reports-id-fkey-constraint-cmd
+  "alter table certnames add constraint certnames_reports_id_fkey
+     foreign key (latest_report_id) references reports(id)
+     on delete set null")
+
 (defn version-2yz-to-300-migration
   ;; This migration includes:
   ;;   Insertion of the factsets hash column
@@ -745,8 +754,8 @@
 
       "ALTER TABLE resource_events ADD CONSTRAINT resource_events_unique
          UNIQUE (report_id, resource_type, resource_title, property)"
-      "ALTER TABLE resource_events ADD CONSTRAINT resource_events_report_id_fkey
-         FOREIGN KEY (report_id) REFERENCES reports(id) ON DELETE CASCADE"
+
+      add-resource-events-report-id-fkey-constraint-cmd
 
       "ALTER TABLE certnames ADD CONSTRAINT certnames_pkey
          PRIMARY KEY (certname)"
@@ -765,9 +774,7 @@
          FOREIGN KEY (certname) REFERENCES certnames(certname)
          ON DELETE CASCADE"
 
-      "ALTER TABLE certnames ADD CONSTRAINT certnames_reports_id_fkey
-         FOREIGN KEY (latest_report_id) REFERENCES reports(id)
-         ON DELETE SET NULL")))
+      add-certnames-reports-id-fkey-constraint-cmd)))
 
 (defn add-expired-to-certnames
   "Add a 'expired' column to the 'certnames' table, to track

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1370,6 +1370,15 @@
                  "select certname from certnames order by certname asc"))
            ["node1" "node3"]))))
 
+(deftest-db node-expiration-does-not-change-schema
+  (add-certname! "node1")
+  (let [initial-schema (schema-info-map *db*)]
+    (expire-node! "node1" (-> 3 days ago))
+    (purge-deactivated-and-expired-nodes! (now))
+    (is (= {:index-diff nil, :table-diff nil}
+           (diff-schema-maps initial-schema
+                             (schema-info-map *db*))))))
+
 (deftest-db report-sweep-nullifies-latest-report
   (testing "ensure that if the latest report is swept, latest_report_id is updated to nil"
     (let [report1 (assoc (:basic reports) :end_time (-> 12 days ago))


### PR DESCRIPTION
Drop contraints while sweeping reports (and reestablish them afterward)
to avoid triggering per-report checks during delete.

This appears to substantially decrease the sweep time, and we believe it
should be safe because all of the operations involved should be covered
by PostgreSQL MVCC (i.e. guarded by the transaction).