### PR TITLE
(PDB-2621) Force all textual errors to be text/plain

### DIFF
--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -5,7 +5,6 @@
             [puppetlabs.puppetdb.query-eng :as qe]
             [puppetlabs.puppetdb.utils.metrics :refer [multitime!]]
             [puppetlabs.puppetdb.http :as http]
-            [ring.util.response :as rr]
             [ring.util.request :as request]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -74,9 +73,8 @@
         (let [auth-result (authorize req)]
           (if (= :authorized auth-result)
             (app req)
-            (-> (str "Permission denied: " auth-result)
-                (rr/response)
-                (rr/status http/status-forbidden))))))))
+            (http/error-response (str "Permission denied: " auth-result)
+                                 http/status-forbidden)))))))
 
 (defn wrap-with-certificate-cn
   "Ring middleware that will annotate the request with an
@@ -128,8 +126,8 @@
          content-type
          (headers "accept"))
       (app req)
-      (rr/status (rr/response (str "must accept " content-type))
-                 http/status-not-acceptable))))
+      (http/error-response (str "must accept " content-type)
+                           http/status-not-acceptable))))
 
 (defn verify-content-type
   "Verification for the specified list of content-types."
@@ -142,8 +140,8 @@
                         (str (media/base-type content-type)))]
       (if (or (nil? mediatype) (some #{mediatype} content-types))
         (app req)
-        (rr/status (rr/response (str "content type " mediatype " not supported"))
-                   http/status-unsupported-type)))))
+        (http/error-response (str "content type " mediatype " not supported")
+                             http/status-unsupported-type)))))
 
 (defn validate-query-params
   "Ring middleware that verifies that the query params in the request

--- a/test/puppetlabs/puppetdb/http/aggregate_event_counts_test.clj
+++ b/test/puppetlabs/puppetdb/http/aggregate_event_counts_test.clj
@@ -21,18 +21,22 @@
   (store-example-report! (:basic reports) (now))
 
   (testing "summarize_by rejects unsupported values"
-    (let [{:keys [body status]} (query-response method endpoint
-                                                ["=" "certname" "foo.local"]
-                                                {:summarize_by "illegal-summarize-by"})]
+    (let [{:keys [body headers status]}
+          (query-response method endpoint
+                          ["=" "certname" "foo.local"]
+                          {:summarize_by "illegal-summarize-by"})]
       (is (= status http/status-bad-request))
+      (is (= headers {"Content-Type" http/error-response-content-type}))
       (is (re-find #"Unsupported value for 'summarize_by': 'illegal-summarize-by'" body))))
 
   (testing "count_by rejects unsupported values"
-    (let [{:keys [status body]}  (query-response method endpoint
-                                                 ["=" "certname" "foo.local"]
-                                                 {:summarize_by "certname"
-                                                  :count_by "illegal-count-by"})]
+    (let [{:keys [status body headers]}
+          (query-response method endpoint
+                          ["=" "certname" "foo.local"]
+                          {:summarize_by "certname"
+                           :count_by "illegal-count-by"})]
       (is (= status http/status-bad-request))
+      (is (= headers {"Content-Type" http/error-response-content-type}))
       (is (re-find #"Unsupported value for 'count_by': 'illegal-count-by'" body))))
 
   (testing "summarize_by accepts multiple parameters"

--- a/test/puppetlabs/puppetdb/http/event_counts_test.clj
+++ b/test/puppetlabs/puppetdb/http/event_counts_test.clj
@@ -33,10 +33,12 @@
                 :failures 0 :successes 0 :noops 0 :skips 1}]
 
   (testing "summarize_by rejects unsupported values"
-    (let [{:keys [body status]} (query-response method endpoint
-                                                ["=" "certname" "foo.local"]
-                                                {:summarize_by "illegal-summarize-by"})]
+    (let [{:keys [body status headers]}
+          (query-response method endpoint
+                          ["=" "certname" "foo.local"]
+                          {:summarize_by "illegal-summarize-by"})]
       (is (= status http/status-bad-request))
+      (is (= headers {"Content-Type" http/error-response-content-type}))
       (is (re-find #"Unsupported value for 'summarize_by': 'illegal-summarize-by'"
                    body))))
 
@@ -53,12 +55,14 @@
           (is (= expected (count result))))))
 
     (testing "order_by rejects invalid fields"
-      (let [{:keys [status body]} (query-response
-                                    method endpoint
-                                    nil
-                                    {:summarize_by "certname"
-                                     :order_by "invalid"})]
+      (let [{:keys [status body headers]}
+            (query-response
+             method endpoint
+             nil
+             {:summarize_by "certname"
+              :order_by "invalid"})]
         (is (= status http/status-bad-request))
+        (is (= headers {"Content-Type" http/error-response-content-type}))
         (is (re-find #"Illegal value 'invalid' for :order_by" body))))
 
     (testing "numerical fields"
@@ -76,12 +80,14 @@
 
   (testing "count_by"
     (testing "count_by rejects unsupported values"
-      (let [{:keys [status body]}  (query-response
-                                     method endpoint
-                                     ["=" "certname" "foo.local"]
-                                     {:summarize_by "certname"
-                                      :count_by "illegal-count-by"})]
+      (let [{:keys [status body headers]}
+            (query-response
+             method endpoint
+             ["=" "certname" "foo.local"]
+             {:summarize_by "certname"
+              :count_by "illegal-count-by"})]
         (is (= status http/status-bad-request))
+        (is (= headers {"Content-Type" http/error-response-content-type}))
         (is (re-find #"Unsupported value for 'count_by': 'illegal-count-by'"
                      body))))
 

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -198,6 +198,7 @@
                                                                 [{:field "resource-title"}])})
               body (get response :body "null")]
           (is (= (:status response) http/status-bad-request))
+          (is (= (:headers response) {"Content-Type" http/error-response-content-type}))
           (is (re-find #"Unrecognized column 'resource-title' specified in :order_by" body)))))))
 
 (deftest-http-app query-distinct-resources
@@ -215,6 +216,7 @@
                                       {:distinct_resources true})
             body (get response :body "null")]
         (is (= (:status response) http/status-bad-request))
+        (is (= (:headers response) {"Content-Type" http/error-response-content-type}))
         (is (re-find
              #"'distinct_resources' query parameter requires accompanying parameters 'distinct_start_time' and 'distinct_end_time'"
              body)))
@@ -222,6 +224,7 @@
                                      {:distinct_resources true :distinct_start_time 0})
             body (get response :body "null")]
         (is (= (:status response) http/status-bad-request))
+        (is (= (:headers response) {"Content-Type" http/error-response-content-type}))
         (is (re-find
              #"'distinct_resources' query parameter requires accompanying parameters 'distinct_start_time' and 'distinct_end_time'"
              body)))
@@ -229,6 +232,7 @@
                                      {:distinct_resources true :distinct_end_time 0})
             body (get response :body "null")]
         (is (= (:status response) http/status-bad-request))
+        (is (= (:headers response) {"Content-Type" http/error-response-content-type}))
         (is (re-find
              #"'distinct_resources' query parameter requires accompanying parameters 'distinct_start_time' and 'distinct_end_time'"
              body)))
@@ -237,6 +241,7 @@
                                       {:distinct_start_time 0 :distinct_end_time 0})
             body      (get response :body "null")]
         (is (= (:status response) http/status-bad-request))
+        (is (= (:headers response) {"Content-Type" http/error-response-content-type}))
         (is (re-find
              #"'distinct_resources' query parameter must accompany parameters 'distinct_start_time' and 'distinct_end_time'"
              body))))
@@ -468,10 +473,12 @@
 
   (doseq [[query msg] (get versioned-invalid-subqueries endpoint)]
     (testing (str "query: " query " should fail with msg: " msg)
-      (let [{:keys [status body] :as result} (query-response
-                                               method endpoint query)]
+      (let [{:keys [status body headers]}
+            (query-response
+             method endpoint query)]
         (is (re-find msg body))
-        (is (= status http/status-bad-request))))))
+        (is (= status http/status-bad-request))
+        (is (= headers {"Content-Type" http/error-response-content-type}))))))
 
 (def versioned-invalid-queries
   (omap/ordered-map
@@ -493,9 +500,11 @@
 
   (doseq [[query msg] (get versioned-invalid-queries endpoint)]
     (testing (str "query: " query " should fail with msg: " msg)
-      (let [{:keys [status body] :as result} (query-response method endpoint query)]
+      (let [{:keys [status body headers]}
+            (query-response method endpoint query)]
         (is (re-find msg body))
-        (is (= status http/status-bad-request))))))
+        (is (= status http/status-bad-request))
+        (is (= headers {"Content-Type" http/error-response-content-type}))))))
 
 (def pg-versioned-invalid-regexps
   (omap/ordered-map
@@ -512,6 +521,8 @@
 
   (doseq [[query msg] (get pg-versioned-invalid-regexps endpoint)]
     (testing (str "query: " query " should fail with msg: " msg)
-      (let [{:keys [status body] :as result} (query-response method endpoint query)]
+      (let [{:keys [status body headers]}
+            (query-response method endpoint query)]
         (is (re-find msg body))
-        (is (= status http/status-bad-request))))))
+        (is (= status http/status-bad-request))
+        (is (= headers {"Content-Type" http/error-response-content-type}))))))

--- a/test/puppetlabs/puppetdb/http/fact_names_test.clj
+++ b/test/puppetlabs/puppetdb/http/fact_names_test.clj
@@ -203,10 +203,12 @@
                 {:path ["domain"], :type "string"}]))))
 
     (testing "invalid query throws an error"
-      (let [{:keys [status body]} (query-response
-                                    method endpoint ["=" "myfield" "myval"])
+      (let [{:keys [status body headers]}
+            (query-response
+             method endpoint ["=" "myfield" "myval"])
             result (parse-result body)]
         (is (= status http/status-bad-request))
+        (is (= headers {"Content-Type" http/error-response-content-type}))
         (is (re-find #"is not a queryable object" result))))
 
     (testing "subqueries"

--- a/test/puppetlabs/puppetdb/http/index_test.clj
+++ b/test/puppetlabs/puppetdb/http/index_test.clj
@@ -52,17 +52,21 @@
     (scf-store/deactivate-node! "host3")
 
     (testing "invalid from query"
-      (let [{:keys [status body]} (query-response method endpoint ["from" "foobar"])]
+      (let [{:keys [status body headers]} (query-response method endpoint ["from" "foobar"])]
         (is (re-find #"Invalid entity" body))
+        (is (= headers {"Content-Type" http/error-response-content-type
+                        "Warning" "The root endpoint is experimental"}))
         (is (= status http/status-bad-request)))
 
       ;; Ensure we parse anything that looks like AST/JSON as JSON not PQL
-      (let [{:keys [status body]} (query-response method endpoint "[\"from\",\"foobar\"")]
+      (let [{:keys [status body headers]} (query-response method endpoint "[\"from\",\"foobar\"")]
         (is (= "Malformed JSON for query: [\"from\",\"foobar\"" body))
+        (is (= headers {"Content-Type" http/error-response-content-type}))
         (is (= http/status-bad-request status)))
 
-      (let [{:keys [status body]} (query-response method endpoint "foobar {}")]
+      (let [{:keys [status body headers]} (query-response method endpoint "foobar {}")]
         (is (re-find #"PQL parse error at line 1, column 1" body))
+        (is (= headers {"Content-Type" http/error-response-content-type}))
         (is (= status http/status-bad-request))))
 
     (testing "pagination"

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -393,8 +393,9 @@
 
                          (re-pattern (format "'sourcefile' is not a queryable object.*" (last (name version))))}]
       (testing (str endpoint " query: " query " should fail with msg: " msg)
-        (let [{:keys [status body]} (query-response method endpoint query)]
+        (let [{:keys [status body headers]} (query-response method endpoint query)]
           (is (= status http/status-bad-request))
+          (is (= headers {"Content-Type" http/error-response-content-type}))
           (is (re-find msg body)))))))
 
 (deftest-http-app query-with-pretty-printing
@@ -555,9 +556,10 @@
    method [:get :post]
    [query msg] invalid-projection-queries]
   (testing (str "query: " query " should fail with msg: " msg)
-    (let [{:keys [status body] :as result} (query-response method endpoint query)]
+    (let [{:keys [status body headers] :as result} (query-response method endpoint query)]
       (is (re-find msg body))
-      (is (= status http/status-bad-request)))))
+      (is (= status http/status-bad-request))
+      (is (= headers {"Content-Type" http/error-response-content-type})))))
 
 (def pg-versioned-invalid-regexps
   (omap/ordered-map

--- a/test/puppetlabs/puppetdb/http/paging_test.clj
+++ b/test/puppetlabs/puppetdb/http/paging_test.clj
@@ -25,6 +25,7 @@
                                               {:order_by malformed-JSON}))
           body            (get response :body "null")]
       (is (= (:status response) http/status-bad-request))
+      (is (= (:headers response) {"Content-Type" http/error-response-content-type}))
       (is (re-find #"Illegal value '.*' for :order_by; expected a JSON array of maps" body))))
 
   (testing "'limit' should only accept positive non-zero integers"
@@ -38,6 +39,7 @@
                                           {:limit invalid-limit}))
             body      (get response :body "null")]
         (is (= (:status response) http/status-bad-request))
+        (is (= (:headers response) {"Content-Type" http/error-response-content-type}))
         (is (re-find #"Illegal value '.*' for :limit; expected a positive non-zero integer" body)))))
 
   (testing "'offset' should only accept positive integers"
@@ -50,6 +52,7 @@
                                           {:offset invalid-offset}))
             body      (get response :body "null")]
         (is (= (:status response) http/status-bad-request))
+        (is (= (:headers response) {"Content-Type" http/error-response-content-type}))
         (is (re-find #"Illegal value '.*' for :offset; expected a non-negative integer" body)))))
 
   (testing "'order_by' :order should only accept nil, 'asc', or 'desc' (case-insensitive)"
@@ -62,4 +65,5 @@
                                           {:order_by (json/generate-string invalid-order-by)}))
             body      (get response :body "null")]
         (is (= (:status response) http/status-bad-request))
+        (is (= (:headers response) {"Content-Type" http/error-response-content-type}))
         (is (re-find #"Illegal value '.*' in :order_by; 'order' must be either 'asc' or 'desc'" body))))))

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -11,7 +11,7 @@
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.examples.reports :refer [reports]]
-            [puppetlabs.puppetdb.http :as http :refer [status-bad-request]]
+            [puppetlabs.puppetdb.http :as http]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.reports :as reports]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
@@ -702,9 +702,10 @@
 
   (doseq [[query msg] invalid-projection-queries]
     (testing (str "query: " query " should fail with msg: " msg)
-      (let [{:keys [status body] :as result} (query-response method endpoint query)]
+      (let [{:keys [status body headers] :as result} (query-response method endpoint query)]
         (is (re-find msg body))
-        (is (= status status-bad-request))))))
+        (is (= status http/status-bad-request))
+        (is (= headers {"Content-Type" http/error-response-content-type}))))))
 
 (def pg-versioned-invalid-regexps
   (omap/ordered-map
@@ -721,9 +722,10 @@
 
   (doseq [[query msg] (get pg-versioned-invalid-regexps endpoint)]
     (testing (str "query: " query " should fail with msg: " msg)
-      (let [{:keys [status body] :as result} (query-response method endpoint query)]
+      (let [{:keys [status body headers] :as result} (query-response method endpoint query)]
         (is (re-find msg body))
-        (is (= status http/status-bad-request))))))
+        (is (= status http/status-bad-request))
+        (is (= headers {"Content-Type" http/error-response-content-type}))))))
 
 (def no-parent-endpoints [[:v4 "/v4/reports/foo/events"]
                           [:v4 "/v4/reports/foo/metrics"]
@@ -732,8 +734,9 @@
 (deftest-http-app unknown-parent-handling
   [[version endpoint] no-parent-endpoints
    method [:get :post]]
-  (let [{:keys [status body]} (query-response method endpoint)]
+  (let [{:keys [status body headers]} (query-response method endpoint)]
     (is (= status http/status-not-found))
+    (is (= headers {"Content-Type" http/json-response-content-type}))
     (is (= {:error "No information is known about report foo"} (json/parse-string body true)))))
 
 (deftest reports-retrieval


### PR DESCRIPTION
This patch fixes the cases where text errors were not returning the correct
text/plain Content-Type header by fixing error-response to do this, and forcing
all relevant code to use this function instead of trying to create errors
themeselves.

This also adds tests to ensure errors return the correct content-type.

Signed-off-by: Ken Barber <ken@bob.sh>