### PR TITLE
(PDB-2663) Bump ezbake version to include xenial fixes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -135,7 +135,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "0.3.24"
+                      :plugins [[puppetlabs/lein-ezbake "0.3.25"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}


### PR DESCRIPTION
This bumpes ezbake so we can fix PuppetDB on xenial pulling in java 9.

Signed-off-by: Ken Barber <ken@bob.sh>