### PR TITLE
(PE-15026) Allow configuration of the ActiveMQ Broker's MemoryLimit

### DIFF
--- a/config.sample.ini
+++ b/config.sample.ini
@@ -52,6 +52,9 @@ vardir = /var/lib/puppetdb
 # Maximum amount of disk space (in MB) to allow for ActiveMQ temporary message storage
 # temp-usage = 51200
 
+# Maximum amount of memory (in MB) to allow for ActiveMQ Broker
+# memory-usage = 2048
+
 [jetty]
 # What host to listen on, defaults to binding to 'localhost'
 # host = foo.my.net

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -481,6 +481,11 @@ This setting sets the maximum amount of space in megabytes that PuppetDB's Activ
 
 This setting sets the maximum amount of space in megabytes that PuppetDB's ActiveMQ can use for temporary message storage.
 
+### `memory-usage`
+
+This setting sets the maximum amount of memory in megabytes available for
+PuppetDB's ActiveMQ Broker.
+
 ### `max-frame-size`
 
 This setting sets the maximum frame size for persisted activemq messages

--- a/resources/ext/config/conf.d/config.ini
+++ b/resources/ext/config/conf.d/config.ini
@@ -17,3 +17,6 @@ logging-config = /etc/puppetlabs/puppetdb/logback.xml
 
 # Maximum amount of disk space (in MB) to allow for ActiveMQ temporary message storage
 # temp-usage = 51200
+
+# Maximum amount of memory (in MB) to allow for ActiveMQ Broker
+# memory-usage = 2048

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -127,6 +127,7 @@
      :threads (pls/defaulted-maybe s/Int half-the-cores)
      :store-usage s/Int
      :max-frame-size (pls/defaulted-maybe s/Int 209715200)
+     :memory-usage s/Int
      :temp-usage s/Int}))
 
 (def command-processing-out
@@ -134,6 +135,7 @@
   {:dlo-compression-threshold Period
    :threads s/Int
    :max-frame-size s/Int
+   (s/optional-key :memory-usage) s/Int
    (s/optional-key :store-usage) s/Int
    (s/optional-key :temp-usage) s/Int})
 

--- a/src/puppetlabs/puppetdb/mq.clj
+++ b/src/puppetlabs/puppetdb/mq.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.puppetdb.mq
   (:import [org.apache.activemq.broker BrokerService]
            [org.apache.activemq ScheduledMessage]
-           [org.apache.activemq.usage SystemUsage]
+           [org.apache.activemq.usage SystemUsage MemoryUsage]
            [javax.jms Connection Message TextMessage BytesMessage Session]
            [org.apache.activemq ActiveMQConnectionFactory]
            [org.apache.activemq.pool PooledConnectionFactory])
@@ -44,6 +44,17 @@
   Returns the (potentially modified) `broker` object."
   [broker megabytes]
   (set-usage!* broker megabytes #(.getStoreUsage %) "StoreUsage"))
+
+(defn- set-memory-usage!
+  "Configures the `MemoryUsage` setting for an instance of `BrokerService`.
+
+  `broker`     - the `BrokerService` to configure
+  `megabytes ` - the maximum amount of memory usage to allow for the BrokeService,
+  or `nil` to use the default value of 1GB.
+
+  Returns the (potentially modified) `broker` object."
+  [broker megabytes]
+  (set-usage!* broker megabytes #(.getMemoryUsage %) "MemoryUsage"))
 
 (defn- set-temp-usage!
   "Configures the `TempUsage` setting for an instance of `BrokerService`.
@@ -102,6 +113,7 @@
               (.setSchedulerSupport true)
               (.setPersistent true)
               (enable-jmx true)
+              (set-memory-usage! (:memory-usage config))
               (set-store-usage! (:store-usage config))
               (set-temp-usage!  (:temp-usage config)))
          mc (doto (.getManagementContext mq)

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -45,6 +45,10 @@
       (let [config (configure-command-params {:command-processing {:temp-usage 10000}})]
         (is (= (get-in config [:command-processing :temp-usage]) 10000))))
 
+    (testing "should use the memory-usage specified"
+      (let [config (configure-command-params {:command-processing {:memory-usage 10000}})]
+        (is (= (get-in config [:command-processing :memory-usage]) 10000))))
+
     (let [with-ncores (fn [cores]
                         (with-redefs [kitchensink/num-cpus (constantly cores)]
                           (half-the-cores*)))]

--- a/test/puppetlabs/puppetdb/mq_test.clj
+++ b/test/puppetlabs/puppetdb/mq_test.clj
@@ -101,12 +101,14 @@
 
             broker (build-embedded-broker "localhost" "somedir"
                                           {:store-usage size-megs
-                                           :temp-usage  size-megs})]
+                                           :temp-usage  size-megs
+                                           :memory-usage size-megs})]
         (is (instance? BrokerService broker))
         (is (.. broker (getPersistenceAdapter) (isIgnoreMissingJournalfiles)))
         (is (.. broker (getPersistenceAdapter) (isArchiveCorruptedIndex)))
         (is (.. broker (getPersistenceAdapter) (isCheckForCorruptJournalFiles)))
         (is (.. broker (getPersistenceAdapter) (isChecksumJournalFiles)))
+        (is (= size-bytes (.. broker (getSystemUsage) (getMemoryUsage) (getLimit))))
         (is (= size-bytes (.. broker (getSystemUsage) (getStoreUsage) (getLimit))))
         (is (= size-bytes (.. broker (getSystemUsage) (getTempUsage) (getLimit)))))
       (finally


### PR DESCRIPTION
This commit adds the ability to configure the ActiveMQ Broker's
MemoryLimit in PuppetDB. Before this commit the MemoryLimit was always
the default 1GB.