### PR TITLE
(PDB-2680) Refactor PuppetDBStatus service to a plain function

### DIFF
--- a/resources/puppetlabs/puppetdb/bootstrap.cfg
+++ b/resources/puppetlabs/puppetdb/bootstrap.cfg
@@ -18,7 +18,6 @@ puppetlabs.puppetdb.cli.services/puppetdb-service
 puppetlabs.puppetdb.mq-listener/message-listener-service
 puppetlabs.puppetdb.command/command-service
 puppetlabs.puppetdb.pdb-routing/maint-mode-service
-puppetlabs.puppetdb.pdb-routing/pdb-status-service
 puppetlabs.puppetdb.pdb-routing/pdb-routing-service
 puppetlabs.puppetdb.config/config-service
 

--- a/src/puppetlabs/puppetdb/status.clj
+++ b/src/puppetlabs/puppetdb/status.clj
@@ -1,0 +1,39 @@
+(ns puppetlabs.puppetdb.status
+  (:require [puppetlabs.puppetdb.scf.storage-utils :as sutils]
+            [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.mq :as mq]
+            [puppetlabs.puppetdb.schema :as pls]
+            [schema.core :as s]
+            [puppetlabs.trapperkeeper.services.status.status-core :as status-core]))
+
+(def status-details-schema {:maintenance_mode? s/Bool
+                            :queue_depth s/Int
+                            :read_db_up? s/Bool
+                            :write_db_up? s/Bool})
+
+(pls/defn-validated status-details :- status-details-schema
+  "Returns a map containing status information on the various parts of
+  a running PuppetDB system. This data can be interpreted to determine
+  whether the system is considered up"
+  [config :- {s/Any s/Any}
+   shared-globals-fn :- pls/Function
+   maint-mode-fn? :- pls/Function]
+  (let [globals (shared-globals-fn)]
+    {:maintenance_mode? (maint-mode-fn?)
+     :queue_depth (utils/nil-on-failure
+                   (->> (get-in config [:command-processing :mq :endpoint])
+                        (mq/queue-size "localhost")))
+     :read_db_up? (sutils/db-up? (:scf-read-db globals))
+     :write_db_up? (sutils/db-up? (:scf-write-db globals))}))
+
+(pls/defn-validated create-status-map :- status-core/StatusCallbackResponse
+  "Returns a status map containing the state of the currently running
+  system (starting/running/error etc)"
+  [{:keys [maintenance_mode? read_db_up? write_db_up?]
+    :as status-details} :- status-details-schema]
+  (let [state (cond
+                maintenance_mode? :starting
+                (and read_db_up? write_db_up?) :running
+                :else :error)]
+    {:state state
+     :status status-details}))

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -323,3 +323,11 @@
      result#))
 
 (def byte-array-class (Class/forName "[B"))
+
+(defmacro nil-on-failure
+  "Executes `body` and if an exception is thrown, returns nil"
+  [& body]
+  `(try
+     ~@body
+     (catch Exception _#
+       nil)))

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -30,8 +30,7 @@
             [clojure.tools.logging :as log]
             [puppetlabs.puppetdb.dashboard :refer [dashboard-redirect-service]]
             [puppetlabs.puppetdb.pdb-routing :refer [pdb-routing-service
-                                                     maint-mode-service
-                                                     pdb-status-service]]
+                                                     maint-mode-service]]
             [puppetlabs.puppetdb.config :refer [config-service]]))
 
 ;; See utils.clj for more information about base-urls.
@@ -72,7 +71,6 @@
    #'dashboard-redirect-service
    #'pdb-routing-service
    #'maint-mode-service
-   #'pdb-status-service
    #'config-service])
 
 (defn call-with-puppetdb-instance


### PR DESCRIPTION
These changes will allow our extensions in PE to have a separate status that includes information from PE core but can also include additional dependencies when determining whether or not PuppetDB is 'up'.