### PR TITLE
(PE-15587) Set noop flag on a report to true only if all its resource events are noop

### DIFF
--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -38,7 +38,7 @@ Puppet::Reports.register_report(:puppetdb) do
       end
 
       resources = build_resources_list
-      is_noop = resources.any? { |rs| has_noop_event?(rs) } and resources.none? { |rs| has_failed_event?(rs) }
+      is_noop = resources.any? { |rs| has_noop_event?(rs) } && resources.none? { |rs| has_enforcement_event?(rs) }
 
 
       defaulted_catalog_uuid = defined?(catalog_uuid) ? catalog_uuid : transaction_uuid
@@ -74,8 +74,8 @@ Puppet::Reports.register_report(:puppetdb) do
 
   # @return TrueClass
   # @api private
-  def has_failed_event?(resource)
-    resource["events"].any? { |event| event["status"] == 'failed' }
+  def has_enforcement_event?(resource)
+    resource["events"].any? { |event| event["status"] != 'noop' }
   end
 
   # @return Array[Hash]


### PR DESCRIPTION
This commit improves the algorithm which tries to recognize that puppet run was started with `--noop` param. Originally, any noop resource event caused that the whole report was marked as noop. However, a noop puppet run would have all resource events in noop state. With this commit, all resource events need to be noop to mark the whole report as noop.

The current implementation is not able to recognize an unchanged noop puppet run since it doesn't contain any events. So, this improvement is just a workaround. To be able to recognize noop puppet runs properly, puppet needs to report in which mode was the run started. This problem is logged as PUP-6294.