### PR TITLE
(MAINT) Bump testing timeouts to deal with slow infra

### DIFF
--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -1425,7 +1425,7 @@
                        {:certname "foo.local" :producer_timestamp (java.util.Date.)}
                        command-uuid)
       (let [received-uuid (async/alt!! response-chan ([msg] (:id msg))
-                                       (async/timeout 2000) ::timeout)]
+                                       (async/timeout 10000) ::timeout)]
        (is (= command-uuid received-uuid))))))
 
 ;; Local Variables:

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -324,7 +324,7 @@
   "Syncronously post a command to PDB by blocking until the message is consumed
    off the queue."
   [base-url certname cmd version payload]
-  (let [timeout-seconds 10]
+  (let [timeout-seconds 20]
     (let [response (pdb-client/submit-command-via-http!
                      base-url certname cmd version payload timeout-seconds)]
       (if (>= (:status response) 400)


### PR DESCRIPTION
When the CI infrastructure is running slow, these some tests can exceed
their timeouts. Bumping those to allow them more time to finish.