### PR TITLE
(doc) Update references to package repos.

### DIFF
--- a/documentation/connect_puppet_apply.markdown
+++ b/documentation/connect_puppet_apply.markdown
@@ -16,7 +16,7 @@ canonical: "/puppetdb/latest/connect_puppet_apply.html"
 [jetty]: ./configure.html#jetty-http-settings
 [settings_namespace]: /puppet/latest/reference/lang_facts_and_builtin_vars.html#variables-set-by-the-puppet-master
 [ssl_script]: ./install_from_source.html#step-3-option-a-run-the-ssl-configuration-script
-[package_repos]: /guides/puppetlabs_package_repositories.html
+[package_repos]: /puppet/latest/reference/puppet_collections.html
 
 > Note: To use PuppetDB, the nodes at your site must be running Puppet version 3.8.1 or later.
 
@@ -51,8 +51,8 @@ You will have to sign a certificate for every new node you add to your site.
 
 Currently, Puppet needs extra Ruby plugins in order to use PuppetDB. Unlike custom facts or functions, these cannot be loaded from a module and must be installed in Puppet's main source directory.
 
-* First, ensure that the appropriate [Puppet package repository][package_repos]
-  is enabled. You can use a [package][] resource to do this or use the
+* First, ensure that the appropriate [Puppet Collection repository][package_repos]
+  repository is enabled. You can use a [package][] resource to do this or the
   `apt::source` (from the [puppetlabs-apt][apt] module) and [`yumrepo`][] types.
 * Next, use Puppet to ensure that the `puppetdb-termini` package is installed:
 

--- a/documentation/connect_puppet_master.markdown
+++ b/documentation/connect_puppet_master.markdown
@@ -33,7 +33,7 @@ Currently, Puppet masters need additional Ruby plug-ins in order to use PuppetDB
 
 ### On platforms with packages
 
-[Enable the Puppet repo](/guides/puppetlabs_package_repositories.html#open-source-repositories) and then install the `puppetdb-termini` package:
+[Enable the Puppet Collection repo](/puppet/latest/reference/puppet_collections.html) and then install the `puppetdb-termini` package:
 
     $ sudo puppet resource package puppetdb-termini ensure=latest
 

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -64,11 +64,11 @@ seconds`.
 > [manually configure PuppetDB's SSL credentials][keystore_instructions] before
 > the Puppet master will be able to connect to PuppetDB.
 
-Step 2: Enable the Puppet package repository
+Step 2: Enable the Puppet Collection package repository
 -----
 
 If you didn't already use it to install Puppet, you will need to
-[enable the Puppet package repository](/guides/puppetlabs_package_repositories.html)
+[enable the Puppet Collection package repository](/puppet/latest/reference/puppet_collections.html)
 
 Step 3: Install PuppetDB
 -----

--- a/documentation/install_via_module.markdown
+++ b/documentation/install_via_module.markdown
@@ -3,7 +3,7 @@ title: "PuppetDB 4.1: Installing PuppetDB via Puppet module"
 layout: default
 ---
 
-[module]: http://forge.puppetlabs.com/puppetlabs/puppetdb
+[module]: http://forge.puppet.com/puppetlabs/puppetdb
 [config_with_module]: ./configure.html#playing-nice-with-the-puppetdb-module
 
 > **Note:** If you are running Puppet Enterprise version 3.0 or later, you do
@@ -21,12 +21,12 @@ and the PuppetDB-termini for your Puppet master) using
   follow our guide to
   [installing PuppetDB from packages](./install_from_packages.html).
 
-Step 1: Enable the Puppet package repository
+Step 1: Enable the Puppet Collection package repository
 -----
 
 If you haven't done so already, you will need to do **one** of the following:
 
-* [Enable the Puppet package repository](/guides/puppetlabs_package_repositories.html)
+* [Enable the Puppet Collection package repository](/puppet/latest/reference/puppet_collections.html)
   on your PuppetDB server and Puppet master server.
 * Grab the PuppetDB and PuppetDB-termini packages, and import them into your
   site's local package repos.

--- a/documentation/pdb_client_tools.markdown
+++ b/documentation/pdb_client_tools.markdown
@@ -4,7 +4,7 @@ layout: default
 ---
 
 [installpuppet]: /puppet/latest/reference/install_pre.html
-[repos]: /guides/puppetlabs_package_repositories.html
+[repos]: /puppet/latest/reference/puppet_collections.html
 [export]: ./anonymization.html
 
 # PuppetDB CLI
@@ -27,32 +27,32 @@ seconds`.
 
     $ export PATH=/opt/puppetlabs/bin:$PATH
     $ export MANPATH=/opt/puppetlabs/client/tools/share/man:$MANPATH
-    
+
 The rest of this documentation assumes that these two directories have been
 added to their proper path configurations.
 
-### Step 2: Enable the Puppet Labs package repository
+### Step 2: Enable the Puppet Collection package repository
 
 If you didn't already use it to install Puppet, you will need to
-[enable the Puppet Labs package repository][repos] for your system.
+[enable the Puppet Collection package repository][repos] for your system.
 
 ### Step 3: Install and configure the PuppetDB CLI
 
 Use Puppet to install the PuppetDB CLI:
 
     $ puppet resource package puppet-client-tools ensure=latest
-  
+
 If the node you installed the CLI on is not the same node as your PuppetDB
 server, you will need to add the CLI node's certname to the PuppetDB
 certificate-whitelist and specify the paths to the CLI node's cacert, cert, and
 private key when using the CLI either with flags or a configuration file.
-  
+
 To configure the PuppetDB CLI to talk to your PuppetDB with flags, add a
 configuration file at `$HOME/.puppetlabs/client-tools/puppetdb.conf`. For more
 details see the installed man page:
 
     $ man puppetdb_conf
-  
+
 ### Step 4: Enjoy!
 
 Here are some examples of using the CLI.
@@ -62,17 +62,17 @@ Here are some examples of using the CLI.
 Query PuppetDB using PQL:
 
     $ puppet query 'nodes [ certname ]{ limit 1 }'
-  
+
 Or query PuppetDB using the AST syntax:
 
     $ puppet query '["from", "nodes", ["extract", "certname"], ["limit", "1"]]'
-  
-For more information on the `query` command: 
+
+For more information on the `query` command:
 
     $ man puppet-query
-  
+
 #### Using `puppet db`
-  
+
 Handle your PuppetDB exports:
 
     $ puppet db export pdb-archive.tgz --anonymization full
@@ -84,6 +84,6 @@ Or handle your PuppetDB imports:
 For more information on the `db` command:
 
     $ man puppet-db
-  
+
 For more information about PuppetDB exports, imports, and anonymization
 [see][export].


### PR DESCRIPTION
We're retiring the doc at https://docs.puppet.com/guides/puppetlabs_package_repositories.html. Change these links to point to the versioned docs at https://docs.puppet.com/puppet/latest/reference/puppet_collections.html, and note that we're referring to Puppet Collections.