### PR TITLE
(PDB-2771) expose depth for fact-path querying

### DIFF
--- a/documentation/api/query/v4/fact-paths.markdown
+++ b/documentation/api/query/v4/fact-paths.markdown
@@ -37,6 +37,7 @@ See [the AST query language page][ast].
 
 * `path` (path): the path associated with a fact node.
 * `type` (string): the type of the value a the fact node.
+* `depth` (integer): the depth of the paths returned
 
 ### Subquery relationships
 

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -221,7 +221,11 @@
                                      :field :type}
                              "path" {:type :path
                                      :queryable? true
-                                     :field :path}}
+                                     :field :path}
+                             "depth" {:type :integer
+                                      :queryable? true
+                                      :query-only? true
+                                      :field :fp.depth}}
                :selection {:from [[:fact_paths :fp]]
                            :join [[:facts :f]
                                   [:= :f.fact_path_id :fp.id]

--- a/test/puppetlabs/puppetdb/http/fact_names_test.clj
+++ b/test/puppetlabs/puppetdb/http/fact_names_test.clj
@@ -184,6 +184,19 @@
                [{:path ["my_SF" "baz" 0], :type "float"}
                 {:path ["my_SF" "baz" 1], :type "float"}
                 {:path ["my_SF" "foo"], :type "string"}]))))
+
+    (testing "querying for depth"
+      (let [{:keys [status body]} (query-response
+                                    method
+                                    endpoint
+                                    [">" "depth" 0])
+            result (parse-result body)]
+        (is (= status http/status-ok))
+        (is (= result
+               [{:path ["my_SF" "baz" 0], :type "float"}
+                {:path ["my_SF" "baz" 1], :type "float"}
+                {:path ["my_SF" "foo"], :type "string"}]))))
+
     (testing "paging for fact-paths"
       (let [{:keys [status body]} (query-response
                                     method endpoint nil


### PR DESCRIPTION
Expose depth as a queryable field for the /fact-paths endpoint. This will allow
the middleware to query fact-paths more efficiently by excluding structured
facts.