### PR TITLE
(PDB-2782) Add "producers" as a queryable entity

### DIFF
--- a/documentation/_puppetdb_nav.html
+++ b/documentation/_puppetdb_nav.html
@@ -65,6 +65,7 @@
       <li><a href="{{puppetdb}}/api/query/v4/index.html">Root endpoint (experimental)</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/nodes.html">Nodes endpoint</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/environments.html">Environments endpoint</a></li>
+      <li><a href="{{puppetdb}}/api/query/v4/producers.html">Producers endpoint</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/factsets.html">Factsets endpoint</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/facts.html">Facts endpoint</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/fact-names.html">Fact-names endpoint</a></li>

--- a/documentation/api/query/v4/ast.markdown
+++ b/documentation/api/query/v4/ast.markdown
@@ -13,6 +13,7 @@ canonical: "/puppetdb/latest/api/query/v4/ast.html"
 [fact-contents]: ./fact-contents.html
 [fact-paths]: ./fact-paths.html
 [nodes]: ./nodes.html
+[producers]: ./producers.html
 [query]: ./query.html
 [reports]: ./reports.html
 [resources]: ./resources.html
@@ -176,7 +177,7 @@ Extract can also be used with a standalone function application:
 
     ["extract", [["function", "count"]], ["~", "certname", ".\*.com"]]
 
-or 
+or
 
     ["extract", [["function", "count"]]]
 
@@ -423,7 +424,7 @@ which is equivalent to the following query:
 The `in`-`array` operators support much of the same syntax as the `=` operator.
 For example, the following query on the `/nodes` endpoint is valid:
 
-    ["in", ["fact", "uptime_seconds"], 
+    ["in", ["fact", "uptime_seconds"],
      ["array",
       [20000.0,
        150.0,
@@ -480,6 +481,7 @@ Each subquery acts as a normal query to one of the PuppetDB endpoints. For info 
 * [`select_fact_contents`][fact-contents]
 * [`select_fact_paths`][fact-paths]
 * [`select_nodes`][nodes]
+* [`select_producers`][producers]
 * [`select_reports`][reports]
 * [`select_resources`][resources]
 

--- a/documentation/api/query/v4/catalogs.markdown
+++ b/documentation/api/query/v4/catalogs.markdown
@@ -12,6 +12,7 @@ canonical: "/puppetdb/latest/api/query/v4/catalogs.html"
 [ast]: ./ast.html
 [edges]: ./edges.html
 [environments]: ./environments.html
+[producers]: ./producers.html
 [nodes]: ./nodes.html
 [resources]: ./resources.html
 
@@ -56,6 +57,7 @@ result set using implicit subqueries. For more information consult the
 documentation for [subqueries][subqueries].
 
 * [`nodes`][nodes]: node for a catalog.
+* [`producers`][producers]: the master that sent the catalog to PuppetDB.
 * [`environments`][environments]: environment for a catalog.
 * [`edges`][edges]: resource edges received for a catalog.
 * [`resources`][resources]: resources received for a catalog.

--- a/documentation/api/query/v4/entities.markdown
+++ b/documentation/api/query/v4/entities.markdown
@@ -15,6 +15,7 @@ canonical: "/puppetdb/latest/api/query/v4/entities.html"
 [fact-contents]: ./fact-contents.html
 [fact-paths]: ./fact-paths.html
 [nodes]: ./nodes.html
+[producers]: ./producers.html
 [query]: ./query.html
 [reports]: ./reports.html
 [resources]: ./resources.html
@@ -49,6 +50,7 @@ Entity Name                                        | REST Endpoint
 [`fact_names`][fact-names]                         | [/pdb/query/v4/fact-names][fact-names]
 [`fact_paths`][fact-paths]                         | [/pdb/query/v4/fact-paths][fact-paths]
 [`nodes`][nodes]                                   | [/pdb/query/v4/nodes][nodes]
+[`producers`][producers]                           | [/pdb/query/v4/producers][producers]
 [`reports`][reports]                               | [/pdb/query/v4/reports][reports]
 [`resources`][resources]                           | [/pdb/query/v4/resources][resources]
 

--- a/documentation/api/query/v4/factsets.markdown
+++ b/documentation/api/query/v4/factsets.markdown
@@ -13,6 +13,7 @@ canonical: "/puppetdb/latest/api/query/v4/factsets.html"
 [facts]: ./facts.html
 [fact-contents]: ./fact_contents.html
 [environments]: ./environments.html
+[producers]: ./producers.html
 [nodes]: ./nodes.html
 
 You can query factsets by making an HTTP request to the `/factsets` endpoint.
@@ -53,6 +54,7 @@ The following list contains related entities that can be used to constrain the r
 * [`facts`][facts]: fact names and values received from a factset.
 * [`fact_contents`][fact-contents]: factset paths and values received from a factset.
 * [`nodes`][nodes]: the node that a factset was received from.
+* [`producers`][producers]: the master that sent the factset to PuppetDB.
 
 ### Response format
 

--- a/documentation/api/query/v4/producers.markdown
+++ b/documentation/api/query/v4/producers.markdown
@@ -1,0 +1,102 @@
+---
+title: "PuppetDB 4.1: Producers endpoint"
+layout: default
+canonical: "/puppetdb/latest/api/query/v4/producers.html"
+---
+
+[curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
+[paging]: ./paging.html
+[query]: ./query.html
+[subqueries]: ./ast.html#subquery-operators
+[factsets]: ./factsets.html
+[reports]: ./reports.html
+[catalogs]: ./catalogs.html
+
+Producers are the Puppet masters that send reports, catalogs, and factsets to PuppetDB.
+
+When PuppetDB stores a report, catalog, or factset, it keeps track of the producer
+of the report/catalog/factset. PuppetDB also keeps a list of producers it has seen.
+You can query this list by making an HTTP request to the `/producers` endpoint.
+
+## `/pdb/query/v4/producers`
+
+This will return all producers known to PuppetDB.
+
+### URL parameters
+
+* `query`: optional. A JSON array containing the query in prefix notation. If
+  not provided, all results will be returned. See the sections below for the
+  supported operators and fields. For general info about queries,
+  see [our guide to query structure.][query]
+
+### Query operators
+
+See [the AST query language page](./ast.html)
+
+### Query fields
+
+* `name` (string): the certname of a producer.
+
+### Subquery relationships
+
+The following list contains related entities that can be used to constrain the result set by using implicit subqueries. For more information, consult the documentation for [subqueries][subqueries].
+
+* [`factsets`][factsets]: factsets received for a producer.
+* [`reports`][reports]: reports received for a producer.
+* [`catalogs`][catalogs]: catalogs received for a producer.
+
+### Response format
+
+The response is a JSON array of hashes, where each hash has the form:
+
+    {"name": <string>}
+
+The array is unsorted.
+
+### Example
+
+[You can use `curl`][curl] to query information about nodes:
+
+    curl 'http://localhost:8080/pdb/query/v4/producers'
+
+## `/pdb/query/v4/producers/<PRODUCER>`
+
+This will return the name of the producer if it currently exists in PuppetDB.
+
+### URL parameters / query operators / query fields
+
+This route supports the same URL parameters and query fields/operators
+as the '/pdb/query/v4/producers' route above.
+
+### Response format
+
+The response is a JSON hash of the form:
+
+    {"name": <string>}
+
+### Examples
+
+[You can use `curl`][curl] to query information about nodes like so:
+
+    curl 'http://localhost:8080/pdb/query/v4/producers/master.example.com'
+
+    {
+      "name" : "master.example.com"
+    }
+
+## `/pdb/query/v4/producers/<PRODUCER>/[catalogs|factsets|reports]`
+
+These routes are identical to issuing a request to
+`/pdb/query/v4/[catalogs|factsets|reports]`, with a query
+parameter of `["=","producer","<PRODUCER>"]`. All query
+parameters and route suffixes from the original routes are
+supported. The result format is also the same. Additional query
+parameters are ANDed with the producer clause. See
+[/pdb/query/v4/catalogs][catalogs], [/pdb/query/v4/factsets][factsets], or
+[/pdb/query/v4/reports][reports] for more information.
+
+## Paging
+
+This query endpoint supports paged results via the common PuppetDB paging
+URL parameters. For more information, please see the documentation
+on [paging][paging].

--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -13,6 +13,7 @@ canonical: "/puppetdb/latest/api/query/v4/reports.html"
 [8601]: http://en.wikipedia.org/wiki/ISO_8601
 [subqueries]: ./ast.html#subquery-operators
 [environments]: ./environments.html
+[producers]: ./producers.html
 [events]: ./events.html
 [nodes]: ./nodes.html
 
@@ -120,6 +121,7 @@ documentation for [subqueries][subqueries].
 * [`environments`][environments]: environment from where a report was received.
 * [`events`][events]: events received in a report.
 * [`nodes`][nodes]: node from where a report was received.
+* [`producers`][producers]: the master that sent the report to PuppetDB.
 
 ### Response format
 

--- a/src/puppetlabs/puppetdb/http/handlers.clj
+++ b/src/puppetlabs/puppetdb/http/handlers.clj
@@ -127,6 +127,17 @@
                        identity
                        (http/status-not-found-response "environment" environment)))))
 
+(defn producer-status
+  "Produce a response body for a single producer."
+  [version]
+  (fn [{:keys [globals route-params]}]
+    (let [producer (:producer route-params)]
+      (status-response version
+                       ["from" "producers" ["=" "name" producer]]
+                       (http-q/narrow-globals globals)
+                       identity
+                       (http/status-not-found-response "producer" producer)))))
+
 ;; Routes
 
 (pls/defn-validated events-routes :- bidi-schema/RoutePair
@@ -319,6 +330,34 @@
                                       (append-handler http-q/restrict-query-to-environment)))))
                   version :environment :environment))))
 
+(pls/defn-validated producers-routes :- bidi-schema/RoutePair
+  [version :- s/Keyword]
+  (cmdi/routes
+   (extract-query
+    (cmdi/ANY "" []
+              (create-query-handler version "producers")))
+   (cmdi/context ["/" (route-param :producer)]
+                 (cmdi/ANY "" []
+                   (validate-query-params (producer-status version)
+                                          {:optional ["pretty"]}))
+                 (wrap-with-parent-check
+                  (cmdi/routes
+                   (extract-query
+                    (cmdi/context "/factsets"
+                                  (-> (factset-routes version)
+                                      (append-handler http-q/restrict-query-to-producer))))
+
+                  (extract-query
+                    (cmdi/context "/catalogs"
+                                  (-> (catalog-routes version)
+                                      (append-handler http-q/restrict-query-to-producer))))
+
+                   (extract-query
+                    (cmdi/context "/reports"
+                                  (-> (reports-routes version)
+                                      (append-handler http-q/restrict-query-to-producer)))))
+                  version :producer :producer))))
+
 (pls/defn-validated fact-contents-routes :- bidi-schema/RoutePair
   [version :- s/Keyword]
   (extract-query
@@ -352,4 +391,3 @@
    (cmdi/ANY "" []
              (create-query-handler version
                                    "aggregate_event_counts"))))
-

--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -153,6 +153,15 @@
   (restrict-query ["=" "environment" (get-in req [:route-params :environment])]
                   req))
 
+(defn restrict-query-to-producer
+  "Restrict the query parameter of the supplied request so that it
+   only returns results for the supplied producer"
+  [req]
+  {:pre  [(string? (get-in req [:route-params :producer]))]
+   :post [(are-queries-different? req %)]}
+  (restrict-query ["=" "producer" (get-in req [:route-params :producer])]
+                  req))
+
 (defn restrict-fact-query-to-name
   "Restrict the query parameter of the supplied request so that it
    only returns facts with the given name"

--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -44,6 +44,7 @@
                 "/fact-paths" handlers/fact-path-routes
                 "/nodes" handlers/node-routes
                 "/environments" handlers/environments-routes
+                "/producers" handlers/producers-routes
                 "/resources" handlers/resources-routes
                 "/catalogs" handlers/catalog-routes
                 "/events" handlers/events-routes

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -45,6 +45,8 @@
              :rec eng/nodes-query}
      :environments {:munge (constantly identity)
                     :rec eng/environments-query}
+     :producers {:munge (constantly identity)
+                 :rec eng/producers-query}
      :events {:munge events/munge-result-rows
               :rec eng/report-events-query}
      :edges {:munge edges/munge-result-rows
@@ -63,7 +65,7 @@
   (if-let [munge-result (get-in @entity-fn-idx [entity :munge])]
     munge-result
     (throw (IllegalArgumentException.
-            (i18n/tru "Invalid entity '{0}' in query"
+            (i18n/tru "Invalid entity ''{0}'' in query"
                       (utils/dashes->underscores (name entity)))))))
 
 (defn orderable-columns
@@ -229,6 +231,9 @@
                     :environment "SELECT 1
                                   FROM environments
                                   WHERE environment=?"
+                    :producer "SELECT 1
+                                  FROM producers
+                                  WHERE name=?"
                     :factset "SELECT 1
                               FROM certnames
                               INNER JOIN factsets

--- a/test/puppetlabs/puppetdb/http/producers_test.clj
+++ b/test/puppetlabs/puppetdb/http/producers_test.clj
@@ -1,0 +1,175 @@
+(ns puppetlabs.puppetdb.http.producers-test
+  (:require [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.http :as http]
+            [puppetlabs.puppetdb.scf.storage :as storage]
+            [puppetlabs.puppetdb.query-eng :as eng]
+            [clojure.test :refer :all]
+            [puppetlabs.puppetdb.testutils.db :refer [without-db-var]]
+            [puppetlabs.puppetdb.testutils.http :refer [deftest-http-app
+                                                        query-response
+                                                        query-result]]
+            [puppetlabs.puppetdb.testutils.nodes :as tu-nodes]))
+
+(def endpoints [[:v4 "/v4/producers"]])
+
+(deftest-http-app test-all-producers
+  [[version endpoint] endpoints
+   method [:get :post]]
+
+  (testing "without producers"
+    (is (empty? (query-result method endpoint))))
+
+  (testing "with producers"
+    (doseq [prod ["foo" "bar" "baz"]]
+      (storage/ensure-producer prod))
+
+    (without-db-var
+     (fn []
+       (is (= #{{:name "foo"}
+                {:name "bar"}
+                {:name "baz"}}
+              (query-result method endpoint)))))
+
+    (without-db-var
+     (fn []
+       (let [res (query-response method endpoint)]
+         (is (= #{{:name "foo"}
+                  {:name "bar"}
+                  {:name "baz"}}
+                (set @(future (-> (query-response method endpoint)
+                                  :body
+                                  slurp
+                                  (json/parse-string true)))))))))))
+
+(deftest-http-app test-query-producer
+  [[version endpoint] endpoints
+   method [:get :post]]
+
+  (testing "without producers"
+    (without-db-var
+     (fn []
+       (is (= 404 (:status (query-response method (str endpoint "/foo"))))))))
+
+  (testing "with producers"
+    (doseq [prod ["foo" "bar" "baz"]]
+      (storage/ensure-producer prod))
+    (without-db-var
+     (fn []
+       (is (= {:name "foo"}
+              (-> (query-response method (str endpoint "/foo"))
+                  :body
+                  (json/parse-string true))))))))
+
+(deftest-http-app producer-queries
+  [[version endpoint] endpoints
+   method [:get :post]]
+
+  (let [{:keys [web1 web2 db puppet]} (tu-nodes/store-example-nodes)]
+    (are [query expected] (= expected
+                             (query-result method endpoint query))
+
+         ["=" "name" "foo.com"]
+         #{{:name "foo.com"}}
+
+         ["~" "name" "f.*"]
+         #{{:name "foo.com"}}
+
+         ["not" ["=" "name" "foo.com"]]
+         #{{:name "bar.com"}
+           {:name "mom.com"}}
+
+         ;;;;;;;;;;;;
+         ;; Basic reports subquery examples
+         ;;;;;;;;;;;;
+
+         ;; In syntax: select_reports
+         ["in" "name"
+          ["extract" "producer"
+           ["select_reports"
+            ["and"
+             ["=" "certname" "web1.example.com"]
+             ["=" "environment" "DEV"]]]]]
+         #{{:name "bar.com"}}
+
+         ;; In syntax: from
+         ["in" "name"
+          ["from" "reports"
+           ["extract" "producer"
+            ["and"
+             ["=" "certname" "web1.example.com"]
+             ["=" "environment" "DEV"]]]]]
+         #{{:name "bar.com"}}
+
+         ;; Implicit subquery syntax
+         ["subquery" "reports"
+          ["and"
+           ["=" "certname" "web1.example.com"]
+           ["=" "environment" "DEV"]]]
+         #{{:name "bar.com"}}
+
+         ;;;;;;;;;;;;;
+         ;; Not-wrapped subquery syntax
+         ;;;;;;;;;;;;;
+
+         ;; In syntax: select_reports
+         ["not"
+          ["in" "name"
+           ["extract" "producer"
+            ["select_factsets"
+             ["and"
+              ["=" "certname" "web1.example.com"]
+              ["=" "environment" "DEV"]]]]]]
+         #{{:name "bar.com"}
+           {:name "mom.com"}}
+
+         ;; In syntax: from
+         ["not"
+          ["in" "name"
+           ["from" "factsets"
+            ["extract" "producer"
+             ["and"
+              ["=" "certname" "web1.example.com"]
+              ["=" "environment" "DEV"]]]]]]
+         #{{:name "bar.com"}
+           {:name "mom.com"}}
+
+         ;; Implict subquery syntax
+         ["not"
+          ["subquery" "factsets"
+          ["and"
+           ["=" "certname" "web1.example.com"]
+           ["=" "environment" "DEV"]]]]
+         #{{:name "bar.com"}
+           {:name "mom.com"}}))
+
+  (testing "failed comparison"
+    (are [query]
+          (let [{:keys [status body]} (query-response method endpoint query)]
+            (re-find
+             #"Query operators >,>=,<,<= are not allowed on field name" body))
+
+      ["<=" "name" "foo.com"]
+      [">=" "name" "foo.com"]
+      ["<" "name" "foo.com"]
+      [">" "name" "foo.com"])))
+
+(def no-parent-endpoints [[:v4 "/v4/producers/foo.com/catalogs"]
+                          [:v4 "/v4/producers/foo.com/factsets"]
+                          [:v4 "/v4/producers/foo.com/reports"]])
+
+(deftest-http-app unknown-parent-handling
+  [[version endpoint] no-parent-endpoints
+   method [:get :post]]
+
+  (testing "producer-exists? function"
+    (doseq [prod ["bar.com" "baz.com" "mom.com"]]
+      (storage/ensure-producer prod))
+    (is (= false (eng/object-exists? :producer "foo.com")))
+    (is (= true (eng/object-exists? :producer "bar.com")))
+    (is (= true (eng/object-exists? :producer "baz.com")))
+    (is (= true (eng/object-exists? :producer "mom.com"))))
+
+  (let [{:keys [status body]} (query-response method endpoint)]
+    (is (= status http/status-not-found))
+    (is (= {:error "No information is known about producer foo.com"}
+           (json/parse-string body true)))))


### PR DESCRIPTION
This commit adds a "producers" query endpoint and includes reports, catalogs,
and factsets as subquery endpoints.