### PR TITLE
(maint) Intended catalog failed

### DIFF
--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-304bebf8e5fc109ced84e8b086f9bcf8324f3d78.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-304bebf8e5fc109ced84e8b086f9bcf8324f3d78.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "on_failure",
     "certname": "pg1.vm",
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:22:52.014Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-327147ee71a6e67db76112add34d49c674f97b4f.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-327147ee71a6e67db76112add34d49c674f97b4f.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "on_failure",
     "certname": "pg1.vm",
     "configuration_version": "1423833650",
     "end_time": "2015-02-13T13:21:04.382Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-339914cdb0a7a9a7ca4c9c310ab96ba20649376f.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-339914cdb0a7a9a7ca4c9c310ab96ba20649376f.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "not_used",
     "certname": "pg1.vm",
     "configuration_version": "1423833650",
     "end_time": "2015-02-13T13:21:14.240Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-9956b77aba1f29fe276978cd68d4c169f2e34d69.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-9956b77aba1f29fe276978cd68d4c169f2e34d69.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "not_used",
     "certname": "pg1.vm",
     "configuration_version": "1423833650",
     "end_time": "2015-02-13T13:21:49.346Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-a454ec51cbadba8c31beb9c1d66e90e9482ff4a6.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-a454ec51cbadba8c31beb9c1d66e90e9482ff4a6.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "not_used",
     "certname": "pg1.vm",
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:22:42.965Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-193c2a3ae8b277158dbb1073a35290b406c3c073.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-193c2a3ae8b277158dbb1073a35290b406c3c073.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "on_failure",
     "certname": "pg2.vm",
     "configuration_version": "1423834124",
     "end_time": "2015-02-13T13:29:29.626Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-19fce4fd5281b1df9b42d58c808fecb2a783da3b.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-19fce4fd5281b1df9b42d58c808fecb2a783da3b.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "not_used",
     "certname": "pg2.vm",
     "configuration_version": "1423834124",
     "end_time": "2015-02-13T13:28:44.696Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-34ecfe5dcfebc9510d159d2ec010d6e1f9094fb1.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-34ecfe5dcfebc9510d159d2ec010d6e1f9094fb1.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "not_used",
     "certname": "pg2.vm",
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:26:57.691Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-b73c37f620703406b5666e7c919afff00c511f1e.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-b73c37f620703406b5666e7c919afff00c511f1e.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "not_used",
     "certname": "pg2.vm",
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:27:14.717Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-bb3cea0e4f72a38fde935e93a9efca44e540ec3c.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-bb3cea0e4f72a38fde935e93a9efca44e540ec3c.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "not_used",
     "certname": "pg2.vm",
     "configuration_version": "1423834124",
     "end_time": "2015-02-13T13:29:04.147Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-cfdc33f7bb68d2c25d3b3758f3dca50b851b96ea.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-cfdc33f7bb68d2c25d3b3758f3dca50b851b96ea.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "on_failure",
     "certname": "pg2.vm",
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:26:31.273Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-02f72d7b1e2ded2074c4c3d6e2f415f6978d5932.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-02f72d7b1e2ded2074c4c3d6e2f415f6978d5932.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "not_used",
     "certname": "puppetdb1.vm",
     "configuration_version": "1423833558",
     "end_time": "2015-02-13T13:20:11.029Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-05ce58a44a6441dc967559bf89fd82619068f72c.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-05ce58a44a6441dc967559bf89fd82619068f72c.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "not_used",
     "certname": "puppetdb1.vm",
     "configuration_version": "1423834124",
     "end_time": "2015-02-13T13:29:56.692Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-5ba2c61aeb5f3ed8722e45f9c2c7b53d606e402e.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-5ba2c61aeb5f3ed8722e45f9c2c7b53d606e402e.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "not_used",
     "certname": "puppetdb1.vm",
     "configuration_version": "1423834124",
     "end_time": "2015-02-13T13:30:29.332Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-6eade546c696f0c045ec29f955bdb4d6a39a8291.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-6eade546c696f0c045ec29f955bdb4d6a39a8291.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "not_used",
     "certname": "puppetdb1.vm",
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:23:55.758Z",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-9eeca12cedb235b2e8f616967bf1f46d3e1de812.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-9eeca12cedb235b2e8f616967bf1f46d3e1de812.json
@@ -1,4 +1,5 @@
 {
+    "cached_catalog_status": "on_failure",
     "certname": "puppetdb1.vm",
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:23:48.963Z",


### PR DESCRIPTION
- While developing, we often need to pull in various data into PuppetDB. So we use `puppetlabs.puppetdb.cli.benchmark` tool pretty extensively to achieve that.
- This PR allows us in basic setup fill in needed data to populate fields.

- I think that there should also be a case for `noop=>false, status=>failed`, but that kind of report is not included in this data set. I wanted to make this simple so not included in this PR. If this PR is ok, I would like to also include this case.


