### PR TITLE
(PDB-2783) Revisit command versioning

### DIFF
--- a/documentation/versioning_policy.markdown
+++ b/documentation/versioning_policy.markdown
@@ -79,11 +79,15 @@ Commands can be versioned on an individual command basis, so we are generally fr
 
 Commands are primarily represented by a corresponding wire format. Wire formats are versioned along with the corresponding command.
 
-The reasons to trigger a new command version are more common, and in general if we aren’t sure it's easy enough to create another version anyway.
+Changes to an existing command version can be made if the change is backward compatible. For example:
 
-Some examples of changes that will require a new command version:
+* Addition of optional parameters within a command or wire format
+* Change of a required parameter to optional
+* Addition of a new enum value for an existing field
 
-* Any change to the parameters or parameter values within a command or wire format
+Some examples of changes that *will* require a new command version:
+
+* Removal or renaming of parameters or parameter values within a command or wire format
 * Change to serialization for wire formats inside payload
 
 The [API commands][commands] documentation contains more concrete information about the existing commands, versions and statuses for this version of PuppetDB.

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -108,6 +108,10 @@
    "replace catalog" (version-range 4 9)
    "store report" (version-range 3 8)
    "deactivate node" (version-range 1 3)})
+   
+(def latest-catalog-version (apply max (get supported-command-versions "replace catalog")))
+(def latest-report-version (apply max (get supported-command-versions "store report")))
+(def latest-facts-version (apply max (get supported-command-versions "replace facts")))
 
 (defn- die-on-header-payload-mismatch
   [name in-header in-body]

--- a/src/puppetlabs/puppetdb/export.clj
+++ b/src/puppetlabs/puppetdb/export.clj
@@ -11,6 +11,7 @@
             [puppetlabs.puppetdb.catalogs :as catalogs]
             [puppetlabs.puppetdb.factsets :as factsets]
             [puppetlabs.puppetdb.reports :as reports]
+            [puppetlabs.puppetdb.command :as command]
             [puppetlabs.puppetdb.utils :as utils]
             [clj-time.format :as time-fmt]
             [clj-time.coerce :as time-coerce]
@@ -19,16 +20,10 @@
 
 (def export-metadata-file-name "export-metadata.json")
 (def query-api-version :v4)
-(def ^:private command-versions
-  ;; This is not ideal that we are hard-coding the command version here, but
-  ;;  in our current architecture I don't believe there is any way to introspect
-  ;;  on which version of the `replace catalog` matches up with the current
-  ;;  version of the `catalog` endpoint... or even to query what the latest
-  ;;  version of a command is.  We should improve that.
-  {:replace_catalog 9
-   :store_report 8
-   :replace_facts 5})
-
+(def latest-command-versions
+  {:replace_catalog command/latest-catalog-version
+   :store_report command/latest-report-version
+   :replace_facts command/latest-facts-version})
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Utility Functions
 
@@ -108,6 +103,6 @@
    (with-open [tar-writer (archive/tarball-writer outfile)]
      (utils/add-tar-entry
       tar-writer {:file-suffix [export-metadata-file-name]
-                  :contents (json/generate-pretty-string {:timestamp (now) :command_versions command-versions})})
+                  :contents (json/generate-pretty-string {:timestamp (now) :command_versions latest-command-versions})})
      (export!* tar-writer query-fn anonymize-profile))
    (log/infof "Finished exporting PuppetDB")))

--- a/test/puppetlabs/puppetdb/acceptance/cli.clj
+++ b/test/puppetlabs/puppetdb/acceptance/cli.clj
@@ -4,6 +4,7 @@
             [puppetlabs.puppetdb.cli.export :as cli-export]
             [puppetlabs.puppetdb.cli.import :as cli-import]
             [puppetlabs.puppetdb.anonymizer :as anon]
+            [puppetlabs.puppetdb.command :as command]
             [puppetlabs.puppetdb.testutils :as tu]
             [puppetlabs.puppetdb.testutils.facts :as tuf]
             [puppetlabs.puppetdb.testutils.reports :as tur]
@@ -23,11 +24,11 @@
          (is (empty? (get-nodes)))
 
          (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                      "replace catalog" 9 example-catalog)
+                                      "replace catalog" command/latest-catalog-version example-catalog)
          (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                      "store report" 8 example-report)
+                                      "store report" command/latest-report-version example-report)
          (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                      "replace facts" 5 example-facts)
+                                      "replace facts" command/latest-facts-version example-facts)
 
          (is (= (tuc/munge-catalog example-catalog)
                 (tuc/munge-catalog (get-catalogs example-certname))))

--- a/test/puppetlabs/puppetdb/admin_test.clj
+++ b/test/puppetlabs/puppetdb/admin_test.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.puppetdb.admin-test
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetdb.cli.services :refer :all]
-            [puppetlabs.puppetdb.command :refer [enqueue-command]]
+            [puppetlabs.puppetdb.command :as command]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.export :as export]
             [puppetlabs.puppetdb.import :as import]
@@ -32,11 +32,11 @@
        (is (empty? (get-nodes)))
 
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "replace catalog" 9 example-catalog)
+                                    "replace catalog" command/latest-catalog-version example-catalog)
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "store report" 8 example-report)
+                                    "store report" command/latest-report-version example-report)
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "replace facts" 5 example-facts)
+                                    "replace facts" command/latest-facts-version example-facts)
 
        (is (= (tuc/munge-catalog example-catalog)
               (tuc/munge-catalog (get-catalogs example-certname))))
@@ -54,7 +54,7 @@
 
        (let [dispatcher (tk-app/get-service svc-utils/*server*
                                             :PuppetDBCommandDispatcher)
-             submit-command-fn (partial enqueue-command dispatcher)]
+             submit-command-fn (partial command/enqueue-command dispatcher)]
          (import/import! export-out-file submit-command-fn))
 
        @(tu/block-until-results 200 (first (get-catalogs example-certname)))
@@ -78,11 +78,11 @@
          (is (empty? (get-nodes)))
 
          (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                      "replace catalog" 9 example-catalog)
+                                      "replace catalog" command/latest-catalog-version example-catalog)
          (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                      "store report" 8 example-report)
+                                      "store report" command/latest-report-version example-report)
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "replace facts" 5 example-facts)
+                                    "replace facts" command/latest-facts-version example-facts)
 
          (is (= (tuc/munge-catalog example-catalog)
                 (tuc/munge-catalog (get-catalogs example-certname))))
@@ -112,18 +112,20 @@
         (is (empty? (get-nodes)))
 
         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                     "replace catalog" 9 example-catalog)
-        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url)
-                                     "bar.com"
-                                     "replace catalog" 9
+                                     "replace catalog" command/latest-catalog-version
+                                     example-catalog)
+        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "bar.com"
+                                     "replace catalog" command/latest-catalog-version
                                      example-catalog2)
 
         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                     "store report" 8 example-report)
+                                     "store report" command/latest-report-version
+                                     example-report)
         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                     "replace facts" 5 example-facts)
+                                     "replace facts" command/latest-facts-version
+                                     example-facts)
         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "bar.com"
-                                     "replace facts" 5
+                                     "replace facts" command/latest-facts-version
                                      example-facts2)
 
         (sutils/vacuum-analyze *db*)

--- a/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
+++ b/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
@@ -3,6 +3,7 @@
             [puppetlabs.puppetdb.client :as pdb-client]
             [puppetlabs.puppetdb.cli.export :as cli-export]
             [puppetlabs.puppetdb.cli.import :as cli-import]
+            [puppetlabs.puppetdb.command :as command]
             [puppetlabs.puppetdb.testutils :as tu]
             [puppetlabs.puppetdb.testutils.db :refer [*db* with-test-db]]
             [puppetlabs.puppetdb.testutils.facts :as tuf]
@@ -24,11 +25,11 @@
        (is (empty? (get-nodes)))
 
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "replace catalog" 9 example-catalog)
+                                    "replace catalog" command/latest-catalog-version example-catalog)
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "store report" 8 example-report)
+                                    "store report" command/latest-report-version example-report)
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "replace facts" 5 example-facts)
+                                    "replace facts" command/latest-facts-version example-facts)
 
        (is (= (tuc/munge-catalog example-catalog)
               (tuc/munge-catalog (get-catalogs example-certname))))
@@ -66,7 +67,8 @@
      (fn []
        (is (empty? (get-nodes)))
 
-       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname "replace facts" 5 example-facts)
+       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname 
+                                    "replace facts" command/latest-facts-version example-facts)
 
        (is (empty? (get-catalogs example-certname)))
        (is (empty? (get-reports example-certname)))
@@ -108,7 +110,7 @@
        (pdb-client/submit-command-via-http! (svc-utils/pdb-cmd-url)
                                             example-certname
                                             "replace catalog"
-                                            9
+                                            command/latest-catalog-version
                                             example-catalog)
 
        (is (thrown-with-msg?

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -482,7 +482,7 @@
 (deftest catalog-with-updated-resource-line
   (dotestseq [version catalog-versions
               :let [command {:command (command-names :replace-catalog)
-                             :version 9
+                             :version latest-catalog-version
                              :payload basic-wire-catalog}
                     command-1 (stringify-payload command)
                     command-2 (stringify-payload
@@ -509,7 +509,7 @@
 (deftest catalog-with-updated-resource-file
   (dotestseq [version catalog-versions
               :let [command {:command (command-names :replace-catalog)
-                             :version 9
+                             :version latest-catalog-version
                              :payload basic-wire-catalog}
                     command-1 (stringify-payload command)
                     command-2 (stringify-payload
@@ -536,7 +536,7 @@
 (deftest catalog-with-updated-resource-exported
   (dotestseq [version catalog-versions
               :let [command {:command (command-names :replace-catalog)
-                             :version 9
+                             :version latest-catalog-version
                              :payload basic-wire-catalog}
                     command-1 (stringify-payload command)
                     command-2 (stringify-payload
@@ -561,7 +561,7 @@
 (deftest catalog-with-updated-resource-tags
   (dotestseq [version catalog-versions
               :let [command {:command (command-names :replace-catalog)
-                             :version 9
+                             :version latest-catalog-version
                              :payload basic-wire-catalog}
                     command-1 (stringify-payload command)
                     command-2 (stringify-payload
@@ -866,7 +866,7 @@
 
 (deftest replace-facts-bad-payload
   (let [bad-command {:command (command-names :replace-facts)
-                     :version 5
+                     :version latest-facts-version
                      :payload "bad stuff"}]
     (dotestseq [version fact-versions
                 :let [command bad-command]]


### PR DESCRIPTION
*Replace hard-coded command versions with calls to the maximum supported command versions defined in command.clj.
*Edit command versioning policy to more closely match the query versioning policy.