### PR TITLE
(PDB-2838) server side changes for remediation field

### DIFF
--- a/documentation/api/command/v1/commands.markdown
+++ b/documentation/api/command/v1/commands.markdown
@@ -125,8 +125,8 @@ payload of this command.
 
 ### "store report", version 8
 
-* The nullable `producer` property has been added.
-* The nullable `noop_pending` property has been added.
+* The nullable `producer`, `noop_pending`, and `corrective_change` fields have
+  been added.
 
 The payload is expected to be a report, containing events that occurred on
 Puppet resources. It is structured as a JSON object, conforming to the

--- a/documentation/api/query/v4/nodes.markdown
+++ b/documentation/api/query/v4/nodes.markdown
@@ -67,6 +67,10 @@ The below fields are allowed as filter criteria and are returned in all response
 * `latest_report_noop_pending` (boolean): indicates whether the most recent
   report for the node contained noop events.
 
+* `latest_report_corrective_change` (boolean): a flag indicating whether the latest
+  report for the node included events that remediated configuration drift. This
+  field is only populated in PE.
+
 * `cached_catalog_status` (string): Cached catalog status of the
   last puppet run for the node. Possible values are `explicitly_requested`,
   `on_failure`, `not_used` or `null`.

--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -112,6 +112,9 @@ run used a cached catalogs and whether or not the cached catalog was used due to
 an error or not. Possible values include `explicitly_requested`, `on_failure`,
 `not_used` or `null`.
 
+* `corrective_change`: (Boolean): a flag indicating whether any of the report's
+  events remediated configuration drift. This field is only populated in PE.
+
 * `latest_report?` (Boolean): return only reports associated with the most
   recent Puppet run for each node. **Note:** this field does not appear in the
   response.

--- a/documentation/api/wire_format/report_format_v8.markdown
+++ b/documentation/api/wire_format/report_format_v8.markdown
@@ -28,6 +28,7 @@ noted, `null` is not allowed anywhere in the report.
         "cached_catalog_status": <string>,
         "status": <string>,
         "noop": <boolean>,
+        "corrective_change": <boolean>,
         "noop_pending": <boolean>
     }
 
@@ -81,6 +82,9 @@ error or not. This field may be `null`.
 events. These may result from use of the `--noop` flag, or from resources
 tagged with the `noop` parameter. This field may be `null`.
 
+`"corrective_change"` is a flag that indicates whether the report contained changes
+to correct configuration drift. This field may be `null`.
+
 `"resources"` is an array of objects of the following form:
 
 
@@ -104,6 +108,7 @@ In each `<resource>` object `"events"` is an array of objects of the following f
       "new_value": <new value for resource property>,
       "old_value": <old value of resource property>,
       "message": <description of what happened during event>,
+      "corrective_change": <flag indicating whether the event corrected system drift>
     }
 
 `"metrics"` is either null or an array of metric objects:
@@ -127,7 +132,8 @@ In each `<resource>` object `"events"` is an array of objects of the following f
      }
 
 >**Note: Fields that allow `NULL` values**
->In the resource_event schema above, `containment_path`, `new_value`, `old_value`, `property`, `file`, `line`, `status`, and `message` may all be null.
+>In the resource_event schema above, `containment_path`, `new_value`, `old_value`,
+`property`, `file`, `line`, `status`, `corrective_change`, and `message` may all be null.
 
 ### Encoding
 

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -142,96 +142,96 @@ msgstr ""
 msgid "''not'' takes exactly one argument, but {0} were supplied"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:375
+#: src/puppetlabs/puppetdb/query.clj:376
 msgid "The argument to extract must be a select operator, not ''{0}''"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:379
+#: src/puppetlabs/puppetdb/query.clj:380
 msgid "Can't extract unknown {0} field ''{1}''. Acceptable fields are: {2}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:395
+#: src/puppetlabs/puppetdb/query.clj:396
 msgid ""
 "Can''t match on unknown {0} field ''{1}'' for ''in''. Acceptable fields are: "
 "{2}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:399
+#: src/puppetlabs/puppetdb/query.clj:400
 msgid "The subquery argument of ''in'' must be an ''extract'', not ''{0}''"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:465 src/puppetlabs/puppetdb/query.clj:655
-#: src/puppetlabs/puppetdb/query.clj:746
+#: src/puppetlabs/puppetdb/query.clj:466 src/puppetlabs/puppetdb/query.clj:656
+#: src/puppetlabs/puppetdb/query.clj:747
 msgid "= requires exactly two arguments, but {0} were supplied"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:499
+#: src/puppetlabs/puppetdb/query.clj:500
 msgid "''{0}'' is not a queryable object for resources in the version {1} API"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:531
+#: src/puppetlabs/puppetdb/query.clj:532
 msgid ""
 "''{0}'' cannot be the target of a regexp match for version {1} of the "
 "resources API"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:563
+#: src/puppetlabs/puppetdb/query.clj:564
 msgid "{0} is not a queryable object for version {1} of the facts query api"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:594
+#: src/puppetlabs/puppetdb/query.clj:595
 msgid "{0} is not a valid version {1} operand for regexp comparison"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:614
+#: src/puppetlabs/puppetdb/query.clj:615
 msgid "{0} is not a queryable object for facts"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:616
+#: src/puppetlabs/puppetdb/query.clj:617
 msgid "Value {0} must be a number for {1} comparison."
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:627 src/puppetlabs/puppetdb/query.clj:764
+#: src/puppetlabs/puppetdb/query.clj:628 src/puppetlabs/puppetdb/query.clj:765
 msgid "{0} requires exactly two arguments, but {1} were supplied"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:640
+#: src/puppetlabs/puppetdb/query.clj:641
 msgid "''{0}'' is not a valid timestamp value"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:643
+#: src/puppetlabs/puppetdb/query.clj:644
 msgid "{0} operator does not support object ''{1}'' for resource events"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:698 src/puppetlabs/puppetdb/query.clj:735
+#: src/puppetlabs/puppetdb/query.clj:699 src/puppetlabs/puppetdb/query.clj:736
 msgid ""
 "''{0}'' is not a queryable object for version {1} of the resource events API"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:710
+#: src/puppetlabs/puppetdb/query.clj:711
 msgid "~ requires exactly two arguments, but {0} were supplied"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:754
+#: src/puppetlabs/puppetdb/query.clj:755
 msgid "{0} is not a queryable object for event counts"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:772
+#: src/puppetlabs/puppetdb/query.clj:773
 msgid "{0} operator does not support object ''{1}'' for event counts"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query_eng.clj:66
-msgid "Invalid entity '{0}' in query"
+#: src/puppetlabs/puppetdb/query_eng.clj:68
+msgid "Invalid entity ''{0}'' in query"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query_eng.clj:193
-#: src/puppetlabs/puppetdb/query_eng.clj:199
+#: src/puppetlabs/puppetdb/query_eng.clj:195
+#: src/puppetlabs/puppetdb/query_eng.clj:201
 msgid ""
 "Error executing query ''{0}'' with query options ''{1}''. Returning a 400 "
 "error code."
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query_eng.clj:204
+#: src/puppetlabs/puppetdb/query_eng.clj:206
 msgid "Caught PSQL processing exception"
 msgstr ""
 

--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -44,6 +44,7 @@ Puppet::Reports.register_report(:puppetdb) do
       defaulted_code_id = defined?(code_id) ? code_id : nil
       defaulted_cached_catalog_status = defined?(cached_catalog_status) ? cached_catalog_status : nil
       defaulted_noop_pending = defined?(noop_pending) ? noop_pending : nil
+      defaulted_corrective_change = defined?(corrective_change) ? corrective_change : nil
 
       {
         "certname" => host,
@@ -58,6 +59,7 @@ Puppet::Reports.register_report(:puppetdb) do
         "status" => status,
         "noop" => is_noop,
         "noop_pending" => defaulted_noop_pending,
+        "corrective_change" => defaulted_corrective_change,
         "logs" => build_logs_list,
         "metrics" => build_metrics_list,
         "resources" => resources,
@@ -154,12 +156,14 @@ Puppet::Reports.register_report(:puppetdb) do
   # @return Hash[<String, Object>]
   # @api private
   def event_to_hash(event)
+    corrective_change = defined?(event.corrective_change) ? event.corrective_change : nil
     {
       "status"            => event.status,
       "timestamp"         => Puppet::Util::Puppetdb.to_wire_time(event.time),
       "property"          => event.property,
       "new_value"         => event.desired_value,
       "old_value"         => event.previous_value,
+      "corrective_change" => corrective_change,
       "message"           => event.message,
     }
   end
@@ -177,15 +181,17 @@ Puppet::Reports.register_report(:puppetdb) do
   # @return Hash[<String, Object>]
   # @api private
   def resource_status_to_hash(resource_status)
+    defaulted_corrective_change = defined?(resource_status.corrective_change) ? resource_status.corrective_change : nil
     {
-      "skipped"          => resource_status.skipped,
-      "timestamp"        => Puppet::Util::Puppetdb.to_wire_time(resource_status.time),
-      "resource_type"    => resource_status.resource_type,
-      "resource_title"   => resource_status.title.to_s,
-      "file"             => resource_status.file,
-      "line"             => resource_status.line,
-      "containment_path" => resource_status.containment_path,
-      "events"           => build_events_list(resource_status.events),
+      "skipped"           => resource_status.skipped,
+      "timestamp"         => Puppet::Util::Puppetdb.to_wire_time(resource_status.time),
+      "resource_type"     => resource_status.resource_type,
+      "resource_title"    => resource_status.title.to_s,
+      "file"              => resource_status.file,
+      "line"              => resource_status.line,
+      "containment_path"  => resource_status.containment_path,
+      "corrective_change" => defaulted_corrective_change,
+      "events"            => build_events_list(resource_status.events),
     }
   end
 

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -116,6 +116,18 @@ describe processor do
       end
     end
 
+    it "should include corrective_change or nil" do
+      if defined?(subject.corrective_change) then
+        subject["corrective_change"] = false
+      end
+      result = subject.send(:report_to_hash)
+      if defined?(subject.corrective_change) then
+        result["corrective_change"].should == false
+      else
+        result["corrective_change"].should == nil
+      end
+    end
+
     it "should include the cached_catalog_status or nil" do
       if defined?(subject.cached_catalog_status) then
         subject.cached_catalog_status = 'not_used'
@@ -204,6 +216,9 @@ describe processor do
           event.desired_value = "fooval"
           event.previous_value = "oldfooval"
           event.message = "foomessage"
+          if defined?(event.corrective_change) then
+            event.corrective_change = true
+          end
           status.add_event(event)
 
           result = subject.send(:report_to_hash)
@@ -216,12 +231,22 @@ describe processor do
           res["line"].should == 1
           res["containment_path"].should == ["foo", "bar", "baz"]
           res["events"].length.should == 1
+          if defined?(event.corrective_change) then
+            res["corrective_change"].should == true
+          else
+            res["corrective_change"].should == nil
+          end
 
           res_event = res["events"][0]
           res_event["property"].should == "fooprop"
           res_event["new_value"].should == "fooval"
           res_event["old_value"].should == "oldfooval"
           res_event["message"].should == "foomessage"
+          if defined?(event.corrective_change) then
+            res_event["corrective_change"].should == true
+          else
+            res_event["corrective_change"].should == nil
+          end
         end
       end
 

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-304bebf8e5fc109ced84e8b086f9bcf8324f3d78.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-304bebf8e5fc109ced84e8b086f9bcf8324f3d78.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:22:52.014Z",
     "environment": "production",
+    "corrective_change": false,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -244,18 +246,23 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:22:54.116Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 3,
             "resource_title": "foo",
+            "corrective_change": false,
             "resource_type": "Notify",
             "skipped": false,
             "timestamp": "2015-02-13T13:22:54.116Z"
         }
     ],
     "start_time": "2015-02-13T13:22:51.075Z",
+    "catalog_uuid": "2e59e974-7d40-4e41-bb81-20d91e2c2679",
+    "producer": "foo.com",
+    "code_id": "5ce7eda4-a281-49d5-94e9-edb4b3b1d0b5",
     "status": "changed",
     "transaction_uuid": "6906e9f2-d15a-414d-928c-ec1eac4b5e92"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-327147ee71a6e67db76112add34d49c674f97b4f.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-327147ee71a6e67db76112add34d49c674f97b4f.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423833650",
     "end_time": "2015-02-13T13:21:04.382Z",
     "environment": "production",
+    "corrective_change": false,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -472,10 +474,12 @@
                     "old_value": "{md5}a3f731187a6aaaa23d4a7b244f223f33",
                     "property": "content",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:21:06.444Z"
                 }
             ],
             "file": "/etc/puppet/modules/motd/manifests/init.pp",
+            "corrective_change": false,
             "line": 33,
             "resource_title": "/etc/motd",
             "resource_type": "File",
@@ -495,11 +499,13 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:21:06.488Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 3,
+            "corrective_change": false,
             "resource_title": "foo",
             "resource_type": "Notify",
             "skipped": false,
@@ -519,12 +525,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:21:06.575Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
             "line": 113,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:21:06.575Z"
@@ -543,12 +551,14 @@
                     "old_value": "{md5}df14e44b311152c34358a675ae34afe0",
                     "property": "content",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:21:06.589Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
             "line": 113,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:21:06.589Z"
@@ -556,5 +566,8 @@
     ],
     "start_time": "2015-02-13T13:21:03.326Z",
     "status": "unchanged",
+    "catalog_uuid": "90de2540-d70e-40bb-a264-c84e5a95bbef",
+    "producer": "foo.com",
+    "code_id": "6764b61b-6f2a-4187-85e8-cef3e29cda5e",
     "transaction_uuid": "d00ab23c-bd14-42a5-b5ef-855ceede8a40"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-339914cdb0a7a9a7ca4c9c310ab96ba20649376f.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-339914cdb0a7a9a7ca4c9c310ab96ba20649376f.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423833650",
     "end_time": "2015-02-13T13:21:14.240Z",
     "environment": "production",
+    "corrective_change": false,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -2672,6 +2674,7 @@
                     "old_value": "{md5}a3f731187a6aaaa23d4a7b244f223f33",
                     "property": "content",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:21:16.348Z"
                 }
             ],
@@ -2679,6 +2682,7 @@
             "line": 33,
             "resource_title": "/etc/motd",
             "resource_type": "File",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:21:16.348Z"
         },
@@ -2695,6 +2699,7 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:21:16.393Z"
                 }
             ],
@@ -2703,6 +2708,7 @@
             "resource_title": "foo",
             "resource_type": "Notify",
             "skipped": false,
+            "corrective_change": false,
             "timestamp": "2015-02-13T13:21:16.393Z"
         },
         {
@@ -2719,12 +2725,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:21:16.508Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
             "line": 113,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:21:16.508Z"
@@ -2743,6 +2751,7 @@
                     "old_value": "{md5}df14e44b311152c34358a675ae34afe0",
                     "property": "content",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:21:16.523Z"
                 }
             ],
@@ -2750,11 +2759,15 @@
             "line": 113,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
             "resource_type": "File",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:21:16.523Z"
         }
     ],
     "start_time": "2015-02-13T13:21:13.238Z",
     "status": "unchanged",
+    "catalog_uuid": "dcedddbf-25be-43fa-bf6d-a8ffdf765c73",
+    "producer": "foo.com",
+    "code_id": "b6187ff7-0e4f-4400-818d-8ee1dfd0fe38",
     "transaction_uuid": "ac63fb6f-d191-4d8a-94af-995ccaadb7dd"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-9956b77aba1f29fe276978cd68d4c169f2e34d69.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-9956b77aba1f29fe276978cd68d4c169f2e34d69.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423833650",
     "end_time": "2015-02-13T13:21:49.346Z",
     "environment": "production",
+    "corrective_change": true,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -279,12 +281,14 @@
                     "old_value": "{md5}02d304aace03a918311acc96cd339cc3",
                     "property": "content",
                     "status": "success",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:21:52.052Z"
                 }
             ],
             "file": "/etc/puppet/modules/motd/manifests/init.pp",
             "line": 33,
             "resource_title": "/etc/motd",
+            "corrective_change": true,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:21:52.052Z"
@@ -302,12 +306,14 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:21:52.095Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 3,
             "resource_title": "foo",
+            "corrective_change": false,
             "resource_type": "Notify",
             "skipped": false,
             "timestamp": "2015-02-13T13:21:52.095Z"
@@ -315,5 +321,8 @@
     ],
     "start_time": "2015-02-13T13:21:48.201Z",
     "status": "changed",
+    "catalog_uuid": "a86149f6-e0fd-46e4-9080-f873002837bb",
+    "producer": "foo.com",
+    "code_id": "75ffb3e4-ae64-4a58-9017-1d84563852b2",
     "transaction_uuid": "af8d1c1c-f1b9-450a-949d-f6990cf24d63"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-a454ec51cbadba8c31beb9c1d66e90e9482ff4a6.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-a454ec51cbadba8c31beb9c1d66e90e9482ff4a6.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:22:42.965Z",
     "environment": "production",
+    "corrective_change": false,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -244,11 +246,13 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:22:45.121Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 3,
+            "corrective_change": false,
             "resource_title": "foo",
             "resource_type": "Notify",
             "skipped": false,
@@ -257,5 +261,8 @@
     ],
     "start_time": "2015-02-13T13:22:42.019Z",
     "status": "changed",
+    "catalog_uuid": "065ebf9f-8592-4f83-8537-d270a69dd91e",
+    "producer": "foo.com",
+    "code_id": "9d1df9cd-99e6-4f8e-8536-5d892aca3600",
     "transaction_uuid": "8659eaf5-90a6-41d7-8898-6b0aec08d106"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-193c2a3ae8b277158dbb1073a35290b406c3c073.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-193c2a3ae8b277158dbb1073a35290b406c3c073.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423834124",
     "end_time": "2015-02-13T13:29:29.626Z",
     "environment": "production",
+    "corrective_change": false,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -1260,11 +1262,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:33.744Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/client.pp",
             "line": 85,
+            "corrective_change": false,
             "resource_title": "snmp.conf",
             "resource_type": "File",
             "skipped": false,
@@ -1284,12 +1288,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.716Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/init.pp",
             "line": 164,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.716Z"
@@ -1307,12 +1313,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.090Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/client.pp",
             "line": 76,
             "resource_title": "snmp-client",
+            "corrective_change": false,
             "resource_type": "Package",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.090Z"
@@ -1331,6 +1339,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.973Z"
                 }
             ],
@@ -1338,6 +1347,7 @@
             "line": 113,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
             "resource_type": "File",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.973Z"
         },
@@ -1354,11 +1364,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.134Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 41,
+            "corrective_change": false,
             "resource_title": "etckeeper",
             "resource_type": "Package",
             "skipped": false,
@@ -1377,6 +1389,7 @@
                     "old_value": "{md5}d41d8cd98f00b204e9800998ecf8427e",
                     "property": "content",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:31.924Z"
                 }
             ],
@@ -1385,6 +1398,7 @@
             "resource_title": "/etc/motd",
             "resource_type": "File",
             "skipped": false,
+            "corrective_change": false,
             "timestamp": "2015-02-13T13:29:31.924Z"
         },
         {
@@ -1401,6 +1415,7 @@
                     "old_value": null,
                     "property": null,
                     "status": "failure",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:33.118Z"
                 }
             ],
@@ -1409,6 +1424,7 @@
             "resource_title": "/tmp/file",
             "resource_type": "File",
             "skipped": false,
+            "corrective_change": false,
             "timestamp": "2015-02-13T13:29:33.118Z"
         },
         {
@@ -1424,12 +1440,14 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.178Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 3,
             "resource_title": "foo",
+            "corrective_change": false,
             "resource_type": "Notify",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.178Z"
@@ -1447,6 +1465,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.284Z"
                 }
             ],
@@ -1454,6 +1473,7 @@
             "line": 465,
             "resource_title": "snmptrapd.sysconfig",
             "resource_type": "File",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.284Z"
         },
@@ -1471,11 +1491,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:33.045Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
             "line": 113,
+            "corrective_change": false,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
             "resource_type": "File",
             "skipped": false,
@@ -1494,6 +1516,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.336Z"
                 }
             ],
@@ -1501,6 +1524,7 @@
             "line": 410,
             "resource_title": "var-net-snmp",
             "resource_type": "File",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.336Z"
         },
@@ -1517,6 +1541,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:33.660Z"
                 }
             ],
@@ -1524,6 +1549,7 @@
             "line": 60,
             "resource_title": "python-pip",
             "resource_type": "Package",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:29:33.660Z"
         },
@@ -1540,12 +1566,14 @@
                     "old_value": "stopped",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:33.221Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/init.pp",
             "line": 517,
             "resource_title": "snmpd",
+            "corrective_change": false,
             "resource_type": "Service",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:33.221Z"
@@ -1563,6 +1591,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.292Z"
                 }
             ],
@@ -1570,6 +1599,7 @@
             "line": 441,
             "resource_title": "snmpd.sysconfig",
             "resource_type": "File",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.292Z"
         },
@@ -1586,12 +1616,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:33.407Z"
                 }
             ],
             "file": "/etc/puppet/modules/git/manifests/init.pp",
             "line": 12,
             "resource_title": "git",
+            "corrective_change": false,
             "resource_type": "Package",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:33.407Z"
@@ -1609,10 +1641,12 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:33.738Z"
                 }
             ],
             "file": "/etc/puppet/modules/python/manifests/install.pp",
+            "corrective_change": false,
             "line": 59,
             "resource_title": "python-virtualenv",
             "resource_type": "Package",
@@ -1632,6 +1666,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.175Z"
                 }
             ],
@@ -1640,6 +1675,7 @@
             "resource_title": "snmpd",
             "resource_type": "Package",
             "skipped": false,
+            "corrective_change": false,
             "timestamp": "2015-02-13T13:29:32.175Z"
         },
         {
@@ -1655,12 +1691,14 @@
                     "old_value": "stopped",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.416Z"
                 }
             ],
             "file": "/etc/puppet/modules/ntp/manifests/service.pp",
             "line": 9,
             "resource_title": "ntp",
+            "corrective_change": false,
             "resource_type": "Service",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.416Z"
@@ -1678,11 +1716,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:33.687Z"
                 }
             ],
             "file": "/etc/puppet/modules/python/manifests/install.pp",
             "line": 61,
+            "corrective_change": false,
             "resource_title": "python-devel",
             "resource_type": "Package",
             "skipped": false,
@@ -1701,12 +1741,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.711Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/init.pp",
             "line": 453,
             "resource_title": "snmptrapd.conf",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.711Z"
@@ -1725,11 +1767,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.713Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/init.pp",
             "line": 144,
+            "corrective_change": false,
             "resource_title": "/var/lib/puppet/concat/_tmp_file",
             "resource_type": "File",
             "skipped": false,
@@ -1748,12 +1792,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.444Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 69,
             "resource_title": "hkp_server_20BC0A86",
+            "corrective_change": false,
             "resource_type": "Gnupg_key",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.444Z"
@@ -1772,12 +1818,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.971Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/init.pp",
             "line": 149,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.971Z"
@@ -1796,6 +1844,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.715Z"
                 }
             ],
@@ -1803,6 +1852,7 @@
             "line": 159,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat",
             "resource_type": "File",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.715Z"
         },
@@ -1819,11 +1869,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:33.123Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/init.pp",
             "line": 429,
+            "corrective_change": false,
             "resource_title": "snmpd.conf",
             "resource_type": "File",
             "skipped": false,
@@ -1845,12 +1897,14 @@
                     "old_value": "notrun",
                     "property": "returns",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:33.112Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/init.pp",
             "line": 187,
             "resource_title": "concat_/tmp/file",
+            "corrective_change": false,
             "resource_type": "Exec",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:33.112Z"
@@ -1868,11 +1922,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.334Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 45,
+            "corrective_change": false,
             "resource_title": "sample setting",
             "resource_type": "Ini_setting",
             "skipped": false,
@@ -1891,12 +1947,14 @@
                     "old_value": "stopped",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.280Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 4,
             "resource_title": "cron",
+            "corrective_change": false,
             "resource_type": "Service",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.280Z"
@@ -1914,12 +1972,14 @@
                     "old_value": "{md5}7fda24f62b1c7ae951db0f746dc6e0cc",
                     "property": "content",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:32.328Z"
                 }
             ],
             "file": "/etc/puppet/modules/ntp/manifests/config.pp",
             "line": 14,
             "resource_title": "/etc/ntp.conf",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:32.328Z"
@@ -1927,5 +1987,8 @@
     ],
     "start_time": "2015-02-13T13:29:26.846Z",
     "status": "failed",
+    "catalog_uuid": "974b0567-11bf-4600-a659-e293f14d0a03",
+    "producer": "foo.com",
+    "code_id": "01167c6f-95ce-4163-98d8-60ae9b5fbf15",
     "transaction_uuid": "1fb6bf81-0b2a-488c-b1d7-610a81b06b27"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-19fce4fd5281b1df9b42d58c808fecb2a783da3b.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-19fce4fd5281b1df9b42d58c808fecb2a783da3b.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423834124",
     "end_time": "2015-02-13T13:28:44.696Z",
     "environment": "production",
+    "corrective_change": true,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -1260,12 +1262,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.231Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 45,
             "resource_title": "sample setting",
+            "corrective_change": true,
             "resource_type": "Ini_setting",
             "skipped": false,
             "timestamp": "2015-02-13T13:28:47.231Z"
@@ -1283,11 +1287,13 @@
                     "old_value": "stopped",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.177Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 4,
+            "corrective_change": true,
             "resource_title": "cron",
             "resource_type": "Service",
             "skipped": false,
@@ -1306,12 +1312,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:48.688Z"
                 }
             ],
             "file": "/etc/puppet/modules/python/manifests/install.pp",
             "line": 59,
             "resource_title": "python-virtualenv",
+            "corrective_change": true,
             "resource_type": "Package",
             "skipped": false,
             "timestamp": "2015-02-13T13:28:48.688Z"
@@ -1329,10 +1337,12 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.072Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
+            "corrective_change": true,
             "line": 3,
             "resource_title": "foo",
             "resource_type": "Notify",
@@ -1353,10 +1363,12 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.919Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/init.pp",
+            "corrective_change": true,
             "line": 149,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments",
             "resource_type": "File",
@@ -1376,11 +1388,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:48.637Z"
                 }
             ],
             "file": "/etc/puppet/modules/python/manifests/install.pp",
             "line": 61,
+            "corrective_change": true,
             "resource_title": "python-devel",
             "resource_type": "Package",
             "skipped": false,
@@ -1399,11 +1413,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:48.609Z"
                 }
             ],
             "file": "/etc/puppet/modules/python/manifests/install.pp",
             "line": 60,
+            "corrective_change": true,
             "resource_title": "python-pip",
             "resource_type": "Package",
             "skipped": false,
@@ -1423,11 +1439,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.701Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/init.pp",
             "line": 144,
+            "corrective_change": true,
             "resource_title": "/var/lib/puppet/concat/_tmp_file",
             "resource_type": "File",
             "skipped": false,
@@ -1446,11 +1464,13 @@
                     "old_value": "stopped",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:48.164Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/init.pp",
             "line": 517,
+            "corrective_change": true,
             "resource_title": "snmpd",
             "resource_type": "Service",
             "skipped": false,
@@ -1469,6 +1489,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.026Z"
                 }
             ],
@@ -1476,6 +1497,7 @@
             "line": 41,
             "resource_title": "etckeeper",
             "resource_type": "Package",
+            "corrective_change": true,
             "skipped": false,
             "timestamp": "2015-02-13T13:28:47.026Z"
         },
@@ -1493,6 +1515,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.921Z"
                 }
             ],
@@ -1500,6 +1523,7 @@
             "line": 113,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
             "resource_type": "File",
+            "corrective_change": true,
             "skipped": false,
             "timestamp": "2015-02-13T13:28:47.921Z"
         },
@@ -1517,11 +1541,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.705Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/init.pp",
             "line": 164,
+            "corrective_change": true,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
             "resource_type": "File",
             "skipped": false,
@@ -1540,6 +1566,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:48.351Z"
                 }
             ],
@@ -1548,6 +1575,7 @@
             "resource_title": "git",
             "resource_type": "Package",
             "skipped": false,
+            "corrective_change": true,
             "timestamp": "2015-02-13T13:28:48.351Z"
         },
         {
@@ -1564,11 +1592,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.989Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
             "line": 113,
+            "corrective_change": true,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
             "resource_type": "File",
             "skipped": false,
@@ -1590,11 +1620,13 @@
                     "old_value": "notrun",
                     "property": "returns",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:48.056Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/init.pp",
             "line": 187,
+            "corrective_change": true,
             "resource_title": "concat_/tmp/file",
             "resource_type": "Exec",
             "skipped": false,
@@ -1614,11 +1646,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.703Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/init.pp",
             "line": 159,
+            "corrective_change": true,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat",
             "resource_type": "File",
             "skipped": false,
@@ -1637,6 +1671,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:48.067Z"
                 }
             ],
@@ -1644,6 +1679,7 @@
             "line": 429,
             "resource_title": "snmpd.conf",
             "resource_type": "File",
+            "corrective_change": true,
             "skipped": false,
             "timestamp": "2015-02-13T13:28:48.067Z"
         },
@@ -1660,11 +1696,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:46.980Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/client.pp",
             "line": 76,
+            "corrective_change": true,
             "resource_title": "snmp-client",
             "resource_type": "Package",
             "skipped": false,
@@ -1684,6 +1722,7 @@
                     "old_value": null,
                     "property": null,
                     "status": "failure",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:48.062Z"
                 }
             ],
@@ -1692,6 +1731,7 @@
             "resource_title": "/tmp/file",
             "resource_type": "File",
             "skipped": false,
+            "corrective_change": true,
             "timestamp": "2015-02-13T13:28:48.062Z"
         },
         {
@@ -1707,12 +1747,14 @@
                     "old_value": "{md5}7fda24f62b1c7ae951db0f746dc6e0cc",
                     "property": "content",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.224Z"
                 }
             ],
             "file": "/etc/puppet/modules/ntp/manifests/config.pp",
             "line": 14,
             "resource_title": "/etc/ntp.conf",
+            "corrective_change": true,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:28:47.224Z"
@@ -1730,6 +1772,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.234Z"
                 }
             ],
@@ -1737,6 +1780,7 @@
             "line": 410,
             "resource_title": "var-net-snmp",
             "resource_type": "File",
+            "corrective_change": true,
             "skipped": false,
             "timestamp": "2015-02-13T13:28:47.234Z"
         },
@@ -1753,6 +1797,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.069Z"
                 }
             ],
@@ -1760,6 +1805,7 @@
             "line": 405,
             "resource_title": "snmpd",
             "resource_type": "Package",
+            "corrective_change": true,
             "skipped": false,
             "timestamp": "2015-02-13T13:28:47.069Z"
         },
@@ -1776,11 +1822,13 @@
                     "old_value": "{md5}d41d8cd98f00b204e9800998ecf8427e",
                     "property": "content",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:46.797Z"
                 }
             ],
             "file": "/etc/puppet/modules/motd/manifests/init.pp",
             "line": 33,
+            "corrective_change": true,
             "resource_title": "/etc/motd",
             "resource_type": "File",
             "skipped": false,
@@ -1799,12 +1847,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.439Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 69,
             "resource_title": "hkp_server_20BC0A86",
+            "corrective_change": true,
             "resource_type": "Gnupg_key",
             "skipped": false,
             "timestamp": "2015-02-13T13:28:47.439Z"
@@ -1822,6 +1872,7 @@
                     "old_value": "stopped",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.393Z"
                 }
             ],
@@ -1829,6 +1880,7 @@
             "line": 9,
             "resource_title": "ntp",
             "resource_type": "Service",
+            "corrective_change": true,
             "skipped": false,
             "timestamp": "2015-02-13T13:28:47.393Z"
         },
@@ -1845,12 +1897,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.182Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/init.pp",
             "line": 465,
             "resource_title": "snmptrapd.sysconfig",
+            "corrective_change": true,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:28:47.182Z"
@@ -1868,6 +1922,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.191Z"
                 }
             ],
@@ -1875,6 +1930,7 @@
             "line": 441,
             "resource_title": "snmpd.sysconfig",
             "resource_type": "File",
+            "corrective_change": true,
             "skipped": false,
             "timestamp": "2015-02-13T13:28:47.191Z"
         },
@@ -1891,12 +1947,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:48.694Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/client.pp",
             "line": 85,
             "resource_title": "snmp.conf",
+            "corrective_change": true,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:28:48.694Z"
@@ -1914,6 +1972,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:28:47.699Z"
                 }
             ],
@@ -1922,10 +1981,14 @@
             "resource_title": "snmptrapd.conf",
             "resource_type": "File",
             "skipped": false,
+            "corrective_change": true,
             "timestamp": "2015-02-13T13:28:47.699Z"
         }
     ],
     "start_time": "2015-02-13T13:28:41.219Z",
     "status": "failed",
+    "catalog_uuid": "a1bec548-67cf-4588-a2df-2f357f496cf4",
+    "producer": "foo.com",
+    "code_id": "06c0074c-139d-4795-a45a-5d31acc0b07f",
     "transaction_uuid": "1fe685d2-cf15-46ba-8a07-84854c584703"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-34ecfe5dcfebc9510d159d2ec010d6e1f9094fb1.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-34ecfe5dcfebc9510d159d2ec010d6e1f9094fb1.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:26:57.691Z",
     "environment": "production",
+    "corrective_change": true,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -596,11 +598,13 @@
                     "old_value": "notrun",
                     "property": "returns",
                     "status": "success",
+                    "corrective_change": true,
                     "timestamp": "2015-02-13T13:26:57.409Z"
                 }
             ],
             "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
             "line": 83,
+            "corrective_change": true,
             "resource_title": "postgresql_data_directory",
             "resource_type": "Exec",
             "skipped": false,
@@ -619,6 +623,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:26:58.573Z"
                 }
             ],
@@ -626,6 +631,7 @@
             "line": 120,
             "resource_title": "/etc/sysconfig/pgsql/postgresql-8.4",
             "resource_type": "File",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:26:58.573Z"
         },
@@ -643,11 +649,13 @@
                     "old_value": "need_to_run",
                     "property": "returns",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:26:58.781Z"
                 }
             ],
             "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
             "line": 90,
+            "corrective_change": false,
             "resource_title": "override PGDATA in /etc/sysconfig/pgsql/postgresql",
             "resource_type": "Augeas",
             "skipped": false,
@@ -667,6 +675,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:26:58.814Z"
                 }
             ],
@@ -674,6 +683,7 @@
             "line": 105,
             "resource_title": "data_directory",
             "resource_type": "Postgresql_conf",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:26:58.814Z"
         },
@@ -691,12 +701,14 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:26:58.975Z"
                 }
             ],
             "file": "/etc/puppet/manifests/site.pp",
             "line": 6,
             "resource_title": "foo",
+            "corrective_change": false,
             "resource_type": "Notify",
             "skipped": false,
             "timestamp": "2015-02-13T13:26:58.975Z"
@@ -714,11 +726,13 @@
                     "old_value": "stopped",
                     "property": "ensure",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:26:59.281Z"
                 }
             ],
             "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
             "line": 14,
+            "corrective_change": false,
             "resource_title": "postgresqld",
             "resource_type": "Service",
             "skipped": false,
@@ -727,5 +741,8 @@
     ],
     "start_time": "2015-02-13T13:26:52.564Z",
     "status": "changed",
+    "catalog_uuid": "f9e15df3-bbfb-404c-80bd-f29ecdbe5283",
+    "producer": "foo.com",
+    "code_id": "8589ce99-5690-4900-a249-a052e044ca11",
     "transaction_uuid": "9df4e7ce-5646-4178-8ff8-db6add84e9fc"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-b73c37f620703406b5666e7c919afff00c511f1e.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-b73c37f620703406b5666e7c919afff00c511f1e.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:27:14.717Z",
     "environment": "production",
+    "corrective_change": false,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -250,12 +252,14 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:27:17.956Z"
                 }
             ],
             "file": "/etc/puppet/manifests/site.pp",
             "line": 6,
             "resource_title": "foo",
+            "corrective_change": false,
             "resource_type": "Notify",
             "skipped": false,
             "timestamp": "2015-02-13T13:27:17.956Z"
@@ -263,5 +267,8 @@
     ],
     "start_time": "2015-02-13T13:27:12.891Z",
     "status": "changed",
+    "catalog_uuid": "b7505625-6d8d-4014-beea-b67b785b8b6b",
+    "producer": "foo.com",
+    "code_id": "87680666-21a4-43b1-8c23-cc69f1832d74",
     "transaction_uuid": "5c4f17ad-d6df-4514-881b-e31ef107076e"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-bb3cea0e4f72a38fde935e93a9efca44e540ec3c.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-bb3cea0e4f72a38fde935e93a9efca44e540ec3c.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423834124",
     "end_time": "2015-02-13T13:29:04.147Z",
     "environment": "production",
+    "corrective_change": false,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -1335,12 +1337,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.164Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
             "line": 113,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:10.164Z"
@@ -1359,6 +1363,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.110Z"
                 }
             ],
@@ -1366,6 +1371,7 @@
             "line": 144,
             "resource_title": "/var/lib/puppet/concat/_tmp_file",
             "resource_type": "File",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:29:10.110Z"
         },
@@ -1382,6 +1388,7 @@
                     "old_value": "{md5}7fda24f62b1c7ae951db0f746dc6e0cc",
                     "property": "content",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:09.741Z"
                 }
             ],
@@ -1390,6 +1397,7 @@
             "resource_title": "/etc/ntp.conf",
             "resource_type": "File",
             "skipped": false,
+            "corrective_change": false,
             "timestamp": "2015-02-13T13:29:09.741Z"
         },
         {
@@ -1408,6 +1416,7 @@
                     "old_value": "notrun",
                     "property": "returns",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.230Z"
                 }
             ],
@@ -1431,6 +1440,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.885Z"
                 }
             ],
@@ -1454,6 +1464,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.504Z"
                 }
             ],
@@ -1477,6 +1488,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:09.423Z"
                 }
             ],
@@ -1500,12 +1512,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:09.325Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/client.pp",
             "line": 76,
             "resource_title": "snmp-client",
+            "corrective_change": false,
             "resource_type": "Package",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:09.325Z"
@@ -1523,11 +1537,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:09.751Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/init.pp",
             "line": 410,
+            "corrective_change": false,
             "resource_title": "var-net-snmp",
             "resource_type": "File",
             "skipped": false,
@@ -1546,11 +1562,13 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:09.521Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/init.pp",
             "line": 405,
+            "corrective_change": false,
             "resource_title": "snmpd",
             "resource_type": "Package",
             "skipped": false,
@@ -1570,12 +1588,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.158Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/init.pp",
             "line": 149,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:10.158Z"
@@ -1593,12 +1613,14 @@
                     "old_value": "stopped",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.275Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/init.pp",
             "line": 517,
             "resource_title": "snmpd",
+            "corrective_change": false,
             "resource_type": "Service",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:10.275Z"
@@ -1616,12 +1638,14 @@
                     "old_value": "stopped",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:09.871Z"
                 }
             ],
             "file": "/etc/puppet/modules/ntp/manifests/service.pp",
             "line": 9,
             "resource_title": "ntp",
+            "corrective_change": false,
             "resource_type": "Service",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:09.871Z"
@@ -1639,12 +1663,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.820Z"
                 }
             ],
             "file": "/etc/puppet/modules/python/manifests/install.pp",
             "line": 61,
             "resource_title": "python-devel",
+            "corrective_change": false,
             "resource_type": "Package",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:10.820Z"
@@ -1662,12 +1688,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:09.702Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/init.pp",
             "line": 441,
             "resource_title": "snmpd.sysconfig",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:09.702Z"
@@ -1685,12 +1713,14 @@
                     "old_value": "{md5}d41d8cd98f00b204e9800998ecf8427e",
                     "property": "content",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:09.090Z"
                 }
             ],
             "file": "/etc/puppet/modules/motd/manifests/init.pp",
             "line": 33,
             "resource_title": "/etc/motd",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:09.090Z"
@@ -1708,12 +1738,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.108Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/init.pp",
             "line": 453,
             "resource_title": "snmptrapd.conf",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:10.108Z"
@@ -1731,6 +1763,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:09.693Z"
                 }
             ],
@@ -1738,6 +1771,7 @@
             "line": 465,
             "resource_title": "snmptrapd.sysconfig",
             "resource_type": "File",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:29:09.693Z"
         },
@@ -1755,12 +1789,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.160Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
             "line": 113,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:10.160Z"
@@ -1778,12 +1814,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.892Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/client.pp",
             "line": 85,
             "resource_title": "snmp.conf",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:10.892Z"
@@ -1802,6 +1840,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.114Z"
                 }
             ],
@@ -1809,6 +1848,7 @@
             "line": 164,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
             "resource_type": "File",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:29:10.114Z"
         },
@@ -1826,11 +1866,13 @@
                     "old_value": null,
                     "property": null,
                     "status": "failure",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.233Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/init.pp",
             "line": 169,
+            "corrective_change": false,
             "resource_title": "/tmp/file",
             "resource_type": "File",
             "skipped": false,
@@ -1849,12 +1891,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.235Z"
                 }
             ],
             "file": "/etc/puppet/modules/snmp/manifests/init.pp",
             "line": 429,
             "resource_title": "snmpd.conf",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:10.235Z"
@@ -1872,12 +1916,14 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:09.523Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 3,
             "resource_title": "foo",
+            "corrective_change": false,
             "resource_type": "Notify",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:09.523Z"
@@ -1895,12 +1941,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.786Z"
                 }
             ],
             "file": "/etc/puppet/modules/python/manifests/install.pp",
             "line": 60,
             "resource_title": "python-pip",
+            "corrective_change": false,
             "resource_type": "Package",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:10.786Z"
@@ -1918,12 +1966,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:09.749Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 45,
             "resource_title": "sample setting",
+            "corrective_change": false,
             "resource_type": "Ini_setting",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:09.749Z"
@@ -1942,12 +1992,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:10.112Z"
                 }
             ],
             "file": "/etc/puppet/modules/concat/manifests/init.pp",
             "line": 159,
             "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat",
+            "corrective_change": false,
             "resource_type": "File",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:10.112Z"
@@ -1965,12 +2017,14 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:09.901Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 69,
             "resource_title": "hkp_server_20BC0A86",
+            "corrective_change": false,
             "resource_type": "Gnupg_key",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:09.901Z"
@@ -1988,12 +2042,14 @@
                     "old_value": "stopped",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:09.687Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 4,
             "resource_title": "cron",
+            "corrective_change": false,
             "resource_type": "Service",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:09.687Z"
@@ -2001,5 +2057,8 @@
     ],
     "start_time": "2015-02-13T13:29:01.341Z",
     "status": "failed",
+    "catalog_uuid": "48b574f9-fd1c-4d5d-9dc6-abb8b479e390",
+    "producer": "foo.com",
+    "code_id": "90102f12-0f34-429f-8280-3e7931295784",
     "transaction_uuid": "f2b3642a-27e8-4311-a213-aad48859b9ac"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-cfdc33f7bb68d2c25d3b3758f3dca50b851b96ea.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-cfdc33f7bb68d2c25d3b3758f3dca50b851b96ea.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:26:31.273Z",
     "environment": "production",
+    "corrective_change": false,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -692,12 +694,14 @@
                     "old_value": "notrun",
                     "property": "returns",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:26:34.422Z"
                 }
             ],
             "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
             "line": 83,
             "resource_title": "postgresql_data_directory",
+            "corrective_change": false,
             "resource_type": "Exec",
             "skipped": false,
             "timestamp": "2015-02-13T13:26:34.422Z"
@@ -715,6 +719,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:26:34.425Z"
                 }
             ],
@@ -722,6 +727,7 @@
             "line": 120,
             "resource_title": "/etc/sysconfig/pgsql/postgresql-8.4",
             "resource_type": "File",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:26:34.425Z"
         },
@@ -739,12 +745,14 @@
                     "old_value": "need_to_run",
                     "property": "returns",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:26:34.488Z"
                 }
             ],
             "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
             "line": 90,
             "resource_title": "override PGDATA in /etc/sysconfig/pgsql/postgresql",
+            "corrective_change": false,
             "resource_type": "Augeas",
             "skipped": false,
             "timestamp": "2015-02-13T13:26:34.488Z"
@@ -763,6 +771,7 @@
                     "old_value": "absent",
                     "property": "ensure",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:26:34.498Z"
                 }
             ],
@@ -770,6 +779,7 @@
             "line": 105,
             "resource_title": "data_directory",
             "resource_type": "Postgresql_conf",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:26:34.498Z"
         },
@@ -787,6 +797,7 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "noop",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:26:35.125Z"
                 }
             ],
@@ -794,11 +805,15 @@
             "line": 6,
             "resource_title": "foo",
             "resource_type": "Notify",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:26:35.125Z"
         }
     ],
     "start_time": "2015-02-13T13:26:28.549Z",
     "status": "unchanged",
+    "catalog_uuid": "7fd93195-cf36-4845-98a1-8fe460f32a1a",
+    "producer": "foo.com",
+    "code_id": "5a002ce2-643f-4147-ac17-5d7ca216ca8a",
     "transaction_uuid": "441eb073-d81a-4c3d-9c75-8c4bb1ca1cd1"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-02f72d7b1e2ded2074c4c3d6e2f415f6978d5932.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-02f72d7b1e2ded2074c4c3d6e2f415f6978d5932.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423833558",
     "end_time": "2015-02-13T13:20:11.029Z",
     "environment": "production",
+    "corrective_change": false,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -244,12 +246,14 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:20:12.320Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 3,
             "resource_title": "foo",
+            "corrective_change": false,
             "resource_type": "Notify",
             "skipped": false,
             "timestamp": "2015-02-13T13:20:12.320Z"
@@ -257,5 +261,8 @@
     ],
     "start_time": "2015-02-13T13:20:09.897Z",
     "status": "changed",
+    "catalog_uuid": "ad67b622-ed6d-4336-80f3-88a1cef89d1d",
+    "producer": "foo.com",
+    "code_id": "3b415ed0-115b-4c73-a34f-883a7cf8b1a1",
     "transaction_uuid": "ed18c9ae-0998-483d-ba93-0e97b24b6ac1"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-05ce58a44a6441dc967559bf89fd82619068f72c.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-05ce58a44a6441dc967559bf89fd82619068f72c.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423834124",
     "end_time": "2015-02-13T13:29:56.692Z",
     "environment": "production",
+    "corrective_change": false,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -244,12 +246,14 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:29:57.795Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 3,
             "resource_title": "foo",
+            "corrective_change": false,
             "resource_type": "Notify",
             "skipped": false,
             "timestamp": "2015-02-13T13:29:57.795Z"
@@ -257,5 +261,8 @@
     ],
     "start_time": "2015-02-13T13:29:55.639Z",
     "status": "changed",
+    "catalog_uuid": "40cca17a-5367-400e-ae95-df85bd05daf0",
+    "producer": "foo.com",
+    "code_id": "e1f6c288-7510-451f-8f11-c9d9471f9441",
     "transaction_uuid": "9e531f81-426c-4d91-8e10-649f067cf8a2"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-5ba2c61aeb5f3ed8722e45f9c2c7b53d606e402e.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-5ba2c61aeb5f3ed8722e45f9c2c7b53d606e402e.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423834124",
     "end_time": "2015-02-13T13:30:29.332Z",
     "environment": "production",
+    "corrective_change": false,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -244,12 +246,14 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:30:30.477Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 3,
             "resource_title": "foo",
+            "corrective_change": false,
             "resource_type": "Notify",
             "skipped": false,
             "timestamp": "2015-02-13T13:30:30.477Z"
@@ -257,5 +261,8 @@
     ],
     "start_time": "2015-02-13T13:30:28.352Z",
     "status": "changed",
+    "catalog_uuid": "fc0132b7-3c19-4084-840a-9c58cedf46de",
+    "producer": "foo.com",
+    "code_id": "d83f1aca-055d-45d5-9372-e88b115c810b",
     "transaction_uuid": "3c99e9cc-bc56-45a5-bc71-e1b4fa2aff37"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-6eade546c696f0c045ec29f955bdb4d6a39a8291.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-6eade546c696f0c045ec29f955bdb4d6a39a8291.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:23:55.758Z",
     "environment": "production",
+    "corrective_change": true,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -244,12 +246,14 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:23:56.965Z"
                 }
             ],
             "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
             "line": 3,
             "resource_title": "foo",
+            "corrective_change": false,
             "resource_type": "Notify",
             "skipped": false,
             "timestamp": "2015-02-13T13:23:56.965Z"
@@ -257,5 +261,8 @@
     ],
     "start_time": "2015-02-13T13:23:54.881Z",
     "status": "changed",
+    "catalog_uuid": "bc71e138-e067-4150-995f-9273eaa81376",
+    "producer": "foo.com",
+    "code_id": "538e7abc-dd45-49fc-81e7-0034588344dd",
     "transaction_uuid": "f0099317-b053-4b88-8c9c-198945c1b8a8"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-9eeca12cedb235b2e8f616967bf1f46d3e1de812.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-9eeca12cedb235b2e8f616967bf1f46d3e1de812.json
@@ -4,6 +4,8 @@
     "configuration_version": "1423833741",
     "end_time": "2015-02-13T13:23:48.963Z",
     "environment": "production",
+    "corrective_change": true,
+    "noop_pending": false,
     "logs": [
         {
             "file": null,
@@ -244,6 +246,7 @@
                     "old_value": "absent",
                     "property": "message",
                     "status": "success",
+                    "corrective_change": false,
                     "timestamp": "2015-02-13T13:23:50.136Z"
                 }
             ],
@@ -251,11 +254,15 @@
             "line": 3,
             "resource_title": "foo",
             "resource_type": "Notify",
+            "corrective_change": false,
             "skipped": false,
             "timestamp": "2015-02-13T13:23:50.136Z"
         }
     ],
     "start_time": "2015-02-13T13:23:48.073Z",
     "status": "changed",
+    "catalog_uuid": "76e7a26a-f7a2-44bc-b0fd-8db6edd8ec9e",
+    "producer": "foo.com",
+    "code_id": "87bf8011-918c-40b3-aded-cee4ec9d5536",
     "transaction_uuid": "d6c4f3f3-afc5-41e6-8b1b-73e84400ca70"
 }

--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -212,7 +212,7 @@
         factset (some-> factset
                         (update-factset rand-percentage stamp))]
     (when catalog (>!! command-send-ch [:catalog host 6 catalog]))
-    (when report (>!! command-send-ch [:report host 6 report]))
+    (when report (>!! command-send-ch [:report host 8 report]))
     (when factset (>!! command-send-ch [:factset host 4 factset]))
 
     (assoc state

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -270,6 +270,7 @@
    "report_receive_time"    ["latest_events"]
    "hash"                   ["latest_events" "report"]
    "status"                 ["latest_events"]
+   "corrective_change"      ["latest_events"]
    "timestamp"              ["latest_events"]
    "resource_type"          ["latest_events"]
    "resource_title"         ["latest_events"]

--- a/src/puppetlabs/puppetdb/query/events.clj
+++ b/src/puppetlabs/puppetdb/query/events.clj
@@ -66,6 +66,7 @@
                             receive_time as report_receive_time,
                             hash,
                             status,
+                            resource_events.corrective_change as corrective_change,
                             distinct_events.latest_timestamp AS timestamp,
                             distinct_events.resource_type AS resource_type,
                             distinct_events.resource_title AS resource_title,

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -149,6 +149,9 @@
                              "latest_report_status" {:type :string
                                                      :queryable? true
                                                      :field :report_statuses.status}
+                             "latest_report_corrective_change" {:type :boolean
+                                                                :queryable? true
+                                                                :field :reports.corrective_change}
                              "cached_catalog_status" {:type :string
                                                       :queryable? true
                                                       :field :reports.cached_catalog_status}
@@ -441,36 +444,39 @@
   "Query for the reports entity"
   (map->Query
     {:projections
-     {"hash"            {:type :string
-                         :queryable? true
-                         :field (hsql-hash-as-str :reports.hash)}
-      "certname"        {:type :string
-                         :queryable? true
-                         :field :reports.certname}
-      "noop_pending"    {:type :boolean
-                         :queryable? true
-                         :field :reports.noop_pending}
-      "puppet_version"  {:type :string
-                         :queryable? true
-                         :field :reports.puppet_version}
-      "report_format"   {:type :integer
-                         :queryable? true
-                         :field :reports.report_format}
+     {"hash" {:type :string
+              :queryable? true
+              :field (hsql-hash-as-str :reports.hash)}
+      "certname" {:type :string
+                  :queryable? true
+                  :field :reports.certname}
+      "noop_pending" {:type :boolean
+                      :queryable? true
+                      :field :reports.noop_pending}
+      "puppet_version" {:type :string
+                        :queryable? true
+                        :field :reports.puppet_version}
+      "report_format" {:type :integer
+                       :queryable? true
+                       :field :reports.report_format}
       "configuration_version" {:type :string
                                :queryable? true
                                :field :reports.configuration_version}
-      "start_time"      {:type :timestamp
-                         :queryable? true
-                         :field :reports.start_time}
-      "end_time"        {:type :timestamp
-                         :queryable? true
-                         :field :reports.end_time}
+      "start_time" {:type :timestamp
+                    :queryable? true
+                    :field :reports.start_time}
+      "end_time" {:type :timestamp
+                  :queryable? true
+                  :field :reports.end_time}
       "producer_timestamp" {:type :timestamp
                             :queryable? true
                             :field :reports.producer_timestamp}
-      "producer"        {:type :string
-                         :queryable? true
-                         :field :producers.name}
+      "producer" {:type :string
+                  :queryable? true
+                  :field :producers.name}
+      "corrective_change" {:type :string
+                           :queryable? true
+                           :field :reports.corrective_change}
       "metrics" {:type :json
                  :queryable? false
                  :field {:select [(h/row-to-json :t)]
@@ -485,33 +491,33 @@
                                [[(h/coalesce :logs (h/scast :logs_json :jsonb)) :data]
                                 [(hsql-hash-as-href (su/sql-hash-as-str "hash") :reports :logs)
                                  :href]]} :t]]}}
-      "receive_time"    {:type :timestamp
-                         :queryable? true
-                         :field :reports.receive_time}
+      "receive_time" {:type :timestamp
+                      :queryable? true
+                      :field :reports.receive_time}
       "transaction_uuid" {:type :string
                           :queryable? true
                           :field (hsql-uuid-as-str :reports.transaction_uuid)}
       "catalog_uuid" {:type :string
                       :queryable? true
                       :field (hsql-uuid-as-str :reports.catalog_uuid)}
-      "noop"            {:type :boolean
-                         :queryable? true
-                         :field :reports.noop}
+      "noop" {:type :boolean
+              :queryable? true
+              :field :reports.noop}
       "code_id" {:type :string
                  :queryable? true
                  :field :reports.code_id}
       "cached_catalog_status" {:type :string
                                :queryable? true
                                :field :reports.cached_catalog_status}
-      "environment"     {:type :string
-                         :queryable? true
-                         :field :environments.environment}
-      "status"          {:type :string
-                         :queryable? true
-                         :field :report_statuses.status}
-      "latest_report?"   {:type :string
-                          :queryable? true
-                          :query-only? true}
+      "environment" {:type :string
+                     :queryable? true
+                     :field :environments.environment}
+      "status" {:type :string
+                :queryable? true
+                :field :report_statuses.status}
+      "latest_report?" {:type :string
+                        :queryable? true
+                        :query-only? true}
       "resource_events" {:type :json
                          :queryable? false
                          :field {:select [(h/row-to-json :event_data)]
@@ -524,6 +530,7 @@
                                                     :re.resource_type
                                                     :re.resource_title
                                                     :re.property
+                                                    :re.corrective_change
                                                     (h/scast :re.new_value :jsonb)
                                                     (h/scast :re.old_value :jsonb)
                                                     :re.message
@@ -777,6 +784,9 @@
                              "status" {:type :string
                                        :queryable? true
                                        :field :status}
+                             "corrective_change" {:type :boolean
+                                                  :queryable? true
+                                                  :field :events.corrective_change}
                              "timestamp" {:type :timestamp
                                           :queryable? true
                                           :field :timestamp}

--- a/src/puppetlabs/puppetdb/reports.clj
+++ b/src/puppetlabs/puppetdb/reports.clj
@@ -13,6 +13,7 @@
 
 (def event-wireformat-schema
   {:status s/Str
+   :corrective_change (s/maybe s/Bool)
    :timestamp pls/Timestamp
    :property (s/maybe s/Str)
    :new_value (s/maybe pls/JSONable)
@@ -27,6 +28,7 @@
    :file (s/maybe s/Str)
    :line (s/maybe s/Int)
    :containment_path [s/Str]
+   :corrective_change (s/maybe s/Bool)
    :events [event-wireformat-schema]})
 
 (def metric-wireformat-schema
@@ -52,6 +54,7 @@
    :end_time pls/Timestamp
    :producer_timestamp pls/Timestamp
    :producer (s/maybe s/Str)
+   :corrective_change (s/maybe s/Bool)
    :resources [resource-wireformat-schema]
    :noop (s/maybe s/Bool)
    :noop_pending (s/maybe s/Bool)
@@ -66,7 +69,7 @@
 
 (def report-v7-wireformat-schema
  (-> report-wireformat-schema
-     (dissoc :producer :noop_pending)))
+     (dissoc :producer :noop_pending :corrective_change)))
 
 (def report-v6-wireformat-schema
   (-> report-v7-wireformat-schema
@@ -75,7 +78,8 @@
 (def resource-event-v5-wireformat-schema
   (-> resource-wireformat-schema
       (dissoc :skipped :events)
-      (merge event-wireformat-schema)))
+      (merge event-wireformat-schema)
+      (dissoc :corrective_change)))
 
 (def report-v5-wireformat-schema
   (-> report-v6-wireformat-schema
@@ -107,6 +111,7 @@
    :resource_title s/Str
    :resource_type s/Str
    :timestamp pls/Timestamp
+   :corrective_change (s/maybe s/Bool)
    :containing_class (s/maybe s/Str)
    :containment_path (s/maybe [s/Str])
    :property (s/maybe s/Str)
@@ -141,6 +146,7 @@
    (s/optional-key :end_time) pls/Timestamp
    (s/optional-key :producer_timestamp) pls/Timestamp
    (s/optional-key :producer) (s/maybe s/Str)
+   (s/optional-key :corrective_change) (s/maybe s/Bool)
    (s/optional-key :noop) (s/maybe s/Bool)
    (s/optional-key :noop_pending) (s/maybe s/Bool)
    (s/optional-key :report_format) s/Int
@@ -164,6 +170,15 @@
        :data
        (map #(dissoc %
                      :report :certname :containing_class :configuration_version
+                     :run_start_time :run_end_time :report_receive_time :environment
+                     :corrective_change))))
+
+(pls/defn-validated munge-resource-events-for-v8
+  [resource-events :- resource-events-expanded-query-schema]
+  (->> resource-events
+       :data
+       (map #(dissoc %
+                     :report :certname :containing_class :configuration_version
                      :run_start_time :run_end_time :report_receive_time :environment))))
 
 (defn generic-query->wire-transform
@@ -179,7 +194,7 @@
   [report]
   (-> report
       generic-query->wire-transform
-      (dissoc :noop_pending)
+      (dissoc :noop_pending :corrective_change)
       (update :resource_events resource-events-query->wire-v5)))
 
 (pls/defn-validated reports-query->wire-v5 :- [report-v5-wireformat-schema]
@@ -192,23 +207,30 @@
        (sp/transform [:resource_events sp/ALL sp/ALL]
                      #(update % 0 utils/dashes->underscores))))
 
-(defn- resource-event-v5->resource
+(defn- resource-event->resource
   [resource-event]
   (-> resource-event
       (select-keys [:file :line :timestamp :resource_type :resource_title :containment_path])
       (assoc :skipped (= "skipped" (:status resource-event)))))
 
-(defn resource-events-v5->resources
+(defn resource-events-wire->resources
   [resource-events]
   (vec
-   (for [[resource resource-events] (group-by resource-event-v5->resource resource-events)
-         :let [events (mapv #(dissoc % :file :line :resource_type :resource_title :containment_path) resource-events)]]
-     (assoc resource :events events))))
+    (for [[resource resource-events] (group-by resource-event->resource resource-events)
+          :let [events (mapv #(-> %
+                                  (dissoc :file :line :resource_type
+                                          :resource_title :containment_path)
+                                  (utils/assoc-when :corrective_change nil))
+                             resource-events)]]
+      (-> resource
+          (assoc :events events)
+          (utils/assoc-when :corrective_change nil)))))
 
 (defn wire-v7->wire-v8
   [report]
   (utils/assoc-when report
                     :noop_pending nil
+                    :corrective_change nil
                     :producer nil))
 
 (defn wire-v6->wire-v8
@@ -222,7 +244,7 @@
 (defn wire-v5->wire-v8
   [report]
   (-> report
-      (update :resource_events resource-events-v5->resources)
+      (update :resource_events resource-events-wire->resources)
       (set/rename-keys {:resource_events :resources})
       wire-v6->wire-v8))
 
@@ -236,7 +258,6 @@
              :producer_timestamp received-time)
       wire-v5->wire-v8))
 
-
 (defn wire-v3->wire-v8
   [report received-time]
   (-> report
@@ -247,8 +268,8 @@
   [report :- report-query-schema]
   (-> report
       generic-query->wire-transform
-      (update :resource_events (comp resource-events-v5->resources
-                                     resource-events-query->wire-v5))
+      (update :resource_events (comp resource-events-wire->resources
+                                     munge-resource-events-for-v8))
       (set/rename-keys {:resource_events :resources})))
 
 (defn reports-query->wire-v8 [reports]
@@ -260,7 +281,7 @@
   (-> resource
       ;; We also need to grab the timestamp when the resource is `skipped'
       (select-keys [:resource_type :resource_title :file :line :containment_path :timestamp])
-      (merge {:status "skipped" :property nil :old_value nil :new_value nil :message nil})
+      (merge {:status "skipped" :property nil :old_value nil :new_value nil :message nil :corrective_change false})
       vector))
 
 (defn- resource->resource-events

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1062,6 +1062,12 @@
     "ALTER TABLE reports ADD COLUMN noop_pending boolean"
     "CREATE INDEX idx_reports_noop_pending on reports using btree (noop_pending) where (noop_pending = true)"))
 
+(defn add-corrective-change-columns
+  []
+  (jdbc/do-commands
+    "alter table reports add column corrective_change boolean"
+    "alter table resource_events add column corrective_change boolean"))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1087,7 +1093,8 @@
    45 index-certnames-latest-report-id
    46 drop-certnames-latest-id-index
    47 add-producer-to-reports-catalogs-and-factsets
-   48 add-noop-pending-to-reports})
+   48 add-noop-pending-to-reports
+   49 add-corrective-change-columns})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/test/puppetlabs/puppetdb/acceptance/cli.clj
+++ b/test/puppetlabs/puppetdb/acceptance/cli.clj
@@ -31,7 +31,8 @@
 
          (is (= (tuc/munge-catalog example-catalog)
                 (tuc/munge-catalog (get-catalogs example-certname))))
-         (is (= [example-report] (get-reports example-certname)))
+         (is (= [(tur/update-report-pe-fields example-report)]
+                (get-reports example-certname)))
          (is (= (tuf/munge-facts example-facts)
                 (tuf/munge-facts (get-factsets example-certname))))
 

--- a/test/puppetlabs/puppetdb/admin_test.clj
+++ b/test/puppetlabs/puppetdb/admin_test.clj
@@ -40,7 +40,8 @@
 
        (is (= (tuc/munge-catalog example-catalog)
               (tuc/munge-catalog (get-catalogs example-certname))))
-       (is (= [example-report] (get-reports example-certname)))
+       (is (= [(tur/update-report-pe-fields example-report)]
+              (get-reports example-certname)))
        (is (= (tuf/munge-facts example-facts)
               (tuf/munge-facts (get-factsets example-certname))))
 
@@ -62,7 +63,8 @@
 
        (is (= (tuc/munge-catalog example-catalog)
               (tuc/munge-catalog (get-catalogs example-certname))))
-       (is (= [example-report] (get-reports example-certname)))
+       (is (= [(tur/update-report-pe-fields example-report)]
+              (get-reports example-certname)))
        (is (= (tuf/munge-facts example-facts)
               (tuf/munge-facts (get-factsets example-certname))))))))
 
@@ -84,7 +86,8 @@
 
          (is (= (tuc/munge-catalog example-catalog)
                 (tuc/munge-catalog (get-catalogs example-certname))))
-         (is (= [example-report] (get-reports example-certname)))
+         (is (= [(tur/update-report-pe-fields example-report)]
+                (get-reports example-certname)))
          (is (= (tuf/munge-facts example-facts)
                 (tuf/munge-facts (get-factsets example-certname))))
 

--- a/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
+++ b/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
@@ -32,7 +32,8 @@
 
        (is (= (tuc/munge-catalog example-catalog)
               (tuc/munge-catalog (get-catalogs example-certname))))
-       (is (= [example-report] (get-reports example-certname)))
+       (is (= [(tur/update-report-pe-fields example-report)]
+              (get-reports example-certname)))
        (is (= (tuf/munge-facts example-facts)
               (tuf/munge-facts (get-factsets example-certname))))
 
@@ -54,7 +55,8 @@
 
        (is (= (tuc/munge-catalog example-catalog)
               (tuc/munge-catalog (get-catalogs example-certname))))
-       (is (= [example-report] (get-reports example-certname)))
+       (is (= [(tur/update-report-pe-fields example-report)]
+              (get-reports example-certname)))
        (is (= (tuf/munge-facts example-facts)
               (tuf/munge-facts (get-factsets example-certname))))))))
 

--- a/test/puppetlabs/puppetdb/examples/reports.clj
+++ b/test/puppetlabs/puppetdb/examples/reports.clj
@@ -18,6 +18,7 @@
     :status                 "unchanged"
     :noop                   false
     :noop_pending           true
+    :corrective_change      true
     :logs
     {:href ""
      :data
@@ -50,66 +51,70 @@
     :resource_events
     {:href ""
      :data
-     [{:certname         "foo.local"
-       :status           "success"
-       :timestamp        "2011-01-01T12:00:01-03:00"
-       :resource_type    "Notify"
-       :resource_title   "notify, yo"
-       :environment      "DEV"
-       :property         "message"
-       :new_value        "notify, yo"
-       :old_value        ["what" "the" "woah"]
-       :message          "defined 'message' as 'notify, yo'"
-       :file             "foo.pp"
-       :line             1
+     [{:certname "foo.local"
+       :status "success"
+       :timestamp "2011-01-01T12:00:01-03:00"
+       :resource_type "Notify"
+       :resource_title "notify, yo"
+       :environment "DEV"
+       :property "message"
+       :new_value "notify, yo"
+       :old_value ["what" "the" "woah"]
+       :corrective_change true
+       :message "defined 'message' as 'notify, yo'"
+       :file "foo.pp"
+       :line 1
        :containment_path nil
        :containing_class nil}
-      {:certname         "foo.local"
-       :status           "success"
-       :timestamp        "2011-01-01T12:00:03-03:00"
-       :resource_type    "Notify"
-       :environment      "DEV"
-       :resource_title   "notify, yar"
-       :property         "message"
-       :new_value        {"absent" 5}
-       :old_value        {"absent" true}
-       :message          "defined 'message' as 'notify, yo'"
-       :file             nil
-       :line             nil
+      {:certname "foo.local"
+       :status "success"
+       :timestamp "2011-01-01T12:00:03-03:00"
+       :resource_type "Notify"
+       :environment "DEV"
+       :corrective_change false
+       :resource_title "notify, yar"
+       :property "message"
+       :new_value {"absent" 5}
+       :old_value {"absent" true}
+       :message "defined 'message' as 'notify, yo'"
+       :file nil
+       :line nil
        :containment_path []
        :containing_class nil}
-      {:certname         "foo.local"
-       :status           "skipped"
-       :timestamp        "2011-01-01T12:00:02-03:00"
-       :environment      "DEV"
-       :resource_type    "Notify"
-       :resource_title   "hi"
-       :property         nil
-       :new_value        nil
-       :old_value        nil
-       :message          nil
-       :file             "bar"
-       :line             2
+      {:certname "foo.local"
+       :status "skipped"
+       :timestamp "2011-01-01T12:00:02-03:00"
+       :environment "DEV"
+       :resource_type "Notify"
+       :resource_title "hi"
+       :corrective_change false
+       :property nil
+       :new_value nil
+       :old_value nil
+       :message nil
+       :file "bar"
+       :line 2
        :containment_path ["Foo" "" "Bar[Baz]"]
        :containing_class "Foo"}]}}
 
    :basic2
-   {:certname               "foo.local"
-    :puppet_version         "3.0.1"
-    :report_format          4
-    :transaction_uuid       "5ea3a70b-84c8-426c-813c-dd6492fb829b"
+   {:certname "foo.local"
+    :puppet_version "3.0.1"
+    :report_format 4
+    :transaction_uuid "5ea3a70b-84c8-426c-813c-dd6492fb829b"
     :catalog_uuid "5ea3a70b-84c8-426c-813c-dd6492fb829b"
     :code_id nil
     :cached_catalog_status "not_used"
-    :configuration_version  "bja3985a23"
-    :start_time             "2013-08-28T19:00:00-03:00"
-    :end_time               "2013-08-28T19:10:00-03:00"
-    :producer_timestamp     "2013-08-28T19:11:00-03:00"
-    :producer               "bar.com"
-    :environment            "DEV"
-    :status                 "unchanged"
-    :noop                   true
-    :noop_pending           true
+    :configuration_version "bja3985a23"
+    :start_time "2013-08-28T19:00:00-03:00"
+    :end_time "2013-08-28T19:10:00-03:00"
+    :producer_timestamp "2013-08-28T19:11:00-03:00"
+    :producer "bar.com"
+    :environment "DEV"
+    :corrective_change false
+    :status "unchanged"
+    :noop true
+    :noop_pending true
     :logs
     {:href ""
      :data
@@ -142,63 +147,67 @@
     :resource_events
     {:href ""
      :data
-     [{:certname         "foo.local"
-       :status           "success"
-       :timestamp        "2013-08-28T19:36:34.000Z"
-       :resource_type    "Notify"
-       :resource_title   "Creating tmp directory at /Users/foo/tmp"
-       :property         "message"
-       :new_value        "Creating tmp directory at /Users/foo/tmp"
-       :old_value        "absent"
-       :message          "defined 'message' as 'Creating tmp directory at /Users/foo/tmp'"
-       :file             "/Users/foo/workspace/puppetlabs/conf/puppet/master/conf/manifests/site.pp"
-       :line             8
+     [{:certname "foo.local"
+       :status "success"
+       :timestamp "2013-08-28T19:36:34.000Z"
+       :resource_type "Notify"
+       :resource_title "Creating tmp directory at /Users/foo/tmp"
+       :property "message"
+       :new_value "Creating tmp directory at /Users/foo/tmp"
+       :old_value "absent"
+       :corrective_change false
+       :message "defined 'message' as 'Creating tmp directory at /Users/foo/tmp'"
+       :file "/Users/foo/workspace/puppetlabs/conf/puppet/master/conf/manifests/site.pp"
+       :line 8
        :containment_path nil
        :containing_class nil}
-      {:certname         "foo.local"
-       :status           "success"
-       :timestamp        "2013-08-28T17:55:45.000Z"
-       :resource_type    "File"
-       :resource_title   "puppet-managed-file"
-       :property         "ensure"
-       :new_value        "present"
-       :old_value        "absent"
-       :message          "created"
-       :file             "/Users/foo/workspace/puppetlabs/conf/puppet/master/conf/manifests/site.pp"
-       :line             17
+      {:certname "foo.local"
+       :status "success"
+       :timestamp "2013-08-28T17:55:45.000Z"
+       :resource_type "File"
+       :resource_title "puppet-managed-file"
+       :property "ensure"
+       :new_value "present"
+       :old_value "absent"
+       :corrective_change false
+       :message "created"
+       :file "/Users/foo/workspace/puppetlabs/conf/puppet/master/conf/manifests/site.pp"
+       :line 17
        :containment_path []
        :containing_class nil}
-      {:certname         "foo.local"
-       :status           "success"
-       :timestamp        "2013-08-28T17:55:45.000Z"
-       :resource_type    "File"
-       :resource_title   "tmp-directory"
-       :property         "ensure"
-       :new_value        "directory"
-       :old_value        "absent"
-       :message          "created"
-       :file             "/Users/foo/workspace/puppetlabs/conf/puppet/master/conf/manifests/site.pp"
-       :line             11
+      {:certname "foo.local"
+       :status "success"
+       :timestamp "2013-08-28T17:55:45.000Z"
+       :resource_type "File"
+       :resource_title "tmp-directory"
+       :property "ensure"
+       :new_value "directory"
+       :old_value "absent"
+       :corrective_change false
+       :message "created"
+       :file "/Users/foo/workspace/puppetlabs/conf/puppet/master/conf/manifests/site.pp"
+       :line 11
        :containment_path ["Foo" "" "Bar[Baz]"]
        :containing_class "Foo"}]}}
 
    :basic3
-   {:certname               "foo.local"
-    :puppet_version         "3.0.1"
-    :report_format          4
-    :transaction_uuid       "e1e561ba-212f-11e3-9d58-60a44c233a9d"
-    :configuration_version  "a81jasj123"
-    :start_time             "2011-01-03T12:00:00-03:00"
-    :end_time               "2011-01-03T12:10:00-03:00"
-    :producer_timestamp     "2011-01-03T12:11:00-03:00"
-    :producer               "bar.com"
+   {:certname "foo.local"
+    :puppet_version "3.0.1"
+    :report_format 4
+    :transaction_uuid "e1e561ba-212f-11e3-9d58-60a44c233a9d"
+    :configuration_version "a81jasj123"
+    :start_time "2011-01-03T12:00:00-03:00"
+    :corrective_change false
+    :end_time "2011-01-03T12:10:00-03:00"
+    :producer_timestamp "2011-01-03T12:11:00-03:00"
+    :producer "bar.com"
     :catalog_uuid "5ea3a70b-84c8-426c-813c-dd6492fb829b"
     :code_id nil
     :cached_catalog_status "not_used"
-    :environment            "DEV"
-    :status                 "unchanged"
-    :noop                   false
-    :noop_pending           false
+    :environment "DEV"
+    :status "unchanged"
+    :noop false
+    :noop_pending false
     :logs
     {:href ""
      :data
@@ -231,63 +240,67 @@
     :resource_events
     {:href ""
      :data
-     [{:certname         "foo.local"
-       :status           "success"
-       :timestamp        "2011-01-03T12:00:00-03:00"
-       :resource_type    "Notify"
-       :resource_title   "notify, yo"
-       :property         "message"
-       :new_value        "notify, yo"
-       :old_value        ["what" "the" "woah"]
-       :message          "defined 'message' as 'notify, yo'"
-       :file             "foo.pp"
-       :line             1
+     [{:certname "foo.local"
+       :status "success"
+       :timestamp "2011-01-03T12:00:00-03:00"
+       :resource_type "Notify"
+       :resource_title "notify, yo"
+       :property "message"
+       :new_value "notify, yo"
+       :old_value ["what" "the" "woah"]
+       :corrective_change false
+       :message "defined 'message' as 'notify, yo'"
+       :file "foo.pp"
+       :line 1
        :containment_path nil
        :containing_class nil}
-      {:certname         "foo.local"
-       :status           "failure"
-       :timestamp        "2011-01-03T12:00:00-03:00"
-       :resource_type    "Notify"
-       :resource_title   "notify, yar"
-       :property         "message"
-       :new_value        {"absent" 5}
-       :old_value        {"absent" true}
-       :message          "defined 'message' as 'notify, yo'"
-       :file             nil
-       :line             nil
+      {:certname "foo.local"
+       :status "failure"
+       :timestamp "2011-01-03T12:00:00-03:00"
+       :resource_type "Notify"
+       :resource_title "notify, yar"
+       :property "message"
+       :corrective_change false
+       :new_value {"absent" 5}
+       :old_value {"absent" true}
+       :message "defined 'message' as 'notify, yo'"
+       :file nil
+       :line nil
        :containment_path []
        :containing_class nil}
-      {:certname         "foo.local"
-       :status           "skipped"
-       :timestamp        "2011-01-03T12:00:00-03:00"
-       :resource_type    "Notify"
-       :resource_title   "hi"
-       :property         nil
-       :new_value        nil
-       :old_value        nil
-       :message          nil
-       :file             "bar"
-       :line             2
+      {:certname "foo.local"
+       :status "skipped"
+       :timestamp "2011-01-03T12:00:00-03:00"
+       :resource_type "Notify"
+       :resource_title "hi"
+       :property nil
+       :new_value nil
+       :old_value nil
+       :corrective_change false
+       :message nil
+       :file "bar"
+       :line 2
        :containment_path ["Foo" "" "Bar[Baz]"]
        :containing_class "Foo"}]}}
 
    :basic4
-   {:certname               "foo.local"
-    :puppet_version         "3.0.1"
-    :report_format          4
-    :transaction_uuid       "e1e561ba-212f-11e3-9d58-60a44c233a9d"
+   {:certname "foo.local"
+    :puppet_version "3.0.1"
+    :report_format 4
+    :transaction_uuid "e1e561ba-212f-11e3-9d58-60a44c233a9d"
     :catalog_uuid "5ea3a70b-84c8-426c-813c-dd6492fb829b"
     :code_id nil
     :cached_catalog_status "not_used"
-    :configuration_version  "a81jasj123"
-    :start_time             "2011-01-03T12:00:00-03:00"
-    :end_time               "2011-01-03T12:10:00-03:00"
-    :producer_timestamp     "2011-01-03T12:11:00-03:00"
-    :producer               "bar.com"
-    :environment            "DEV"
-    :status                 "unchanged"
-    :noop                   false
-    :noop_pending           true
+    :configuration_version "a81jasj123"
+    :start_time "2011-01-03T12:00:00-03:00"
+    :end_time "2011-01-03T12:10:00-03:00"
+    :producer_timestamp "2011-01-03T12:11:00-03:00"
+    :producer "bar.com"
+    :corrective_change false
+    :environment "DEV"
+    :status "unchanged"
+    :noop false
+    :noop_pending true
     :logs
     {:href ""
      :data
@@ -320,43 +333,46 @@
     :resource_events
     {:href ""
      :data
-     [{:certname         "foo.local"
-       :status           "success"
-       :timestamp        "2011-01-03T12:00:00-03:00"
-       :resource_type    "Notify"
-       :resource_title   "notify, yo"
-       :property         "message"
-       :new_value        "notify, yo"
-       :old_value        ["what" "the" "woah"]
-       :message          "defined 'message' as 'notify, yo'"
-       :file             "aaa.pp"
-       :line             1
+     [{:certname "foo.local"
+       :status "success"
+       :timestamp "2011-01-03T12:00:00-03:00"
+       :resource_type "Notify"
+       :resource_title "notify, yo"
+       :property "message"
+       :new_value "notify, yo"
+       :corrective_change false
+       :old_value ["what" "the" "woah"]
+       :message "defined 'message' as 'notify, yo'"
+       :file "aaa.pp"
+       :line 1
        :containment_path nil
        :containing_class nil}
-      {:certname         "foo.local"
-       :status           "success"
-       :timestamp        "2012-01-03T12:00:00-03:00"
-       :resource_type    "Notify"
-       :resource_title   "notify, yar"
-       :property         "message"
-       :new_value        {"absent" 5}
-       :old_value        {"absent" true}
-       :message          "defined 'message' as 'notify, yo'"
-       :file             "bbb.pp"
-       :line             2
+      {:certname "foo.local"
+       :status "success"
+       :timestamp "2012-01-03T12:00:00-03:00"
+       :resource_type "Notify"
+       :resource_title "notify, yar"
+       :property "message"
+       :corrective_change false
+       :new_value {"absent" 5}
+       :old_value {"absent" true}
+       :message "defined 'message' as 'notify, yo'"
+       :file "bbb.pp"
+       :line 2
        :containment_path []
        :containing_class nil}
-      {:certname         "foo.local"
-       :status           "skipped"
-       :timestamp        "2013-01-03T12:00:00-03:00"
-       :resource_type    "Notify"
-       :resource_title   "hi"
-       :property         nil
-       :new_value        nil
-       :old_value        nil
-       :message          nil
-       :file             "ccc.pp"
-       :line             3
+      {:certname "foo.local"
+       :status "skipped"
+       :timestamp "2013-01-03T12:00:00-03:00"
+       :resource_type "Notify"
+       :resource_title "hi"
+       :corrective_change false
+       :property nil
+       :new_value nil
+       :old_value nil
+       :message nil
+       :file "ccc.pp"
+       :line 3
        :containment_path ["Foo" "" "Bar[Baz]"]
        :containing_class "Foo"}]}}
    })

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -353,6 +353,19 @@
                                     {} munge-event-values)]
         (is (= response expected))))))
 
+(deftest-http-app query-by-corrective_change
+  [[version endpoint] endpoints
+   method [:get :post]]
+  (let [basic (store-example-report! (:basic reports) (now))
+        basic-events (get-in reports [:basic :resource_events :data])
+        expected1 (expected-resource-events basic-events basic)
+        response1 (query-result method endpoint ["null?" "corrective_change" true]
+                                {}  munge-event-values)
+        response2 (query-result method endpoint ["=" "corrective_change" true])]
+    (testing "queries on corrective_change is null"
+      (is (= response1 expected1))
+      (is (= response2 #{})))))
+
 (def versioned-subqueries
   (omap/ordered-map
    "/v4/events"
@@ -363,6 +376,7 @@
                                              ["=" "title" "foobar"]]]]]
 
     #{{:containment_path ["Foo" "" "Bar[Baz]"]
+       :corrective_change nil
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
@@ -388,6 +402,7 @@
                                              ["=" "value" "1.1.1.1"]]]]]
 
     #{{:containment_path ["Foo" "" "Bar[Baz]"]
+       :corrective_change nil
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
@@ -415,6 +430,7 @@
        ["select_resources" ["=" "title" "foobar"]]]]]
 
     #{{:containment_path ["Foo" "" "Bar[Baz]"]
+       :corrective_change nil
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -44,8 +44,8 @@
       (is (= #{:certname :deactivated :expired :catalog_timestamp :facts_timestamp :report_timestamp
                :catalog_environment :facts_environment :report_environment
                :latest_report_status :latest_report_hash :latest_report_noop
-               :latest_report_noop_pending
-               :cached_catalog_status} (keyset res))
+               :latest_report_noop_pending :cached_catalog_status
+               :latest_report_corrective_change} (keyset res))
           (str "Query was: " query))
       (is (= (set expected) (set (mapv :certname result)))
           (str "Query was: " query)))
@@ -79,6 +79,12 @@
     (testing "equality is supported on facts_environment"
       (is-query-result' ["=" "facts_environment" "DEV"]
                         [web1 web2 puppet db]))
+
+    (testing "query on last corrective_change status returns an empty result"
+      (is-query-result' ["=" "latest_report_corrective_change" true] []))
+
+    (testing "all nodes have last corrective_change status null"
+      (is-query-result' ["null?" "latest_report_corrective_change" true] [db puppet web1 web2]))
 
     (testing "regular expressions are supported for name"
       (is-query-result' ["~" "certname" "web\\d+.example.com"] [web1 web2])

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -552,6 +552,19 @@
     (is (= basic2-result-body
            (munge-reports-for-comparison [basic basic2])))))
 
+(deftest-http-app query-for-corrective_change
+  [[version endpoint] endpoints
+   method [:get :post]]
+  (let [basic (:basic reports)
+        _ (store-example-report! basic (now))
+        basic-result (first (query-result method endpoint))
+        corrective_change-result (query-result method endpoint ["=" "corrective_change" true])]
+
+    (testing "query on corrective_change does not fail"
+      (is (empty? corrective_change-result)))
+    (testing "result contains corrective_change key valued with nil"
+      (is (nil? (get basic-result :corrective_change "oops"))))))
+
 (deftest-http-app query-by-start-and-end-time
   [[version endpoint] endpoints
    method [:get :post]]

--- a/test/puppetlabs/puppetdb/reports_test.clj
+++ b/test/puppetlabs/puppetdb/reports_test.clj
@@ -39,7 +39,7 @@
 
 (def v7-example-report
   (-> v8-example-report
-      (dissoc :producer :noop_pending)))
+      (dissoc :producer :corrective_change :noop_pending)))
 
 (def v6-example-report
   (-> v7-example-report
@@ -48,7 +48,7 @@
 (def v5-example-report
   (-> reports
       :basic
-      (dissoc :code_id :catalog_uuid :cached_catalog_status :producer)
+      (dissoc :code_id :catalog_uuid :cached_catalog_status :producer :corrective_change)
       report-query->wire-v5))
 
 (def v4-example-report

--- a/test/puppetlabs/puppetdb/testutils/events.clj
+++ b/test/puppetlabs/puppetdb/testutils/events.clj
@@ -22,7 +22,9 @@
              :configuration_version (:configuration_version report)
              :run_start_time (to-timestamp (:start_time report))
              :run_end_time (to-timestamp (:end_time report))
-             :report_receive_time (to-timestamp (:receive_time report)))
+             :report_receive_time (to-timestamp (:receive_time report))
+             ;; corrective_change is nil in FOSS
+             :corrective_change nil)
       ;; we need to convert the datetime fields from the examples to timestamp objects
       ;; in order to compare them.
       (update :timestamp to-timestamp)

--- a/test/puppetlabs/puppetdb/testutils/reports.clj
+++ b/test/puppetlabs/puppetdb/testutils/reports.clj
@@ -94,6 +94,19 @@
       normalize-time
       munge-children))
 
+(defn update-event-corrective_changes
+  "replace corrective_change field in events with nil for comparison to foss response"
+  [resources]
+  (for [r resources]
+    (update r :events (fn [x] (map #(assoc % :corrective_change nil) x)))))
+
+(defn update-report-pe-fields
+  "associate nil for pe-only fields in foss response"
+  [report]
+  (-> report
+      (update :resources update-event-corrective_changes)
+      (assoc :corrective_change nil)))
+
 (defn munge-reports-for-comparison
   "Convert actual results for reports queries to wire format ready for comparison."
   [reports]


### PR DESCRIPTION
Add support for the new "remediation" field in the /reports and /nodes
responses, along with corresponding changes for the benchmark tool.