### PR TITLE
(PDB-2847) Add a gated threadpool, fed by channel

### DIFF
--- a/src/puppetlabs/puppetdb/threadpool.clj
+++ b/src/puppetlabs/puppetdb/threadpool.clj
@@ -1,0 +1,113 @@
+(ns puppetlabs.puppetdb.threadpool
+  (:import [javax.jms ExceptionListener JMSException MessageListener Session
+            ConnectionFactory Connection Queue Message]
+           [java.util.concurrent Semaphore ThreadPoolExecutor TimeUnit SynchronousQueue
+            RejectedExecutionException ExecutorService]
+           [org.apache.commons.lang3.concurrent BasicThreadFactory BasicThreadFactory$Builder])
+  (:require [clojure.core.async :as async]
+            [clojure.tools.logging :as log]))
+
+(def logging-exception-handler
+  "Exception handler that ensures any uncaught exception that occurs
+  on this thread is logged"
+  (reify Thread$UncaughtExceptionHandler
+    (uncaughtException [_ thread throwable]
+      (log/error throwable "Error processing command"))))
+
+(defn thread-factory
+  "Creates a command thread factory, wrapping the
+  `pool-thread-factory`. Using this thread factory ensures that we
+  have distinguishable names for threads in this pool and that all
+  uncaught exceptions are logged as errors. Without this uncaught
+  exceptions get the default which is standard error"
+  [threadpool-name-pattern pool-thread-factory]
+  (-> (BasicThreadFactory$Builder.)
+      (.wrappedFactory pool-thread-factory)
+      (.namingPattern threadpool-name-pattern)
+      (.uncaughtExceptionHandler logging-exception-handler)
+      (.daemon true)
+      .build))
+
+(defn shutdown
+  "Shuts down the gated threadpool, ensuring in-flight work is
+  complete before tearing it down. Currently waits up to 5 minutes for
+  that work to complete"
+  [{:keys [^Semaphore semaphore ^ExecutorService threadpool shutdown-timeout]}]
+
+  ;; Prevent new work from being accepted
+  (.drainPermits semaphore)
+
+  ;; Shutdown the threadpool, allowing in-flight work to finish
+  (.shutdown threadpool)
+
+  ;; This will block, waiting for the threadpool to shutdown
+  (when-not (.awaitTermination threadpool shutdown-timeout java.util.concurrent.TimeUnit/MILLISECONDS)
+
+    (log/warn "Attempted to shutdown threadpool, not stopped after 5 minutes, forcibly shutting it down")
+
+    ;; This will force the shutdown of the threadpool and will
+    ;; not allow current threads to finish
+    (.shutdownNow threadpool)
+    (log/warn "Threadpool forcibly shutdown")))
+
+(defrecord GatedThreadpool [^Semaphore semaphore ^ExecutorService threadpool shutdown-timeout]
+  java.io.Closeable
+  (close [this]
+    (shutdown this)))
+
+(defn create-threadpool
+  "Creates an unbounded threadpool with the intent that access to the
+  threadpool is bounded by the semaphore. Implicitly the threadpool is
+  bounded by `size`, but since the semaphore is handling that aspect,
+  it's more efficient to use an unbounded pool and not duplicate the
+  constraint in both the semaphore and the threadpool"
+  [size name-pattern shutdown-timeout-in-ms]
+  (let [threadpool (ThreadPoolExecutor. 1
+                                        Integer/MAX_VALUE
+                                        1
+                                        TimeUnit/MINUTES
+                                        (SynchronousQueue.))]
+    (->> threadpool
+         .getThreadFactory
+         (thread-factory name-pattern)
+         (.setThreadFactory threadpool))
+
+    (map->GatedThreadpool
+     {:semaphore (Semaphore. size)
+      :threadpool threadpool
+      :shutdown-timeout shutdown-timeout-in-ms})))
+
+(defn call-on-threadpool
+  "Executes `f` on a gated threadpool. Calls `on-complete` with the
+  results of inoking `f`"
+  [{:keys [^Semaphore semaphore ^ExecutorService threadpool] :as gated-threadpool}
+   f]
+  (.acquire semaphore)
+  (try
+    (.execute threadpool (fn []
+                           (try
+                             (f)
+                             (finally
+                               (.release semaphore)))))
+    (catch RejectedExecutionException e
+      (log/error e "Message not submitted to command processing threadpool")
+      (.release semaphore))))
+
+(defn exec-from-channel
+  "Executes `on-input` for each input found on `in-chan`, with a
+  threadpool of size `parallelism`. The results of the `on-input`
+  invocations will be put to the `out-chan` in the order it has
+  completed"
+  [gated-threadpool in-chan on-input]
+  (loop [cmd (async/<!! in-chan)]
+    (when cmd
+      (call-on-threadpool
+       gated-threadpool
+       (fn []
+         (on-input cmd)))
+      (recur (async/<!! in-chan)))))
+
+
+
+
+

--- a/test/puppetlabs/puppetdb/threadpool_test.clj
+++ b/test/puppetlabs/puppetdb/threadpool_test.clj
@@ -1,0 +1,109 @@
+(ns puppetlabs.puppetdb.threadpool-test
+  (:require [clojure.core.async :as async]
+            [clojure.test :refer :all]
+            [puppetlabs.puppetdb.threadpool :refer :all]))
+
+(defn wrap-out-chan [out-chan f]
+  (fn [cmd]
+    (async/>!! out-chan (f cmd))))
+
+(deftest exec-from-channel-test
+
+  (testing "basic exec lifecycle"
+    (let [counter (atom 0)
+          in-chan (async/chan 10)
+          out-chan (async/chan 10)
+          worker-fn (wrap-out-chan
+                     out-chan
+                     (fn [{:keys [id]}]
+                       (swap! counter inc)
+                       [:done id]))]
+
+      (with-open [gtp (create-threadpool 1 "test-pool-%d" 1000)]
+        (let [fut (future
+                    (exec-from-channel gtp in-chan worker-fn))]
+          (async/>!! in-chan {:id :a})
+          (is (= [:done :a] (async/<!! out-chan)))
+          (is (= 1 @counter))
+          (async/close! in-chan)
+          (is (not= ::timed-out (deref fut 1000 ::timed-out)))
+          (is (true? (future-done? fut)))))))
+
+  (testing "message in-flight shutdown"
+    (let [counter (atom 0)
+          stop-here (promise)
+          in-chan (async/chan 10)
+          out-chan (async/chan 10)
+          worker-fn (wrap-out-chan
+                     out-chan
+                     (fn [some-command]
+                       @stop-here
+                       (swap! counter inc)
+                       [:done (:foo some-command)]))]
+
+      (with-open [gtp (create-threadpool 1 "test-pool-%d" 1000)]
+        (let [fut (future
+                    (exec-from-channel gtp in-chan worker-fn))]
+
+          (async/>!! in-chan {:foo 1})
+          (async/close! in-chan)
+
+          (is (= 0 @counter))
+
+          (deliver stop-here true)
+
+          (is (= [:done 1] (async/<!! out-chan)))
+          
+          (is (not= ::timed-out (deref fut 1000 ::timed-out)))
+          (is (true? (future-done? fut)))))))
+
+  (testing "blocking put on gated threadpool"
+    (let [seen (atom [])
+          in-flight-promises {:a (promise)
+                              :b (promise)
+                              :c (promise)}
+
+          stop-here {:a (promise)
+                     :b (promise)
+                     :c (promise)}
+
+          in-chan (async/chan 10)
+          out-chan (async/chan 10)
+          worker-fn (wrap-out-chan
+                     out-chan
+                     (fn [{:keys [id]}]
+                       (swap! seen conj id)
+                       (deliver (get in-flight-promises id) true)
+                       @(get stop-here id)
+                       [:done id]))]
+      
+      (with-open [gtp (create-threadpool 2 "test-pool-%d" 1000)]
+        (let [fut (future
+                    (exec-from-channel gtp in-chan worker-fn))]
+
+          (async/>!! in-chan {:id :a})
+          (is (= true (deref (:a in-flight-promises) 100 ::not-found)))
+
+          (async/>!! in-chan {:id :b})
+          (is (= true (deref (:b in-flight-promises) 100 ::not-found)))
+
+          (async/>!! in-chan {:id :c})
+          (async/close! in-chan)
+
+          (is (= ::not-found (deref (:c in-flight-promises) 100 ::not-found)))
+          (is (= [:a :b] @seen))
+
+          (deliver (get stop-here :a) true)
+
+          (is (= [:done :a] (async/<!! out-chan)))
+          (is (= true (deref (:c in-flight-promises) 100 ::not-found)))
+          (is (= [:a :b :c] @seen))
+
+          (deliver (get stop-here :b) true)
+          (is (= [:done :b] (async/<!! out-chan)))
+
+          (deliver (get stop-here :c) true)
+          (is (= [:done :c] (async/<!! out-chan)))
+          
+          (is (not= ::timed-out (deref fut 1000 ::timed-out)))
+          (is (true? (future-done? fut))))))))

--- a/test/puppetlabs/puppetdb/threadpool_test.clj
+++ b/test/puppetlabs/puppetdb/threadpool_test.clj
@@ -1,7 +1,15 @@
 (ns puppetlabs.puppetdb.threadpool-test
+  (:import [java.util.concurrent TimeUnit])
   (:require [clojure.core.async :as async]
             [clojure.test :refer :all]
-            [puppetlabs.puppetdb.threadpool :refer :all]))
+            [puppetlabs.puppetdb.threadpool :refer :all]
+            [puppetlabs.puppetdb.testutils :as tu]
+            [puppetlabs.trapperkeeper.testutils.logging :refer [atom-logger
+                                                                with-logging-to-atom
+                                                                with-log-suppressed-unless-notable]]
+            [puppetlabs.puppetdb.test-protocols :as test-protos]
+            [clojure.string :as str]
+            [slingshot.test]))
 
 (defn wrap-out-chan [out-chan f]
   (fn [cmd]
@@ -21,7 +29,7 @@
 
       (with-open [gtp (create-threadpool 1 "test-pool-%d" 1000)]
         (let [fut (future
-                    (exec-from-channel gtp in-chan worker-fn))]
+                    (dochan gtp worker-fn in-chan))]
           (async/>!! in-chan {:id :a})
           (is (= [:done :a] (async/<!! out-chan)))
           (is (= 1 @counter))
@@ -43,7 +51,7 @@
 
       (with-open [gtp (create-threadpool 1 "test-pool-%d" 1000)]
         (let [fut (future
-                    (exec-from-channel gtp in-chan worker-fn))]
+                    (dochan gtp worker-fn in-chan))]
 
           (async/>!! in-chan {:foo 1})
           (async/close! in-chan)
@@ -53,7 +61,7 @@
           (deliver stop-here true)
 
           (is (= [:done 1] (async/<!! out-chan)))
-          
+
           (is (not= ::timed-out (deref fut 1000 ::timed-out)))
           (is (true? (future-done? fut)))))))
 
@@ -76,10 +84,10 @@
                        (deliver (get in-flight-promises id) true)
                        @(get stop-here id)
                        [:done id]))]
-      
+
       (with-open [gtp (create-threadpool 2 "test-pool-%d" 1000)]
         (let [fut (future
-                    (exec-from-channel gtp in-chan worker-fn))]
+                    (dochan gtp worker-fn in-chan))]
 
           (async/>!! in-chan {:id :a})
           (is (= true (deref (:a in-flight-promises) 100 ::not-found)))
@@ -104,6 +112,126 @@
 
           (deliver (get stop-here :c) true)
           (is (= [:done :c] (async/<!! out-chan)))
-          
+
           (is (not= ::timed-out (deref fut 1000 ::timed-out)))
           (is (true? (future-done? fut))))))))
+
+
+(def max-log-check-attempts 1000)
+(def log-sleep-duration-in-ms 10)
+
+(defn await-log-entry
+  "This function looks for a log entry in `log-atom`. If one is not
+  found it sleeps for `log-sleep-duration-in-ms` and repeats the
+  check. It does this `max-log-check-attempts` times and will
+  eventually throw an exception if it's not found"
+  [log-atom]
+  (loop [times 0]
+    (when-not (seq @log-atom)
+      (if (> times max-log-check-attempts)
+        (-> (* log-sleep-duration-in-ms max-log-check-attempts)
+            (format "Log entry not found after %s ms")
+            RuntimeException.
+            throw)
+        (do
+          (Thread/sleep log-sleep-duration-in-ms)
+          (recur (inc times)))))))
+
+(def critical-error-pred (comp #{:fatal :error} :level))
+
+(defn not-submitted? [message]
+  (str/includes? message "not submitted"))
+
+(deftest threadpool-logging
+  (testing "successful message"
+    (let [log-output (atom [])]
+      (with-log-suppressed-unless-notable critical-error-pred
+        (with-logging-to-atom "puppetlabs.puppetdb.threadpool" log-output
+          (let [{:keys [threadpool semaphore] :as threadpool-ctx} (create-threadpool 1 "testpool-%d" 5000)
+                handler-fn (tu/mock-fn)]
+            (try
+
+              (is (= 1 (.availablePermits semaphore)))
+              (is (not (test-protos/called? handler-fn)))
+
+              (call-on-threadpool threadpool-ctx handler-fn)
+
+              (is (.tryAcquire semaphore 1 TimeUnit/SECONDS)
+                  "Failed to aquire token from the semaphore")
+              (is (= [] @log-output))
+              (is (test-protos/called? handler-fn))
+
+              (finally
+                (.shutdownNow threadpool))))))))
+
+  (testing "failure of thread"
+    (let [log-output (atom [])]
+      (with-log-suppressed-unless-notable (every-pred critical-error-pred
+                                                      (comp (complement #(.startsWith % "Broken"))
+                                                            :message))
+        (with-logging-to-atom "puppetlabs.puppetdb.threadpool" log-output
+          (let [{:keys [threadpool semaphore] :as threadpool-ctx} (create-threadpool 1 "testpool-%d" 5000)]
+            (try
+              (is (= 1 (.availablePermits semaphore)))
+              (call-on-threadpool threadpool-ctx (fn [] (throw (RuntimeException. "Broken!"))))
+
+              ;; Releasing the semaphore happens right before the
+              ;; message is logged with the uncaughtExceptionHandler
+              (is (.tryAcquire semaphore 1 TimeUnit/SECONDS)
+                  "Failed to aquire token from the semaphore")
+
+              (await-log-entry log-output)
+
+              (is (= 1 (count @log-output)))
+
+              (let [log-event (first @log-output)]
+                (is (= "ERROR"
+                       (-> log-event
+                           .getLevel
+                           str)))
+
+                (is (= "testpool-1" (.getThreadName log-event))))
+
+              (finally
+                (.shutdownNow threadpool))))))))
+
+  (testing "threadpool shutdown"
+    (let [log-output (atom [])]
+      (with-log-suppressed-unless-notable (every-pred critical-error-pred
+                                                      (comp (complement not-submitted?) :message))
+       (with-logging-to-atom "puppetlabs.puppetdb.threadpool" log-output
+         (let [{:keys [threadpool semaphore] :as threadpool-ctx} (create-threadpool 1 "testpool-%d" 5000)
+               handler-fn (tu/mock-fn)
+               in-chan (async/chan 10)]
+
+           (try
+
+             (is (= 1 (.availablePermits semaphore)))
+
+             ;; Acquire a permit, so that shutdown can't grab the permit
+             (is (.tryAcquire semaphore 1 TimeUnit/SECONDS))
+
+             (shutdown threadpool-ctx)
+             (is (.awaitTermination threadpool 1 TimeUnit/SECONDS)
+                 "threadpool not shutdown")
+
+             ;; Although we are shutting the threadpool down, it will
+             ;; wait for in flight work to finish, it's possible that
+             ;; we could release the permit and attempt to put new
+             ;; work on the threadpool.
+             (is (nil? (.release semaphore)))
+             (async/>!! in-chan "message")
+
+             ;; Shutting down the threadpool when the channel is not
+             ;; empty will result in an exception, below ensures that
+             ;; happens
+             (is (thrown+-with-msg? (fn [obj]
+                                      (and (= (:message obj)
+                                              "message")
+                                           (= (:kind obj)
+                                              :puppetlabs.puppetdb.threadpool/rejected)))
+                                    #"Threadpool shutting down"
+                                    (dochan threadpool-ctx handler-fn in-chan)))
+
+             (finally
+               (.shutdownNow threadpool)))))))))


### PR DESCRIPTION
This commit adds code that allows data from an core.async input channel
to be processed on a bounded threadpool. When the threadpool reaches
it's max size, it blocks the calling thread on put. The threadpool is
shutdown once the input channel has been closed and in-flight work as
finished.