### PR TITLE
Maint/move postgres test setup docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ top of things.
 * Check for unnecessary whitespace with `git diff --check` before committing.
 * Make sure your commit messages are in the proper format.
 
-````
+```
     (PUP-1234) Make the example in CONTRIBUTING imperative and concrete
 
     Without this patch applied the example commit message in the CONTRIBUTING
@@ -91,7 +91,7 @@ always necessary to create a new ticket in Jira. In this case, it is
 appropriate to start the first line of a commit with '(doc)' instead of
 a ticket number.
 
-````
+```
     (doc) Add documentation commit example to CONTRIBUTING
 
     There is no example for contributing a documentation commit
@@ -102,7 +102,7 @@ a ticket number.
     place of what would have been the ticket number in a
     non-documentation related commit. The body describes the nature of
     the new documentation or comments added.
-````
+```
 
 ## Submitting Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,11 @@
+
+---
+title: "PuppetDB 4.1: Contributing to PuppetDB"
+layout: default
+---
+
+[configure_postgres]: documentation/configure.html#using-postgresql
+
 # How to contribute
 
 Third-party patches are essential for keeping puppet great. We simply can't
@@ -41,10 +49,38 @@ top of things.
     The first line is a real life imperative statement with a ticket number
     from our issue tracker.  The body describes the behavior without the patch,
     why this is a problem, and how the patch fixes the problem when applied.
-````
+```
 
 * Make sure you have added the necessary tests for your changes.
 * Run _all_ the tests to assure nothing else was accidentally broken.
+
+### Running the tests
+
+In order to run the local test suite, you will first need to have a PostgreSQL
+instance [configured][configure_postgres], and will need to create the test
+users:
+
+    $ createuser -DRSP pdb_test
+    $ createuser -dRsP pdb_test_admin
+
+You will also need to set the following environment variables if the
+default values aren't appropriate:
+
+  * PDB\_TEST\_DB\_HOST (defaults to localhost)
+  * PDB\_TEST\_DB\_PORT (defaults to 5432)
+  * PDB\_TEST\_DB\_USER (defaults to pdb\_test)
+  * PDB\_TEST\_DB\_PASSWORD (defaults to pdb\_test)
+  * PDB\_TEST\_DB\_ADMIN (defaults to pdb\_test\_admin)
+  * PDB\_TEST\_DB\_ADMIN\_PASSWORD (defaults to pdb\_test\_admin)
+
+Then you can run the test suite:
+
+    $ lein test
+
+And if you'd like to preserve the temporary test databases on failure, you can
+set PDB\_TEST\_PRESERVE\_DB\_ON\_FAIL to true:
+
+    $ PDB\_TEST\_KEEP\_DB\_ON\_FAIL=true lein test
 
 ## Making Trivial Changes
 

--- a/documentation/_puppetdb_nav.html
+++ b/documentation/_puppetdb_nav.html
@@ -4,6 +4,7 @@
   <li><strong>General information</strong>
     <ul>
       <li><a href="{{puppetdb}}/index.html">Overview and requirements</a></li>
+      <li><a href="contributing.html">Contributing to PuppetDB</a></li>
       <li><a href="{{puppetdb}}/puppetdb-faq.html">Frequently asked questions</a></li>
       <li><a href="{{puppetdb}}/release_notes.html">Release notes</a></li>
       <li><a href="{{puppetdb}}/versioning_policy.html">Versioning policy</a></li>

--- a/documentation/install_from_source.markdown
+++ b/documentation/install_from_source.markdown
@@ -8,6 +8,7 @@ layout: default
 [configure_heap]: ./configure.html#configuring-the-java-heap-size
 [module]: ./install_via_module.html
 [packages]: ./install_from_packages.html
+[running_tests]: /CONTRIBUTING.html#running-the-tests
 
 > **Note:** If you are running Puppet Enterprise version 3.0 or later, you do
 > not need to install PuppetDB, as it is already installed as part of PE.
@@ -105,31 +106,7 @@ A sample config file is provided in the root of the source repo:
 `config.sample.ini`. You can also provide a conf.d-style directory instead of a
 flat config file.
 
-In order to run the local test suite, you will first need to have a PostgreSQL
-instance [configured][configure_postgres], and will need to create the test
-users:
-
-    $ createuser -DRSP pdb_test
-    $ createuser -dRsP pdb_test_admin
-
-You will also need to set the following environment variables if the
-default values aren't appropriate:
-
-  * PDB\_TEST\_DB\_HOST (defaults to localhost)
-  * PDB\_TEST\_DB\_PORT (defaults to 5432)
-  * PDB\_TEST\_DB\_USER (defaults to pdb\_test)
-  * PDB\_TEST\_DB\_PASSWORD (defaults to pdb\_test)
-  * PDB\_TEST\_DB\_ADMIN (defaults to pdb\_test\_admin)
-  * PDB\_TEST\_DB\_ADMIN\_PASSWORD (defaults to pdb\_test\_admin)
-
-Then you can run the test suite:
-
-    $ lein test
-
-And if you'd like to preserve the temporary test databases on failure, you can
-set PDB\_TEST\_PRESERVE\_DB\_ON\_FAIL to true:
-
-    $ PDB\_TEST\_KEEP\_DB\_ON\_FAIL=true lein test
+Next, you will need to [setup some test users](running_tests) to run the tests locally
 
 Step 3: Configure a database
 -----


### PR DESCRIPTION
This pull request moves how to set up postgresql to run the unit tests into
the CONTRIBUTING doc. It also includes the contributing document in the
navigation header.