### PR TITLE
(PDB-2632) add inventory endpoint and support for dotted fields

### DIFF
--- a/documentation/_puppetdb_nav.html
+++ b/documentation/_puppetdb_nav.html
@@ -72,6 +72,7 @@
       <li><a href="{{puppetdb}}/api/query/v4/fact-names.html">Fact-names endpoint</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/fact-paths.html">Fact-paths endpoint</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/fact-contents.html">Fact-contents endpoint</a></li>
+      <li><a href="{{puppetdb}}/api/query/v4/inventory.html">Inventory endpoint</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/catalogs.html">Catalogs endpoint</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/resources.html">Resources endpoint</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/edges.html">Edges endpoint</a></li>

--- a/documentation/api/query/v4/ast.markdown
+++ b/documentation/api/query/v4/ast.markdown
@@ -216,6 +216,70 @@ To get the average uptime for your nodes:
 
     ["extract", [["function", "avg", "value"]], ["=", "name", "uptime_seconds"]]
 
+## Dot notation
+
+*Note*: Dot notation for hash descendence is experimental. Currently it has
+full support on the `facts` and `trusted` response keys of the `inventory`
+endpoint, and partial support on the `parameters` column of the resources
+endpoint.
+
+Certain types of JSON data returned by PuppetDB can be queried in a structured
+way using `dot notation`. The rules for dot notation are:
+* Hash descendence is represented by a period-separated sequence of key names
+* Array indexing (`inventory` only) is represented with brackets ([]) on the
+end of a key.
+* Regular expression matching (`inventory` only) is represented with the
+  `match` keyword.
+
+For example, given the inventory response
+    {
+        "certname" : "mbp.local",
+        "timestamp" : "2016-07-11T20:02:33.190Z",
+        "environment" : "production",
+        "facts" : {
+            "kernel" : "Darwin",
+            "operatingsystem" : "Darwin",
+            "macaddress_p2p0" : "0e:15:c2:d6:f8:4e",
+            "system_uptime" : {
+                "days" : 0,
+                "hours" : 1,
+                "uptime" : "1:52 hours",
+                "seconds" : 6733
+            },
+            "macaddress_awdl0" : "6e:31:ef:e6:36:54",
+            "processors": {
+                "models": [
+                    "Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz",
+                    "Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz",
+                    "Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz",
+                    "Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz"],
+                "count": 4,
+                "physicalcount": 1
+            },
+            ...
+        },
+        "trusted" : {
+            "domain" : "local",
+            "certname" : "mbp.local",
+            "hostname" : "mbp",
+            "extensions" : { },
+            "authenticated" : "remote"
+        }
+    }
+
+valid queries would include
+
+*    ["=", "facts.kernel", "Darwin"]
+
+*    ["=", "facts.system_uptime.days", 0]
+
+*    [">", "facts.system_uptime.hours", 0]
+
+*    ["~", "facts.processors.models[0]", "Intel.*"]
+
+*    ["=", "partitions.match(\"sda.*\").mount", "/home"]
+
+
 ## Context operators
 
 *Note:* Context setting support is new and experimental. Setting the context at

--- a/documentation/api/query/v4/inventory.markdown
+++ b/documentation/api/query/v4/inventory.markdown
@@ -1,0 +1,127 @@
+---
+title: "PuppetDB 4.1: Inventory endpoint"
+layout: default
+canonical: "/puppetdb/latest/api/query/v4/inventory.html"
+---
+
+[curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
+[subqueries]: ./ast.html#subquery-operators
+[dotted]: ./ast.html#dot-notation
+[environments]: ./environments.html
+[factsets]: ./factsets.html
+[catalogs]: ./catalogs.html
+[facts]: ./facts.html
+[fact-contents]: ./fact_contents.html
+[events]: ./events.html
+[edges]: ./edges.html
+[resources]: ./resources.html
+[nodes]: ./nodes.html
+
+The `/inventory` endpoint enables an alternative query syntax for digging into
+structured facts, and can be used instead of the `facts`, `fact-contents`, and
+`factsets` endpoints for most fact-related queries.
+
+## `/pdb/query/v4/inventory`
+
+This will return an array of `node inventories` matching the given query.
+Inventories for deactivated nodes are not included in the response.
+
+### URL parameters
+
+* `query`: optional. A JSON array containing the query in prefix notation
+  (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`). See the sections below for the
+  supported operators and fields. For general information about queries, see
+  [our guide to query structure.][query]
+
+
+### Query operators
+
+See [the AST query language page][ast] for the full list of available operators.
+
+Note: This endpoint supports [dot notation][dotted] on the `facts` and
+`trusted` response fields.
+
+### Query fields
+
+* `certname` (string): the name of the node associated with the inventory.
+
+* `timestamp` (string): the time at which PuppetDB received the facts in the inventory.
+
+* `environment` (string): the environment associated with the inventory's
+  certname.
+
+* `facts` (json): a JSON hash of fact names to fact values.
+
+* `trusted` (json): a JSON hash of trusted data for the node.
+
+### Subquery relationships
+
+The following list contains related entities that can be used to constrain the result set with implicit subqueries. For more information, consult the documentation for [subqueries][subqueries].
+
+* [`environments`][environments]: the environment where a node inventory exists.
+* [`factsets`][factsets]: the factset corresponding to a node inventory's certname.
+* [`catalogs`][catalogs]: the catalog corresponding to a node inventory's certname.
+* [`facts`][facts]: the facts corresponding to a node inventory's certname.
+* [`fact-contents`][fact-contents]: the fact contents corresponding to a node inventory's certname.
+* [`events`][events]: the events corresponding to a node inventory's certname.
+* [`edges`][edges]: the catalog edges corresponding to a node inventory's certname.
+* [`resources`][resources]: the resources corresponding to a node inventory's certname.
+* [`nodes`][nodes]: the node corresponding to an inventory.
+
+### Response format
+Successful responses will be in `application/json`.
+
+The result will be a JSON array with one entry per certname. Each entry is of
+the form:
+
+    {
+      "certname": <node certname>,
+      "timestamp": <timestamp of fact reception>,
+      "environment": <node environment>,
+      "facts": {
+                 <fact name>: <fact value>,
+                 ...
+               },
+      "trusted": {
+                   <data name>: <data value>,
+                   ...
+                 }
+    }
+
+### Examples
+
+[Using `curl` from localhost][curl]
+
+    curl -X GET http://localhost:8080/pdb/query/v4/inventory -d 'query=["=", "facts.operatingsystem", "Darwin"]'
+
+    [ {
+        "certname" : "mbp.local",
+            "timestamp" : "2016-07-11T20:02:33.190Z",
+            "environment" : "production",
+            "facts" : {
+                "kernel" : "Darwin",
+                "operatingsystem" : "Darwin",
+                "memoryfree" : "3.51 GB",
+                "macaddress_p2p0" : "0e:15:c2:d6:f8:4e",
+                "system_uptime" : {
+                    "days" : 0,
+                    "hours" : 1,
+                    "uptime" : "1:52 hours",
+                    "seconds" : 6733
+                },
+                "netmask_lo0" : "255.0.0.0",
+                "sp_physical_memory" : "16 GB",
+                "operatingsystemrelease" : "14.4.0",
+                "macosx_productname" : "Mac OS X",
+                "sp_boot_mode" : "normal_boot",
+                "macaddress_awdl0" : "6e:31:ef:e6:36:54",
+                ...
+            },
+            "trusted" : {
+                "domain" : "local",
+                "certname" : "mbp.local",
+                "hostname" : "mbp",
+                "extensions" : { },
+                "authenticated" : "remote"
+            }
+    } ]

--- a/documentation/api/query/v4/resources.markdown
+++ b/documentation/api/query/v4/resources.markdown
@@ -12,6 +12,7 @@ canonical: "/puppetdb/latest/api/query/v4/resources.html"
 [catalogs]: ./catalogs.html
 [environments]: ./environments.html
 [nodes]: ./nodes.html
+[dotted]: ./ast.html#dot-notation
 
 You can query resources by making an HTTP request to the
 `/resources` endpoint.
@@ -26,6 +27,8 @@ deactivated nodes are not included in the response.
 * `query`: optional. A JSON array of query predicates, in prefix notation (`["<OPERATOR>", "<FIELD>", "<VALUE>"]`). See the sections below for the supported operators and fields. For general info about queries, see [our guide to query structure.][query]
 
 If no query is provided, all resources will be returned.
+
+Note: This endpoint supports [dot notation][dotted] on the `parameters` field.
 
 ### Query operators
 
@@ -54,6 +57,8 @@ See [the AST query language page][ast] for the full list of available operators.
 * `environment` (string): the environment of the node associated to the resource.
 
 * `resource` (string): a SHA-1 hash of the resource's type, title, and parameters, for identification.
+
+* `parameters` (json): a JSON hash of the resource's parameters.
 
 ### Subquery relationships
 
@@ -152,6 +157,27 @@ this route.
       "title" : "bar",
       "type" : "User",
       "certname" : "host2.mydomain.com"}]
+
+    curl -X GET http://localhost:8080/pdb/query/v4/resources -d 'query=["=","parameters.groups", "users"]'
+
+    [{"parameters" : {
+        "uid" : "1001,
+        "shell" : "/bin/bash",
+        "managehome" : false,
+        "gid" : "1001,
+        "home" : "/home/bar,
+        "groups" : "users,
+        "ensure" : "present"
+     },
+     "line" : 20,
+     "resource" : "514cc3d67baf20c1c5e053e6a74b249558031311",
+     "file" : "/etc/puppetlabs/code/environments/production/manifests/site.pp",
+     "exported" : false,
+     "environment": "production",
+     "tags" : [ "foo", "bar" ],
+     "title" : "bar",
+     "type" : "User",
+     "certname" : "host2.mydomain.com"}]
 
 ## `/pdb/query/v4/resources/<TYPE>/<TITLE>`
 

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -25,7 +25,11 @@ msgstr ""
 msgid "Another cleanup is already in progress"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/config.clj:366
+#: src/puppetlabs/puppetdb/command.clj:425
+msgid "Exception throw in L1 retry attempt {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/config.clj:369
 msgid ""
 "Configuring the route for `{0}` is not allowed. The default route is `{1}` "
 "and server is `{2}`."
@@ -110,11 +114,11 @@ msgstr ""
 msgid "Fatal error parsing command: {0}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/mq_listener.clj:266
+#: src/puppetlabs/puppetdb/mq_listener.clj:265
 msgid "[{0}] [{1}] Fatal error on attempt {2} for {3}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/mq_listener.clj:296
+#: src/puppetlabs/puppetdb/mq_listener.clj:283
 msgid "[{0}] [{1}] Retrying after attempt {2} for {3}, due to: {4}"
 msgstr ""
 
@@ -220,19 +224,52 @@ msgstr ""
 msgid "{0} operator does not support object ''{1}'' for event counts"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query_eng.clj:68
+#: src/puppetlabs/puppetdb/query_eng.clj:70
 msgid "Invalid entity ''{0}'' in query"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query_eng.clj:195
-#: src/puppetlabs/puppetdb/query_eng.clj:201
+#: src/puppetlabs/puppetdb/query_eng.clj:197
+#: src/puppetlabs/puppetdb/query_eng.clj:203
 msgid ""
 "Error executing query ''{0}'' with query options ''{1}''. Returning a 400 "
 "error code."
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query_eng.clj:206
+#: src/puppetlabs/puppetdb/query_eng.clj:208
 msgid "Caught PSQL processing exception"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj:1306
+msgid "Value {0} of type {1} unsupported."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj:1310
+msgid "Operator ''{0}'' not allowed on value ''{1}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj:1419
+msgid "Field 'latest_report?' not supported on endpoint ''{0}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/threadpool.clj:18
+msgid "Error processing command on thread {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/threadpool.clj:51
+msgid ""
+"Threadpool not stopped after {0} milliseconds, forcibly shutting it down"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/threadpool.clj:57
+msgid "Threadpool forcibly shutdown"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/threadpool.clj:97
+msgid "Thread interrupted while processing on threadpool"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/threadpool.clj:122
+msgid "Threadpool shutting down, message rejected"
 msgstr ""
 
 #: src/puppetlabs/puppetdb/utils.clj:37

--- a/resources/puppetlabs/puppetdb/pql/pql-grammar-experimental.ebnf
+++ b/resources/puppetlabs/puppetdb/pql/pql-grammar-experimental.ebnf
@@ -40,6 +40,7 @@ extract = <lbracket>, [<whitespace>], [extractfields], [<whitespace>], <rbracket
            'factsets' |
            'fact_paths' |
            'fact_contents' |
+           'inventory' |
            'edges' |
            'events';
 
@@ -81,11 +82,16 @@ groupedarglist = <lparens>, [<whitespace>], [arglist], [<whitespace>], <rparens>
 <stringlist>   = string , [ [<whitespace>], <','>, [<whitespace>], stringlist ];
 
 (* Represents a field from an entity *)
-<field> = #'[a-zA-Z0-9_]+\??';
+field = #'[a-zA-Z0-9_]+\??' | (dottedfield, fieldpath);
+<fieldpath> = <'.'>, (quotedfield | standardfield | matchfield) , [fieldpath];
+<quotedfield> = #'\".*?\"(?=\.|\s)';
+<matchfield> = #'match\(.*?\)';
+<standardfield> = #'[^\s\.\"]+';
+<dottedfield> = 'facts' | 'trusted' | 'parameters';
 
 <condregexp>      = '~';
 <condregexparray> = '~>';
-<condinequality>      = '>=' | '<=' | '<' | '>';
+<condinequality>  = '>=' | '<=' | '<' | '>';
 <condmatch>       = '=';
 <condin>          = 'in';
 

--- a/src/puppetlabs/puppetdb/facts.clj
+++ b/src/puppetlabs/puppetdb/facts.clj
@@ -40,7 +40,7 @@
    :value_string (s/maybe s/Str)
    :value_integer (s/maybe s/Int)
    :value_boolean (s/maybe s/Bool)
-   :value (s/maybe s/Str)
+   :value (s/maybe s/Any)
    :value_type_id s/Int})
 
 ;; GLOBALS
@@ -149,7 +149,7 @@
                             3 :value_boolean
                             5 :value)]
         (assoc initial-map value-keyword value
-          :value (sutils/db-serialize value))))))
+          :value (sutils/munge-jsonb-for-storage value))))))
 
 (defn flatten-facts-with
   "Returns a collection of (leaf-fn path leaf) for all of the paths

--- a/src/puppetlabs/puppetdb/honeysql.clj
+++ b/src/puppetlabs/puppetdb/honeysql.clj
@@ -31,6 +31,10 @@
   [expr :- key-or-sql]
   (hcore/call :json_agg expr))
 
+(pls/defn-validated json-object-agg :- SqlCall
+  [& args]
+  (apply hcore/call :json_object_agg args))
+
 (pls/defn-validated row-to-json :- SqlCall
   "row_to_json(record) sql function"
   [record :- key-or-sql]

--- a/src/puppetlabs/puppetdb/http/handlers.clj
+++ b/src/puppetlabs/puppetdb/http/handlers.clj
@@ -241,6 +241,14 @@
                                             http-q/restrict-fact-query-to-value
                                             http-q/restrict-query-to-active-nodes))))))
 
+(pls/defn-validated inventory-routes :- bidi-schema/RoutePair
+  [version :- s/Keyword]
+  (extract-query
+    (cmdi/routes
+      (cmdi/ANY "" []
+                (create-query-handler version "inventory"
+                                      http-q/restrict-query-to-active-nodes)))))
+
 (pls/defn-validated factset-routes :- bidi-schema/RoutePair
   [version :- s/Keyword]
   (extract-query

--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -39,6 +39,7 @@
                 "/facts" handlers/facts-routes
                 "/edges" handlers/edge-routes
                 "/factsets" handlers/factset-routes
+                "/inventory" handlers/inventory-routes
                 "/fact-names" handlers/fact-names-routes
                 "/fact-contents" handlers/fact-contents-routes
                 "/fact-paths" handlers/fact-path-routes

--- a/src/puppetlabs/puppetdb/pql/transform.clj
+++ b/src/puppetlabs/puppetdb/pql/transform.clj
@@ -123,6 +123,10 @@
             (second arg)
             (vec (rest arg)))))])
 
+(defn transform-field
+  [& args]
+  (str/join "." args))
+
 (def transform-specification
   {:from               transform-from
    :subquery           transform-subquery
@@ -145,5 +149,6 @@
    :exp                transform-exp
    :groupby            transform-groupby
    :limit              transform-limit
+   :field              transform-field
    :offset             transform-offset
    :orderby            transform-orderby})

--- a/src/puppetlabs/puppetdb/query/fact_contents.clj
+++ b/src/puppetlabs/puppetdb/query/fact_contents.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.puppetdb.query.fact-contents
   (:require [puppetlabs.puppetdb.facts :as f]
+            [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.schema :as pls]
             [puppetlabs.puppetdb.utils :as utils]
@@ -10,7 +11,7 @@
    (s/optional-key :environment) (s/maybe s/Str)
    (s/optional-key :path) s/Str
    (s/optional-key :name) s/Str
-   (s/optional-key :value) (s/maybe s/Str)})
+   (s/optional-key :value) (s/maybe s/Any)})
 
 (def converted-row-schema
   {(s/optional-key :certname) s/Str
@@ -24,7 +25,7 @@
    an array structure."
   [row :- row-schema]
   (-> row
-      (utils/update-when [:value] json/parse-string)
+      (utils/update-when [:value] sutils/parse-db-json)
       (utils/update-when [:path] f/string-to-factpath)))
 
 (pls/defn-validated munge-result-rows

--- a/src/puppetlabs/puppetdb/query/facts.clj
+++ b/src/puppetlabs/puppetdb/query/facts.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.puppetdb.query.facts
   "Fact query generation"
   (:require [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.facts :as facts]
             [puppetlabs.puppetdb.query :as query]
             [puppetlabs.puppetdb.query.paging :as paging]
@@ -37,8 +38,7 @@
   (fn [rows]
     (if (empty? rows)
       []
-      (->> rows
-           (map deserialize-fact-value)))))
+      (map #(utils/update-when % [:value] sutils/parse-db-json) rows))))
 
 (defn munge-path-result-rows
   [_ _]

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -29,6 +29,8 @@
                               :rec nil}
      :event-counts {:munge event-counts/munge-result-rows
                     :rec nil}
+     :inventory {:munge (constantly identity)
+                 :rec eng/inventory-query}
      :facts {:munge facts/munge-result-rows
              :rec eng/facts-query}
      :fact-contents {:munge fact-contents/munge-result-rows

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.puppetdb.query-eng.engine
   (:require [clojure.core.match :as cm]
             [clojure.string :as str]
+            [puppetlabs.i18n.core :as i18n]
             [clojure.set :refer [map-invert]]
             [clojure.tools.logging :as log]
             [honeysql.core :as hcore]
@@ -23,6 +24,10 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Plan - functions/transformations of the internal query plan
+
+(defn validate-dotted-field
+  [dotted-field]
+  (and (string? dotted-field) (re-find #"(facts|trusted)\..+" dotted-field)))
 
 (def field-schema (s/cond-pre s/Keyword
                               SqlCall SqlRaw
@@ -68,6 +73,11 @@
     [column :- column-schema
      value])
 
+(s/defrecord JsonContainsExpression
+  [field :- s/Str
+   column-data :- column-schema
+   value])
+
 (s/defrecord InExpression
     [column :- [column-schema]
      ;; May not want this if it's recursive and not just "instance?"
@@ -112,6 +122,76 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Queryable Entities
+
+(def inventory-query
+  "Query for inventory"
+  (map->Query {:projections {"certname" {:type :string
+                                         :queryable? true
+                                         :field :certnames.certname}
+                             "timestamp" {:type :timestamp
+                                          :queryable? true
+                                          :field :fs.timestamp}
+                             "environment" {:type :string
+                                            :queryable? true
+                                            :field :environments.environment}
+                             "facts" {:type :json
+                                      :queryable? true
+                                      :field {:select [[(h/json-object-agg :name :value) :facts]]
+                                              :from [[{:select [:fp.name  :fv.value]
+                                                       :from [[:facts :f]]
+                                                       :join [[:fact_values :fv]
+                                                              [:= :fv.id :f.fact_value_id]
+
+                                                              [:fact_paths :fp]
+                                                              [:= :fp.id :f.fact_path_id]
+
+                                                              [:value_types :vt]
+                                                              [:= :vt.id :fv.value_type_id]]
+                                                       :where [:and
+                                                               [:= :fp.depth 0]
+                                                               [:= :f.factset_id :fs.id]]}
+                                                      :facts_data]]}}
+                             "trusted" {:type :queryable-json
+                                        :queryable? true
+                                        :field  {:select [[:fv.value :trusted]]
+                                                 :from [[:facts :f]]
+                                                 :join [[:fact_values :fv]
+                                                        [:= :fv.id :f.fact_value_id]
+
+                                                        [:fact_paths :fp]
+                                                        [:= :fp.id :f.fact_path_id]
+
+                                                        [:value_types :vt]
+                                                        [:= :vt.id :fv.value_type_id]]
+                                                 :where [:and
+                                                         [:= :fp.depth 0]
+                                                         [:= :f.factset_id :fs.id]
+                                                         [:= :fp.name (hcore/raw "'trusted'")]]}}}
+
+               :selection {:from [[:factsets :fs]]
+                           :left-join [:environments
+                                       [:= :fs.environment_id :environments.id]
+
+                                       :producers
+                                       [:= :fs.producer_id :producers.id]
+
+                                       :certnames
+                                       [:= :fs.certname :certnames.certname]]}
+
+              :alias "inventory"
+              :relationships {"factsets" {:columns ["certname"]}
+                              "reports" {:columns ["certname"]}
+                              "catalogs" {:columns ["certname"]}
+                              "nodes" {:columns ["certname"]}
+                              "facts" {:columns ["certname"]}
+                              "fact_contents" {:columns ["certname"]}
+                              "events" {:columns ["certname"]}
+                              "edges" {:columns ["certname"]}
+                              "resources" {:columns ["certname"]}}
+
+              :dotted-fields ["facts\\..*" "trusted\\..*"]
+              :entity :inventory
+              :subquery? false}))
 
 (def nodes-query
   "Query for nodes entities, mostly used currently for subqueries"
@@ -734,9 +814,9 @@
                              "line" {:type :integer
                                      :queryable? true
                                      :field :line}
-                             "parameters" {:type :json
+                             "parameters" {:type :queryable-json
                                            :queryable? true
-                                           :field (h/scast :rpc.parameters :json)}}
+                                           :field :rpc.parameters}}
 
                :selection {:from [[:catalog_resources :resources]]
                            :join [:latest_catalogs
@@ -759,6 +839,7 @@
 
                :alias "resources"
                :subquery? false
+               :dotted-fields ["parameters\\..*"]
                :source-table "catalog_resources"}))
 
 (def report-events-query
@@ -991,7 +1072,7 @@
 (defn compile-fnexpression
   ([expr]
    (compile-fnexpression expr true))
-  ([{:keys [function column params] :as foobar} alias?]
+  ([{:keys [function column params]} alias?]
    (let [honeysql-fncall (apply hcore/call function (cons column params))]
      (hcore/format (if alias?
                      [honeysql-fncall (get pg-fns->pdb-fns function)]
@@ -1055,7 +1136,11 @@
     [:in (mapv :field column)
      (-plan->sql subquery)])
 
-  BinaryExpression
+  JsonContainsExpression
+  (-plan->sql [{:keys [field]}]
+    (su/json-contains field))
+
+ BinaryExpression
   (-plan->sql [{:keys [column operator value]}]
     (apply vector
            :or
@@ -1124,6 +1209,22 @@
       (instance? ArrayBinaryExpression node)
       (instance? ArrayRegexExpression node)))
 
+(defn path->nested-map
+  "Given path [a b c] and value d, produce {a {b {c d}}}"
+  [path value]
+  (reduce #(hash-map (utils/maybe-strip-escaped-quotes %2) %1)
+          (rseq (conj (vec path) value))))
+
+(defn parse-dot-query
+  "Transforms a dotted query into a JSON structure appropriate
+   for comparison in the database."
+  [{:keys [field value] :as node} state]
+  (let [[column & path] (map utils/maybe-strip-escaped-quotes
+                             (su/dotted-query->path field))]
+    {:node (assoc node :value "?" :field column)
+     :state (conj state (su/munge-jsonb-for-storage
+                          (path->nested-map path value)))}))
+
 (defn extract-params
   "Extracts the node's expression value, puts it in state
    replacing it with `?`, used in a prepared statement"
@@ -1132,6 +1233,9 @@
     (binary-expression? node)
     {:node (assoc node :value "?")
      :state (conj state (:value node))}
+
+    (instance? JsonContainsExpression node)
+    (parse-dot-query node state)
 
     (instance? FnExpression node)
     {:state (apply conj (:params node) state)}))
@@ -1165,6 +1269,7 @@
    "select_latest_report" latest-report-query
    "select_params" resource-params-query
    "select_reports" reports-query
+   "select_inventory" inventory-query
    "select_resources" resources-query})
 
 (defn user-query->logical-obj
@@ -1182,6 +1287,33 @@
   query language"
   [node]
   (cm/match [node]
+
+            [[(op :guard #{"=" ">" "<" "<=" ">=" "~"}) (column :guard validate-dotted-field) value]]
+            (when (= :inventory (get-in (meta node) [:query-context :entity]))
+              (let [[head & path] (->> column
+                                       utils/parse-matchfields
+                                       su/dotted-query->path
+                                       (map utils/maybe-strip-escaped-quotes))
+                    path (if (= head "trusted")
+                           (cons head path)
+                           path)
+                    value-column (cond
+                                   (string? value) "value_string"
+                                   (ks/boolean? value) "value_boolean"
+                                   (integer? value) "value_integer"
+                                   (float? value) "value_float"
+                                   :else (throw (IllegalArgumentException.
+                                                 (i18n/tru "Value {0} of type {1} unsupported." value (type value)))))]
+
+                (if (or (and (or (ks/boolean? value) (number? value)) (= op "~"))
+                        (and (or (ks/boolean? value) (string? value)) (contains? #{"<=" "<" ">" ">="} op)))
+                  (throw (i18n/tru "Operator ''{0}'' not allowed on value ''{1}''" op value))
+                  ["in" "certname"
+                   ["extract" "certname"
+                    ["select_fact_contents"
+                     ["and"
+                      ["~>" "path" (utils/split-indexing path)]
+                      [op value-column value]]]]])))
 
             [[(op :guard #{"=" "<" ">" "<=" ">="}) "value" (value :guard #(number? %))]]
             ["or" [op "value_integer" value] [op "value_float" value]]
@@ -1284,7 +1416,7 @@
                                       ["select_latest_report"]]]
 
                                     (throw (IllegalArgumentException.
-                                             (format "Field 'latest_report?' not supported on endpoint '%s'" entity))))]
+                                            (i18n/tru "Field 'latest_report?' not supported on endpoint ''{0}''" entity))))]
               (if value
                 expanded-latest
                 ["not" expanded-latest]))
@@ -1550,7 +1682,8 @@
   [query-rec node]
   (cm/match [node]
             [["=" column-name value]]
-            (let [cinfo (get-in query-rec [:projections column-name])]
+            (let [colname (first (str/split column-name #"\."))
+                  cinfo (get-in query-rec [:projections colname])]
               (case (:type cinfo)
                :timestamp
                (map->BinaryExpression {:operator :=
@@ -1565,6 +1698,11 @@
                (map->BinaryExpression {:operator :=
                                        :column cinfo
                                        :value (facts/factpath-to-string value)})
+
+               :queryable-json
+               (map->JsonContainsExpression {:field column-name
+                                             :column-data cinfo
+                                             :value value})
 
                (map->BinaryExpression {:operator :=
                                        :column cinfo
@@ -1782,9 +1920,11 @@
   [node state]
   (cm/match [node]
             [[(:or "=" "~" ">" "<" "<=" ">=") field _]]
-            (let [{:keys [alias] :as query-context} (:query-context (meta node))
+            (let [{:keys [alias dotted-fields] :as query-context} (:query-context (meta node))
                   qfields (queryable-fields query-context)]
-              (when-not (or (vec? field) (contains? (set qfields) field))
+              (when-not (or (vec? field)
+                            (contains? (set qfields) field)
+                            (some #(re-matches % field) (map re-pattern dotted-fields)))
                 {:node node
                  :state (conj state
                               (format "'%s' is not a queryable object for %s, %s" field alias
@@ -1807,9 +1947,11 @@
                  :state (conj state column-validation-message)}))
 
             [["in" field ["array" _]]]
-            (let [{:keys [alias] :as query-context} (:query-context (meta node))
+            (let [{:keys [alias dotted-fields] :as query-context} (:query-context (meta node))
                   qfields (queryable-fields query-context)]
-              (when-not (or (vec? field) (contains? (set qfields) field))
+              (when-not (or (vec? field)
+                            (contains? (set qfields) field)
+                            (some #(re-matches % field) (map re-pattern dotted-fields)))
                 {:node node
                  :state (conj state
                               (format "'%s' is not a queryable object for %s, %s" field alias

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -59,6 +59,14 @@
             [puppetlabs.puppetdb.jdbc :as jdbc :refer [query-to-vec]]
             [puppetlabs.puppetdb.config :as conf]))
 
+;; taken from storage.clj; preserved here in case of change
+(defn insert-records*
+  "Nil/empty safe insert-records, see java.jdbc's insert-records for more "
+  [table
+   record-coll]
+  (when (seq record-coll)
+    (apply jdbc/insert! table record-coll)))
+
 (defn init-through-2-3-8
   []
 
@@ -1068,6 +1076,91 @@
     "alter table reports add column corrective_change boolean"
     "alter table resource_events add column corrective_change boolean"))
 
+(defn migrate-through-app
+  "stream data from table1 through the application and into table2, applying
+   munge-fn to each row"
+  [table1 table2 column-list batchsize munge-fn] 
+  (let [columns (string/join "," column-list)]
+    (jdbc/query-with-resultset
+      [(format "select %s from %s" columns (name table1))]
+      (fn [rs]
+        (->> (sql/result-set-seq rs)
+             (map munge-fn)
+             (partition-all batchsize)
+             (map #(insert-records* (name table2) %))
+             dorun)))))
+
+(defn resource-params-cache-parameters-to-jsonb
+  []
+  (jdbc/do-commands
+    (sql/create-table-ddl :resource_params_cache_transform
+                          ["resource" "bytea NOT NULL"]
+                          ["parameters" "jsonb"]))
+
+  (migrate-through-app
+    :resource_params_cache
+    :resource_params_cache_transform
+    ["encode(resource::bytea, 'hex') as resource" "parameters"]
+    500
+    #(-> %
+         (update :parameters (comp sutils/munge-jsonb-for-storage json/parse-string))
+         (update :resource sutils/munge-hash-for-storage)))
+
+  (jdbc/do-commands
+    "alter table catalog_resources drop constraint catalog_resources_resource_fkey"
+    "alter table resource_params drop constraint resource_params_resource_fkey"
+    "drop table resource_params_cache"
+
+    "alter table resource_params_cache_transform rename to resource_params_cache"
+
+    "alter table resource_params_cache add constraint resource_params_cache_pkey
+     primary key (resource)"
+    "alter table catalog_resources add constraint catalog_resources_resource_fkey
+     foreign key (resource) references resource_params_cache(resource) on delete cascade"
+    "alter table resource_params add constraint resource_params_resource_fkey
+     foreign key (resource) references resource_params_cache(resource) on delete cascade"
+    "create index rpc_hash_expr_idx on resource_params_cache(encode(resource, 'hex'))")   )
+
+(defn fact-values-value-to-jsonb
+  []
+  (jdbc/do-commands
+    (sql/create-table-ddl :fact_values_transform
+                          ["id" "bigint NOT NULL PRIMARY KEY DEFAULT nextval('fact_values_id_seq')"]
+                          ["value_hash" "bytea NOT NULL UNIQUE"]
+                          ["value_type_id" "bigint NOT NULL"]
+                          ["value_integer" "bigint"]
+                          ["value_float" "double precision"]
+                          ["value_string" "text"]
+                          ["value_boolean" "boolean"]
+                          ["value" "jsonb"]))
+
+  (migrate-through-app
+    :fact_values
+    :fact_values_transform
+    ["id" "encode(value_hash::bytea, 'hex') as value_hash" "value_type_id"
+     "value_integer" "value_float" "value_string" "value_boolean" "value"]
+    500
+    #(-> %
+         (update :value (comp sutils/munge-jsonb-for-storage json/parse-string))
+         (update :value_hash sutils/munge-hash-for-storage)))
+
+  (jdbc/do-commands
+    "alter table facts drop constraint fact_value_id_fk"
+
+    "drop table fact_values"
+    "alter table fact_values_transform rename to fact_values"
+
+    "alter table fact_values rename constraint fact_values_transform_value_hash_key
+     to fact_values_value_hash_key"
+
+    "alter table fact_values rename constraint fact_values_transform_pkey
+     to fact_values_pkey"
+
+    "alter table facts add constraint fact_value_id_fk foreign key
+     (fact_value_id) references fact_values(id) on update restrict on delete restrict"
+    "create index fact_values_value_float_idx on fact_values(value_float)"
+    "create index fact_values_value_integer_idx on fact_values(value_integer)"))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1094,7 +1187,9 @@
    46 drop-certnames-latest-id-index
    47 add-producer-to-reports-catalogs-and-factsets
    48 add-noop-pending-to-reports
-   49 add-corrective-change-columns})
+   49 add-corrective-change-columns
+   50 fact-values-value-to-jsonb
+   51 resource-params-cache-parameters-to-jsonb})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -488,14 +488,17 @@
     (insert-records*
      :resource_params_cache
      (map (fn [[resource-hash params]]
-            {:resource (sutils/munge-hash-for-storage resource-hash) :parameters (when params (sutils/db-serialize params))})
+            {:resource (sutils/munge-hash-for-storage resource-hash)
+             :parameters (some-> params sutils/munge-jsonb-for-storage)})
           new-params))
 
     (insert-records*
      :resource_params
      (for [[resource-hash params] new-params
            [k v] params]
-       {:resource (sutils/munge-hash-for-storage resource-hash) :name (name k) :value (sutils/db-serialize v)}))))
+       {:resource (sutils/munge-hash-for-storage resource-hash)
+        :name (name k)
+        :value (sutils/db-serialize v)}))))
 
 (def resource-ref?
   "Returns true of the map is a resource reference"

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -264,6 +264,32 @@
       (apply assoc m new-kvs)
       m)))
 
+(defn maybe-strip-escaped-quotes
+  [s]
+  (if (and (> (count s) 1)
+           (string/starts-with? s "\"")
+           (string/ends-with? s "\""))
+    (subs s 1 (dec (count s)))
+    s))
+
+(defn parse-matchfields
+  [s]
+  (string/replace s #"match\((\".*\")\)" "$1"))
+
+(defn parse-indexing
+  [s]
+  (string/replace s #"\[(\d+)\]" ".$1"))
+
+(defn split-indexing
+  [path]
+  (flatten
+    (for [s path]
+      (if (re-find #"\[\d+\]$" s)
+        (-> s
+            (string/split #"(?=\[\d+\]$)")
+            (update 1 #(Integer/parseInt (subs % 1 (dec (count %))))))
+        s))))
+
 (defn str-schema
   "Function for converting a schema with keyword keys to
    to one with string keys. Doens't walk the map so nested

--- a/test/puppetlabs/puppetdb/http/inventory_test.clj
+++ b/test/puppetlabs/puppetdb/http/inventory_test.clj
@@ -1,0 +1,133 @@
+(ns puppetlabs.puppetdb.http.inventory-test
+  (:require [cheshire.core :as json]
+            [clojure.test :refer :all]
+            [clojure.walk :refer [stringify-keys]]
+            [puppetlabs.puppetdb.jdbc :as jdbc]
+            [puppetlabs.puppetdb.testutils.db :refer [*db*]]
+            [clj-time.coerce :refer [to-timestamp to-string]]
+            [puppetlabs.puppetdb.scf.storage :as scf-store]
+            [puppetlabs.puppetdb.http :as http]
+            [flatland.ordered.map :as omap]
+            [clj-time.core :refer [now]]
+            [puppetlabs.puppetdb.testutils.http :refer [*app*
+                                                        query-response
+                                                        deftest-http-app]]
+            [puppetlabs.puppetdb.testutils :refer [get-request
+                                                   assert-success!]]))
+
+(def inventory-endpoints [[:v4 "/v4/inventory"]])
+(def c-t http/json-response-content-type)
+
+(def inventory1
+  {:certname "bar.com"
+   :timestamp nil
+   :environment "DEV"
+   :trusted {:foo {:baz "bar"}}
+   :facts {:domain "testing.com"
+           :hostname "bar.com"
+           :trusted {:foo {:baz "bar"}}
+           :kernel "Linux"
+           :array_fact {:foo ["biz" "baz"]}
+           :my_structured_fact {:foo {:bar 1
+                                      :baz 2}}
+           :operatingsystem "Debian"
+           :some_version "1.3.7+build.11.e0f985a"
+           :uptime_seconds 4000
+           :my_weird_fact {:blah {:dotted.thing {(keyword "quoted\"thing") "foo"}}}}})
+
+(def inventory2
+  {:certname "foo.com"
+   :timestamp nil
+   :environment "DEV"
+   :trusted {:foo {:baz "biz"}}
+   :facts {:domain "testing.com"
+           :hostname "foo.com"
+           :kernel "Windows"
+           :trusted {:foo {:baz "biz"}}
+           :my_structured_fact {:foo {:bar 1
+                                      :baz 3}}
+           :operatingsystem "Debian"
+           :some_version "1.3.7+build.11.e0f985a"
+           :uptime_seconds 4000}})
+
+(defn queries-and-results
+  [timestamp]
+  (let [response1 (assoc inventory1 :timestamp (to-string timestamp))
+        response2 (assoc inventory2 :timestamp (to-string timestamp))]
+    (omap/ordered-map
+      nil
+      #{response1 response2}
+
+      ["=" "certname" "bar.com"]
+      #{response1}
+
+      ["=" "facts.kernel" "Linux"]
+      #{response1}
+
+      ["=" "facts.array_fact.foo[1]" "baz"]
+      #{response1}
+
+      ["~" "facts.array_fact.foo[0]" "bi.*"]
+      #{response1}
+
+      ["=" "facts.match(\".*\")" "Debian"]
+      #{response1 response2}
+
+      ["=" "facts.match(\".*\")" "Windows"]
+      #{response2}
+
+      ["=" "facts.my_structured_fact.foo.baz" 3]
+      #{response2}
+
+      ["<=" "facts.my_structured_fact.foo.baz" 4]
+      #{response1 response2}
+
+      ["=" "trusted.foo.baz" "bar"]
+      #{response1}
+
+      ["~" "trusted.foo.baz" "ba.*"]
+      #{response1}
+
+      ["=" "facts.my_weird_fact.blah.\"dotted.thing\".\"quoted\"thing\"" "foo"]
+      #{response1})))
+
+(deftest-http-app inventory-queries
+  [[version endpoint] inventory-endpoints
+   method [:get :post]]
+
+  (let [facts1 (:facts inventory1)
+        facts2 (:facts inventory2)
+        timestamp (now)]
+    (jdbc/with-transacted-connection *db*
+      (scf-store/add-certname! "foo.com")
+      (scf-store/add-certname! "bar.com")
+      (scf-store/add-facts! {:certname "bar.com"
+                             :values (stringify-keys facts1)
+                             :timestamp timestamp
+                             :environment "DEV"
+                             :producer_timestamp timestamp
+                             :producer "bar1"})
+      (scf-store/add-facts! {:certname "foo.com"
+                             :values (stringify-keys facts2)
+                             :timestamp timestamp
+                             :environment "DEV"
+                             :producer_timestamp timestamp
+                             :producer "bar1"}))
+
+    (testing "query without param should not fail"
+      (let [response (query-response method endpoint)]
+        (assert-success! response)
+        (slurp (:body response))))
+
+    (testing "inventory queries"
+      (testing "well-formed queries"
+        (doseq [[query result] (queries-and-results timestamp)]
+          (testing (format "Query %s" query)
+            (let [request (if query
+                            (get-request endpoint (json/generate-string query))
+                            (get-request endpoint))
+                  {:keys [status body headers]} (*app* request)]
+              (is (= status http/status-ok))
+              (is (= (headers "Content-Type") c-t))
+              (is (= (set result)
+                     (set (json/parse-string (slurp body) true)))))))))))

--- a/test/puppetlabs/puppetdb/http/resources_test.clj
+++ b/test/puppetlabs/puppetdb/http/resources_test.clj
@@ -72,14 +72,23 @@ to the result of the form supplied to this method."
                               [["not" ["~" ["parameter" "owner"] "ro.t"]] #{foo2 bar2}]]]
         (is (= (query-result (query-response method endpoint query)) result))))
 
+    (testing "dot-style querying for parameters"
+      (doseq [[query result] [[["=" "parameters.ensure" "file"] #{foo1 bar1}]
+                              [["=" "parameters.owner" "root"] #{foo1 bar1}]
+                              [["=" "parameters.acl" ["john:rwx" "fred:rwx"]] #{foo1 bar1}]]]
+        (is (= (query-result (query-response method endpoint query)) result))))
+
     (testing "fact subqueries are supported"
-      (let [{:keys [body status]} (query-response method endpoint
-                                                ["and"
-                                                 ["=" "type" "File"]
-                                                 ["in" "certname" ["extract" "certname" ["select_facts"
-                                                                                         ["and"
-                                                                                          ["=" "name" "operatingsystem"]
-                                                                                          ["=" "value" "Debian"]]]]]])]
+      (let [{:keys [body status]}
+            (query-response method endpoint
+                            ["and"
+                             ["=" "type" "File"]
+                             ["in" "certname"
+                              ["extract" "certname"
+                               ["select_facts"
+                                ["and"
+                                 ["=" "name" "operatingsystem"]
+                                 ["=" "value" "Debian"]]]]]])]
         (is (= status http/status-ok))
         (is (= (set (json/parse-string (slurp body) true)) #{foo1})))
 

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1123,7 +1123,7 @@
    #(-> (sql/result-set-seq %)
         first
         :params
-        (json/parse-string true))))
+        sutils/parse-db-json)))
 
 (defn foobar-param-hash []
   (jdbc/query-with-resultset

--- a/test/puppetlabs/puppetdb/scf/storage_utils_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_utils_test.clj
@@ -42,3 +42,27 @@
     (testing "test to see if an index does exist"
       (jdbc/do-commands "CREATE INDEX foobar ON fact_values(value_float)")
       (is (true? (index-exists? "foobar"))))))
+
+(deftest dotted-query-to-path
+  (testing "vanilla dotted path"
+    (is (= (dotted-query->path "facts.foo.bar")
+           ["facts" "foo" "bar"])))
+  (testing "dot inside quotes"
+    (is (= (dotted-query->path "facts.\"foo.bar\".baz")
+           ["facts" "\"foo.bar\"" "baz"]))
+    (is (= (dotted-query->path "facts.\"foo.baz.bar\".baz")
+           ["facts" "\"foo.baz.bar\"" "baz"]))
+    (is (= (dotted-query->path "facts.\"foo.bar\".\"baz.bar\"")
+           ["facts" "\"foo.bar\"" "\"baz.bar\""])))
+  (testing "consecutive dots"
+    (is (= (dotted-query->path "facts.\"foo..bar\"")
+           ["facts" "\"foo..bar\""])))
+  (testing "path with quote in middle"
+    (is (= (dotted-query->path "facts.foo\"bar.baz")
+           ["facts" "foo\"bar" "baz"])))
+  (testing "path containing escaped quote"
+    (is (= (dotted-query->path "\"fo\\\".o\"")
+           ["\"fo\\\".o\""])))
+  (testing "dotted path with quote"
+    (is (= (dotted-query->path "facts.\"foo.bar\"baz\".biz"))
+        ["facts" "\"foo.bar\"baz\"" "biz"])))

--- a/test/puppetlabs/puppetdb/testutils/resources.clj
+++ b/test/puppetlabs/puppetdb/testutils/resources.clj
@@ -6,28 +6,33 @@
             [puppetlabs.puppetdb.scf.storage
              :refer [add-facts! ensure-environment]]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils
-             :refer [db-serialize to-jdbc-varchar-array]]
+             :refer [to-jdbc-varchar-array]]
             [puppetlabs.puppetdb.testutils.db :refer [*db*]]))
 
 (defn store-example-resources
   ([] (store-example-resources true))
   ([environment?]
-     (jdbc/with-transacted-connection *db*
-       (jdbc/insert!
-        :resource_params_cache
-        {:resource (sutils/munge-hash-for-storage "01")
-         :parameters (db-serialize {"ensure" "file"
-                                    "owner"  "root"
-                                    "group"  "root"
-                                    "acl"    ["john:rwx" "fred:rwx"]})}
-        {:resource (sutils/munge-hash-for-storage "02")
-         :parameters nil})
-       (jdbc/insert!
-        :resource_params
-        {:resource (sutils/munge-hash-for-storage "01") :name "ensure" :value (db-serialize "file")}
-        {:resource (sutils/munge-hash-for-storage "01") :name "owner"  :value (db-serialize "root")}
-        {:resource (sutils/munge-hash-for-storage "01") :name "group"  :value (db-serialize "root")}
-        {:resource (sutils/munge-hash-for-storage "01") :name "acl"    :value (db-serialize ["john:rwx" "fred:rwx"])})
+   (jdbc/with-transacted-connection *db*
+     (jdbc/insert!
+       :resource_params_cache
+       {:resource (sutils/munge-hash-for-storage "01")
+        :parameters (sutils/munge-jsonb-for-storage
+                      {"ensure" "file"
+                       "owner"  "root"
+                       "group"  "root"
+                       "acl"    ["john:rwx" "fred:rwx"]})}
+       {:resource (sutils/munge-hash-for-storage "02")
+        :parameters nil})
+     (jdbc/insert!
+       :resource_params
+       {:resource (sutils/munge-hash-for-storage "01") :name "ensure"
+        :value (sutils/db-serialize "file")}
+       {:resource (sutils/munge-hash-for-storage "01") :name "owner"
+        :value (sutils/db-serialize "root")}
+       {:resource (sutils/munge-hash-for-storage "01") :name "group"
+        :value (sutils/db-serialize "root")}
+       {:resource (sutils/munge-hash-for-storage "01") :name "acl"
+        :value (sutils/db-serialize ["john:rwx" "fred:rwx"])})
        (jdbc/insert!
         :certnames
         {:id 1 :certname "one.local"}


### PR DESCRIPTION
Add an inventory endpoint of fact name=>value pairs, along with capability to
query it and the resources parameters column with "dotted syntax" like
[= parameters.foo bar]. Also add support in PQL. This does not include
projection, regex matching of path elements, or array indexing of path
elements.