### PR TITLE
(PDB-2888) Set hisotrical-catalogs-limit default to 2

### DIFF
--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -167,7 +167,7 @@
   (all-optional
     {:certificate-whitelist s/Str
      ;; The `historical-catalogs-limit` setting is only used by `pe-puppetdb`
-     :historical-catalogs-limit (pls/defaulted-maybe s/Int 3)
+     :historical-catalogs-limit (pls/defaulted-maybe s/Int 2)
      :disable-update-checking (pls/defaulted-maybe String "false")}))
 
 (def puppetdb-config-out

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -29,7 +29,7 @@
 
     (testing "should allow for `pe-puppetdb`'s historical-catalogs-limit setting"
       (let [config (configure-puppetdb {})]
-        (is (= (get-in config [:puppetdb :historical-catalogs-limit]) 3)))
+        (is (= (get-in config [:puppetdb :historical-catalogs-limit]) 2)))
       (let [config (configure-puppetdb {:puppetdb {:historical-catalogs-limit 5}})]
         (is (= (get-in config [:puppetdb :historical-catalogs-limit]) 5))))
 


### PR DESCRIPTION
We only ever "need" the latest two catalogs in the console for the
resource-graph feature. This commit doesn't store extra data for users
who don't need it.