### PR TITLE
(PDB-2888) Turn off historical-catalogs by default in Couch

### DIFF
--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -167,7 +167,7 @@
   (all-optional
     {:certificate-whitelist s/Str
      ;; The `historical-catalogs-limit` setting is only used by `pe-puppetdb`
-     :historical-catalogs-limit (pls/defaulted-maybe s/Int 2)
+     :historical-catalogs-limit (pls/defaulted-maybe s/Int 0)
      :disable-update-checking (pls/defaulted-maybe String "false")}))
 
 (def puppetdb-config-out

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -29,7 +29,7 @@
 
     (testing "should allow for `pe-puppetdb`'s historical-catalogs-limit setting"
       (let [config (configure-puppetdb {})]
-        (is (= (get-in config [:puppetdb :historical-catalogs-limit]) 2)))
+        (is (= (get-in config [:puppetdb :historical-catalogs-limit]) 0)))
       (let [config (configure-puppetdb {:puppetdb {:historical-catalogs-limit 5}})]
         (is (= (get-in config [:puppetdb :historical-catalogs-limit]) 5))))
 


### PR DESCRIPTION
This commit changes PuppetDB to turn off historical catalogs by default.