### PR TITLE
(PDB-2891) Allow whitespace around expression parens in PQL

### DIFF
--- a/resources/puppetlabs/puppetdb/pql/pql-grammar-experimental.ebnf
+++ b/resources/puppetlabs/puppetdb/pql/pql-grammar-experimental.ebnf
@@ -52,7 +52,7 @@ extract = <lbracket>, [<whitespace>], [extractfields], [<whitespace>], <rbracket
 expr-or      = expr-and { <whitespace>, or, <whitespace>, expr-or };
 expr-and     = expr-not { <whitespace>, and, <whitespace>, expr-and };
 expr-not     = ( not, [<whitespace>], expr-not ) | expr-rest;
-<expr-rest>  = ( <lparens>, expression, <rparens> ) | condexpression | condexpnull | subquery;
+<expr-rest>  = ( <lparens>, [<whitespace>], expression, [<whitespace>], <rparens> ) | condexpression | condexpnull | subquery;
 
 (* Implicit subqueries *)
 subquery = entity, [<whitespace>], where;

--- a/test/puppetlabs/puppetdb/pql_test.clj
+++ b/test/puppetlabs/puppetdb/pql_test.clj
@@ -125,6 +125,20 @@
          ["=" "c" 3]]
         ["=" "d" 4]]]]]
 
+    ;; Whitespace around parentheses
+
+    "nodes { ( a = 1 or b = 2) }"
+    ["from" "nodes"
+     ["or"
+      ["=" "a" 1]
+      ["=" "b" 2]]]
+
+    "nodes { (a = 1 or b = 2 ) }"
+    ["from" "nodes"
+     ["or"
+      ["=" "a" 1]
+      ["=" "b" 2]]]
+
     ;; Extractions
 
     "nodes[] {}"


### PR DESCRIPTION
Prior to this commit trailing whitespace after a left-paren in an
expression (in PQL) would raise a syntax error. This commit changes the
PQL grammar to allow whitespace around the expression parens.