### PR TITLE
(maint) fix package build host to unbreak our sed in s3 transfer

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -65,7 +65,7 @@ module PuppetDBExtensions
           nil,
           "'hostname for package build output'",
           "PUPPETDB_PACKAGE_BUILD_HOST",
-          "builds.puppetlabs.lan")
+          "builds.delivery.puppetlabs.net")
 
     package_repo_host =
         get_option_value(options[:puppetdb_package_repo_host],


### PR DESCRIPTION
This should fix our s3 transfer so repos are available in acceptance tests.