### PR TITLE
(PDB-2310) Add helpful error message for invalid subquery operators

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -6,6 +6,7 @@
             [honeysql.core :as hcore]
             [honeysql.helpers :as hsql]
             [honeysql.types :as htypes]
+            [puppetlabs.i18n.core :as i18n]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.facts :as facts]
@@ -1759,6 +1760,15 @@
                    ;;problems with the validation below when it was
                    ;;included in the validate-query-fields function
                    :state (cond-> state column-validation-message (conj column-validation-message))
+                   :cut true})
+
+                [["extract" column [subquery-name :guard (complement #{"not" "group_by"}) _]]]
+                (let [underscored-subquery-name (utils/dashes->underscores subquery-name)
+                      error (if (contains? (set (keys user-name->query-rec-name)) underscored-subquery-name)
+                              (i18n/trs "Unsupported subquery `{0}` - did you mean `{1}`?" subquery-name underscored-subquery-name)
+                              (i18n/trs "Unsupported subquery `{0}`" subquery-name))]
+                  {:node node
+                   :state (conj state error)
                    :cut true})
 
                 [["subquery" relationship expr]]

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -154,6 +154,21 @@
                         #"'foo' is not a queryable object for resources, known queryable objects are.*"
                         (compile-user-query->sql resources-query ["=" "foo" "bar"]))))
 
+(deftest test-valid-subqueries
+  (is (thrown-with-msg? IllegalArgumentException
+                        #"Unsupported subquery `foo`"
+                        (compile-user-query->sql facts-query ["and",
+                                                              ["=", "name", "uptime_hours"],
+                                                              ["in", "certname",
+                                                               ["extract", "certname",
+                                                                ["foo",
+                                                                 ["=", "facts_environment", "production"]]]]])))
+  (is (thrown-with-msg? IllegalArgumentException
+                        #"Unsupported subquery `select-facts` - did you mean `select_facts`?"
+                        (compile-user-query->sql fact-contents-query ["in", "certname",
+                                                                      ["extract", "certname",
+                                                                       ["select-facts",
+                                                                        ["=", "name", "osfamily"]]]]))))
 (deftest-http-app query-recs-are-swappable
   [version [:v4]
    endpoint ["/v4/fact-names"]


### PR DESCRIPTION
This commit checks for subqueries under 'extract' nodes and throws an exception
with an informative error message if the subquery operator is not among the
acceptable 'select_<entity>' operators.