### PR TITLE
(PDB-2890) Allow dumping pdb log on test failures

### DIFF
--- a/ext/jenkins/lein-test.sh
+++ b/ext/jenkins/lein-test.sh
@@ -5,6 +5,8 @@ set -x
 
 ulimit -u 4096
 
+export PDB_TEST_DUMP_LOG_ON_FAILURE=true
+
 pghost=fixture-pg94.delivery.puppetlabs.net
 pgport=5432
 

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -16,6 +16,8 @@ run-unit-tests()
   ext/bin/pdb-test-env "$pgdir" lein2 test
 )
 
+export PDB_TEST_DUMP_LOG_ON_FAILURE=true
+
 case "$PDB_TEST_LANG" in
   clojure)
     java -version


### PR DESCRIPTION
If PDB_TEST_DUMP_LOG_ON_FAILURE is set to true, and the
clojure.test *report-counters* register any change in the error or
failure count while inside call-with-log-suppressed-unless-notable, dump
the log to *err*.

Set PDB_TEST_DUMP_LOG_ON_FAILURE=true for the Travis and Jenkins tests.