### PR TITLE
(PDB-2910) Ezbake 0.4.3, empty pidfile fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -142,7 +142,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "0.3.25"
+                      :plugins [[puppetlabs/lein-ezbake "0.4.3"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}


### PR DESCRIPTION
This commit updates to lein-ezbake 0.4.3, which contains a fix for
a bug where EL sysv init script could create an empty pidfile before the
service was started.