### PR TITLE
(PDB-2851) Reject POST query requests that are missing content-type

### DIFF
--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -9,6 +9,7 @@
                                                     wrap-with-metrics
                                                     wrap-with-illegal-argument-catch
                                                     verify-accepts-json
+                                                    verify-content-type
                                                     make-pdb-handler]]
             [ring.util.response :as rr]
             [puppetlabs.comidi :as cmdi]
@@ -65,6 +66,7 @@
     (let [handler (-> (make-pdb-handler routes identity)
                       wrap-with-illegal-argument-catch
                       verify-accepts-json
+                      (verify-content-type ["application/json"])
                       (wrap-with-metrics (atom {}) http/leading-uris)
                       (wrap-with-globals get-shared-globals))]
       (handler req))))

--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -120,13 +120,15 @@
   {:pre [(coll? content-types)
          (every? string? content-types)]}
   (fn [{:keys [headers] :as req}]
-    (let [content-type (headers "content-type")
-          mediatype (if (nil? content-type) nil
-                        (str (media/base-type content-type)))]
-      (if (or (nil? mediatype) (some #{mediatype} content-types))
-        (app req)
-        (http/error-response (i18n/tru "content type {0} not supported" mediatype)
-                             http/status-unsupported-type)))))
+    (if (= (:request-method req) :post)
+      (let [content-type (headers "content-type")
+            mediatype (if (nil? content-type) nil
+                          (str (media/base-type content-type)))]
+        (if (or (nil? mediatype) (some #{mediatype} content-types))
+          (app req)
+          (http/error-response (i18n/tru "content type {0} not supported" mediatype)
+                               http/status-unsupported-type)))
+      (app req))))
 
 (defn validate-query-params
   "Ring middleware that verifies that the query params in the request are legal

--- a/test/puppetlabs/puppetdb/middleware_test.clj
+++ b/test/puppetlabs/puppetdb/middleware_test.clj
@@ -112,7 +112,8 @@
 
 (deftest verify-content-type-test
   (testing "with content-type of application/json"
-    (let [test-req {:content-type "application/json"
+    (let [test-req {:request-method :post
+                    :content-type "application/json"
                     :headers {"content-type" "application/json"}}]
 
       (testing "should succeed with matching content type"

--- a/test/puppetlabs/puppetdb/testutils/http.clj
+++ b/test/puppetlabs/puppetdb/testutils/http.clj
@@ -44,6 +44,14 @@
     response-body
     (slurp response-body)))
 
+(defn convert-response
+  [response]
+  (-> response
+      :body
+      slurp-unless-string
+      (json/parse-string true)
+      vec))
+
 (defn ordered-query-result
   ([method endpoint] (ordered-query-result method endpoint nil))
   ([method endpoint query] (ordered-query-result method endpoint query {}))
@@ -52,12 +60,7 @@
          handle-fn (apply comp (vec handlers))
          response (query-response method endpoint query params)]
      (is (= http/status-ok (:status response)))
-     (-> response
-         :body
-         slurp-unless-string
-         (json/parse-string true)
-         vec
-         handle-fn))))
+     (handle-fn (convert-response response)))))
 
 (defn query-result
   ([method endpoint] (query-result method endpoint nil))


### PR DESCRIPTION
This commit adds a check for content type in POST requests and throws
an exception if the content type is "application/x-www-form-urlencoded",
which is the default if no content type is specified, instead of returning
all results from the endpoint.