### PR TITLE
(maint) Switch to stubbing correct object method for corrective_change test

### DIFF
--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -118,7 +118,7 @@ describe processor do
 
     it "should include corrective_change or nil" do
       if defined?(subject.corrective_change) then
-        subject["corrective_change"] = false
+        subject.stubs(:corrective_change).returns(false)
       end
       result = subject.send(:report_to_hash)
       if defined?(subject.corrective_change) then


### PR DESCRIPTION
The test was presuming that a report could be modified like an array, but it
really needed the property method. This property is an attr_reader, stubbing
gets around this access problem though.

Signed-off-by: Ken Barber <ken@bob.sh>