### PR TITLE
(PDB-2946) single-arity usage of or/and broken in subqueries

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -1900,7 +1900,7 @@
                    :state (cond-> state column-validation-message (conj column-validation-message))
                    :cut true})
 
-                [["extract" column [subquery-name :guard (complement #{"not" "group_by"}) _]]]
+                [["extract" column [subquery-name :guard (complement #{"not" "group_by" "or" "and"}) _]]]
                 (let [underscored-subquery-name (utils/dashes->underscores subquery-name)
                       error (if (contains? (set (keys user-name->query-rec-name)) underscored-subquery-name)
                               (i18n/trs "Unsupported subquery `{0}` - did you mean `{1}`?" subquery-name underscored-subquery-name)

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -168,7 +168,10 @@
                         (compile-user-query->sql fact-contents-query ["in", "certname",
                                                                       ["extract", "certname",
                                                                        ["select-facts",
-                                                                        ["=", "name", "osfamily"]]]]))))
+                                                                        ["=", "name", "osfamily"]]]])))
+  (is (not (nil? (:results-query (compile-user-query->sql reports-query ["extract", ["hash"],
+                                                                         ["or", ["=", "certname", "host-3"]]]))))))
+
 (deftest-http-app query-recs-are-swappable
   [version [:v4]
    endpoint ["/v4/fact-names"]


### PR DESCRIPTION
This commit adds 'or' and 'and' to the list of operators to ignore when checking
for invalid subqueries in nodes of the form ["extract" column [subquery-name _]].