### PR TITLE
(PE-17059) Make sure that reports.noop flag is always set.

### DIFF
--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -38,7 +38,9 @@ Puppet::Reports.register_report(:puppetdb) do
       end
 
       resources = build_resources_list
-      is_noop = defined?(noop) ? noop : resources.any? { |rs| has_noop_event?(rs) } && resources.none? { |rs| has_enforcement_event?(rs) }
+      is_noop = (defined?(noop) && (not noop.nil?)) ?
+                  noop :
+                  resources.any? { |rs| has_noop_event?(rs) } && resources.none? { |rs| has_enforcement_event?(rs) }
 
       defaulted_catalog_uuid = defined?(catalog_uuid) ? catalog_uuid : transaction_uuid
       defaulted_code_id = defined?(code_id) ? code_id : nil

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -146,7 +146,7 @@ describe processor do
       end
 
       it "should include truthy noop flag" do
-        unless defined?(subject.noop) then
+        unless (defined?(subject.noop) && (not subject.noop.nil?)) then
           event = Puppet::Transaction::Event.new
           event.status = "noop"
           status.add_event(event)
@@ -162,7 +162,7 @@ describe processor do
       end
 
       it "should include falsey noop flag" do
-        unless defined?(subject.noop) then
+        unless (defined?(subject.noop) && (not subject.noop.nil?)) then
           event = Puppet::Transaction::Event.new
           event.status = "success"
           status.add_event(event)


### PR DESCRIPTION
Is was discovered that the latest PDB terminus with an older puppet agent can produce reports with noop set to nil. When noop flag in not defined or is nil in Puppet report the original PuppetDB heuristic needs to be used to set the flag.