### PR TITLE
(maint) Missing implicit inventory relationships

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -244,6 +244,7 @@
                                                    :field :reports_environment.environment}}
 
                :relationships {;; Children - direct
+                               "inventory" {:columns ["certname"]}
                                "factsets" {:columns ["certname"]}
                                "reports" {:columns ["certname"]}
                                "catalogs" {:columns ["certname"]}
@@ -949,6 +950,8 @@
                :selection {:from [:environments]}
 
                :relationships {;; Children - direct
+                               "inventory" {:local-columns ["name"]
+                                            :foreign-columns ["environment"]}
                                "factsets" {:local-columns ["name"]
                                            :foreign-columns ["environment"]}
                                "catalogs" {:local-columns ["name"]


### PR DESCRIPTION
This adds relationships from environment and node entities to inventory, to
behave in a similar way to factsets. This allows implicit subqueries to work.

Without this patch, you can't do queries of this nature:

    nodes { inventory { facts.operatingsystem = "CentOS" } }

You are forced to use explicit querying:

    nodes { certname in inventory[certname] { facts.operatingsystem = "CentOS" } }

Which is a lot more verbose, and should be unnecessary.

Signed-off-by: Ken Barber <ken@bob.sh>