### PR TITLE
(ORCH-1491) Better PQL examples and docs structure

### DIFF
--- a/documentation/_puppetdb_nav.html
+++ b/documentation/_puppetdb_nav.html
@@ -47,11 +47,17 @@
       <li><a href="{{puppetdb}}/trouble_session_logging.html">Session logging</a></li>
     </ul>
   </li>
+  <li><strong>PQL - Puppet Query Language (experimental)</strong></li>
+    <ul>
+      <li><a href="{{puppetdb}}/api/query/tutorial-pql.html">Tutorial</a></li>
+      <li><a href="{{puppetdb}}/api/query/v4/pql.html">Reference guide</a></li>
+      <li><a href="{{puppetdb}}/api/query/examples-pql.html">Examples</a></li>
+    </ul>
+  </li>
   <li><strong>API</strong>
     <ul>
       <li><a href="{{puppetdb}}/api/index.html">Overview</a></li>
       <li><a href="{{puppetdb}}/api/query/tutorial.html">Query tutorial</a></li>
-      <li><a href="{{puppetdb}}/api/query/tutorial-pql.html">PQL Query tutorial (experimental)</a></li>
       <li><a href="{{puppetdb}}/api/query/curl.html">Curl tips</a></li>
     </ul>
   </li>
@@ -61,7 +67,6 @@
       <li><a href="{{puppetdb}}/api/query/v4/query.html">Query structure</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/entities.html">Entities</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/ast.html">AST query language</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/pql.html">Puppet query language (PQL)</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/paging.html">Query paging</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/index.html">Root endpoint (experimental)</a></li>
       <li><a href="{{puppetdb}}/api/query/v4/nodes.html">Nodes endpoint</a></li>

--- a/documentation/api/query/examples-pql.markdown
+++ b/documentation/api/query/examples-pql.markdown
@@ -1,0 +1,447 @@
+---
+title: "PuppetDB 4.2 » Puppet query language (PQL) » Examples"
+layout: default
+---
+
+[tutorial]: ./tutorial-pql.html
+[reference]: ./v4/pql.html
+
+## Example Queries
+
+Below is a list of example PQL queries that you may find useful.
+
+Other resources you may also find useful include:
+
+* [PQL tutorial][tutorial]
+* [PQL reference guide][reference]
+
+***
+
+### Filtering on node names
+
+Query nodes with `green` in their name.
+
+``` ruby
+nodes { certname ~ 'green' }
+```
+
+*Output:*
+
+``` json
+[
+    {
+        "cached_catalog_status": "not_used",
+        "catalog_environment": "production",
+        "catalog_timestamp": "2016-08-15T11:06:26.275Z",
+        "certname": "greenserver.vm",
+        "deactivated": null,
+        "expired": null,
+        "facts_environment": "production",
+        "facts_timestamp": "2016-08-15T11:06:26.140Z",
+        "latest_report_corrective_change": null,
+        "latest_report_hash": "4a956674b016d95a7b77c99513ba26e4a744f8d1",
+        "latest_report_noop": false,
+        "latest_report_noop_pending": null,
+        "latest_report_status": "changed",
+        "report_environment": "production",
+        "report_timestamp": "2016-08-15T11:06:18.393Z"
+    }
+]
+```
+
+***
+
+### Basic fact filtering
+
+Nodes with operating system name `CentOS`.
+
+``` ruby
+inventory { facts.os.name = "CentOS" }
+```
+
+*Output (abbreviated):*
+
+``` json
+[
+    {
+        "certname": "centos70.vm",
+        "environment": "production",
+        "facts": {
+            ...
+            "operatingsystem": "CentOS",
+            "operatingsystemmajrelease": "7",
+            "operatingsystemrelease": "7.0.1406",
+            "os": {
+                "architecture": "x86_64",
+                "family": "RedHat",
+                "hardware": "x86_64",
+                "name": "CentOS",
+                "release": {
+                    "full": "7.0.1406",
+                    "major": "7",
+                    "minor": "0"
+                },
+                "selinux": {
+                    "enabled": false
+                }
+            },
+            "osfamily": "RedHat",
+            ...
+        },
+        "timestamp": "2016-08-15T11:06:26.140Z",
+        "trusted": {
+            "authenticated": "remote",
+            "certname": "centos70.vm",
+            "domain": "vm",
+            "extensions": {},
+            "hostname": "centos70"
+        }
+    }
+]
+```
+
+***
+
+### Fact and resource filtering
+
+Nodes with `CentOS` operating system, and with a declared `httpd` service resource.
+
+``` ruby
+inventory[certname] { facts.operatingsystem = "CentOS" and
+                      resources { type = "Service" and title = "http" } }
+```
+
+*Output:*
+
+``` json
+[
+    {
+        "certname": "greenserver.vm"
+    }
+]
+```
+
+***
+
+### Fact, resource and resource parameter filtering
+
+`Redhat` boxes in the `PDX` datacenter, that have their `java` package forced to `1.7.0`.
+
+``` ruby
+inventory[certname] { facts.osfamily = "Redhat" and
+                      facts.datacentre = "PDX" and
+                      resources { type = "Package" and
+                                  title = "java" and
+                                  parameters.ensure = "1.7.0" } }
+```
+
+*Output:*
+
+``` json
+[
+    {
+        "certname": "greenserver.vm"
+    }
+]
+```
+
+***
+
+### Fact and resource filtering for classes
+
+CentOS boxes with the `apache` Puppet class.
+
+``` ruby
+inventory[certname] { facts.operatingsystem = "CentOS" and
+                      resources { type = "Class" and
+                                  title = "apache" } }
+```
+
+*Output:*
+
+``` json
+[
+    {
+        "certname": "greenserver.vm"
+    }
+]
+```
+
+***
+
+### Fact, resource and environment filtering
+
+All windows servers, with service `sqlserver` in a particular feature branch environment.
+
+``` ruby
+nodes { certname in inventory[certname] { facts.osfamily = "Windows" } and
+        resources { type = "Service" and
+                    title = "sqlserver" } and
+        report_environment = "feature_SYS-4926" }
+```
+
+*Output:*
+
+``` json
+[ {
+  "deactivated" : null,
+  "latest_report_hash" : "4a956674b016d95a7b77c99513ba26e4a744f8d1",
+  "facts_environment" : "laboratory",
+  "cached_catalog_status" : "not_used",
+  "report_environment" : "laboratory",
+  "latest_report_corrective_change" : false,
+  "catalog_environment" : "laboratory",
+  "facts_timestamp" : "2016-07-18T04:12:12.912Z",
+  "latest_report_noop" : false,
+  "expired" : null,
+  "latest_report_noop_pending" : null,
+  "report_timestamp" : "2016-07-18T04:12:15.907Z",
+  "certname" : "windowserver.vm",
+  "catalog_timestamp" : "2016-07-18T04:12:12.917Z",
+  "latest_report_status" : "success"
+} ]
+```
+
+***
+
+### Timestamp filtering
+
+Nodes that haven't checked in for 7 days.
+
+``` ruby
+nodes { report_timestamp <= "2016-08-03 00:00:00" }
+```
+
+*Output:*
+
+``` json
+[
+    {
+        "cached_catalog_status": "not_used",
+        "catalog_environment": "production",
+        "catalog_timestamp": "2016-08-15T11:06:26.275Z",
+        "certname": "greenserver.vm",
+        "deactivated": null,
+        "expired": null,
+        "facts_environment": "production",
+        "facts_timestamp": "2016-08-15T11:06:26.140Z",
+        "latest_report_corrective_change": null,
+        "latest_report_hash": "4a956674b016d95a7b77c99513ba26e4a744f8d1",
+        "latest_report_noop": false,
+        "latest_report_noop_pending": null,
+        "latest_report_status": "changed",
+        "report_environment": "production",
+        "report_timestamp": "2016-08-15T11:06:18.393Z"
+    }
+]
+```
+
+***
+
+### Mcollective sub-collective filtering
+
+Show nodes that belong in the sub-collective `dc1`.
+
+``` ruby
+inventory[certname] { facts.mcollective.server.collectives.match("\d+") = "dc1" }
+```
+
+*Output:*
+
+``` json
+[
+    {
+        "certname": "greenserver.vm"
+    },
+    {
+        "certname": "yellowserver.vm"
+    }
+]
+```
+
+***
+
+### Profile querying
+
+Show nodes that have the profile class `Profile::Remote_mgmt` applied to it.
+
+``` ruby
+nodes { resources { type = "Class" and title = "Profile::Remote_mgmt" } }
+```
+
+*Output:*
+
+``` json
+[
+    {
+        "cached_catalog_status": "not_used",
+        "catalog_environment": "production",
+        "catalog_timestamp": "2016-08-15T11:06:26.275Z",
+        "certname": "greenserver.vm",
+        "deactivated": null,
+        "expired": null,
+        "facts_environment": "production",
+        "facts_timestamp": "2016-08-15T11:06:26.140Z",
+        "latest_report_corrective_change": null,
+        "latest_report_hash": "4a956674b016d95a7b77c99513ba26e4a744f8d1",
+        "latest_report_noop": false,
+        "latest_report_noop_pending": null,
+        "latest_report_status": "changed",
+        "report_environment": "production",
+        "report_timestamp": "2016-08-15T11:06:18.393Z"
+    }
+]
+```
+
+***
+
+### Querying catalog submission time
+
+Check for nodes that haven't had a catalog applied since a certain time.
+
+``` ruby
+nodes { catalog_timestamp < "2016-08-15T11:37:00.000Z" }
+```
+
+*Output:*
+
+``` json
+[
+    {
+        "cached_catalog_status": "not_used",
+        "catalog_environment": "production",
+        "catalog_timestamp": "2016-08-15T11:06:26.275Z",
+        "certname": "greenserver.vm",
+        "deactivated": null,
+        "expired": null,
+        "facts_environment": "production",
+        "facts_timestamp": "2016-08-15T11:06:26.140Z",
+        "latest_report_corrective_change": null,
+        "latest_report_hash": "4a956674b016d95a7b77c99513ba26e4a744f8d1",
+        "latest_report_noop": false,
+        "latest_report_noop_pending": null,
+        "latest_report_status": "changed",
+        "report_environment": "production",
+        "report_timestamp": "2016-08-15T11:06:18.393Z"
+    }
+]
+```
+
+***
+
+### List of nodes with report status failed
+
+List all nodes that have had a failure on their last run.
+
+``` ruby
+nodes { latest_report_status = 'failed' }
+```
+
+*Output:*
+
+``` json
+[
+    {
+        "cached_catalog_status": "not_used",
+        "catalog_environment": "production",
+        "catalog_timestamp": "2016-08-15T11:03:26.275Z",
+        "certname": "redserver.vm",
+        "deactivated": null,
+        "expired": null,
+        "facts_environment": "production",
+        "facts_timestamp": "2016-08-15T11:03:26.140Z",
+        "latest_report_corrective_change": null,
+        "latest_report_hash": "68f56674b016d95a7b77c99513ba26e4a744f001",
+        "latest_report_noop": false,
+        "latest_report_noop_pending": null,
+        "latest_report_status": "failed",
+        "report_environment": "production",
+        "report_timestamp": "2016-08-15T11:03:18.393Z"
+    }
+]
+```
+
+***
+
+### Query code_id from latest reports
+
+Query all latest reports and show the certname and code_id.
+
+``` ruby
+reports[certname, code_id] { latest_report? = true }
+```
+
+*Output:*
+
+``` json
+[
+    {
+        "certname": "greenserver.vm",
+        "code_id": "urn:puppet:code-id:1:519e404a1b6217b010cc543494c2dc50df8a53e3;production"
+    },
+    {
+        "certname": "yellowserver.vm",
+        "code_id": "urn:puppet:code-id:1:519e404a1b6217b010cc543494c2dc50df8a53e3;production"
+    }
+]
+```
+
+***
+
+### Reports that have not applied a code_id
+
+Show reports that have not had a particular code_id applied.
+
+``` ruby
+reports[certname, receive_time] {
+  latest_report? = true and
+  ! code_id = 'urn:puppet:code-id:1:519e404a1b6217b010cc543494c2dc50df8a53e3;production'
+}
+```
+
+*Output:*
+
+``` json
+[
+    {
+        "certname": "whiteserver.vm",
+        "receive_time": "2016-08-15T10:33:07.130Z"
+    },
+    {
+        "certname": "brownserver.vm",
+        "receive_time": "2016-08-15T11:06:26.553Z"
+    }
+]
+```
+
+***
+
+### Show all exported resources
+
+Show all exported resources
+
+``` ruby
+resources[certname, type, title] { exported = true }
+```
+
+*Output:*
+
+``` json
+[
+    {
+        "certname": "purpleserver.vm",
+        "title": "purpleserver.vm-mysql",
+        "type": "Monitor"
+    },
+    {
+        "certname": "purpleserver.vm",
+        "title": "purpleserver.vm-httpd",
+        "type": "Monitor"
+    },
+    {
+        "certname": "purpleserver.vm",
+        "title": "purpleserver.vm-/etc",
+        "type": "Backup"
+    }
+]
+```

--- a/documentation/api/query/tutorial-pql.markdown
+++ b/documentation/api/query/tutorial-pql.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 4.2: PQL query tutorial"
+title: "PuppetDB 4.2 » Puppet query language (PQL) » Tutorial"
 layout: default
 ---
 
@@ -14,6 +14,7 @@ layout: default
 [in]: ./v4/pql.html#array-match-in
 [implicit]: ./v4/pql.html#implicit-subqueries
 [cli_install]: ../../pdb_client_tools.html
+[examples]: ./examples-pql.html
 
 > **Experimental Feature**: PQL is experimental, and it may be altered or
 > removed in a future release.
@@ -21,7 +22,10 @@ layout: default
 This page walks through the construction of several types of PuppetDB PQL
 queries. We use the **version 4 API** in all examples.
 
-Consult the [PQL reference guide][pql] for more information about the language.
+Other resources you may also find useful include:
+
+* [PQL examples][examples]
+* [PQL reference guide][pql]
 
 ## How to query
 

--- a/documentation/api/query/v4/pql.markdown
+++ b/documentation/api/query/v4/pql.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 4.2 » API » v4 » Puppet query language (PQL)"
+title: "PuppetDB 4.2 » Puppet query language (PQL) » Reference guide"
 layout: default
 ---
 
@@ -8,12 +8,19 @@ layout: default
 [ast]: ./ast.html
 [client-tools]: ../../../pdb_client_tools.html
 [config_jetty]: ../../../configure.html#jetty-http-settings
+[examples]: ../examples-pql.html
+[tutorial]: ../tutorial-pql.html
 
 > **Experimental Feature**: This featureset is experimental and is subject to rapid development and change.
 
 Puppet Query Language (PQL) is a query language designed with PuppetDB and
 Puppet data in mind. It provides a string-based query language as an alternative
 to the [AST query language][ast] PuppetDB has always supported.
+
+Other resources you may also find useful include:
+
+* [PQL tutorial][tutorial]
+* [PQL examples][examples]
 
 ## Executing PQL queries using the PuppetDB CLI
 


### PR DESCRIPTION
This patch adds a new PQL examples page with a list examples containing:

* a title
* description
* pql
* output

It also makes the PQL documentation a top-level element in navigation so it
and other related articles can be found easier.

The tutorial and references pages also have links to each other now so they
are easier to find.

Signed-off-by: Ken Barber <ken@bob.sh>