### PR TITLE
(PDB-2962) Missing implicit inventory relationships

### DIFF
--- a/documentation/api/query/v4/environments.markdown
+++ b/documentation/api/query/v4/environments.markdown
@@ -15,6 +15,7 @@ canonical: "/puppetdb/latest/api/query/v4/environments.html"
 [fact-contents]: ./fact_contents.html
 [events]: ./events.html
 [resources]: ./resources.html
+[inventory]: ./inventory.html
 
 Environments are semi-isolated groups of nodes managed by Puppet. Nodes are assigned to environments by their own configuration, or by the Puppet master's external node classifier.
 
@@ -43,6 +44,7 @@ See [the AST query language page](./ast.html)
 
 The following list contains related entities that can be used to constrain the result set by using implicit subqueries. For more information, consult the documentation for [subqueries][subqueries].
 
+* [`inventory`][inventory]: inventory for an environment.
 * [`factsets`][factsets]: factsets received for an environment.
 * [`reports`][reports]: reports received for an environment.
 * [`catalogs`][catalogs]: catalogs received for an environment.

--- a/documentation/api/query/v4/nodes.markdown
+++ b/documentation/api/query/v4/nodes.markdown
@@ -20,6 +20,7 @@ canonical: "/puppetdb/latest/api/query/v4/nodes.html"
 [events]: ./events.html
 [edges]: ./edges.html
 [resources]: ./resources.html
+[inventory]: ./inventory.html
 
 Nodes can be queried by making an HTTP request to the `/nodes` endpoint.
 
@@ -87,6 +88,7 @@ The below fields are allowed as filter criteria and are returned in all response
 Here is a list of related entities that can be used to constrain the result set using
 implicit subqueries. For more information, consult the documentation for [subqueries][subqueries].
 
+* [`inventory`][inventory]: inventory for a node.
 * [`factsets`][factsets]: factsets received for a node.
 * [`reports`][reports]: reports received for a node.
 * [`catalogs`][catalogs]: catalogs received for a node.

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -244,6 +244,7 @@
                                                    :field :reports_environment.environment}}
 
                :relationships {;; Children - direct
+                               "inventory" {:columns ["certname"]}
                                "factsets" {:columns ["certname"]}
                                "reports" {:columns ["certname"]}
                                "catalogs" {:columns ["certname"]}
@@ -949,6 +950,8 @@
                :selection {:from [:environments]}
 
                :relationships {;; Children - direct
+                               "inventory" {:local-columns ["name"]
+                                            :foreign-columns ["environment"]}
                                "factsets" {:local-columns ["name"]
                                            :foreign-columns ["environment"]}
                                "catalogs" {:local-columns ["name"]


### PR DESCRIPTION
This adds relationships from environment and node entities to inventory to
behave in a similar way to factsets. This allows implicit subqueries to work.

Without this patch you cannot do queries of this nature:

    nodes { inventory { facts.operatingsystem = "CentOS" } }

Instead you are forced to use explicit querying:

    nodes { certname in inventory[certname] { facts.operatingsystem = "CentOS" } }

Which is a lot more verbose and should be unnecessary.

Signed-off-by: Ken Barber <ken@bob.sh>