### PR TITLE
(maint) don't dump test log on failure

### DIFF
--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -16,8 +16,6 @@ run-unit-tests()
   ext/bin/pdb-test-env "$pgdir" lein2 test
 )
 
-export PDB_TEST_DUMP_LOG_ON_FAILURE=true
-
 case "$PDB_TEST_LANG" in
   clojure)
     java -version


### PR DESCRIPTION
Dumping the log on failure will produce a log file that is too big for travis
to handle, causing the job to get aborted.