### PR TITLE
(maint) Have s3 resolve symlinks for apt repo sync

### DIFF
--- a/ext/jenkins/packaging.sh
+++ b/ext/jenkins/packaging.sh
@@ -51,6 +51,10 @@ export REPO_DIR REPO_HOST
 
 
 # Now rebuild the metadata
+# We add the `--follow-symlinks` flag to the apt metadata in preparation for
+# the switch from reprepro to aptly. Aptly employs symlinks to maintain the
+# current expected directory structure. As we cannot ship symlinks to s3, this
+# flag will send over the resolved files.
 ssh $REPO_HOST <<PUBLISH_PACKAGES
 
 set -e
@@ -60,7 +64,7 @@ echo "BUCKET_NAME IS: ${BUCKET_NAME}"
 
 time s3cmd --verbose --acl-public --delete-removed  sync ${REPO_CONFIGS}/*  ${S3_BRANCH_PATH}/repo_configs/
 
-time s3cmd --verbose --acl-public --delete-removed  sync ${REPO_DIR}/apt/{jessie,lucid,precise,trusty,wheezy,wily,xenial}  ${S3_BRANCH_PATH}/repos/apt/
+time s3cmd --verbose --acl-public --delete-removed  --follow-symlinks sync ${REPO_DIR}/apt/{jessie,lucid,precise,trusty,wheezy,wily,xenial}  ${S3_BRANCH_PATH}/repos/apt/
 
 time s3cmd --verbose --acl-public --delete-removed  sync ${REPO_DIR}/el/{5,6,7}  ${S3_BRANCH_PATH}/repos/el/
 


### PR DESCRIPTION
This commit updates the s3 command used to sync out apt repos to s3.
This change is meant to help enable the switchover from reprepro to
aptly for apt repo creation. In order to maintain the current expected
repo format with aptly, we are forced to create symlinks. However, since
s3 does not support symlinks, we need to ensure they are resolved before
we attempt to send those files to s3. The addition of this flag handles
that.