### PR TITLE
(PDB-2988) Fix pg 9.4.9 concurrent-fact-updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: clojure
 lein: lein2
-# Disabled due to buffer overflow issue below
-#sudo: false
 
 jdk:
   - openjdk7
@@ -25,14 +23,17 @@ script: ext/travisci/test.sh
 notifications:
   email: false
 
+# Host addons handle buffer overflow in jdk 7 with travis' long
+# hostnames:
+#   https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
+#   http://mail.openjdk.java.net/pipermail/net-dev/2012-July/004603.html
+#   http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7089443
+#   http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7112670
+
 addons:
+  hosts:
+    - pdbtest
+  hostname: pdbtest
   postgresql: "9.4"
 
 services: postgresql
-
-# workaround for buffer overflow issue, ref https://github.com/travis-ci/travis-ci/issues/5227
-before_install:
-  - cat /etc/hosts # optionally check the content *before*
-  - sudo hostname "$(hostname | cut -c1-63)"
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
-  - cat /etc/hosts # optionally check the content *after*

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -16,6 +16,9 @@ run-unit-tests()
   ext/bin/pdb-test-env "$pgdir" lein2 test
 )
 
+cat /etc/hosts
+hostname --fqdn
+
 case "$PDB_TEST_LANG" in
   clojure)
     java -version

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -18,6 +18,7 @@
             [puppetlabs.puppetdb.testutils
              :refer [args-supplied call-counter dotestseq times-called]]
             [puppetlabs.puppetdb.jdbc :refer [query-to-vec] :as jdbc]
+            [puppetlabs.puppetdb.jdbc-test :refer [full-sql-exception-msg]]
             [puppetlabs.puppetdb.examples :refer :all]
             [puppetlabs.puppetdb.testutils.services :as svc-utils]
             [puppetlabs.puppetdb.command.constants :refer [command-names]]
@@ -954,7 +955,9 @@
                        :payload facts}
 
             hand-off-queue (java.util.concurrent.SynchronousQueue.)
-            storage-replace-facts! scf-store/update-facts!]
+            storage-replace-facts! scf-store/update-facts!
+            failures (atom ())
+            orig-annotate-attempt mql/annotate-with-attempt]
 
         (jdbc/with-db-transaction []
           (scf-store/add-certname! certname)
@@ -963,9 +966,14 @@
                                  :timestamp (-> 2 days ago)
                                  :environment nil
                                  :producer_timestamp (-> 2 days ago)
-                                 :producer "bar.com"}))
+                                 :producer "bar.com"})
+          (scf-store/ensure-environment "DEV"))
 
-        (with-redefs [scf-store/update-facts!
+        (with-redefs [mql/annotate-with-attempt
+                      (fn [msg ex]
+                        (swap! failures conj ex)
+                        (orig-annotate-attempt msg ex))
+                      scf-store/update-facts!
                       (fn [fact-data]
                         (.put hand-off-queue "got the lock")
                         (.poll hand-off-queue 5 TimeUnit/SECONDS)
@@ -989,9 +997,10 @@
 
             (test-msg-handler new-facts-cmd publish discard-dir
               (reset! second-message? true)
+              (is (= 1 (count @failures)))
               (is (re-matches
                    #"(?sm).*ERROR: could not serialize access due to concurrent update.*"
-                   (extract-error-message publish))))
+                   (full-sql-exception-msg (first @failures)))))
             @fut
             (is (true? @first-message?))
             (is (true? @second-message?))))))))


### PR DESCRIPTION
Fix the concurrent-fact-updates test to work with newer versions of
postgres (9.4.9 at least).

It appears that postgres has changed the way it handles the relevant
transaction, rejecting it for its environments constraint violation
instead of the serialization error.

Establish the relevant "DEV" environment at the start of the test so
that it's no longer part of the transaction, and then change the code to
examine the entire exception chain instead of just the first item
because the serialization exception is no longer at the front.