### PR TITLE
(PDB-2997) Fix upgrade OOM related to migrate-through-application

### DIFF
--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -95,7 +95,9 @@
 
 (defn query-with-resultset
   "Calls clojure.jdbc/db-query-with-resultset after adding (jdbc/db)
-  as the first argument."
+   as the first argument. Note that this will hold the whole resultset in memory
+   due to the default jdbc fetchsize of 0. If streaming is required, use
+   with-query-results-cursor."
   {:arglists '([[sql-string & params] func]
                [[stmt & params] func]
                [[options-map sql-string & params] func])}


### PR DESCRIPTION
By default, the jdbc driver will set a fetchsize of 0 for prepared statements,
which causes all results to be held in memory. Changing the with-resultset-seq
call to with-query-results-cursor causes us to use a fetchsize of 500,
eliminating the memory problem.