### PR TITLE
(PDB-2985) Bump to 0.4.2 of clj-i18n

### DIFF
--- a/dev-resources/Makefile.i18n
+++ b/dev-resources/Makefile.i18n
@@ -8,72 +8,100 @@
 # have messages without any further effort
 MESSAGE_LOCALE=en
 
-# The name of the package into which tranlsations will be placed
-PACKAGE=puppetlabs.puppetdb
+# The name of the package into which the translations bundle will be placed
+BUNDLE=puppetlabs.puppetdb
+# The list of names of packages covered by the translation bundle;
+# by default it contains a single package - the same where the translations
+# bundle itself is placed - but this can be overridden - preferably in
+# the top level Makefile
+PACKAGES?=$(BUNDLE)
 LOCALES=$(basename $(notdir $(wildcard locales/*.po)))
-PACKAGE_DIR=$(subst .,/,$(PACKAGE))
-BUNDLE_FILES=$(patsubst %,resources/$(PACKAGE_DIR)/Messages_%.class,$(LOCALES) $(MESSAGE_LOCALE))
-SRC_FILES=$(shell find src -name \*.clj)
+BUNDLE_DIR=$(subst .,/,$(BUNDLE))
+BUNDLE_FILES=$(patsubst %,resources/$(BUNDLE_DIR)/Messages_%.class,$(MESSAGE_LOCALE) $(LOCALES))
+FIND_SOURCES=find src -name \*.clj
+# xgettext before 0.19 does not understand --add-location=file. Even CentOS
+# 7 ships with an older gettext. We will therefore generate full location
+# info on those systems, and only file names where xgettext supports it
+LOC_OPT=$(shell xgettext --add-location=file -f - </dev/null >/dev/null 2>&1 && echo --add-location=file || echo --add-location)
 
-i18n: setup update-pot msgfmt
+LOCALES_CLJ=resources/locales.clj
+define LOCALES_CLJ_CONTENTS
+{
+  :locales  #{$(patsubst %,"%",$(MESSAGE_LOCALE) $(LOCALES))}
+  :packages [$(patsubst %,"%",$(PACKAGES))]
+  :bundle   $(patsubst %,"%",$(BUNDLE).Messages)
+}
+endef
+export LOCALES_CLJ_CONTENTS
+
+
+i18n: update-pot msgfmt
 
 # Update locales/messages.pot
 update-pot: locales/messages.pot
 
-locales/messages.pot: $(SRC_FILES)
-	@tmp=$(mktemp $@.tmp.XXXX);                                              \
-	find src -name \*.clj                                                    \
-	    | xgettext --from-code=UTF-8 --language=lisp                         \
-	               --copyright-holder 'Puppet Labs <docs@puppetlabs.com>' -F \
-	               --package-name "$(PACKAGE)"                               \
-	               --package-version "$(PACKAGE_VERSION)"                    \
-	               --msgid-bugs-address "docs@puppetlabs.com"                \
-	               -ktrs:1 -ki18n/trs:1                                      \
-	               -ktru:1 -ki18n/tru:1                                      \
-	               -ktrun:1,2 -ki18n/trun:1,2                                \
-	               -ktrsn:1,2 -ki18n/trsn:1,2                                \
-	               --add-comments -o $tmp -f -;                              \
-	sed -i -e 's/charset=CHARSET/charset=UTF-8/' $tmp;                       \
-	sed -i -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $tmp;       \
-	if ! diff -q -I POT-Creation-Date $tmp $@ >& /dev/null; then             \
-		mv $tmp $@;                                                          \
-	else                                                                     \
-		rm $tmp;                                                             \
+locales/messages.pot: $(shell $(FIND_SOURCES)) | locales
+	@tmp=$$(mktemp $@.tmp.XXXX);                                            \
+	$(FIND_SOURCES)                                                         \
+	    | xgettext --from-code=UTF-8 --language=lisp                        \
+	               --copyright-holder='Puppet <docs@puppet.com>'            \
+	               --package-name="$(BUNDLE)"                               \
+	               --package-version="$(BUNDLE_VERSION)"                    \
+	               --msgid-bugs-address="docs@puppet.com"                   \
+	               -k                                                       \
+	               -kmark:1 -ki18n/mark:1                                   \
+	               -ktrs:1 -ki18n/trs:1                                     \
+	               -ktru:1 -ki18n/tru:1                                     \
+	               -ktrun:1,2 -ki18n/trun:1,2                               \
+	               -ktrsn:1,2 -ki18n/trsn:1,2                               \
+	               $(LOC_OPT)                                               \
+	               --add-comments --sort-by-file                            \
+	               -o $$tmp -f -;                                           \
+	sed -i.bak -e 's/charset=CHARSET/charset=UTF-8/' $$tmp;                 \
+	sed -i.bak -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $$tmp; \
+	rm -f $$tmp.bak;                                                        \
+	if ! diff -q -I POT-Creation-Date $$tmp $@ >/dev/null 2>&1; then        \
+	    mv $$tmp $@;                                                        \
+	else                                                                    \
+	    rm $$tmp; touch $@;                                                 \
 	fi
 
 # Run msgfmt over all .po files to generate Java resource bundles
-msgfmt: $(BUNDLE_FILES)
-	@(printf '{\n  :locales #{'; \
-	  printf "\"%s\"" $(MESSAGE_LOCALE); \
-	  for l in $(LOCALES); do printf " \"%s\"" $$l; done; \
-	  printf '}\n'; \
-	  printf '  :package "$(PACKAGE)"\n'; \
-	  printf '  :bundle  "$(PACKAGE).Messages"\n}\n') > resources/locales.clj
+# and create the locales.clj file
+msgfmt: $(BUNDLE_FILES) $(LOCALES_CLJ)
 
-resources/$(PACKAGE_DIR)/Messages_%.class: locales/%.po
-	msgfmt --java2 -d resources -r $(PACKAGE).Messages -l $$(basename $< .po) $<
+# force rebuild of locales.clj if its contents is not the
+# the desired one
+ifneq ($(shell cat $(LOCALES_CLJ) 2> /dev/null),$(shell echo '$(subst ','\'',$(LOCALES_CLJ_CONTENTS))'))
+.PHONY: $(LOCALES_CLJ)
+endif
+$(LOCALES_CLJ): | resources
+	@echo "Writing $@"
+	@echo "$$LOCALES_CLJ_CONTENTS" > $@
 
-resources/$(PACKAGE_DIR)/Messages_$(MESSAGE_LOCALE).class: locales/messages.pot
-	msgfmt --java2 -d resources -r $(PACKAGE).Messages -l $(MESSAGE_LOCALE) $<
+resources/$(BUNDLE_DIR)/Messages_%.class: locales/%.po | resources
+	msgfmt --java2 -d resources -r $(BUNDLE).Messages -l $(*F) $<
+
+resources/$(BUNDLE_DIR)/Messages_$(MESSAGE_LOCALE).class: locales/messages.pot | resources
+	msgfmt --java2 -d resources -r $(BUNDLE).Messages -l $(MESSAGE_LOCALE) $<
 
 # Translators use this when they update translations; this copies any
 # changes in the pot file into their language-specific po file
 locales/%.po: locales/messages.pot
-	@if [ -f $@ ]; then												\
-		msgmerge -U $@ $< && touch $@; 								\
-	else															\
-		touch $@ && 												\
-		msginit --no-translator -l $$(basename $@ .po) -o $@ -i $<;	\
+	@if [ -f $@ ]; then                                           \
+	    msgmerge -U $@ $< && touch $@;                            \
+	else                                                          \
+	    touch $@ && msginit --no-translator -l $(*F) -o $@ -i $<; \
 	fi
+
+resources locales:
+	@mkdir $@
 
 help:
 	$(info $(HELP))
 	@echo
 
-setup:
-	@mkdir -p locales
-
-.PHONY:setup help
+.PHONY: help
 
 define HELP
 This Makefile assists in handling i18n related tasks during development. Files

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
 (def tk-jetty9-version "1.5.9")
 (def ks-version "1.3.1")
 (def tk-status-version "0.4.0")
-(def i18n-version "0.2.2")
+(def i18n-version "0.4.2")
 
 (def pdb-jvm-opts
   (case (System/getProperty "java.specification.version")


### PR DESCRIPTION
This version fixes a performance issue with calls to the translate
function (via trs/tru). The Makefile has also been updated to reflect
the changes for the release.