### PR TITLE
(maint) Add documentation for the PuppetDB CLI configuration options

### DIFF
--- a/documentation/pdb_client_tools.markdown
+++ b/documentation/pdb_client_tools.markdown
@@ -6,10 +6,17 @@ layout: default
 [installpuppet]: /puppet/latest/reference/install_pre.html
 [repos]: /puppet/latest/reference/puppet_collections.html
 [export]: ./anonymization.html
+[installpeclienttools]: /pe/latest/install_pe_client_tools.html
 
 # PuppetDB CLI
 
 ## Installation
+
+For Puppet Enterprise you have the ability to install the PuppetDB CLI via the
+`pe-client-tools` package. If you are installing `pe-client-tools` please see
+[the pe-client-tools installation instructions][installpeclienttools] for
+instructions on installing the PuppetDB CLI on either a workstation managed or
+unmanaged by Puppet.
 
 ### Step 1: Install and configure Puppet
 
@@ -48,10 +55,48 @@ certificate-whitelist and specify the paths to the CLI node's cacert, cert, and
 private key when using the CLI either with flags or a configuration file.
 
 To configure the PuppetDB CLI to talk to your PuppetDB with flags, add a
-configuration file at `$HOME/.puppetlabs/client-tools/puppetdb.conf`. For more
+configuration file at `$HOME/.puppetlabs/client-tools/puppetdb.conf` (or
+`%USERPROFILE%\.puppetlabs\client-tools\puppetdb.conf` for Windows). For more
 details see the installed man page:
 
     $ man puppetdb_conf
+
+The PuppetDB CLI configuration files (the user-specified or global files) can
+take the following settings:
+
+- `server_urls` Either a JSON String (for a single url) or Array (for multiple
+  urls) of your PuppetDB servers to query or manage via the CLI commands. (You
+  can set this with the `puppetdb_urls` parameter in the
+  `puppet_enterprise::profile::controller` class for PE.)
+
+  Default value: https://127.0.0.1:8080
+
+- `cacert` The path for the CA cert.
+
+  *nix sytems - /etc/puppetlabs/puppet/ssl/certs/ca.pem  
+  Windows - C:\ProgramData\PuppetLabs\puppet\etc\ssl\certs\ca.pem
+  
+- `cert` An SSL certificate signed by your site's Puppet CA. Note that the PE
+ version of the CLI supports token auth via `puppet-access` and this option
+ should not be necessary.
+
+- `key` The private key for that certificate. Note that the PE version of the
+ CLI supports token auth via `puppet-access` and this option should not be
+ necessary.
+ 
+#### Example configuration file
+ 
+```json
+{
+  "puppetdb": {
+    "server_urls": "https://alpha-rho.local:8081",
+    "cacert": "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
+    "cert": "/etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem",
+    "key": "/etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem"
+  }
+}
+
+```
 
 ### Step 4: Enjoy!
 


### PR DESCRIPTION
This commit adds documentation for the CLI's configuration options
rather than just linking to the man pages.