### PR TITLE
(OPS-10270) Switch PuppetDB vpc/subnet ids to use new tunnel

### DIFF
--- a/acceptance/config/ec2-west-debian7-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-debian7-64mda-64a.cfg
@@ -21,8 +21,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7

--- a/acceptance/config/ec2-west-debian7-64mda-fallback.cfg
+++ b/acceptance/config/ec2-west-debian7-64mda-fallback.cfg
@@ -21,8 +21,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7

--- a/acceptance/config/ec2-west-debian8-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-debian8-64mda-64a.cfg
@@ -21,8 +21,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7

--- a/acceptance/config/ec2-west-el5-64mda-el5-64a.cfg
+++ b/acceptance/config/ec2-west-el5-64mda-el5-64a.cfg
@@ -21,8 +21,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7

--- a/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-el5-64a-ubuntu1204-64a.cfg
@@ -29,8 +29,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7

--- a/acceptance/config/ec2-west-el6-64mda-el6-64a.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-el6-64a.cfg
@@ -21,8 +21,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7

--- a/acceptance/config/ec2-west-el6-64mda-perf.cfg
+++ b/acceptance/config/ec2-west-el6-64mda-perf.cfg
@@ -14,8 +14,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7

--- a/acceptance/config/ec2-west-el6-64mda.cfg
+++ b/acceptance/config/ec2-west-el6-64mda.cfg
@@ -14,8 +14,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7

--- a/acceptance/config/ec2-west-el7-64mda-el7-64a.cfg
+++ b/acceptance/config/ec2-west-el7-64mda-el7-64a.cfg
@@ -21,8 +21,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7

--- a/acceptance/config/ec2-west-f20-64mda-f20-64a.cfg
+++ b/acceptance/config/ec2-west-f20-64mda-f20-64a.cfg
@@ -22,8 +22,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7

--- a/acceptance/config/ec2-west-ubuntu1204-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1204-64mda-64a.cfg
@@ -21,8 +21,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7

--- a/acceptance/config/ec2-west-ubuntu1404-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1404-64mda-64a.cfg
@@ -21,8 +21,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7

--- a/acceptance/config/ec2-west-ubuntu1510-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1510-64mda-64a.cfg
@@ -21,8 +21,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7

--- a/acceptance/config/ec2-west-ubuntu1604-64mda-64a.cfg
+++ b/acceptance/config/ec2-west-ubuntu1604-64mda-64a.cfg
@@ -21,8 +21,8 @@ HOSTS:
 CONFIG:
   nfs_server: none
   consoleport: 443
-  vpc_id: vpc-cc4aeda9
+  vpc_id: vpc-3cb28658
   subnet_ids:
-    - subnet-4a74d73d
-    - subnet-6169e404
-    - subnet-5870b101
+    - subnet-8990e3ff
+    - subnet-11d78c75
+    - subnet-afaa18f7


### PR DESCRIPTION
This switches us to use operations special subnet/vpc setup, so we
can access various mirrors from our tests out in EC2.

Signed-off-by: Ken Barber <ken@bob.sh>