### PR TITLE
(maint) Add note about configuring token auth for Couch users

### DIFF
--- a/documentation/api/query/curl.markdown
+++ b/documentation/api/query/curl.markdown
@@ -67,6 +67,10 @@ viewing or editting node data depending on the operation.
       -H "X-Authentication: <token contents>"
       --tlsv1 \
       --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem \
+      
+**Note:** PE 2016.2 users will need to set `client-auth = want` under the
+`[jetty]` header of their jetty.ini configuration. Later versions of PE have
+this setting managed by the `puppetlabs-puppet_enterprise` module by default.
 
 ### Locating Puppet certificate files
 


### PR DESCRIPTION
This commit adds a note about configuring token auth for Couch users,
because we forgot to manage the client-auth setting for Jetty in the
Couch PE module.