### PR TITLE
(PDB-3031) Separate stockpile open and load

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -94,7 +94,7 @@
                  [com.taoensso/nippy "2.10.0" :exclusions [org.clojure/tools.reader]]
                  [bidi "1.25.1" :exclusions [org.clojure/clojurescript]]
                  [puppetlabs/comidi "0.3.1"]
-                 [stockpile "0.0.1"]]
+                 [puppetlabs/stockpile "0.0.2"]]
 
   :jvm-opts ~pdb-jvm-opts
 

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -481,9 +481,8 @@
           result (do-enqueue-command q command-chan write-semaphore command
                                      version certname command-stream command-callback)]
       ;; Obviously assumes that if do-* doesn't throw, msg is in
-      (mql/create-metrics-for-command! command version)
+      (mql/inc-cmd-metrics command version)
       (swap! (:stats (service-context this)) update :received-commands inc)
-      (mql/update-counter! :depth command version inc!)
       result))
 
   (response-mult [this]

--- a/src/puppetlabs/puppetdb/command/dlo.clj
+++ b/src/puppetlabs/puppetdb/command/dlo.clj
@@ -8,7 +8,7 @@
    [puppetlabs.puppetdb.nio :refer [copts copt-atomic copt-replace oopts]]
    [puppetlabs.puppetdb.queue :as queue
     :refer [cmdref->entry metadata-str parse-cmd-filename]]
-   [stockpile :as stock])
+   [puppetlabs.stockpile.queue :as stock])
   (:import
    [java.nio.file AtomicMoveNotSupportedException
     FileAlreadyExistsException Files LinkOption]

--- a/src/puppetlabs/puppetdb/mq_listener.clj
+++ b/src/puppetlabs/puppetdb/mq_listener.clj
@@ -119,6 +119,13 @@
       (swap! metrics assoc-in storage-path
              (create-metrics [(keyword command) (keyword (str version))])))))
 
+(defn inc-cmd-metrics
+  "Ensures the `command` + `version` metric exists, then increments the
+  depth for the given `command` and `version`"
+  [command version]
+  (create-metrics-for-command! command version)
+  (update-counter! :depth command version inc!))
+
 (defn fatal?
   "Tests if the supplied exception is a fatal command-processing
   exception or not."

--- a/test/puppetlabs/puppetdb/command/dlo_test.clj
+++ b/test/puppetlabs/puppetdb/command/dlo_test.clj
@@ -13,7 +13,7 @@
    [puppetlabs.puppetdb.queue :refer [cmdref->entry cons-attempt store-command]]
    [puppetlabs.puppetdb.testutils :refer [ordered-matches?]]
    [puppetlabs.puppetdb.testutils.nio :refer [call-with-temp-dir-path]]
-   [stockpile :as stock]))
+   [puppetlabs.stockpile.queue :as stock]))
 
 (defn err-attempt-line? [n s]
   (-> (str "Attempt " n " @ \\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\dZ")

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -31,6 +31,7 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :refer [*logger-factory*]]
             [slingshot.slingshot :refer [throw+ try+]]
+            [slingshot.test]
             [puppetlabs.puppetdb.mq-listener :as mql]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.time :as pt]
@@ -38,7 +39,7 @@
             [clojure.core.async :as async]
             [puppetlabs.kitchensink.core :as ks]
             [clojure.string :as str]
-            [stockpile :as stock]
+            [puppetlabs.stockpile.queue :as stock]
             [puppetlabs.puppetdb.testutils.nio :as nio]
             [puppetlabs.puppetdb.testutils.queue :as tqueue]
             [puppetlabs.puppetdb.queue :as queue]
@@ -260,8 +261,8 @@
               cmdref (tqueue/store-command q "replace catalog" 10 "cats" {:certname "cats"})]
           (is (:payload (queue/cmdref->cmd q cmdref)))
           (mh cmdref)
-          (is (thrown-with-msg? java.nio.file.NoSuchFileException
-                                #"catalog"
+          (is (thrown+-with-msg? [:kind :puppetlabs.stockpile.queue/no-such-entry]
+                                #"No file found"
                                 (queue/cmdref->cmd q cmdref)))))))
 
   (testing "Failures do not cause messages to be acknowledged"

--- a/test/puppetlabs/puppetdb/http/command_test.clj
+++ b/test/puppetlabs/puppetdb/http/command_test.clj
@@ -22,7 +22,7 @@
             [clj-time.format :as time]
             [clj-time.core :refer [now before?]]
             [clj-time.coerce :as tcoerce]
-            [stockpile :as stock]
+            [puppetlabs.stockpile.queue :as stock]
             [puppetlabs.puppetdb.testutils.nio :as nio]
             [clojure.java.io :as io]
             [clojure.java.shell :as shell]

--- a/test/puppetlabs/puppetdb/testutils/queue.clj
+++ b/test/puppetlabs/puppetdb/testutils/queue.clj
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [clojure.java.shell :as shell]
             [me.raynes.fs :refer [delete-dir]]
-            [stockpile :as stock]
+            [puppetlabs.stockpile.queue :as stock]
             [puppetlabs.puppetdb.nio :refer [get-path]]
             [puppetlabs.puppetdb.testutils.nio :refer [create-temp-dir]]
             [puppetlabs.puppetdb.queue :as q]


### PR DESCRIPTION
This commit opens the stockpile queue, then loads the command channel
with existing entries in a background thread. This allows the startup
process to continue while the commands are being re-enqueued in memory.