### PR TITLE
(PDB-2734) Add stockpile upgrade code

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -22,12 +22,8 @@
 
    * Message queue
 
-     We use an embedded instance of AciveMQ to handle queueing duties
-     for the command processing subsystem. The message queue is
-     persistent, and it only allows connections from within the same
-     VM.
-
-     Refer to `puppetlabs.puppetdb.mq` for more details.
+     We use stockpile to durable store commands. The \"in memory\"
+     representation of that queue is a core.async channel.
 
    * REST interface
 

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -22,7 +22,7 @@
 
    * Message queue
 
-     We use stockpile to durable store commands. The \"in memory\"
+     We use stockpile to durably store commands. The \"in memory\"
      representation of that queue is a core.async channel.
 
    * REST interface

--- a/src/puppetlabs/puppetdb/cli/shovel.clj
+++ b/src/puppetlabs/puppetdb/cli/shovel.clj
@@ -1,0 +1,378 @@
+(ns puppetlabs.puppetdb.cli.shovel
+  (:import [javax.jms
+            ExceptionListener
+            JMSException
+            MessageListener
+            Session
+            TextMessage
+            BytesMessage
+            ConnectionFactory
+            Connection
+            MessageConsumer
+            Queue
+            Message]
+           [java.io File ByteArrayInputStream]
+           [org.apache.activemq.broker BrokerService]
+           [org.apache.activemq.usage SystemUsage MemoryUsage]
+           [org.apache.activemq.pool PooledConnectionFactory]
+           [org.apache.activemq ActiveMQConnectionFactory ScheduledMessage])
+  (:require [clojure.tools.logging :as log]
+            [clojure.java.io :as io]
+            [me.raynes.fs :as fs]
+            [stockpile :as stockpile]
+            [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.i18n.core :as i18n]
+            [puppetlabs.trapperkeeper.config :as config]
+            [puppetlabs.trapperkeeper.logging :as logutils]
+            [puppetlabs.kitchensink.core :as kitchensink]
+            [puppetlabs.puppetdb.config :as conf]
+            [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.command.dlo :as dlo]
+            [puppetlabs.kitchensink.core :as ks]
+            [schema.core :as s]))
+
+(def cli-description "Transfer messages from ActiveMQ to Stockpile")
+
+(defn mq-dir [config]
+  (str (io/file (get-in config [:global :vardir]) "mq")))
+
+(defn ^Session create-session [^Connection connection]
+  (.createSession connection false Session/CLIENT_ACKNOWLEDGE))
+
+(defn ^Queue create-queue [^Session session endpoint]
+  (.createQueue session endpoint))
+
+(defn ^Connection create-connection [^ConnectionFactory factory]
+  (doto (.createConnection factory)
+    (.setExceptionListener
+     (reify ExceptionListener
+       (onException [this ex]
+         (log/error ex (i18n/trs "receiver queue connection error")))))
+    (.start)))
+
+(defn extract-headers
+  "Creates a map of custom headers included in `message`, currently only
+  supports String headers."
+  [^Message msg]
+  (into {}
+        (for [k (enumeration-seq (.getPropertyNames msg))]
+          [(keyword k) (.getStringProperty msg k)])))
+
+(defprotocol ConvertMessageBody
+  (convert-message-body ^String [msg]))
+
+(extend-protocol ConvertMessageBody
+  TextMessage
+  (convert-message-body [msg]
+    (-> msg
+        .getText
+        (.getBytes "UTF-8")))
+  BytesMessage
+  (convert-message-body [msg]
+    (let [len (.getBodyLength msg)
+          buf (byte-array len)
+          n (.readBytes msg buf)]
+      (when (not= len n)
+        (throw (Exception. (i18n/trs "Only read {0}/{1} bytes from incoming message" n len))))
+      buf)))
+
+(defn coerce-clj->json-byte-stream
+  "Converts clojure data to JSON serialized bytes on a
+  ByteArrayInputStream. Cheshire will only output to writers and
+  stockpile will only accept input streams, so some conversion needs
+  to be done in this fn"
+  [payload]
+  (let [baos (java.io.ByteArrayOutputStream.)]
+    (with-open [osw (java.io.OutputStreamWriter. baos java.nio.charset.StandardCharsets/UTF_8)]
+      (json/generate-stream payload osw))
+    (.close baos)
+    (-> baos
+        .toByteArray
+        java.io.ByteArrayInputStream.)))
+
+(defn convert-old-command-format
+  "Converts from the command format that didn't include the certname
+  in the toplevel key list and had all the command data dested under
+  payload"
+  [headers message-bytes]
+  (let [{:keys [command version] :as old-command} (json/parse-strict message-bytes true)]
+    {:command command
+     :version (Long/parseLong version)
+     :certname (or (get-in old-command [:payload :certname])
+                   (get-in old-command [:payload :name]))
+     :payload (coerce-clj->json-byte-stream (:payload old-command))}))
+
+(def upgrade-message-schema
+  {:command s/Str
+   :version s/Int
+   :certname s/Str
+   :payload java.io.ByteArrayInputStream})
+
+(s/defn coerce-to-new-command :-  upgrade-message-schema
+  "Commands coming out of this function are suitable for enqueuing
+  into stockpile. They must include command, version, certname and a
+  payload"
+  [{:keys [command version certname] :as headers} message-bytes]
+  (if (and command version certname)
+    {:command command
+     :version (Long/parseLong version)
+     :certname certname
+     :payload (java.io.ByteArrayInputStream. message-bytes)}
+    (convert-old-command-format headers message-bytes)))
+
+(defn discard-amq-message [message-bytes id headers exception dlo]
+  (let [now (ks/timestamp)]
+    (dlo/discard-bytes message-bytes
+                       id
+                       (or (:received headers)
+                           now)
+                       [{:exception exception
+                         :time now}]
+                       dlo)))
+
+(defn create-message-processor
+  [enqueue-fn dlo]
+  (fn [id ^Message message]
+    ;; When the queue is shutting down, it sends nil message
+    (when message
+      (let [headers (extract-headers message)
+            message-bytes (convert-message-body message)]
+        (try
+          (let [{:keys [command version certname payload] :as msg} (coerce-to-new-command headers message-bytes)]
+            (try
+              (enqueue-fn command version certname payload)
+              (catch Exception ex
+                (log/error ex (i18n/trs "[{0}] [{1}] [{2}] Unable to process message"
+                                        command version certname))
+                (discard-amq-message message-bytes id headers ex dlo))))
+          (catch AssertionError ex
+            (log/error ex (i18n/trs "Unable to process message: {0}" id))
+            (discard-amq-message message-bytes id headers ex dlo))
+          (catch Exception ex
+            (log/error ex (i18n/trs "Unable to process message: {0}" id))
+            (discard-amq-message message-bytes id headers ex dlo))
+          (finally
+            (.acknowledge message)))))))
+
+(defn consume-everything
+  "Attempts to read all available messages from ActiveMQ, giving up
+  after 5 seconds if one is not available"
+  [^MessageConsumer consumer process-message]
+  (try
+    (loop [id 0]
+      ;; We'll wait 5 seconds for a message otherwise we'll assume the Queue is
+      ;; drained
+      (when-let [msg (.receive consumer 5000)]
+        (process-message id msg)
+        (recur (inc id))))
+    (catch javax.jms.IllegalStateException e
+      (log/info (i18n/trs "Received IllegalStateException, shutting down")))
+    (catch Exception e
+      (log/error e))))
+
+(defn create-mq-receiver
+  [^ConnectionFactory conn-pool endpoint process-message]
+  (with-open [connection (create-connection conn-pool)
+              session (create-session connection)
+              consumer (.createConsumer session (create-queue session endpoint))]
+    (log/info (i18n/trs "Processing messages from the Queue: {0}" endpoint))
+    (consume-everything consumer process-message)))
+
+(defn create-scheduler-receiver
+  "Drains the scheduler queue (where PuppetDB commands are retried)
+  and enqueues them into the normal queue"
+  [^ConnectionFactory conn-pool endpoint process-message]
+  (with-open [connection (create-connection conn-pool)
+              session (create-session connection)]
+    (let [request-browse (.createTopic session ScheduledMessage/AMQ_SCHEDULER_MANAGEMENT_DESTINATION)
+          browse-dest (.createTemporaryQueue session)]
+      (with-open [producer (.createProducer session request-browse)
+                  consumer (.createConsumer session browse-dest)]
+        (let [request (doto (.createMessage session)
+                        (.setStringProperty ScheduledMessage/AMQ_SCHEDULER_ACTION
+                                            ScheduledMessage/AMQ_SCHEDULER_ACTION_BROWSE)
+                        (.setJMSReplyTo browse-dest))
+              process-message-and-remove (fn [^Message msg]
+                                           (try
+                                             (process-message msg)
+                                             (let [msg-id (.getStringProperty msg
+                                                                              ScheduledMessage/AMQ_SCHEDULED_ID)
+                                                   remove (doto (.createMessage session)
+                                                            (.setStringProperty ScheduledMessage/AMQ_SCHEDULER_ACTION
+                                                                                ScheduledMessage/AMQ_SCHEDULER_ACTION_REMOVE)
+                                                            (.setStringProperty ScheduledMessage/AMQ_SCHEDULED_ID msg-id))]
+                                               (.send producer remove))
+                                             (catch Exception e nil)))]
+          (.send producer request)
+          (Thread/sleep 2000)
+          (log/info (i18n/trs "Processing messages from the Scheduler"))
+          (consume-everything consumer process-message-and-remove))))))
+
+(def default-mq-endpoint "puppetlabs.puppetdb.commands")
+(def retired-mq-endpoint "com.puppetlabs.puppetdb.commands")
+
+(defn- set-usage!
+  "Internal helper function for setting `SystemUsage` values on a `BrokerService`
+  instance.
+
+  `broker`    - the `BrokerService` instance
+  `megabytes` - the value to set as the limit for the desired `SystemUsage` setting
+  `usage-fn`  - a function that accepts a `SystemUsage` instance and returns
+  the child object whose limit we are configuring.
+  `desc`      - description of the setting we're configuring, to be used in a log message
+  "
+  [^BrokerService broker
+   megabytes
+   usage-fn
+   ^String desc]
+  {:pre [((some-fn nil? integer?) megabytes)
+         (fn? usage-fn)]}
+  (when-let [limit (some-> megabytes (* 1024 1024))]
+    (log/info (i18n/trs "Setting ActiveMQ {0} limit to {1} MB" desc megabytes))
+    (-> (.getSystemUsage broker)
+        usage-fn
+        (.setLimit limit)))
+  broker)
+
+(defn ^:dynamic enable-jmx
+  "This function exists to enable starting multiple PuppetDB instances
+  inside a single JVM. Starting up a second instance results in a
+  collision exception between JMX beans from the two
+  instances. Disabling JMX from the broker avoids that issue"
+  [broker should-enable?]
+  (.setUseJmx broker should-enable?))
+
+(defn ^BrokerService build-embedded-broker
+  "Configures an embedded, persistent ActiveMQ broker.
+
+  `name` - What to name to queue. As this is an embedded broker, the
+  full name will be of the form 'vm://foo' where 'foo' is the name
+  you've supplied. That is the full URI you should use for
+  establishing connections to the broker.
+
+  `dir` - What directory in which to store the broker's data files. It
+  will be created if it doesn't exist.
+
+  `config` - an optional map containing configuration values for initializing
+  the broker.  Currently supported options:
+
+  :store-usage  - the maximum amount of disk usage to allow for persistent messages, or `nil` to use the default value of 100GB.
+  :temp-usage   - the maximum amount of disk usage to allow for temporary messages, or `nil` to use the default value of 50GB.
+  :memory-usage - the maximum amount of disk usage to allow for persistent messages, or `nil` to use the default value of 1GB.
+  "
+  [^String name ^String dir {:keys [memory-usage store-usage temp-usage] :as config}]
+  {:pre [(map? config)]}
+  (let [mq (doto (BrokerService.)
+             (.setUseShutdownHook false)
+             (.setBrokerName name)
+             (.setDataDirectory dir)
+             (.setSchedulerSupport true)
+             (.setPersistent true)
+             (enable-jmx true)
+             (set-usage! memory-usage #(.getMemoryUsage %) "MemoryUsage")
+             (set-usage! store-usage #(.getStoreUsage %) "StoreUsage")
+             (set-usage! temp-usage #(.getTempUsage %) "TempUsage"))
+        mc (doto (.getManagementContext mq)
+             (.setCreateConnector false))
+        db (doto (.getPersistenceAdapter mq)
+             (.setIgnoreMissingJournalfiles true)
+             (.setArchiveCorruptedIndex true)
+             (.setCheckForCorruptJournalFiles true)
+             (.setChecksumJournalFiles true))]
+    mq))
+
+(defn ^BrokerService start-broker!
+  "Starts up the supplied broker, making it ready to accept
+  connections."
+  [^BrokerService broker]
+  (doto broker
+    (.start)
+    (.waitUntilStarted)))
+
+(defn stop-broker!
+  "Stops the supplied broker"
+  [^BrokerService broker]
+  (doto broker
+    (.stop)
+    (.waitUntilStopped)))
+
+(defn ^BrokerService retry-build-and-start-broker!
+  [brokername dir config]
+  (try
+    (start-broker! (build-embedded-broker brokername dir config))
+    (catch java.io.EOFException e
+      (log/error e (i18n/trs "EOF Exception caught during broker start, this might be due to KahaDB corruption. Consult the PuppetDB troubleshooting guide."))
+      (throw e))))
+
+(defn ^BrokerService build-and-start-broker!
+  "Builds ands starts a broker in one go, attempts restart upon known exceptions"
+  [brokername dir config]
+  (try
+    (try
+      (start-broker! (build-embedded-broker brokername dir config))
+      (catch java.io.EOFException e
+        (log/warn (i18n/trs "Caught EOFException on broker startup, trying again. This is probably due to KahaDB corruption (see \"KahaDB Corruption\" in the PuppetDB manual)."))
+        (retry-build-and-start-broker! brokername dir config)))
+    (catch java.io.IOException e
+      (throw (java.io.IOException.
+              (i18n/trs "Unable to start broker in {0}. This is probably due to KahaDB corruption or version incompatibility after a PuppetDB downgrade (see \"KahaDB Corruption\" in the PuppetDB manual)." (pr-str dir))
+              e)))))
+
+(defn activemq-connection-factory [spec]
+  (proxy [PooledConnectionFactory java.lang.AutoCloseable]
+      [(ActiveMQConnectionFactory. spec)]
+    (close [] (.stop this))))
+
+;; Questionable code
+
+(defn upgrade-lockfile-path [vardir]
+  (str (io/file vardir "upgraded_mq.lock")))
+
+(defn needs-upgrade?
+  "Returns true if the user has an unmigrated ActiveMQ director in
+  their vardir"
+  [config]
+  (let [vardir (get-in config [:global :vardir])]
+    (and (fs/exists? (io/file vardir "mq"))
+         (not (fs/exists? (upgrade-lockfile-path vardir))))))
+
+(defn lock-upgrade
+  "Puts a lockfile in vardir to indicate the user has already migrated
+  to Stockpile"
+  [config]
+  (fs/touch (upgrade-lockfile-path (get-in config [:global :vardir]))))
+
+;;
+
+(defn activemq->stockpile
+  "Drains the queue found in `cmd-proc-config` and uses `enqueue-fn`
+  to resubmit those commands to PuppetDB (running Stockpile). All
+  failures to enqueue are discarded using the `dlo`"
+  [{global-config :global
+    {mq-config :mq :as cmd-proc-config} :command-processing}
+   enqueue-fn
+   dlo]
+  ;; Starting
+  (let [mq-dir (str (io/file (:vardir global-config) "mq"))
+        mq-broker-url (format "%s&wireFormat.maxFrameSize=%s&marshal=true"
+                              (:address mq-config "vm://localhost?jms.prefetchPolicy.all=1&create=false")
+                              (:max-frame-size cmd-proc-config 209715200))
+        mq-discard-dir (str (io/file mq-dir "discard"))
+        mq-endpoint (:endpoint mq-config default-mq-endpoint)
+        conn-pool (activemq-connection-factory mq-broker-url)
+        broker (do (log/info (i18n/trs "Starting broker"))
+                   (build-and-start-broker! "localhost" mq-dir cmd-proc-config))
+        process-message (create-message-processor enqueue-fn dlo)]
+
+    ;; Drain the scheduler so we don't get any extra messages on the Queue when
+    ;; we're processing
+    (create-scheduler-receiver conn-pool mq-endpoint process-message)
+    (create-mq-receiver conn-pool mq-endpoint process-message)
+    (create-mq-receiver conn-pool retired-mq-endpoint process-message)
+
+    ;; Stopping
+    (do (log/info (i18n/trs "Stopping ActiveMQConnectionFactory"))
+        (.stop conn-pool))
+    (do (log/info (i18n/trs "Stopping broker"))
+        (stop-broker! broker))
+    (log/info (i18n/trs "You may safely delete {0}" mq-dir))))

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -62,7 +62,6 @@
             [puppetlabs.puppetdb.catalogs :as cat]
             [puppetlabs.puppetdb.reports :as report]
             [puppetlabs.puppetdb.facts :as fact]
-            [puppetlabs.puppetdb.mq :as mq]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.jdbc :as jdbc]
@@ -78,11 +77,12 @@
             [clj-time.core :refer [now]]
             [clojure.set :as set]
             [clojure.core.async :as async]
-            [puppetlabs.puppetdb.mq :as mq]
             [metrics.timers :refer [timer time!]]
             [puppetlabs.puppetdb.metrics.core :as metrics]
             [puppetlabs.puppetdb.queue :as queue]
-            [clj-time.coerce :as tcoerce]))
+            [clj-time.coerce :as tcoerce]
+            [puppetlabs.puppetdb.cli.shovel :as shovel]
+            [puppetlabs.puppetdb.command.dlo :as dlo]))
 
 (def mq-metrics-registry (get-in metrics/metrics-registries [:mq :registry]))
 
@@ -422,6 +422,11 @@
                  (make-cmd-processed-message cmd ex))
       (throw ex))))
 
+(defn upgrade-activemq [config enqueue-fn dlo]
+  (when (shovel/needs-upgrade? config)
+    (shovel/activemq->stockpile config enqueue-fn dlo)
+    (shovel/lock-upgrade config)))
+
 (defservice command-service
   PuppetDBCommandDispatcher
   [[:DefaultedConfig get-config]
@@ -443,11 +448,16 @@
              :response-pub (async/pub response-chan-for-pub :id))))
 
   (start [this context]
-    (let [{:keys [scf-write-db]} (shared-globals)
+    (let [{:keys [scf-write-db dlo q]} (shared-globals)
           {:keys [response-chan response-pub]} context]
       (register-listener
        supported-command?
        #(process-command-and-respond! % scf-write-db response-chan (:stats context)))
+
+      (upgrade-activemq (get-config)
+                        (partial enqueue-command this)
+                        dlo)
+
       context))
 
   (stop [this context]

--- a/src/puppetlabs/puppetdb/mq_listener.clj
+++ b/src/puppetlabs/puppetdb/mq_listener.clj
@@ -5,7 +5,6 @@
   (:require [clojure.tools.logging :as log]
             [puppetlabs.i18n.core :as i18n]
             [puppetlabs.puppetdb.command.dlo :as dlo]
-            [puppetlabs.puppetdb.mq :as mq]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.cheshire :as json]
             [slingshot.slingshot :refer [try+ throw+]]
@@ -269,12 +268,12 @@
    handler-fn :- message-fn-schema]
   (swap! listener-atom conj [pred handler-fn]))
 
-(def ten-minutes (* 1000 60 10))
+(def one-hour (* 1000 60 60))
 
 (defn send-delayed-message [command-chan delay-pool]
   (fn [cmd]
     (let [narrowed-entry (dissoc cmd :payload)]
-      (after ten-minutes #(async/>!! command-chan narrowed-entry) delay-pool))))
+      (after one-hour #(async/>!! command-chan narrowed-entry) delay-pool))))
 
 (defn create-command-consumer
   "Create and return a command handler. This function does the work of

--- a/test/puppetlabs/puppetdb/cli/shovel_test.clj
+++ b/test/puppetlabs/puppetdb/cli/shovel_test.clj
@@ -15,7 +15,9 @@
             [puppetlabs.trapperkeeper.app :refer [get-service]]
             [puppetlabs.trapperkeeper.services :refer [service-context]]
             [puppetlabs.kitchensink.core :as ks]
-            [metrics.counters :as mc]))
+            [metrics.counters :as mc]
+            [puppetlabs.trapperkeeper.testutils.logging :refer [with-log-suppressed-unless-notable]]
+            [puppetlabs.puppetdb.testutils.log :as tlog]))
 
 (defn enqueue-and-shutdown [config commands]
   (let [broker (mq/build-and-start-broker! "localhost"
@@ -52,6 +54,7 @@
 
 (deftest shovel-upgrade-test
   (testing "an upgrade with existing catalogs"
+    (with-log-suppressed-unless-notable tlog/critical-errors
       (with-test-db
         (let [config (svc-utils/create-temp-config)
               defaulted-config (conf/process-config! (assoc config :database *db*))
@@ -73,52 +76,56 @@
                                                    cat2]])
           (is (needs-upgrade? config))
 
-          (svc-utils/call-with-puppetdb-instance (assoc config :database *db*)
-                                                 (fn []
-                                                   (is (not (needs-upgrade? config)))
-                                                   (let [results (cli-utils/get-catalogs "basic.wire-catalogs.com")]
-                                                     (is (= 1 (count results)))
-                                                     (is (= (:catalog_uuid cat)
-                                                            (:catalog_uuid (first results)))))
-                                                   (let [results (cli-utils/get-catalogs "empty.wire-catalogs.com")]
-                                                     (is (= 1 (count results)))
-                                                     (is (= (:transaction_uuid cat)
-                                                            (:transaction_uuid (first results))))))))))
+          (svc-utils/call-with-puppetdb-instance
+           (assoc config :database *db*)
+           (fn []
+             (is (not (needs-upgrade? config)))
+             (let [results (cli-utils/get-catalogs "basic.wire-catalogs.com")]
+               (is (= 1 (count results)))
+               (is (= (:catalog_uuid cat)
+                      (:catalog_uuid (first results)))))
+             (let [results (cli-utils/get-catalogs "empty.wire-catalogs.com")]
+               (is (= 1 (count results)))
+               (is (= (:transaction_uuid cat)
+                      (:transaction_uuid (first results)))))))))))
 
   (testing "an upgrade with a bad catalog"
-    (with-test-db
-      (let [config (svc-utils/create-temp-config)
-            defaulted-config (conf/process-config! (assoc config :database *db*))
-            cat (get-in ex/wire-catalogs [9 :basic])]
+    (with-log-suppressed-unless-notable (every-pred tlog/critical-errors
+                                                    (tlog/starting-with "Output of coerce-to-new-command does not"))
+      (with-test-db
+        (let [config (svc-utils/create-temp-config)
+              defaulted-config (conf/process-config! (assoc config :database *db*))
+              cat (get-in ex/wire-catalogs [9 :basic])]
 
-        (is (not (needs-upgrade? config)))
+          (is (not (needs-upgrade? config)))
 
-        (enqueue-and-shutdown defaulted-config [[{"received" (ks/timestamp)
-                                                  "id" (ks/uuid)}
-                                                 {"command" "replace catalog"
-                                                  "version" "4"
-                                                  "payload" (dissoc (get-in ex/wire-catalogs [4 :empty])
-                                                                    :name :environment :version)}]
-                                                [{"command" "replace catalog"
-                                                  "certname" (:certname cat)
-                                                  "version" "9"
-                                                  "received" (ks/timestamp)
-                                                  "id" (ks/uuid)}
-                                                 cat]])
-        (is (needs-upgrade? config))
-
-        (svc-utils/call-with-puppetdb-instance (assoc config :database *db*)
-                                               (fn []
-                                                 (is (= 2
-                                                        (-> svc-utils/*server*
-                                                            dlo-paths
-                                                            count)))
-                                                 (is (not (needs-upgrade? config)))
-                                                 (let [results (cli-utils/get-catalogs (:certname cat))]
-                                                   (is (= 1 (count results)))
-                                                   (is (= (:catalog_uuid cat)
-                                                          (:catalog_uuid (first results))))))))))
+          (enqueue-and-shutdown defaulted-config [[{"received" (ks/timestamp)
+                                                    "id" (ks/uuid)}
+                                                   {"command" "replace catalog"
+                                                    "version" "4"
+                                                    "payload" (dissoc (get-in ex/wire-catalogs [4 :empty])
+                                                                      :name :environment :version)}]
+                                                  [{"command" "replace catalog"
+                                                    "certname" (:certname cat)
+                                                    "version" "9"
+                                                    "received" (ks/timestamp)
+                                                    "id" (ks/uuid)}
+                                                   cat]])
+          (is (needs-upgrade? config))
+          (svc-utils/call-with-puppetdb-instance
+           (assoc config :database *db*)
+           (fn []
+             (is (= 2
+                    (-> svc-utils/*server*
+                        dlo-paths
+                        count)))
+             (is (not (needs-upgrade? config)))
+             (let [results (cli-utils/get-catalogs (:certname cat))]
+               (is (= 1 (count results)))
+               (is (= (:catalog_uuid cat)
+                      (:catalog_uuid (first results)))))))))))
   (testing "no upgrade needed"
+    (with-log-suppressed-unless-notable tlog/critical-errors
       (with-test-db
         (let [config (svc-utils/create-temp-config)
               defaulted-config (conf/process-config! (assoc config :database *db*))
@@ -127,7 +134,8 @@
           (is (not (needs-upgrade? config)))
 
           (with-redefs [activemq->stockpile mock-upgrade-fn]
-            (svc-utils/call-with-puppetdb-instance (assoc config :database *db*)
-                                                   (fn []
-                                                     (is (not @mock-upgrade-fn))
-                                                     (is (not (needs-upgrade? config))))))))))
+            (svc-utils/call-with-puppetdb-instance
+             (assoc config :database *db*)
+             (fn []
+               (is (not @mock-upgrade-fn))
+               (is (not (needs-upgrade? config)))))))))))

--- a/test/puppetlabs/puppetdb/cli/shovel_test.clj
+++ b/test/puppetlabs/puppetdb/cli/shovel_test.clj
@@ -1,0 +1,133 @@
+(ns puppetlabs.puppetdb.cli.shovel-test
+  (:import [java.nio.file Files])
+  (:require [clojure.test :refer :all]
+            [puppetlabs.puppetdb.cli.shovel :refer :all]
+            [puppetlabs.puppetdb.config :as conf]
+            [puppetlabs.puppetdb.mq :as mq]
+            [puppetlabs.puppetdb.testutils.services :as svc-utils]
+            [puppetlabs.puppetdb.examples :as ex]
+            [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.testutils.cli :as cli-utils]
+            [puppetlabs.puppetdb.cli.services :refer [shared-globals]]
+            [puppetlabs.puppetdb.scf.storage-utils :as sutils]
+            [puppetlabs.puppetdb.testutils.db :refer [*db* with-test-db]]
+            [puppetlabs.puppetdb.testutils :as tutils]
+            [puppetlabs.trapperkeeper.app :refer [get-service]]
+            [puppetlabs.trapperkeeper.services :refer [service-context]]
+            [puppetlabs.kitchensink.core :as ks]
+            [metrics.counters :as mc]))
+
+(defn enqueue-and-shutdown [config commands]
+  (let [broker (mq/build-and-start-broker! "localhost"
+                                           (mq-dir config)
+                                           (:command-processing config))
+        endpoint (conf/mq-endpoint config)]
+
+    (.setPersistent broker true)
+    (try
+      (mq/start-broker! broker)
+
+      (with-open [factory (mq/activemq-connection-factory (conf/mq-broker-url config))
+                  conn (doto (.createConnection factory) .start)]
+        (doseq [[header command] commands]
+          (mq/send-message! conn
+                            endpoint
+                            (json/generate-string command)
+                            header)))
+      (finally
+        (mq/stop-broker! broker)))))
+
+(defn dlo-context [server]
+  (-> (get-service server :PuppetDBServer)
+      shared-globals
+      :dlo))
+
+(defn dlo-paths [server]
+  (with-open [path-stream (-> server
+                              dlo-context
+                              :path
+                              Files/newDirectoryStream)]
+    (mapv (comp str #(.toAbsolutePath %))
+          (-> path-stream .iterator iterator-seq))))
+
+(deftest shovel-upgrade-test
+  (testing "an upgrade with existing catalogs"
+      (with-test-db
+        (let [config (svc-utils/create-temp-config)
+              defaulted-config (conf/process-config! (assoc config :database *db*))
+              cat (get-in ex/wire-catalogs [9 :basic])
+              cat2 {"command" "replace catalog"
+                    "version" "4"
+                    "payload" (get-in ex/wire-catalogs [4 :empty])}]
+
+          (is (not (needs-upgrade? config)))
+
+          (enqueue-and-shutdown defaulted-config [[{"command" "replace catalog"
+                                                    "certname" (:certname cat)
+                                                    "version" "9"
+                                                    "received" (ks/timestamp)
+                                                    "id" (ks/uuid)}
+                                                   cat]
+                                                  [{"received" (ks/timestamp)
+                                                    "id" (ks/uuid)}
+                                                   cat2]])
+          (is (needs-upgrade? config))
+
+          (svc-utils/call-with-puppetdb-instance (assoc config :database *db*)
+                                                 (fn []
+                                                   (is (not (needs-upgrade? config)))
+                                                   (let [results (cli-utils/get-catalogs "basic.wire-catalogs.com")]
+                                                     (is (= 1 (count results)))
+                                                     (is (= (:catalog_uuid cat)
+                                                            (:catalog_uuid (first results)))))
+                                                   (let [results (cli-utils/get-catalogs "empty.wire-catalogs.com")]
+                                                     (is (= 1 (count results)))
+                                                     (is (= (:transaction_uuid cat)
+                                                            (:transaction_uuid (first results))))))))))
+
+  (testing "an upgrade with a bad catalog"
+    (with-test-db
+      (let [config (svc-utils/create-temp-config)
+            defaulted-config (conf/process-config! (assoc config :database *db*))
+            cat (get-in ex/wire-catalogs [9 :basic])]
+
+        (is (not (needs-upgrade? config)))
+
+        (enqueue-and-shutdown defaulted-config [[{"received" (ks/timestamp)
+                                                  "id" (ks/uuid)}
+                                                 {"command" "replace catalog"
+                                                  "version" "4"
+                                                  "payload" (dissoc (get-in ex/wire-catalogs [4 :empty])
+                                                                    :name :environment :version)}]
+                                                [{"command" "replace catalog"
+                                                  "certname" (:certname cat)
+                                                  "version" "9"
+                                                  "received" (ks/timestamp)
+                                                  "id" (ks/uuid)}
+                                                 cat]])
+        (is (needs-upgrade? config))
+
+        (svc-utils/call-with-puppetdb-instance (assoc config :database *db*)
+                                               (fn []
+                                                 (is (= 2
+                                                        (-> svc-utils/*server*
+                                                            dlo-paths
+                                                            count)))
+                                                 (is (not (needs-upgrade? config)))
+                                                 (let [results (cli-utils/get-catalogs (:certname cat))]
+                                                   (is (= 1 (count results)))
+                                                   (is (= (:catalog_uuid cat)
+                                                          (:catalog_uuid (first results))))))))))
+  (testing "no upgrade needed"
+      (with-test-db
+        (let [config (svc-utils/create-temp-config)
+              defaulted-config (conf/process-config! (assoc config :database *db*))
+              mock-upgrade-fn (tutils/mock-fn)]
+
+          (is (not (needs-upgrade? config)))
+
+          (with-redefs [activemq->stockpile mock-upgrade-fn]
+            (svc-utils/call-with-puppetdb-instance (assoc config :database *db*)
+                                                   (fn []
+                                                     (is (not @mock-upgrade-fn))
+                                                     (is (not (needs-upgrade? config))))))))))

--- a/test/puppetlabs/puppetdb/http/command_test.clj
+++ b/test/puppetlabs/puppetdb/http/command_test.clj
@@ -18,7 +18,6 @@
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.config :as conf]
             [puppetlabs.puppetdb.http :as http]
-            [puppetlabs.puppetdb.mq :as mq]
             [clj-time.format :as time]
             [clj-time.core :refer [now before?]]
             [clj-time.coerce :as tcoerce]

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -420,7 +420,10 @@
       (invoke [_ _ _ _ _ _ _ _ _] (reset! was-called true))
 
       test-protos/IMockFn
-      (called? [_] @was-called))))
+      (called? [_] @was-called)
+
+     clojure.lang.IDeref
+     (deref [_] @was-called))))
 
 (defn pprint-str
   "Pprints `x` to a string and returns that string"

--- a/test/puppetlabs/puppetdb/testutils/log.clj
+++ b/test/puppetlabs/puppetdb/testutils/log.clj
@@ -192,3 +192,14 @@
   `(#'puppetlabs.puppetdb.testutils.log/call-with-log-suppressed-unless-notable
     ~notable-event?
     (fn [] ~@body)))
+
+;;The below functions are useful with
+;;puppetlabs.trapperkeeper.testutils.logging/with-log-suppressed-unless-notable
+
+(def critical-errors (comp #{:fatal :error} :level))
+
+(defn starting-with
+  "Filters log events that have a message starting with `string`"
+  [string]
+  (fn [event]
+    (.startsWith (:message event) string)))


### PR DESCRIPTION
This commit adds the ability to upgrade from an existing ActiveMQ queue to Stockpile. This happens automatically on startup. If an ActiveMQ queue is present, it moves all of the messages out of the queue and into Stockpile. It leaves a "lock" file in place so that there's no need to initialize the ActiveMQ broker and connections upon restart.

@ajroetker did most of this work, I took what he had and adapted it to how stockpile was integrated into PDB