### PR TITLE
(maint) Add MAINTAINERS file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+  "file_format": "This MAINTAINERS file format is described at http://pup.pt/maintainers",
+  "issues": "https://tickets.puppetlabs.com/browse/PDB",
+  "people": [
+    {
+      "github": "senior",
+      "email": "ryan.senior@puppet.com",
+      "name": "Ryan Senior"
+    },
+    {
+      "github": "wkalt",
+      "email": "wyatt@puppet.com",
+      "name": "Wyatt Alt"
+    },
+    {
+      "github": "kbarber",
+      "email": "ken@puppet.com",
+      "name": "Ken Barber"
+    },
+    {
+      "github": "ajroetker",
+      "email": "andrew.roetker@puppet.com",
+      "name": "Andrew Roetker"
+    },
+    {
+      "github": "mullr",
+      "email": "russell.mull@puppet.com",
+      "name": "Russell Mull"
+    },
+    {
+      "github": "rbrw",
+      "email": "rlb@puppet.com",
+      "name": "Rob Browning"
+    },
+    {
+      "github": "nicklewis",
+      "email": "nick@puppet.com",
+      "name": "Nick Lewis"
+    },
+    {
+      "github": "cprice404",
+      "email": "chris@puppet.com",
+      "name": "Chris Price"
+    }
+  ]
+}


### PR DESCRIPTION
Anticipating some possible questions:

* This PR add a MAINTAINERS file to document who is maintaining this repo. The list of people started with the top 10 PR mergers in the last year, plus a little conversation here https://github.com/puppetlabs/kylo_scratchpad/pull/1/files#r76427096
* If the list seems wrong, let's feel free to edit it.
* The format of the file is documented here: http://github.com/puppetlabs/maintainers
* And I used https://rubygems.org/gems/maintainers to construct the file
* I pushed the PR branch to the puppetlabs space (rather than mine) so that all parties can edit collaboratively as needed
* Note that this is a public repo. The email and name fields are optional here. As a starting point, I pre-populated them with the publicly available names/emails available for all of us on github (but took bogus or non-puppet emails as an indication that you may not want to share your puppet.com email). Please feel free to edit your email and name fields for any reason.

