### PR TITLE
(PDB-3047) Corrective change counts

### DIFF
--- a/documentation/api/query/v4/aggregate-event-counts.markdown
+++ b/documentation/api/query/v4/aggregate-event-counts.markdown
@@ -71,6 +71,25 @@ event-count results that were aggregated.
         "total": 3
     } ]
 
+#### Puppet Enterprise
+
+In PE, the `successes` and `noops` counts are subdivided into intentional and corrective parts.
+Events are mapped to the corresponding counts based on the value of `corrective_change` flag.
+
+    [ {
+        "summarize_by": "containing_class",
+        "intentional_successes": 2,
+        "corrective_successes": 0,
+        "failures": 0,
+        "intentional_noops": 0,
+        "corrective_noops": 0,
+        "skips": 1,
+        "total": 3
+    } ]
+
+`intentional_successes`, `corrective_successes`, `intentional_noops`, and `corrective_noops` fields
+can be used in `counts_filter` too.
+
 ### Examples
 
 You can use [`curl`][curl] to query information about aggregated resource event counts:

--- a/documentation/api/query/v4/event-counts.markdown
+++ b/documentation/api/query/v4/event-counts.markdown
@@ -130,6 +130,37 @@ When summarizing by `containing_class`, the `subject` will contain a `title` key
       }
     ]
 
+#### Puppet Enterprise
+
+In PE, the `successes` and `noops` counts are subdivided into intentional and corrective parts.
+Events are mapped to the corresponding counts based on the value of `corrective_change` flag.
+
+    [
+      {
+        "subject_type": "certname",
+        "subject": { "title": "foo.local" },
+        "failures": 0,
+        "intentional_successes": 2,
+        "corrective_successes": 0,
+        "intentional_noops": 0,
+        "corrective_noops": 0,
+        "skips": 1
+      },
+      {
+        "subject_type": "certname",
+        "subject": { "title": "bar.local" },
+        "failures": 1,
+        "intentional_successes": 0,
+        "corrective_successes": 0,
+        "intentional_noops": 0,
+        "corrective_noops": 0,
+        "skips": 1
+      }
+    ]
+
+`intentional_successes`, `corrective_successes`, `intentional_noops`, and `corrective_noops` fields
+can be used in `counts_filter` too.
+
 ### Examples
 
 You can use [`curl`][curl] to query information about resource event counts:

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -739,7 +739,7 @@
 (defn compile-event-count-equality
   "Compile an = predicate for event-count query.  The `path` represents
   the field to query against, and `value` is the value of the field."
-  [& [path value :as args]]
+  [fields & [path value :as args]]
   {:post [(map? %)
           (string? (:where %))]}
   (when-not (= (count args) 2)
@@ -747,7 +747,7 @@
             (i18n/tru "= requires exactly two arguments, but {0} were supplied" (count args)))))
   (let [db-field (utils/dashes->underscores path)]
     (match [db-field]
-           [(field :guard #{"successes" "failures" "noops" "skips"})]
+           [(field :guard fields)]
            {:where (format "%s = ?" field)
             :params [value]}
 
@@ -757,7 +757,7 @@
 (defn compile-event-count-inequality
   "Compile an inequality for an event-counts query (> < >= <=).  The `path`
   represents the field to query against, and the `value` is the value of the field."
-  [& [op path value :as args]]
+  [fields & [op path value :as args]]
   {:post [(map? %)
           (string? (:where %))]}
   (when-not (= (count args) 3)
@@ -765,7 +765,7 @@
             (i18n/tru "{0} requires exactly two arguments, but {1} were supplied"
                       op (dec (count args))))))
   (match [path]
-         [(field :guard #{"successes" "failures" "noops" "skips"})]
+         [(field :guard fields)]
          {:where (format "%s %s ?" field op)
           :params [value]}
 
@@ -835,8 +835,8 @@
 (defn event-count-ops
   "Maps resource event count operators to the functions implementing them.
   Returns nil if the operator is unknown."
-  [op]
+  [fields op]
   (let [op (str/lower-case op)]
     (cond
-     (= "=" op) compile-event-count-equality
-     (#{">" "<" ">=" "<="} op) (partial compile-event-count-inequality op))))
+     (= "=" op) (partial compile-event-count-equality fields)
+     (#{">" "<" ">=" "<="} op) (partial compile-event-count-inequality fields op))))

--- a/test/puppetlabs/puppetdb/http/aggregate_event_counts_test.clj
+++ b/test/puppetlabs/puppetdb/http/aggregate_event_counts_test.clj
@@ -10,66 +10,71 @@
                                                         query-response
                                                         query-result
                                                         vector-param]]
-            [puppetlabs.puppetdb.testutils.reports :refer [store-example-report!]]))
+            [puppetlabs.puppetdb.testutils.reports :refer [with-corrective-change
+                                                           without-corrective-change
+                                                           store-example-report!]]))
 
 (def endpoints [[:v4 "/v4/aggregate-event-counts"]])
+
+;; Tests without corrective changes support
 
 (deftest-http-app query-aggregate-event-counts
   [[version endpoint] endpoints
    method [:post :get]]
 
-  (store-example-report! (:basic reports) (now))
+  (without-corrective-change
+    (store-example-report! (:basic reports) (now))
 
-  (testing "summarize_by rejects unsupported values"
-    (let [{:keys [body headers status]}
-          (query-response method endpoint
-                          ["=" "certname" "foo.local"]
-                          {:summarize_by "illegal-summarize-by"})]
-      (is (= status http/status-bad-request))
-      (is (= headers {"Content-Type" http/error-response-content-type}))
-      (is (re-find #"Unsupported value for 'summarize_by': 'illegal-summarize-by'" body))))
+    (testing "summarize_by rejects unsupported values"
+      (let [{:keys [body headers status]}
+            (query-response method endpoint
+                            ["=" "certname" "foo.local"]
+                            {:summarize_by "illegal-summarize-by"})]
+        (is (= status http/status-bad-request))
+        (is (= headers {"Content-Type" http/error-response-content-type}))
+        (is (re-find #"Unsupported value for 'summarize_by': 'illegal-summarize-by'" body))))
 
-  (testing "count_by rejects unsupported values"
-    (let [{:keys [status body headers]}
-          (query-response method endpoint
-                          ["=" "certname" "foo.local"]
-                          {:summarize_by "certname"
-                           :count_by "illegal-count-by"})]
-      (is (= status http/status-bad-request))
-      (is (= headers {"Content-Type" http/error-response-content-type}))
-      (is (re-find #"Unsupported value for 'count_by': 'illegal-count-by'" body))))
+    (testing "count_by rejects unsupported values"
+      (let [{:keys [status body headers]}
+            (query-response method endpoint
+                            ["=" "certname" "foo.local"]
+                            {:summarize_by "certname"
+                             :count_by "illegal-count-by"})]
+        (is (= status http/status-bad-request))
+        (is (= headers {"Content-Type" http/error-response-content-type}))
+        (is (re-find #"Unsupported value for 'count_by': 'illegal-count-by'" body))))
 
-  (testing "summarize_by accepts multiple parameters"
-    (let [expected #{{:successes 1
+    (testing "summarize_by accepts multiple parameters"
+      (let [expected #{{:successes 1
+                        :failures 0
+                        :noops 0
+                        :skips 1
+                        :total 1
+                        :summarize_by "certname"}
+                       {:successes 2
+                        :skips 1
+                        :failures 0
+                        :noops 0
+                        :total 3
+                        :summarize_by "resource"}}
+            result (query-result method endpoint
+                                 ["=" "certname" "foo.local"]
+                                 {:summarize_by "certname,resource"})]
+        (is (= result expected))))
+
+    (testing "nontrivial query using all the optional parameters"
+      (let [expected {:successes 0
                       :failures 0
                       :noops 0
                       :skips 1
                       :total 1
-                      :summarize_by "certname"}
-                     {:successes 2
-                      :skips 1
-                      :failures 0
-                      :noops 0
-                      :total 3
-                      :summarize_by "resource"}}
-          result (query-result method endpoint
-                               ["=" "certname" "foo.local"]
-                               {:summarize_by "certname,resource"})]
-      (is (= result expected))))
-
-  (testing "nontrivial query using all the optional parameters"
-    (let [expected {:successes 0
-                    :failures 0
-                    :noops 0
-                    :skips 1
-                    :total 1
-                    :summarize_by "containing_class"}
-          response (query-result method endpoint
-                                 ["or" ["=" "status" "success"] ["=" "status" "skipped"]]
-                                 {:summarize_by "containing_class"
-                                  :count_by      "certname"
-                                  :counts_filter (vector-param method ["<" "successes" 1])})]
-      (is (= (first response) expected)))))
+                      :summarize_by "containing_class"}
+            response (query-result method endpoint
+                                   ["or" ["=" "status" "success"] ["=" "status" "skipped"]]
+                                   {:summarize_by "containing_class"
+                                    :count_by      "certname"
+                                    :counts_filter (vector-param method ["<" "successes" 1])})]
+        (is (= (first response) expected))))))
 
 (deftest-http-app query-distinct-event-counts
   [[version endpoint] endpoints
@@ -83,142 +88,369 @@
                     :noops 0
                     :total 3
                     :summarize_by "resource"}}]
-    (store-example-report! (:basic reports) current-time)
-    (store-example-report! (:basic3 reports) current-time)
-    (are [query] (= expected
-                    (query-result method endpoint query
-                                  {:summarize_by "resource"
-                                   :distinct_resources true
-                                   :distinct_start_time 0
-                                   :distinct_end_time (now)}))
-         nil
-         ["=" "certname" "foo.local"]
-         ["<=" "report_receive_time" current-time-str]
-         ["<=" "run_start_time" current-time-str]
-         ["<=" "run_end_time" current-time-str]))
+    (without-corrective-change
+      (store-example-report! (:basic reports) current-time)
+      (store-example-report! (:basic3 reports) current-time)
+      (are [query] (= expected
+                      (query-result method endpoint query
+                                    {:summarize_by "resource"
+                                     :distinct_resources true
+                                     :distinct_start_time 0
+                                     :distinct_end_time (now)}))
+           nil
+           ["=" "certname" "foo.local"]
+           ["<=" "report_receive_time" current-time-str]
+           ["<=" "run_start_time" current-time-str]
+           ["<=" "run_end_time" current-time-str])
+      (store-example-report! (:basic2 reports) (coerce/to-string (now)))
 
-  (store-example-report! (:basic2 reports) (coerce/to-string (now)))
+      (are [result query] (= result
+                             (query-result method endpoint query
+                                           {:summarize_by "resource"
+                                            :distinct_resources true
+                                            :distinct_start_time 0
+                                            :distinct_end_time (now)}))
 
-  (are [result query] (= result
-                         (query-result method endpoint query
-                                       {:summarize_by "resource"
-                                        :distinct_resources true
-                                        :distinct_start_time 0
-                                        :distinct_end_time (now)}))
+           #{{:summarize_by "resource"
+              :successes 3
+              :failures 0
+              :noops 0
+              :skips 0
+              :total 3}}
+           ["=" "latest_report?" true]
 
-       #{{:summarize_by "resource"
-          :successes 3
-          :failures 0
-          :noops 0
-          :skips 0
-          :total 3}}
-       ["=" "latest_report?" true]
+           #{{:summarize_by "resource"
+              :successes 4
+              :failures 1
+              :noops 0
+              :skips 1
+              :total 6}}
+           []
 
-       #{{:summarize_by "resource"
-          :successes 4
-          :failures 1
-          :noops 0
-          :skips 1
-          :total 6}}
-       []
+           #{{:summarize_by "resource"
+              :successes 1
+              :failures 1
+              :noops 0
+              :skips 1
+              :total 3}}
+           ["=" "latest_report?" false]
 
-       #{{:summarize_by "resource"
-          :successes 1
-          :failures 1
-          :noops 0
-          :skips 1
-          :total 3}}
-       ["=" "latest_report?" false]
-
-       #{{:summarize_by "resource"
-          :successes 3
-          :failures 0
-          :noops 0
-          :skips 0
-          :total 3}}
-       ["and" ["=" "latest_report?" true] ["=" "certname" "foo.local"]]))
+           #{{:summarize_by "resource"
+              :successes 3
+              :failures 0
+              :noops 0
+              :skips 0
+              :total 3}}
+           ["and" ["=" "latest_report?" true] ["=" "certname" "foo.local"]]))))
 
 (deftest-http-app query-with-environment
   [[version endpoint] endpoints
    method [:get :post]]
+  (without-corrective-change
+    (store-example-report! (:basic reports) (now))
+    (store-example-report! (assoc (:basic2 reports)
+                             :certname "bar.local"
+                             :environment "PROD") (now))
+    (are [result query] (= result
+                           (query-result method endpoint query
+                                         {:summarize_by "resource"}))
+         #{{:successes 2
+            :skips 1
+            :failures 0
+            :noops 0
+            :total 3
+            :summarize_by "resource"}}
+         ["=" "environment" "DEV"]
 
-  (store-example-report! (:basic reports) (now))
-  (store-example-report! (assoc (:basic2 reports)
-                           :certname "bar.local"
-                           :environment "PROD") (now))
-  (are [result query] (= result
-                         (query-result method endpoint query
-                                       {:summarize_by "resource"}))
-       #{{:successes 2
-          :skips 1
-          :failures 0
-          :noops 0
-          :total 3
-          :summarize_by "resource"}}
-       ["=" "environment" "DEV"]
+         #{{:successes 5
+            :skips 1
+            :failures 0
+            :noops 0
+            :total 6
+            :summarize_by "resource"}}
+         nil
 
-       #{{:successes 5
-          :skips 1
-          :failures 0
-          :noops 0
-          :total 6
-          :summarize_by "resource"}}
-       nil
+         #{{:successes 2
+            :skips 1
+            :failures 0
+            :noops 0
+            :total 3
+            :summarize_by "resource"}}
+         ["~" "environment" "DE"]
 
-       #{{:successes 2
-          :skips 1
-          :failures 0
-          :noops 0
-          :total 3
-          :summarize_by "resource"}}
-       ["~" "environment" "DE"]
+         #{{:successes 3
+            :skips 0
+            :failures 0
+            :noops 0
+            :total 3
+            :summarize_by "resource"}}
+         ["=" "environment" "PROD"]
 
-       #{{:successes 3
-          :skips 0
-          :failures 0
-          :noops 0
-          :total 3
-          :summarize_by "resource"}}
-       ["=" "environment" "PROD"]
+         #{{:successes 3
+            :skips 0
+            :failures 0
+            :noops 0
+            :total 3
+            :summarize_by "resource"}}
+         ["~" "environment" "PR"]
 
-       #{{:successes 3
-         :skips 0
-         :failures 0
-         :noops 0
-         :total 3
-         :summarize_by "resource"}}
-       ["~" "environment" "PR"]
+         #{{:successes 5
+            :skips 1
+            :failures 0
+            :noops 0
+            :total 6
+            :summarize_by "resource"}}
+         ["~" "environment" "D"]
 
-       #{{:successes 5
-          :skips 1
-          :failures 0
-          :noops 0
-          :total 6
-          :summarize_by "resource"}}
-       ["~" "environment" "D"]
+         #{{:successes 5
+            :skips 1
+            :failures 0
+            :noops 0
+            :total 6
+            :summarize_by "resource"}}
+         ["OR"
+          ["=" "environment" "DEV"]
+          ["=" "environment" "PROD"]]
 
-       #{{:successes 5
-         :skips 1
-         :failures 0
-         :noops 0
-         :total 6
-         :summarize_by "resource"}}
-       ["OR"
-        ["=" "environment" "DEV"]
-        ["=" "environment" "PROD"]]
+         #{{:successes 0
+            :skips 0
+            :failures 0
+            :noops 0
+            :total 0
+            :summarize_by "resource"}}
+         ["<" "timestamp" 0]
 
-       #{{:successes 0
-          :skips 0
-          :failures 0
-          :noops 0
-          :total 0
-          :summarize_by "resource"}}
-       ["<" "timestamp" 0]
+         #{{:summarize_by "resource"
+            :successes 5
+            :failures 0
+            :noops 0
+            :skips 1
+            :total 6}}
+         ["=" "latest_report?" true])))
 
-       #{{:summarize_by "resource"
-          :successes 5
-          :failures 0
-          :noops 0
-          :skips 1
-          :total 6}}
-       ["=" "latest_report?" true]))
+;; Tests with corrective changes support
+
+(deftest-http-app query-aggregate-event-counts-with-corrective-changes
+  [[version endpoint] endpoints
+   method [:post :get]]
+
+  (with-corrective-change
+    (store-example-report! (:basic reports) (now))
+
+    (testing "summarize_by accepts multiple parameters"
+      (let [expected #{{:intentional_successes 1
+                        :corrective_successes 1
+                        :failures 0
+                        :intentional_noops 0
+                        :corrective_noops 0
+                        :skips 1
+                        :total 1
+                        :summarize_by "certname"}
+                       {:intentional_successes 1
+                        :corrective_successes 1
+                        :skips 1
+                        :failures 0
+                        :intentional_noops 0
+                        :corrective_noops 0
+                        :total 3
+                        :summarize_by "resource"}}
+            result (query-result method endpoint
+                                 ["=" "certname" "foo.local"]
+                                 {:summarize_by "certname,resource"})]
+        (is (= result expected))))
+
+    (testing "nontrivial query using all the optional parameters"
+      (let [expected {:intentional_successes 0
+                      :corrective_successes 0
+                      :failures 0
+                      :intentional_noops 0
+                      :corrective_noops 0
+                      :skips 1
+                      :total 1
+                      :summarize_by "containing_class"}
+            response (query-result method endpoint
+                                   ["or" ["=" "status" "success"] ["=" "status" "skipped"]]
+                                   {:summarize_by "containing_class"
+                                    :count_by      "certname"
+                                    :counts_filter (vector-param method ["<" "intentional_successes" 1])})]
+        (is (= (first response) expected))))))
+
+(deftest-http-app query-distinct-event-counts-with-corrective-changes
+  [[version endpoint] endpoints
+   method [:get :post]]
+
+  (let [current-time (now)
+        current-time-str (coerce/to-string current-time)
+        expected #{{:intentional_successes 1
+                    :corrective_successes 0
+                    :skips 1
+                    :failures 1
+                    :intentional_noops 0
+                    :corrective_noops 0
+                    :total 3
+                    :summarize_by "resource"}}]
+    (with-corrective-change
+      (store-example-report! (:basic reports) current-time)
+      (store-example-report! (:basic3 reports) current-time)
+      (are [query] (= expected
+                      (query-result method endpoint query
+                                    {:summarize_by "resource"
+                                     :distinct_resources true
+                                     :distinct_start_time 0
+                                     :distinct_end_time (now)}))
+           nil
+           ["=" "certname" "foo.local"]
+           ["<=" "report_receive_time" current-time-str]
+           ["<=" "run_start_time" current-time-str]
+           ["<=" "run_end_time" current-time-str])
+      (store-example-report! (:basic2 reports) (coerce/to-string (now)))
+
+      (are [result query] (= result
+                             (query-result method endpoint query
+                                           {:summarize_by "resource"
+                                            :distinct_resources true
+                                            :distinct_start_time 0
+                                            :distinct_end_time (now)}))
+
+           #{{:summarize_by "resource"
+              :intentional_successes 3
+              :corrective_successes 0
+              :failures 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0
+              :total 3}}
+           ["=" "latest_report?" true]
+
+           #{{:summarize_by "resource"
+              :intentional_successes 4
+              :corrective_successes 0
+              :failures 1
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 1
+              :total 6}}
+           []
+
+           #{{:summarize_by "resource"
+              :intentional_successes 1
+              :corrective_successes 0
+              :failures 1
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 1
+              :total 3}}
+           ["=" "latest_report?" false]
+
+           #{{:summarize_by "resource"
+              :intentional_successes 3
+              :corrective_successes 0
+              :failures 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0
+              :total 3}}
+           ["and" ["=" "latest_report?" true] ["=" "certname" "foo.local"]]))))
+
+(deftest-http-app query-with-environment-with-corrective-changes
+  [[version endpoint] endpoints
+   method [:get :post]]
+  (with-corrective-change
+    (store-example-report! (:basic reports) (now))
+    (store-example-report! (assoc (:basic2 reports)
+                             :certname "bar.local"
+                             :environment "PROD") (now))
+    (are [result query] (= result
+                           (query-result method endpoint query
+                                         {:summarize_by "resource"}))
+         #{{:intentional_successes 1
+            :corrective_successes 1
+            :skips 1
+            :failures 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :total 3
+            :summarize_by "resource"}}
+         ["=" "environment" "DEV"]
+
+         #{{:intentional_successes 4
+            :corrective_successes 1
+            :skips 1
+            :failures 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :total 6
+            :summarize_by "resource"}}
+         nil
+
+         #{{:intentional_successes 1
+            :corrective_successes 1
+            :skips 1
+            :failures 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :total 3
+            :summarize_by "resource"}}
+         ["~" "environment" "DE"]
+
+         #{{:intentional_successes 3
+            :corrective_successes 0
+            :skips 0
+            :failures 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :total 3
+            :summarize_by "resource"}}
+         ["=" "environment" "PROD"]
+
+         #{{:intentional_successes 3
+            :corrective_successes 0
+            :skips 0
+            :failures 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :total 3
+            :summarize_by "resource"}}
+         ["~" "environment" "PR"]
+
+         #{{:intentional_successes 4
+            :corrective_successes 1
+            :skips 1
+            :failures 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :total 6
+            :summarize_by "resource"}}
+         ["~" "environment" "D"]
+
+         #{{:intentional_successes 4
+            :corrective_successes 1
+            :skips 1
+            :failures 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :total 6
+            :summarize_by "resource"}}
+         ["OR"
+          ["=" "environment" "DEV"]
+          ["=" "environment" "PROD"]]
+
+         #{{:intentional_successes 0
+            :corrective_successes 0
+            :skips 0
+            :failures 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :total 0
+            :summarize_by "resource"}}
+         ["<" "timestamp" 0]
+
+         #{{:summarize_by "resource"
+            :intentional_successes 4
+            :corrective_successes 1
+            :failures 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 1
+            :total 6}}
+         ["=" "latest_report?" true])))

--- a/test/puppetlabs/puppetdb/http/event_counts_test.clj
+++ b/test/puppetlabs/puppetdb/http/event_counts_test.clj
@@ -11,7 +11,9 @@
                                                         query-response query-result
                                                         vector-param
                                                         ordered-query-result]]
-            [puppetlabs.puppetdb.testutils.reports :refer [store-example-report!]]
+            [puppetlabs.puppetdb.testutils.reports :refer [with-corrective-change
+                                                           without-corrective-change
+                                                           store-example-report!]]
             [clj-time.core :refer [now]]))
 
 (def endpoints [[:v4 "/v4/event-counts"]])
@@ -22,110 +24,113 @@
       keywordize-keys
       (assoc :certname "foo.local")))
 
+;; Tests without corrective changes support
+
 (deftest-http-app query-event-counts
   [[version endpoint] endpoints
    method [:get :post]]
 
-  (store-example-report! (:basic reports) (now))
-  (let [count1 {:subject_type "containing_class" :subject {:title nil}
-                :failures 0 :successes 2 :noops 0 :skips 0}
-        count2 {:subject_type "containing_class" :subject {:title "Foo"}
-                :failures 0 :successes 0 :noops 0 :skips 1}]
+  (without-corrective-change
+    (store-example-report! (:basic reports) (now))
+    (let [count1 {:subject_type "containing_class" :subject {:title nil}
+                  :failures 0 :successes 2 :noops 0 :skips 0}
+          count2 {:subject_type "containing_class" :subject {:title "Foo"}
+                  :failures 0 :successes 0 :noops 0 :skips 1}]
 
-  (testing "summarize_by rejects unsupported values"
-    (let [{:keys [body status headers]}
-          (query-response method endpoint
-                          ["=" "certname" "foo.local"]
-                          {:summarize_by "illegal-summarize-by"})]
-      (is (= status http/status-bad-request))
-      (is (= headers {"Content-Type" http/error-response-content-type}))
-      (is (re-find #"Unsupported value for 'summarize_by': 'illegal-summarize-by'"
-                   body))))
-
-  (testing "paging"
-    (testing "limit works"
-      (doseq [[limit expected] [[1 1] [2 2] [3 3] [100 3]]]
-        (let [result (query-result method endpoint nil {:limit limit :summarize_by "resource"})]
-          (is (= expected (count result))))))
-
-    (testing "offset works"
-      (doseq [[offset expected] [[0 3] [1 2] [2 1] [3 0]]]
-        (let [result (query-result method endpoint nil {:offset offset
-                                                        :summarize_by "resource"})]
-          (is (= expected (count result))))))
-
-    (testing "order_by rejects invalid fields"
-      (let [{:keys [status body headers]}
-            (query-response
-             method endpoint
-             nil
-             {:summarize_by "certname"
-              :order_by "invalid"})]
+    (testing "summarize_by rejects unsupported values"
+      (let [{:keys [body status headers]}
+            (query-response method endpoint
+                            ["=" "certname" "foo.local"]
+                            {:summarize_by "illegal-summarize-by"})]
         (is (= status http/status-bad-request))
         (is (= headers {"Content-Type" http/error-response-content-type}))
-        (is (re-find #"Illegal value 'invalid' for :order_by" body))))
-
-    (testing "numerical fields"
-      (doseq [[order expected] [["asc"  [count2 count1]]
-                                ["desc" [count1 count2]]]]
-        (testing order
-          (let [actual (ordered-query-result
-                         method endpoint
-                         ["=" "certname" "foo.local"]
-                         {:summarize_by "containing_class"
-                          :order_by (vector-param
-                                      method [{"field" "successes"
-                                               "order" order}])})]
-            (is (= actual expected)))))))
-
-  (testing "count_by"
-    (testing "count_by rejects unsupported values"
-      (let [{:keys [status body headers]}
-            (query-response
-             method endpoint
-             ["=" "certname" "foo.local"]
-             {:summarize_by "certname"
-              :count_by "illegal-count-by"})]
-        (is (= status http/status-bad-request))
-        (is (= headers {"Content-Type" http/error-response-content-type}))
-        (is (re-find #"Unsupported value for 'count_by': 'illegal-count-by'"
+        (is (re-find #"Unsupported value for 'summarize_by': 'illegal-summarize-by'"
                      body))))
 
-    (testing "resource"
-      (let [expected #{{:failures 0
-                        :successes 0
-                        :noops 0
-                        :skips 1
-                        :subject_type "containing_class"
-                        :subject {:title "Foo"}}
-                       {:failures 0
-                        :successes 2
-                        :noops 0
-                        :skips 0
-                        :subject_type "containing_class"
-                        :subject {:title nil}}}
-            actual (query-result method endpoint ["=" "certname" "foo.local"]
-                                 {:summarize_by "containing_class"
-                                  :count_by "resource"})]
-        (is (= actual expected))))
+    (testing "paging"
+      (testing "limit works"
+        (doseq [[limit expected] [[1 1] [2 2] [3 3] [100 3]]]
+          (let [result (query-result method endpoint nil {:limit limit :summarize_by "resource"})]
+            (is (= expected (count result))))))
 
-    (testing "certname"
-      (let [expected #{{:failures 0
-                        :successes 0
-                        :noops 0
-                        :skips 1
-                        :subject_type "containing_class"
-                        :subject {:title "Foo"}}
-                       {:failures 0
-                        :successes 1
-                        :noops 0
-                        :skips 0
-                        :subject_type "containing_class"
-                        :subject {:title nil}}}
-            actual (query-result method endpoint ["~" "certname" ".*"]
-                                 {:summarize_by "containing_class"
-                                  :count_by "certname"})]
-        (is (= actual expected)))))
+      (testing "offset works"
+        (doseq [[offset expected] [[0 3] [1 2] [2 1] [3 0]]]
+          (let [result (query-result method endpoint nil {:offset offset
+                                                          :summarize_by "resource"})]
+            (is (= expected (count result))))))
+
+      (testing "order_by rejects invalid fields"
+        (let [{:keys [status body headers]}
+              (query-response
+               method endpoint
+               nil
+               {:summarize_by "certname"
+                :order_by "invalid"})]
+          (is (= status http/status-bad-request))
+          (is (= headers {"Content-Type" http/error-response-content-type}))
+          (is (re-find #"Illegal value 'invalid' for :order_by" body))))
+
+      (testing "numerical fields"
+        (doseq [[order expected] [["asc"  [count2 count1]]
+                                  ["desc" [count1 count2]]]]
+          (testing order
+            (let [actual (ordered-query-result
+                           method endpoint
+                           ["=" "certname" "foo.local"]
+                           {:summarize_by "containing_class"
+                            :order_by (vector-param
+                                        method [{"field" "successes"
+                                                 "order" order}])})]
+              (is (= actual expected)))))))
+
+    (testing "count_by"
+      (testing "count_by rejects unsupported values"
+        (let [{:keys [status body headers]}
+              (query-response
+               method endpoint
+               ["=" "certname" "foo.local"]
+               {:summarize_by "certname"
+                :count_by "illegal-count-by"})]
+          (is (= status http/status-bad-request))
+          (is (= headers {"Content-Type" http/error-response-content-type}))
+          (is (re-find #"Unsupported value for 'count_by': 'illegal-count-by'"
+                       body))))
+
+      (testing "resource"
+        (let [expected #{{:failures 0
+                          :successes 0
+                          :noops 0
+                          :skips 1
+                          :subject_type "containing_class"
+                          :subject {:title "Foo"}}
+                         {:failures 0
+                          :successes 2
+                          :noops 0
+                          :skips 0
+                          :subject_type "containing_class"
+                          :subject {:title nil}}}
+              actual (query-result method endpoint ["=" "certname" "foo.local"]
+                                   {:summarize_by "containing_class"
+                                    :count_by "resource"})]
+          (is (= actual expected))))
+
+      (testing "certname"
+        (let [expected #{{:failures 0
+                          :successes 0
+                          :noops 0
+                          :skips 1
+                          :subject_type "containing_class"
+                          :subject {:title "Foo"}}
+                         {:failures 0
+                          :successes 1
+                          :noops 0
+                          :skips 0
+                          :subject_type "containing_class"
+                          :subject {:title nil}}}
+              actual (query-result method endpoint ["~" "certname" ".*"]
+                                   {:summarize_by "containing_class"
+                                    :count_by "certname"})]
+          (is (= actual expected)))))
 
   (testing "nontrivial query using all the optional parameters"
     (let [expected  #{{:subject_type "containing_class"
@@ -149,7 +154,7 @@
                         :noops 0
                         :skips 0
                         :subject_type "resource"
-                        :subject  {:type "Notify" :title "notify, yo"}}
+                        :subject {:type "Notify" :title "notify, yo"}}
                        {:failures 0
                         :successes 1
                         :noops 0
@@ -232,22 +237,22 @@
     (testing (str "should support paging through event-counts " label " counts")
       (let [expected  [{:subject_type "resource"
                         :subject {:type "Notify" :title "hi"}
-                        :failures        0
-                        :successes       0
-                        :noops           0
-                        :skips           1}
+                        :failures              0
+                        :successes             0
+                        :noops                 0
+                        :skips                 1}
                        {:subject_type "resource"
                         :subject {:type "Notify" :title "notify, yar"}
-                        :failures        0
-                        :successes       1
-                        :noops           0
-                        :skips           0}
+                        :failures              0
+                        :successes             1
+                        :noops                 0
+                        :skips                 0}
                        {:subject_type "resource"
                         :subject {:type "Notify" :title "notify, yo"}
-                        :failures        0
-                        :successes       1
-                        :noops           0
-                        :skips           0}]
+                        :failures              0
+                        :successes             1
+                        :noops                 0
+                        :skips                 0}]
             results (ordered-query-result
                       method
                       endpoint
@@ -256,354 +261,1029 @@
                        :order_by (vector-param method [{"field" "resource_title"}])
                        :include_total true})]
         (is (= (count expected) (count results)))
-        (is (= expected results))))))
+        (is (= expected results)))))))
 
 (deftest-http-app query-distinct-event-counts
   [[version endpoint] endpoints
    method [:get :post]]
 
-  (store-example-report! (:basic reports) (now))
-  (store-example-report! (:basic3 reports) (now))
-  (testcat/replace-catalog (json/generate-string example-catalog))
-  (testing "should only count the most recent event for each resource"
-    (are [query result]
-         (is (= (query-result method endpoint query
-                              {:summarize_by "resource"
-                               :distinct_resources true
-                               :distinct_start_time 0
-                               :distinct_end_time (now)})
-                result))
+  (without-corrective-change
+    (store-example-report! (:basic reports) (now))
+    (store-example-report! (:basic3 reports) (now))
+    (testcat/replace-catalog (json/generate-string example-catalog))
+    (testing "should only count the most recent event for each resource"
+      (are [query result]
+           (is (= (query-result method endpoint query
+                                {:summarize_by "resource"
+                                 :distinct_resources true
+                                 :distinct_start_time 0
+                                 :distinct_end_time (now)})
+                  result))
 
 
-         ["=" "latest_report?" true]
-         #{{:failures 0
-            :successes 1
-            :noops 0
-            :skips 0
-            :subject_type "resource"
-            :subject {:type "Notify"
-                      :title "notify, yo"}}
-           {:failures 1
-            :successes 0
-            :noops 0
-            :skips 0
-            :subject_type "resource"
-            :subject {:type "Notify"
-                      :title "notify, yar"}}
-           {:failures 0
-            :successes 0
-            :noops 0
-            :skips 1
-            :subject_type "resource"
-            :subject {:type "Notify"
-                      :title "hi"}}}
+           ["=" "latest_report?" true]
+           #{{:failures 0
+              :successes 1
+              :noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify"
+                        :title "notify, yo"}}
+             {:failures 1
+              :successes 0
+              :noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify"
+                        :title "notify, yar"}}
+             {:failures 0
+              :successes 0
+              :noops 0
+              :skips 1
+              :subject_type "resource"
+              :subject {:type "Notify"
+                        :title "hi"}}}
 
-         ["=" "latest_report?" false]
-         #{{:failures 0
-            :successes 1
-            :noops 0
-            :skips 0
-            :subject_type "resource"
-            :subject {:type "Notify"
-                      :title "notify, yo"}}
-           {:failures 0
-            :successes 1
-            :noops 0
-            :skips 0
-            :subject_type "resource"
-            :subject {:type "Notify"
-                      :title "notify, yar"}}
-           {:failures 0
-            :successes 0
-            :noops 0
-            :skips 1
-            :subject_type "resource"
-            :subject {:type "Notify"
-                      :title "hi"}}}
+           ["=" "latest_report?" false]
+           #{{:failures 0
+              :successes 1
+              :noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify"
+                        :title "notify, yo"}}
+             {:failures 0
+              :successes 1
+              :noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify"
+                        :title "notify, yar"}}
+             {:failures 0
+              :successes 0
+              :noops 0
+              :skips 1
+              :subject_type "resource"
+              :subject {:type "Notify"
+                        :title "hi"}}}
 
-         ["=" "certname" "foo.local"]
-         #{{:subject_type "resource"
-            :subject {:type "Notify" :title "notify, yo"}
-            :failures 0
-            :successes 1
-            :noops 0
-            :skips 0}
-           {:subject_type "resource"
-            :subject {:type "Notify" :title "notify, yar"}
-            :failures 1
-            :successes 0
-            :noops 0
-            :skips 0}
-           {:subject_type "resource"
-            :subject {:type "Notify" :title "hi"}
-            :failures 0
-            :successes 0
-            :noops 0
-            :skips 1}}
+           ["=" "certname" "foo.local"]
+           #{{:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}
+              :failures 0
+              :successes 1
+              :noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}
+              :failures 1
+              :successes 0
+              :noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "hi"}
+              :failures 0
+              :successes 0
+              :noops 0
+              :skips 1}}
 
-         nil
-         #{{:subject_type "resource"
-            :subject {:type "Notify" :title "notify, yo"}
-            :failures 0
-            :successes 1
-            :noops 0
-            :skips 0}
-           {:subject_type "resource"
-            :subject {:type "Notify" :title "notify, yar"}
-            :failures 1
-            :successes 0
-            :noops 0
-            :skips 0}
-           {:subject_type "resource"
-            :subject {:type "Notify" :title "hi"}
-            :failures 0
-            :successes 0
-            :noops 0
-            :skips 1}}
+           nil
+           #{{:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}
+              :failures 0
+              :successes 1
+              :noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}
+              :failures 1
+              :successes 0
+              :noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "hi"}
+              :failures 0
+              :successes 0
+              :noops 0
+              :skips 1}}
 
-         ["~" "certname" ".*"]
-         #{{:subject_type "resource"
-            :subject {:type "Notify" :title "notify, yo"}
-            :failures 0
-            :successes 1
-            :noops 0
-            :skips 0}
-           {:subject_type "resource"
-            :subject {:type "Notify" :title "notify, yar"}
-            :failures 1
-            :successes 0
-            :noops 0
-            :skips 0}
-           {:subject_type "resource"
-            :subject {:type "Notify" :title "hi"}
-            :failures 0
-            :successes 0
-            :noops 0
-            :skips 1}}
+           ["~" "certname" ".*"]
+           #{{:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}
+              :failures 0
+              :successes 1
+              :noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}
+              :failures 1
+              :successes 0
+              :noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "hi"}
+              :failures 0
+              :successes 0
+              :noops 0
+              :skips 1}}
 
-         ["~" "environment" ".*"]
-         #{{:subject_type "resource"
-            :subject {:type "Notify" :title "notify, yo"}
-            :failures 0
-            :successes 1
-            :noops 0
-            :skips 0}
-           {:subject_type "resource"
-            :subject {:type "Notify" :title "notify, yar"}
-            :failures 1
-            :successes 0
-            :noops 0
-            :skips 0}
-           {:subject_type "resource"
-            :subject {:type "Notify" :title "hi"}
-            :failures 0
-            :successes 0
-            :noops 0
-            :skips 1}}
+           ["~" "environment" ".*"]
+           #{{:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}
+              :failures 0
+              :successes 1
+              :noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}
+              :failures 1
+              :successes 0
+              :noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "hi"}
+              :failures 0
+              :successes 0
+              :noops 0
+              :skips 1}}
 
-         ["~" "property" ".*"]
-         #{{:failures 0
-            :successes 1
-            :noops 0
-            :skips 0
-            :subject_type "resource"
-            :subject {:type "Notify" :title "notify, yo"}}
-           {:failures 1
-            :successes 0
-            :noops 0
-            :skips 0
-            :subject_type "resource"
-            :subject {:type "Notify" :title "notify, yar"}}}
+           ["~" "property" ".*"]
+           #{{:failures 0
+              :successes 1
+              :noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}}
+             {:failures 1
+              :successes 0
+              :noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}}}
 
-         ["in" "certname" ["extract" "certname"
-                           ["select_resources" ["~" "certname" ".*"]]]]
-         #{{:failures 0
-            :successes 1
-            :noops 0
-            :skips 0
-            :subject_type "resource"
-            :subject {:type "Notify" :title "notify, yo"}}
-           {:failures 1
-            :successes 0
-            :noops 0
-            :skips 0
-            :subject_type "resource"
-            :subject {:type "Notify" :title "notify, yar"}}
-           {:failures 0
-            :successes 0
-            :noops 0
-            :skips 1
-            :subject_type "resource"
-            :subject {:type "Notify" :title "hi"}}}
+           ["in" "certname" ["extract" "certname"
+                             ["select_resources" ["~" "certname" ".*"]]]]
+           #{{:failures 0
+              :successes 1
+              :noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}}
+             {:failures 1
+              :successes 0
+              :noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}}
+             {:failures 0
+              :successes 0
+              :noops 0
+              :skips 1
+              :subject_type "resource"
+              :subject {:type "Notify" :title "hi"}}}
 
-         ["in" "certname" ["extract" "certname"
-                           ["select_resources" ["~" "tag" ".*"]]]]
-         #{{:failures 0
-            :successes 1
-            :noops 0
-            :skips 0
-            :subject_type "resource"
-            :subject {:type "Notify" :title "notify, yo"}}
-           {:failures 1
-            :successes 0
-            :noops 0
-            :skips 0
-            :subject_type "resource"
-            :subject {:type "Notify" :title "notify, yar"}}
-           {:failures 0
-            :successes 0
-            :noops 0
-            :skips 1
-            :subject_type "resource"
-            :subject {:type "Notify" :title "hi"}}})))
+           ["in" "certname" ["extract" "certname"
+                             ["select_resources" ["~" "tag" ".*"]]]]
+           #{{:failures 0
+              :successes 1
+              :noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}}
+             {:failures 1
+              :successes 0
+              :noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}}
+             {:failures 0
+              :successes 0
+              :noops 0
+              :skips 1
+              :subject_type "resource"
+              :subject {:type "Notify" :title "hi"}}}))))
 
 (deftest-http-app query-with-environment
   [[version endpoint] endpoints
    method [:get :post]]
 
-  (store-example-report! (:basic reports) (now))
-  (store-example-report! (assoc (:basic2 reports)
-                           :certname "bar.local"
-                           :environment "PROD") (now))
-  (are [result query] (is (= (query-result method endpoint query
-                                           {:summarize_by "resource"})
-                             result))
-       #{{:subject_type "resource"
-          :subject {:type "Notify" :title "notify, yo"}
-          :failures 0
-          :successes 1
-          :noops 0
-          :skips 0}
-         {:subject_type "resource"
-          :subject {:type "Notify" :title "notify, yar"}
-          :failures 0
-          :successes 1
-          :noops 0
-          :skips 0}
-         {:subject_type "resource"
-          :subject {:type "Notify" :title "hi"}
-          :failures 0
-          :successes 0
-          :noops 0
-          :skips 1}
-         {:subject_type "resource",
-          :noops 0,
-          :skips 0,
-          :successes 1,
-          :failures 0,
-          :subject {:type "File", :title "tmp-directory"}}
-         {:subject_type "resource",
-          :noops 0,
-          :skips 0,
-          :successes 1,
-          :failures 0,
-          :subject {:type "File", :title "puppet-managed-file"}}
-         {:subject_type "resource",
-          :noops 0,
-          :skips 0,
-          :successes 1,
-          :failures 0,
-          :subject
-          {:type "Notify", :title "Creating tmp directory at /Users/foo/tmp"}}}
-       nil
+  (without-corrective-change
+    (store-example-report! (:basic reports) (now))
+    (store-example-report! (assoc (:basic2 reports)
+                             :certname "bar.local"
+                             :environment "PROD") (now))
+    (are [result query] (is (= (query-result method endpoint query
+                                             {:summarize_by "resource"})
+                               result))
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :successes 0
+            :noops 0
+            :skips 1}
+           {:subject_type "resource",
+            :noops 0,
+            :skips 0,
+            :successes 1,
+            :failures 0,
+            :subject {:type "File", :title "tmp-directory"}}
+           {:subject_type "resource",
+            :noops 0,
+            :skips 0,
+            :successes 1,
+            :failures 0,
+            :subject {:type "File", :title "puppet-managed-file"}}
+           {:subject_type "resource",
+            :noops 0,
+            :skips 0,
+            :successes 1,
+            :failures 0,
+            :subject
+            {:type "Notify", :title "Creating tmp directory at /Users/foo/tmp"}}}
+         nil
 
-       #{{:subject_type "resource"
-          :subject {:type "Notify" :title "notify, yo"}
-          :failures 0
-          :successes 1
-          :noops 0
-          :skips 0}
-         {:subject_type "resource"
-          :subject {:type "Notify" :title "notify, yar"}
-          :failures 0
-          :successes 1
-          :noops 0
-          :skips 0}
-         {:subject_type "resource"
-          :subject {:type "Notify" :title "hi"}
-          :failures 0
-          :successes 0
-          :noops 0
-          :skips 1}}
-       ["=" "environment" "DEV"]
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :successes 0
+            :noops 0
+            :skips 1}}
+         ["=" "environment" "DEV"]
 
-       #{{:subject_type "resource"
-          :subject {:type "Notify" :title "notify, yo"}
-          :failures 0
-          :successes 1
-          :noops 0
-          :skips 0}
-         {:subject_type "resource"
-          :subject {:type "Notify" :title "notify, yar"}
-          :failures 0
-          :successes 1
-          :noops 0
-          :skips 0}
-         {:subject_type "resource"
-          :subject {:type "Notify" :title "hi"}
-          :failures 0
-          :successes 0
-          :noops 0
-          :skips 1}}
-       ["~" "environment" "DE.*"]
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :successes 0
+            :noops 0
+            :skips 1}}
+         ["~" "environment" "DE.*"]
 
-       #{{:subject_type "resource"
-          :subject {:type "Notify" :title "notify, yo"}
-          :failures 0
-          :successes 1
-          :noops 0
-          :skips 0}
-         {:subject_type "resource"
-          :subject {:type "Notify" :title "notify, yar"}
-          :failures 0
-          :successes 1
-          :noops 0
-          :skips 0}
-         {:subject_type "resource"
-          :subject {:type "Notify" :title "hi"}
-          :failures 0
-          :successes 0
-          :noops 0
-          :skips 1}}
-       ["not" ["=" "environment" "PROD"]]
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :successes 0
+            :noops 0
+            :skips 1}}
+         ["not" ["=" "environment" "PROD"]]
 
-       #{{:subject_type "resource"
-          :subject {:type "Notify" :title "notify, yo"}
-          :failures 0
-          :successes 1
-          :noops 0
-          :skips 0}
-         {:subject_type "resource"
-          :subject {:type "Notify" :title "notify, yar"}
-          :failures 0
-          :successes 1
-          :noops 0
-          :skips 0}
-         {:subject_type "resource"
-          :subject {:type "Notify" :title "hi"}
-          :failures 0
-          :successes 0
-          :noops 0
-          :skips 1}
-         {:subject_type "resource",
-          :noops 0,
-          :skips 0,
-          :successes 1,
-          :failures 0,
-          :subject {:type "File", :title "tmp-directory"}}
-         {:subject_type "resource",
-          :noops 0,
-          :skips 0,
-          :successes 1,
-          :failures 0,
-          :subject {:type "File", :title "puppet-managed-file"}}
-         {:subject_type "resource",
-          :noops 0,
-          :skips 0,
-          :successes 1,
-          :failures 0,
-          :subject
-          {:type "Notify", :title "Creating tmp directory at /Users/foo/tmp"}}}
-       ["OR"
-        ["=" "environment" "PROD"]
-        ["=" "environment" "DEV"]]))
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 0
+            :successes 1
+            :noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :successes 0
+            :noops 0
+            :skips 1}
+           {:subject_type "resource",
+            :noops 0,
+            :skips 0,
+            :successes 1,
+            :failures 0,
+            :subject {:type "File", :title "tmp-directory"}}
+           {:subject_type "resource",
+            :noops 0,
+            :skips 0,
+            :successes 1,
+            :failures 0,
+            :subject {:type "File", :title "puppet-managed-file"}}
+           {:subject_type "resource",
+            :noops 0,
+            :skips 0,
+            :successes 1,
+            :failures 0,
+            :subject
+            {:type "Notify", :title "Creating tmp directory at /Users/foo/tmp"}}}
+         ["OR"
+          ["=" "environment" "PROD"]
+          ["=" "environment" "DEV"]])))
+
+;; Tests with corrective changes support
+
+(deftest-http-app query-event-counts-with-corrective-changes
+  [[version endpoint] endpoints
+   method [:get :post]]
+
+  (with-corrective-change
+    (store-example-report! (:basic reports) (now))
+    (let [count1 {:subject_type "containing_class" :subject {:title nil}
+                  :failures 0 :intentional_successes 1 :corrective_successes 1 :intentional_noops 0 :corrective_noops 0 :skips 0}
+          count2 {:subject_type "containing_class" :subject {:title "Foo"}
+                  :failures 0 :intentional_successes 0 :corrective_successes 0 :intentional_noops 0 :corrective_noops 0 :skips 1}]
+
+      (testing "numerical fields"
+        (doseq [[order expected] [["asc"  [count2 count1]]
+                                  ["desc" [count1 count2]]]]
+          (testing order
+            (let [actual (ordered-query-result
+                           method endpoint
+                           ["=" "certname" "foo.local"]
+                           {:summarize_by "containing_class"
+                            :order_by (vector-param
+                                        method [{"field" "intentional_successes"
+                                                 "order" order}])})]
+              (is (= actual expected)))))))
+
+    (testing "count_by"
+      (testing "resource"
+        (let [expected #{{:failures 0
+                          :intentional_successes 0
+                          :corrective_successes 0
+                          :intentional_noops 0
+                          :corrective_noops 0
+                          :skips 1
+                          :subject_type "containing_class"
+                          :subject {:title "Foo"}}
+                         {:failures 0
+                          :intentional_successes 1
+                          :corrective_successes 1
+                          :intentional_noops 0
+                          :corrective_noops 0
+                          :skips 0
+                          :subject_type "containing_class"
+                          :subject {:title nil}}}
+              actual (query-result method endpoint ["=" "certname" "foo.local"]
+                                   {:summarize_by "containing_class"
+                                    :count_by "resource"})]
+          (is (= actual expected))))
+
+      (testing "certname"
+        (let [expected #{{:failures 0
+                          :intentional_successes 0
+                          :corrective_successes 0
+                          :intentional_noops 0
+                          :corrective_noops 0
+                          :skips 1
+                          :subject_type "containing_class"
+                          :subject {:title "Foo"}}
+                         {:failures 0
+                          :intentional_successes 1
+                          :corrective_successes 1
+                          :intentional_noops 0
+                          :corrective_noops 0
+                          :skips 0
+                          :subject_type "containing_class"
+                          :subject {:title nil}}}
+              actual (query-result method endpoint ["~" "certname" ".*"]
+                                   {:summarize_by "containing_class"
+                                    :count_by "certname"})]
+          (is (= actual expected)))))
+
+  (testing "nontrivial query using all the optional parameters"
+    (let [expected  #{{:subject_type "containing_class"
+                       :subject {:title "Foo"}
+                       :failures 0
+                       :intentional_successes 0
+                       :corrective_successes 0
+                       :intentional_noops 0
+                       :corrective_noops 0
+                       :skips 1}}
+          response  (query-result
+                      method endpoint
+                      ["or" ["=" "status" "success"] ["=" "status" "skipped"]]
+                      {:summarize_by "containing_class"
+                       :count_by      "certname"
+                       :counts_filter (vector-param method ["<" "intentional_successes" 1])})]
+      (is (= response expected))))
+
+  (testing "counts_filter"
+    (testing "= operator"
+      (let [expected #{{:failures 0
+                        :intentional_successes 1
+                        :corrective_successes 0
+                        :intentional_noops 0
+                        :corrective_noops 0
+                        :skips 0
+                        :subject_type "resource"
+                        :subject  {:type "Notify" :title "notify, yar"}}}
+            actual (query-result method endpoint
+                                 ["~" "certname" ".*"]
+                                 {:summarize_by "resource"
+                                  :counts_filter (vector-param method ["=" "intentional_successes" 1])})]
+        (is (= actual expected))))
+
+    (testing "> operator"
+      (let [expected #{{:failures 0
+                        :intentional_successes 1
+                        :corrective_successes 1
+                        :intentional_noops 0
+                        :corrective_noops 0
+                        :skips 0
+                        :subject_type "containing_class"
+                        :subject  {:title nil}}}
+            actual (query-result method endpoint
+                                 ["~" "certname" ".*"]
+                                 {:summarize_by "containing_class"
+                                  :counts_filter (vector-param method [">" "intentional_successes" 0])})]
+        (is (= actual expected))))
+
+    (testing ">= operator"
+      (let [expected #{{:failures 0
+                        :intentional_successes 1
+                        :corrective_successes 1
+                        :intentional_noops 0
+                        :corrective_noops 0
+                        :skips 1
+                        :subject_type "certname"
+                        :subject {:title "foo.local"}}}
+            actual (query-result method endpoint
+                                 ["~" "certname" ".*"]
+                                 {:summarize_by "certname"
+                                  :counts_filter (vector-param method [">=" "intentional_successes" 1])})]
+        (is (= actual expected))))
+
+    (testing "< operator"
+      (let [expected #{{:failures 0
+                        :intentional_successes 0
+                        :corrective_successes 0
+                        :intentional_noops 0
+                        :corrective_noops 0
+                        :skips 1
+                        :subject_type "resource"
+                        :subject {:type "Notify"
+                                  :title "hi"}}
+                       {:failures 0
+                        :intentional_successes 0
+                        :corrective_successes 1
+                        :intentional_noops 0
+                        :corrective_noops 0
+                        :skips 0
+                        :subject_type "resource"
+                        :subject {:type "Notify"
+                                  :title "notify, yo"}}}
+            actual (query-result method endpoint
+                                 ["~" "certname" ".*"]
+                                 {:summarize_by "resource"
+                                  :counts_filter (vector-param method ["<" "intentional_successes" 1])})]
+        (is (= actual expected))))
+
+    (testing "<= operator"
+      (let [expected #{{:failures 0
+                        :intentional_successes 0
+                        :corrective_successes 1
+                        :intentional_noops 0
+                        :corrective_noops 0
+                        :skips 0
+                        :subject_type "resource"
+                        :subject {:type "Notify" :title "notify, yo"}}
+                       {:failures 0
+                        :intentional_successes 1
+                        :corrective_successes 0
+                        :intentional_noops 0
+                        :corrective_noops 0
+                        :skips 0
+                        :subject_type "resource"
+                        :subject {:type "Notify" :title "notify, yar"}}
+                       {:failures 0
+                        :intentional_successes 0
+                        :corrective_successes 0
+                        :intentional_noops 0
+                        :corrective_noops 0
+                        :skips 1
+                        :subject_type "resource"
+                        :subject {:type "Notify" :title "hi"}}}
+            actual (query-result method endpoint
+                                 ["~" "certname" ".*"]
+                                 {:summarize_by "resource"
+                                  :counts_filter (vector-param method ["<=" "intentional_successes" 1])})]
+        (is (= actual expected)))))
+
+  (doseq [[label count?] [["without" false]
+                          ["with" true]]]
+    (testing (str "should support paging through event-counts " label " counts")
+      (let [expected  [{:subject_type "resource"
+                        :subject {:type "Notify" :title "hi"}
+                        :failures              0
+                        :intentional_successes 0
+                        :corrective_successes  0
+                        :intentional_noops     0
+                        :corrective_noops      0
+                        :skips                 1}
+                       {:subject_type "resource"
+                        :subject {:type "Notify" :title "notify, yar"}
+                        :failures              0
+                        :intentional_successes 1
+                        :corrective_successes  0
+                        :intentional_noops     0
+                        :corrective_noops      0
+                        :skips                 0}
+                       {:subject_type "resource"
+                        :subject {:type "Notify" :title "notify, yo"}
+                        :failures              0
+                        :intentional_successes 0
+                        :corrective_successes  1
+                        :intentional_noops     0
+                        :corrective_noops      0
+                        :skips                 0}]
+            results (ordered-query-result
+                      method
+                      endpoint
+                      [">" "timestamp" 0]
+                      {:summarize_by "resource"
+                       :order_by (vector-param method [{"field" "resource_title"}])
+                       :include_total true})]
+        (is (= (count expected) (count results)))
+        (is (= expected results)))))))
+
+(deftest-http-app query-distinct-event-counts-with-corrective-changes
+  [[version endpoint] endpoints
+   method [:get :post]]
+
+  (with-corrective-change
+    (store-example-report! (:basic reports) (now))
+    (store-example-report! (:basic3 reports) (now))
+    (testcat/replace-catalog (json/generate-string example-catalog))
+    (testing "should only count the most recent event for each resource"
+      (are [query result]
+           (is (= (query-result method endpoint query
+                                {:summarize_by "resource"
+                                 :distinct_resources true
+                                 :distinct_start_time 0
+                                 :distinct_end_time (now)})
+                  result))
+
+
+           ["=" "latest_report?" true]
+           #{{:failures 0
+              :intentional_successes 1
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify"
+                        :title "notify, yo"}}
+             {:failures 1
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify"
+                        :title "notify, yar"}}
+             {:failures 0
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 1
+              :subject_type "resource"
+              :subject {:type "Notify"
+                        :title "hi"}}}
+
+           ["=" "latest_report?" false]
+           #{{:failures 0
+              :intentional_successes 0
+              :corrective_successes 1
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify"
+                        :title "notify, yo"}}
+             {:failures 0
+              :intentional_successes 1
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify"
+                        :title "notify, yar"}}
+             {:failures 0
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 1
+              :subject_type "resource"
+              :subject {:type "Notify"
+                        :title "hi"}}}
+
+           ["=" "certname" "foo.local"]
+           #{{:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}
+              :failures 0
+              :intentional_successes 1
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}
+              :failures 1
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "hi"}
+              :failures 0
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 1}}
+
+           nil
+           #{{:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}
+              :failures 0
+              :intentional_successes 1
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}
+              :failures 1
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "hi"}
+              :failures 0
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 1}}
+
+           ["~" "certname" ".*"]
+           #{{:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}
+              :failures 0
+              :intentional_successes 1
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}
+              :failures 1
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "hi"}
+              :failures 0
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 1}}
+
+           ["~" "environment" ".*"]
+           #{{:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}
+              :failures 0
+              :intentional_successes 1
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}
+              :failures 1
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0}
+             {:subject_type "resource"
+              :subject {:type "Notify" :title "hi"}
+              :failures 0
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 1}}
+
+           ["~" "property" ".*"]
+           #{{:failures 0
+              :intentional_successes 1
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}}
+             {:failures 1
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}}}
+
+           ["in" "certname" ["extract" "certname"
+                             ["select_resources" ["~" "certname" ".*"]]]]
+           #{{:failures 0
+              :intentional_successes 1
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}}
+             {:failures 1
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}}
+             {:failures 0
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 1
+              :subject_type "resource"
+              :subject {:type "Notify" :title "hi"}}}
+
+           ["in" "certname" ["extract" "certname"
+                             ["select_resources" ["~" "tag" ".*"]]]]
+           #{{:failures 0
+              :intentional_successes 1
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify" :title "notify, yo"}}
+             {:failures 1
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 0
+              :subject_type "resource"
+              :subject {:type "Notify" :title "notify, yar"}}
+             {:failures 0
+              :intentional_successes 0
+              :corrective_successes 0
+              :intentional_noops 0
+              :corrective_noops 0
+              :skips 1
+              :subject_type "resource"
+              :subject {:type "Notify" :title "hi"}}}))))
+
+(deftest-http-app query-with-environment-with-corrective-changes
+  [[version endpoint] endpoints
+   method [:get :post]]
+
+  (with-corrective-change
+    (store-example-report! (:basic reports) (now))
+    (store-example-report! (assoc (:basic2 reports)
+                             :certname "bar.local"
+                             :environment "PROD") (now))
+    (are [result query] (is (= (query-result method endpoint query
+                                             {:summarize_by "resource"})
+                               result))
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :intentional_successes 0
+            :corrective_successes 1
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 0
+            :intentional_successes 1
+            :corrective_successes 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :intentional_successes 0
+            :corrective_successes 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 1}
+           {:subject_type "resource",
+            :intentional_noops 0,
+            :corrective_noops 0,
+            :skips 0,
+            :intentional_successes 1,
+            :corrective_successes 0,
+            :failures 0,
+            :subject {:type "File", :title "tmp-directory"}}
+           {:subject_type "resource",
+            :intentional_noops 0,
+            :corrective_noops 0,
+            :skips 0,
+            :intentional_successes 1,
+            :corrective_successes 0,
+            :failures 0,
+            :subject {:type "File", :title "puppet-managed-file"}}
+           {:subject_type "resource",
+            :intentional_noops 0,
+            :corrective_noops 0,
+            :skips 0,
+            :intentional_successes 1,
+            :corrective_successes 0,
+            :failures 0,
+            :subject
+            {:type "Notify", :title "Creating tmp directory at /Users/foo/tmp"}}}
+         nil
+
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :intentional_successes 0
+            :corrective_successes 1
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 0
+            :intentional_successes 1
+            :corrective_successes 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :intentional_successes 0
+            :corrective_successes 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 1}}
+         ["=" "environment" "DEV"]
+
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :intentional_successes 0
+            :corrective_successes 1
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 0
+            :intentional_successes 1
+            :corrective_successes 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :intentional_successes 0
+            :corrective_successes 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 1}}
+         ["~" "environment" "DE.*"]
+
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :intentional_successes 0
+            :corrective_successes 1
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 0
+            :intentional_successes 1
+            :corrective_successes 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :intentional_successes 0
+            :corrective_successes 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 1}}
+         ["not" ["=" "environment" "PROD"]]
+
+         #{{:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yo"}
+            :failures 0
+            :intentional_successes 0
+            :corrective_successes 1
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "notify, yar"}
+            :failures 0
+            :intentional_successes 1
+            :corrective_successes 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 0}
+           {:subject_type "resource"
+            :subject {:type "Notify" :title "hi"}
+            :failures 0
+            :intentional_successes 0
+            :corrective_successes 0
+            :intentional_noops 0
+            :corrective_noops 0
+            :skips 1}
+           {:subject_type "resource",
+            :intentional_noops 0,
+            :corrective_noops 0,
+            :skips 0,
+            :intentional_successes 1,
+            :corrective_successes 0,
+            :failures 0,
+            :subject {:type "File", :title "tmp-directory"}}
+           {:subject_type "resource",
+            :intentional_noops 0,
+            :corrective_noops 0,
+            :skips 0,
+            :intentional_successes 1,
+            :corrective_successes 0,
+            :failures 0,
+            :subject {:type "File", :title "puppet-managed-file"}}
+           {:subject_type "resource",
+            :intentional_noops 0,
+            :corrective_noops 0,
+            :skips 0,
+            :intentional_successes 1,
+            :corrective_successes 0,
+            :failures 0,
+            :subject
+            {:type "Notify", :title "Creating tmp directory at /Users/foo/tmp"}}}
+         ["OR"
+          ["=" "environment" "PROD"]
+          ["=" "environment" "DEV"]])))

--- a/test/puppetlabs/puppetdb/testutils/reports.clj
+++ b/test/puppetlabs/puppetdb/testutils/reports.clj
@@ -51,6 +51,27 @@
      (scf-store/add-report!* example-report timestamp update-latest-report?)
      (report-for-hash :v4 report-hash))))
 
+(defmacro with-or-without-corrective-change
+  "Runs body in a context where scf-store/store-corrective-change? is set to true or false
+  based on corrective-change? parameter"
+  [corrective-change? & body]
+  `(let [original-scc# @scf-store/store-corrective-change?]
+     (try
+       (reset! scf-store/store-corrective-change? ~corrective-change?)
+       (do ~@body)
+       (finally
+         (reset! scf-store/store-corrective-change? original-scc#)))))
+
+(defmacro with-corrective-change
+  "Runs body in a context where scf-store/store-corrective-change? is set to true"
+  [& body]
+  `(with-or-without-corrective-change true ~@body))
+
+(defmacro without-corrective-change
+  "Runs body in a context where scf-store/store-corrective-change? is set to false"
+  [& body]
+  `(with-or-without-corrective-change false ~@body))
+
 (defn munge-resource-events-for-comparison
   [resource-events]
   (set


### PR DESCRIPTION
This PR subdivides `successes` and `noops` counts into intentional and corrective parts in `event-counts` and `aggregate-event-counts` endpoints for PE. Events are mapped to the corresponding counts based on value of `corrective_change` flag.

The response formats for FOSS are not changed.