### PR TITLE
(maint) Update PDB to use new signing key

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -6,7 +6,7 @@ cows: 'base-precise-i386.cow base-squeeze-i386.cow base-trusty-i386.cow base-whe
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_name: 'info@puppetlabs.com'
-gpg_key: '4BD6EC30'
+gpg_key: '7F438280EF8D349F'
 sign_tar: FALSE
 # a space separated list of mock configs
 final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64'

--- a/test-resources/com/puppetlabs/puppetdb/test/cli/export/big-catalog.json
+++ b/test-resources/com/puppetlabs/puppetdb/test/cli/export/big-catalog.json
@@ -7475,8 +7475,8 @@
         "title" : "import puppet labs apt key",
         "line" : 30,
         "parameters" : {
-            "command" : "/usr/bin/wget -q -O - http://apt.puppetlabs.com/debian/pubkey.gpg | /usr/bin/apt-key add -",
-            "unless" : "/usr/bin/apt-key list | grep -q 4BD6EC30",
+            "command" : "/usr/bin/wget -q -O - http://apt.puppetlabs.com/pubkey.gpg | /usr/bin/apt-key add -",
+            "unless" : "/usr/bin/apt-key list | grep -q EF8D349F",
             "before" : "Exec[apt-get update]",
             "user" : "root"
         },


### PR DESCRIPTION
We are in the process of introducing a new signing key. This commit
updates PDB to switch from the old key to the new one