### PR TITLE
(PDB-3039) Safely embed certnames in queue & DLO filenames

### DIFF
--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -69,7 +69,8 @@
             [puppetlabs.puppetdb.utils :as utils]
             [slingshot.slingshot :refer [try+ throw+]]
             [puppetlabs.puppetdb.mq-listener :as mql]
-            [puppetlabs.puppetdb.command.constants :refer [command-names]]
+            [puppetlabs.puppetdb.command.constants
+             :refer [command-names supported-command-versions]]
             [puppetlabs.trapperkeeper.services
              :refer [defservice service-context]]
             [schema.core :as s]
@@ -109,19 +110,6 @@
     ~@body
     (catch Throwable e#
       (throw+ (fatality e#)))))
-
-(defn version-range [min-version max-version]
-  (set (range min-version (inc max-version))))
-
-(def supported-command-versions
-  {"replace facts" (version-range 2 5)
-   "replace catalog" (version-range 4 9)
-   "store report" (version-range 3 8)
-   "deactivate node" (version-range 1 3)})
-
-(def latest-catalog-version (apply max (get supported-command-versions "replace catalog")))
-(def latest-report-version (apply max (get supported-command-versions "store report")))
-(def latest-facts-version (apply max (get supported-command-versions "replace facts")))
 
 (defn- die-on-header-payload-mismatch
   [name in-header in-body]

--- a/src/puppetlabs/puppetdb/command/constants.clj
+++ b/src/puppetlabs/puppetdb/command/constants.clj
@@ -5,3 +5,21 @@
    :replace-facts   "replace facts"
    :deactivate-node "deactivate node"
    :store-report    "store report"})
+
+(defn- version-range [min-version max-version]
+  (set (range min-version (inc max-version))))
+
+(def supported-command-versions
+  {"replace facts" (version-range 2 5)
+   "replace catalog" (version-range 4 9)
+   "store report" (version-range 3 8)
+   "deactivate node" (version-range 1 3)})
+
+(def latest-catalog-version (apply max (get supported-command-versions "replace catalog")))
+(def latest-report-version (apply max (get supported-command-versions "store report")))
+(def latest-facts-version (apply max (get supported-command-versions "replace facts")))
+
+(def latest-command-versions
+  {:replace_catalog latest-catalog-version
+   :store_report latest-report-version
+   :replace_facts latest-facts-version})

--- a/src/puppetlabs/puppetdb/command/dlo.clj
+++ b/src/puppetlabs/puppetdb/command/dlo.clj
@@ -14,8 +14,6 @@
     FileAlreadyExistsException Files LinkOption]
    [java.nio.file.attribute FileAttribute]))
 
-(def command-names (cons "unknown" queue/metadata-command-names))
-
 (defn- cmd-counters
   "Adds gauges to the dlo for the given category (e.g. \"global\"
   \"replace command\")."

--- a/src/puppetlabs/puppetdb/command/dlo.clj
+++ b/src/puppetlabs/puppetdb/command/dlo.clj
@@ -7,6 +7,7 @@
    [puppetlabs.kitchensink.core :refer [timestamp]]
    [puppetlabs.puppetdb.nio :refer [copts copt-atomic copt-replace oopts]]
    [puppetlabs.puppetdb.queue :as q]
+   [puppetlabs.puppetdb.utils :refer [utf8-length utf8-truncate]]
    [puppetlabs.stockpile.queue :as stock])
   (:import
    [java.nio.file AtomicMoveNotSupportedException
@@ -37,6 +38,13 @@
     metrics
     (assoc metrics cmd (cmd-counters registry cmd))))
 
+(defn- parse-cmd-filename
+  [filename]
+  (let [parse-metadata (q/metadata-parser (cons "unknown" q/metadata-command-names))
+        id-meta-split-rx #"([0-9]+)-(.*)"]
+    (when-let [[_ id qmeta] (re-matches id-meta-split-rx filename)]
+      (parse-metadata qmeta))))
+
 (defn- metrics-for-dir
   "Updates metrics to reflect the discarded commands directly inside
   the path; does not recurse."
@@ -44,10 +52,10 @@
   (with-open [path-stream (Files/newDirectoryStream path)]
     (reduce (fn [metrics p]
               ;; Assume the trailing .json here and in
-              ;; entry-cmd-err-filename below.
+              ;; entry-cmd-data-filename below.
               (let [name (-> p .getFileName str)]
                 (if-let [cmd (:command (and (.endsWith name ".json")
-                                            (q/parse-cmd-filename name)))]
+                                            (parse-cmd-filename name)))]
                   (update-metrics (ensure-cmd-metrics metrics registry cmd)
                                   cmd
                                   (Files/size p))
@@ -68,23 +76,36 @@
                           (.printStackTrace exception out))
                         attempts))))
 
+(defn- strip-metadata-suffix
+  [queue-metadata-str]
+  (str/replace queue-metadata-str #"\.json$" ""))
+
+(defn- dlo-filename
+  [id metadata suffix]
+  (str id \-
+       (utf8-truncate metadata (- 255
+                                  (count (str id))
+                                  1 ; dash after id
+                                  (utf8-length suffix)))
+       suffix))
+
 (defn- entry-cmd-data-filename
-  "Returns a string representing the filename for the given stockpile
-  `entry`. The filename is similar to what stockpile would store the
-  message as '10291-1469469689-cat-4-foo.org.json'"
+  "Returns a string representing the filename for the given stockpile `entry`.
+  The filename is similar to what stockpile would store the message as
+  '10291-1469469689_cat_4_foo.org.json', but in contrast 'unknown' is an allowed
+  command name."
   [entry]
   (let [id (stock/entry-id entry)
-        meta (stock/entry-meta entry)]
-    (str id \- meta)))
+        metadata (stock/entry-meta entry)]
+    (dlo-filename id metadata "")))
 
-(defn- err-filename
-  "Creates a filename string for error metadata associated the
+(defn- entry-cmd-err-filename
+  "Creates a filename string for error metadata associated with the
   stockpile message at `id`. This filename is similar to how stockpile
   would store it but includes a error stuffix to differentiate it,
-  similar tot he following '10291-1469469689-cat-4-foo.org-err.txt'"
+  similar to the following '10291-1469469689_cat_4_foo.org_err.txt'"
   [id metadata]
-  (assert (str/ends-with? metadata ".json"))
-  (str id \- (subs metadata 0 (- (count metadata) 5)) "-err.txt"))
+  (dlo-filename id (strip-metadata-suffix metadata) "_err.txt"))
 
 (defn- store-failed-command-info
   [id metadata command attempts dir]
@@ -92,12 +113,13 @@
   ;; we want the command because id isn't unique by itself (given
   ;; unknown commands).
   (let [tmp (Files/createTempFile dir
-                                  (str "tmp-err-" id \- command) ""
+                                  ;; no need to truncate, implementation will
+                                  (str "tmperr-" id \- command) ""
                                   (make-array FileAttribute 0))]
     ;; Leave the temp file if something goes wrong.
     (with-open [out (java.io.PrintWriter. (.toFile tmp))]
       (write-failure-metadata out attempts))
-    (let [dest (.resolve dir (err-filename id metadata))
+    (let [dest (.resolve dir (entry-cmd-err-filename id metadata))
           moved? (try
                    (Files/move tmp dest (copts [copt-atomic]))
                    (catch FileAlreadyExistsException ex
@@ -130,8 +152,8 @@
   "Stores information about the failed `stockpile` `cmdref` to the
   `dlo` (a Path) for later inspection.  Saves two files named like
   this:
-    10291-1469469689-cat-4-foo.org.json
-    10291-1469469689-cat-4-foo.org-err.txt
+    10291-1469469689_cat_4_foo.org.json
+    10291-1469469689_cat_4_foo.org_err.txt
   The first contains the failed command itself, and the second details
   the cause of the failure.  The command will be moved from the
   `stockpile` queue to the `dlo` directory (a Path) via
@@ -161,8 +183,8 @@
   later inspection.  `attempts` must be a list of {:time t :exception
   ex} maps in reverse chronological order.  Saves two files named like
   this:
-    10291-1469469689-unknown-0-BYTESHASH
-    10291-1469469689-unknown-0-BYTESHASH.txt
+    10291-1469469689_unknown_0_BYTESHASH
+    10291-1469469689_unknown_0_BYTESHASH.txt
   The first contains the bytes provided, and the second details the
   cause of the failure.  Returns {:info Path :command Path}."
   [bytes id received attempts dlo]

--- a/src/puppetlabs/puppetdb/constants.clj
+++ b/src/puppetlabs/puppetdb/constants.clj
@@ -1,0 +1,8 @@
+(ns puppetlabs.puppetdb.constants)
+
+(def filename-forbidden-characters
+  [\/ \u0000 \\ \:])
+
+(def sha1-hex-length
+  "The length (in ASCII/UTF-8 bytes) of a SHA1 sum when encoded in hexadecimal."
+  40)

--- a/src/puppetlabs/puppetdb/export.clj
+++ b/src/puppetlabs/puppetdb/export.clj
@@ -12,6 +12,7 @@
             [puppetlabs.puppetdb.factsets :as factsets]
             [puppetlabs.puppetdb.reports :as reports]
             [puppetlabs.puppetdb.command :as command]
+            [puppetlabs.puppetdb.command.constants :as command-constants]
             [puppetlabs.puppetdb.utils :as utils]
             [clj-time.format :as time-fmt]
             [clj-time.coerce :as time-coerce]
@@ -20,10 +21,8 @@
 
 (def export-metadata-file-name "export-metadata.json")
 (def query-api-version :v4)
-(def latest-command-versions
-  {:replace_catalog command/latest-catalog-version
-   :store_report command/latest-report-version
-   :replace_facts command/latest-facts-version})
+(def latest-command-versions command-constants/latest-command-versions)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Utility Functions
 

--- a/src/puppetlabs/puppetdb/queue.clj
+++ b/src/puppetlabs/puppetdb/queue.clj
@@ -16,7 +16,8 @@
             [slingshot.slingshot :refer [throw+]]
             [clojure.core.async :as async]
             [clojure.core.async.impl.protocols :as async-protos]
-            [puppetlabs.puppetdb.nio :refer [get-path]]))
+            [puppetlabs.puppetdb.nio :refer [get-path]]
+            [puppetlabs.puppetdb.utils :refer [match-any-of]]))
 
 (def metadata-command-names
   (vals constants/command-names))
@@ -36,10 +37,9 @@
 
 (defn metadata-rx [valid-commands]
   (re-pattern (str
-               "([0-9]+)_("
-               (str/join "|" (map #(format "(?:%s)" (re-quote-replacement %))
-                                  valid-commands))
-               ")_([0-9]+)_(.*)\\.json")))
+               "([0-9]+)_"
+               (match-any-of valid-commands)
+               "_([0-9]+)_(.*)\\.json")))
 
 (defn metadata-parser
   ([] (metadata-parser metadata-command-names))

--- a/src/puppetlabs/puppetdb/queue.clj
+++ b/src/puppetlabs/puppetdb/queue.clj
@@ -126,13 +126,6 @@
 
 (def parse-metadata (metadata-parser))
 
-(def parse-cmd-filename
-  (let [parse-metadata (metadata-parser (cons "unknown" metadata-command-names))]
-    (fn [s]
-      (let [rx #"([0-9]+)-(.*)"]
-        (when-let [[_ id qmeta] (re-matches rx s)]
-          (parse-metadata qmeta))))))
-
 (defrecord CommandRef [id command version certname received callback annotations delete?])
 
 (defn cmdref->entry [{:keys [id command version certname received]}]

--- a/test/puppetlabs/puppetdb/acceptance/cli.clj
+++ b/test/puppetlabs/puppetdb/acceptance/cli.clj
@@ -4,7 +4,7 @@
             [puppetlabs.puppetdb.cli.export :as cli-export]
             [puppetlabs.puppetdb.cli.import :as cli-import]
             [puppetlabs.puppetdb.anonymizer :as anon]
-            [puppetlabs.puppetdb.command :as command]
+            [puppetlabs.puppetdb.command.constants :as cmd-consts]
             [puppetlabs.puppetdb.testutils :as tu]
             [puppetlabs.puppetdb.testutils.facts :as tuf]
             [puppetlabs.puppetdb.testutils.reports :as tur]
@@ -24,11 +24,11 @@
          (is (empty? (get-nodes)))
 
          (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                      "replace catalog" command/latest-catalog-version example-catalog)
+                                      "replace catalog" cmd-consts/latest-catalog-version example-catalog)
          (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                      "store report" command/latest-report-version example-report)
+                                      "store report" cmd-consts/latest-report-version example-report)
          (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                      "replace facts" command/latest-facts-version example-facts)
+                                      "replace facts" cmd-consts/latest-facts-version example-facts)
 
          (is (= (tuc/munge-catalog example-catalog)
                 (tuc/munge-catalog (get-catalogs example-certname))))

--- a/test/puppetlabs/puppetdb/admin_test.clj
+++ b/test/puppetlabs/puppetdb/admin_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetdb.cli.services :refer :all]
             [puppetlabs.puppetdb.command :as command]
+            [puppetlabs.puppetdb.command.constants :as cmd-consts]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.export :as export]
             [puppetlabs.puppetdb.import :as import]
@@ -32,11 +33,11 @@
        (is (empty? (get-nodes)))
 
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "replace catalog" command/latest-catalog-version example-catalog)
+                                    "replace catalog" cmd-consts/latest-catalog-version example-catalog)
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "store report" command/latest-report-version example-report)
+                                    "store report" cmd-consts/latest-report-version example-report)
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "replace facts" command/latest-facts-version example-facts)
+                                    "replace facts" cmd-consts/latest-facts-version example-facts)
 
        (is (= (tuc/munge-catalog example-catalog)
               (tuc/munge-catalog (get-catalogs example-certname))))
@@ -78,11 +79,11 @@
          (is (empty? (get-nodes)))
 
          (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                      "replace catalog" command/latest-catalog-version example-catalog)
+                                      "replace catalog" cmd-consts/latest-catalog-version example-catalog)
          (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                      "store report" command/latest-report-version example-report)
+                                      "store report" cmd-consts/latest-report-version example-report)
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "replace facts" command/latest-facts-version example-facts)
+                                    "replace facts" cmd-consts/latest-facts-version example-facts)
 
          (is (= (tuc/munge-catalog example-catalog)
                 (tuc/munge-catalog (get-catalogs example-certname))))
@@ -112,20 +113,20 @@
         (is (empty? (get-nodes)))
 
         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                     "replace catalog" command/latest-catalog-version
+                                     "replace catalog" cmd-consts/latest-catalog-version
                                      example-catalog)
         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "bar.com"
-                                     "replace catalog" command/latest-catalog-version
+                                     "replace catalog" cmd-consts/latest-catalog-version
                                      example-catalog2)
 
         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                     "store report" command/latest-report-version
+                                     "store report" cmd-consts/latest-report-version
                                      example-report)
         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                     "replace facts" command/latest-facts-version
+                                     "replace facts" cmd-consts/latest-facts-version
                                      example-facts)
         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) "bar.com"
-                                     "replace facts" command/latest-facts-version
+                                     "replace facts" cmd-consts/latest-facts-version
                                      example-facts2)
 
         (sutils/vacuum-analyze *db*)

--- a/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
+++ b/test/puppetlabs/puppetdb/cli/import_export_roundtrip_test.clj
@@ -3,7 +3,7 @@
             [puppetlabs.puppetdb.client :as pdb-client]
             [puppetlabs.puppetdb.cli.export :as cli-export]
             [puppetlabs.puppetdb.cli.import :as cli-import]
-            [puppetlabs.puppetdb.command :as command]
+            [puppetlabs.puppetdb.command.constants :as cmd-consts]
             [puppetlabs.puppetdb.testutils :as tu]
             [puppetlabs.puppetdb.testutils.db :refer [*db* with-test-db]]
             [puppetlabs.puppetdb.testutils.facts :as tuf]
@@ -25,11 +25,11 @@
        (is (empty? (get-nodes)))
 
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "replace catalog" command/latest-catalog-version example-catalog)
+                                    "replace catalog" cmd-consts/latest-catalog-version example-catalog)
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "store report" command/latest-report-version example-report)
+                                    "store report" cmd-consts/latest-report-version example-report)
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "replace facts" command/latest-facts-version example-facts)
+                                    "replace facts" cmd-consts/latest-facts-version example-facts)
 
        (is (= (tuc/munge-catalog example-catalog)
               (tuc/munge-catalog (get-catalogs example-certname))))
@@ -68,7 +68,7 @@
        (is (empty? (get-nodes)))
 
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "replace facts" command/latest-facts-version example-facts)
+                                    "replace facts" cmd-consts/latest-facts-version example-facts)
 
        (is (empty? (get-catalogs example-certname)))
        (is (empty? (get-reports example-certname)))

--- a/test/puppetlabs/puppetdb/command/dlo_test.clj
+++ b/test/puppetlabs/puppetdb/command/dlo_test.clj
@@ -42,6 +42,29 @@
       re-pattern
       (re-matches s)))
 
+(deftest parse-cmd-filename-behavior
+  (let [r0 (-> 0 coerce-time/from-long timestamp)
+        r10 (-> 10 coerce-time/from-long timestamp)]
+
+    (are [cmd-info metadata-str] (= cmd-info (#'dlo/parse-cmd-filename metadata-str))
+
+      {:received r0 :version 0 :command "replace catalog" :certname "foo"}
+      "0-0_replace catalog_0_foo.json"
+
+      {:received r0 :version 0 :command "replace catalog" :certname "foo.json"}
+      "0-0_replace catalog_0_foo.json.json"
+
+      {:received r10 :version 10 :command "replace catalog" :certname "foo"}
+      "10-10_replace catalog_10_foo.json"
+
+      {:received r10 :version 42 :command "replace catalog" :certname "foo"}
+      "10-10_replace catalog_42_foo.json"
+
+      {:received r10 :version 10 :command "unknown" :certname "foo"}
+      "10-10_unknown_10_foo.json")
+
+    (is (not (#'dlo/parse-cmd-filename "0-0_foo_0_foo.json")))))
+
 (deftest discard-cmdref
   (call-with-temp-dir-path
    (get-path "target")

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -3,6 +3,8 @@
             [clj-http.client :as client]
             [clojure.java.jdbc :as sql]
             [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.command.constants
+             :refer [latest-catalog-version latest-facts-version]]
             [puppetlabs.puppetdb.command.dlo :as dlo]
             [puppetlabs.puppetdb.metrics.core :refer [new-metrics]]
             [puppetlabs.puppetdb.scf.storage :as scf-store]

--- a/test/puppetlabs/puppetdb/queue_test.clj
+++ b/test/puppetlabs/puppetdb/queue_test.clj
@@ -62,26 +62,6 @@
         (is (= (format "%d_%s_%d_%s.json" recvd-long cmd cmd-ver cname)
                (metadata-str recvd cmd cmd-ver cname)))))))
 
-(deftest parse-cmd-filename-behavior
-  (let [r0 (-> 0 tcoerce/from-long kitchensink/timestamp)
-        r10 (-> 10 tcoerce/from-long kitchensink/timestamp)]
-
-    (are [cmd-info metadata-str] (= cmd-info (parse-cmd-filename metadata-str))
-
-      {:received r0 :version 0 :command "replace catalog" :certname "foo"}
-      "0-0_replace catalog_0_foo.json"
-
-      {:received r0 :version 0 :command "replace catalog" :certname "foo.json"}
-      "0-0_replace catalog_0_foo.json.json"
-
-      {:received r10 :version 10 :command "replace catalog" :certname "foo"}
-      "10-10_replace catalog_10_foo.json"
-
-      {:received r10 :version 10 :command "unknown" :certname "foo"}
-      "10-10_unknown_10_foo.json")
-
-    (is (not (parse-cmd-filename "0-0_foo_0_foo.json")))))
-
 (deftest test-metadata
   (tqueue/with-stockpile q
     (let [now (time/now)

--- a/test/puppetlabs/puppetdb/utils_test.clj
+++ b/test/puppetlabs/puppetdb/utils_test.clj
@@ -109,3 +109,18 @@
   (prop/for-all [w (gen/map underscore-keyword-generator gen/any)]
                 (= w
                    (dash->underscore-keys (underscore->dash-keys w)))))
+
+(deftest test-utf8-truncate
+  (is (= "ಠ" (utf8-truncate "ಠ_ಠ" 3)))
+  (is (= "ಠ_" (utf8-truncate "ಠ_ಠ" 4)))
+  (is (= "ಠ_" (utf8-truncate "ಠ_ಠ" 5)))
+  (is (= "ಠ_" (utf8-truncate "ಠ_ಠ" 6)))
+  (is (= "ಠ_ಠ" (utf8-truncate "ಠ_ಠ" 7)))
+  (is (= "ಠ_ಠ" (utf8-truncate "ಠ_ಠಠ" 8)))
+
+  (testing "when string starts with multi-byte character and is truncated to fewer bytes, yields empty string"
+    (is (= "" (utf8-truncate "ಠ_ಠ" 1)))
+    (is (= "" (utf8-truncate "ಠ_ಠ" 2))))
+
+  (testing "truncation doesn't add extra bytes"
+    (is (= "foo" (utf8-truncate "foo" 256)))))


### PR DESCRIPTION
Change `puppetdb.queue/metadata-str` to replace illegal filename
characters and underscores in the certname it's given, truncate the
certname if its length would cause the metadata string to exceed 255
characters, and add the SHA1 hash of the original certname if the
certname in the metadata string differs in any way (via character
replacement or truncation) from the original certname.

Change the *-filename functions in `puppetlabs.command.dlo` to truncate
just the metadata portions of the filenames if they would cause the
filenames to exceed 255 bytes in length. Truncating the metadata portion
is acceptable since all these filenames contain stockpile IDs, which
ensures they'll be unique.

See the individual commits & messages for more details.