### PR TITLE
(PDB-2982) Shorter Command Names in Queue Metadata

### DIFF
--- a/src/puppetlabs/puppetdb/command/dlo.clj
+++ b/src/puppetlabs/puppetdb/command/dlo.clj
@@ -61,8 +61,7 @@
               ;; Assume the trailing .json here and in
               ;; entry-cmd-data-filename below.
               (let [name (-> p .getFileName str)]
-                (if-let [cmd (:command (and (.endsWith name ".json")
-                                            (parse-cmd-filename name)))]
+                (if-let [cmd (:command (parse-cmd-filename name))]
                   (update-metrics (ensure-cmd-metrics metrics registry cmd)
                                   cmd
                                   (Files/size p))

--- a/src/puppetlabs/puppetdb/command/dlo.clj
+++ b/src/puppetlabs/puppetdb/command/dlo.clj
@@ -38,10 +38,17 @@
     metrics
     (assoc metrics cmd (cmd-counters registry cmd))))
 
+(def ^:private parse-metadata
+  (q/metadata-parser (assoc q/metadata-command->puppetdb-command
+                            "unknown" "unknown")))
+
+(def ^:private serialize-metadata
+  (q/metadata-serializer (assoc q/puppetdb-command->metadata-command
+                                "unknown" "unknown")))
+
 (defn- parse-cmd-filename
   [filename]
-  (let [parse-metadata (q/metadata-parser (cons "unknown" q/metadata-command-names))
-        id-meta-split-rx #"([0-9]+)-(.*)"]
+  (let [id-meta-split-rx #"([0-9]+)-(.*)"]
     (when-let [[_ id qmeta] (re-matches id-meta-split-rx filename)]
       (parse-metadata qmeta))))
 
@@ -160,8 +167,9 @@
   stockpile/discard.  Returns {:info Path :command Path}."
   [cmdref stockpile dlo]
   (let [{:keys [path registry metrics]} dlo
-        {:keys [command received attempts]} cmdref
-        entry (q/cmdref->entry cmdref)
+        {:keys [id received command version certname attempts]} cmdref
+        entry (stock/entry id (serialize-metadata
+                                received command version certname))
         cmd-dest (.resolve path (entry-cmd-data-filename entry))]
     ;; We're going to assume that our moves will be atomic, and if
     ;; they're not, that we don't care about the possibility of
@@ -194,7 +202,7 @@
   ;; indicator that the unknown message may be complete.
   (let [{:keys [path registry metrics]} dlo
         digest (digest/sha1 [bytes])
-        metadata (q/metadata-str received "unknown" 0 digest)
+        metadata (serialize-metadata received "unknown" 0 digest)
         cmd-dest (.resolve path (str id \- metadata))]
     (Files/write cmd-dest bytes (oopts []))
     (let [info-dest (store-failed-command-info id metadata "unknown"

--- a/src/puppetlabs/puppetdb/queue.clj
+++ b/src/puppetlabs/puppetdb/queue.clj
@@ -21,8 +21,17 @@
             [puppetlabs.puppetdb.utils :refer [match-any-of utf8-length
                                                utf8-truncate]]))
 
-(def metadata-command-names
-  (vals command-constants/command-names))
+(def metadata-command->puppetdb-command
+  ;; note that if there are multiple metadata names for the same command then
+  ;; puppetdb-command->metadata-command (defined below) will have to be modified
+  ;; in order to establish a "preferred" metadata name for each command
+  {"catalog" "replace catalog"
+   "facts" "replace facts"
+   "rm-node" "deactivate node"
+   "report" "store report"})
+
+(def puppetdb-command->metadata-command
+  (into {} (for [[md pdb] metadata-command->puppetdb-command] [pdb md])))
 
 (defn stream->json [^InputStream stream]
   (try
@@ -91,15 +100,29 @@
       (utf8-truncate sanitized-certname trunc-length)
       sanitized-certname)))
 
-(defn metadata-str [received command version certname]
-  (let [certname (or certname "unknown-host")
-        recvd-long (tcoerce/to-long received)
-        safe-certname (embeddable-certname received command version certname)]
-    (if (= safe-certname certname)
-      (format "%d_%s_%d_%s.json" recvd-long command version safe-certname)
-      (let [name-hash (kitchensink/utf8-string->sha1 certname)]
-        (format "%d_%s_%d_%s_%s.json"
-                recvd-long command version safe-certname name-hash)))))
+(defn metadata-serializer
+  "Given an (optional) map between the command names used in the rest of
+  PuppetDB and the command names to use in metadata strings, return a function
+  that serializes command metadata to a string. If no map is provided, then the
+  map `puppetdb-command->metadata-command` defined in this namespace is used.
+  Note that the certname in the string will not be the same as the original
+  certname if the certname is long or contains filesystem special characters."
+  ([] (metadata-serializer puppetdb-command->metadata-command))
+  ([puppetdb-command->metadata-command]
+   (fn [received command version certname]
+     (when-not (puppetdb-command->metadata-command command)
+       (throw (IllegalArgumentException. (format "unknown command '%s'" command))))
+     (let [certname (or certname "unknown-host")
+           recvd-long (tcoerce/to-long received)
+           short-command (puppetdb-command->metadata-command command)
+           safe-certname (embeddable-certname received short-command version certname)]
+       (if (= safe-certname certname)
+         (format "%d_%s_%d_%s.json" recvd-long short-command version safe-certname)
+         (let [name-hash (kitchensink/utf8-string->sha1 certname)]
+           (format "%d_%s_%d_%s_%s.json"
+                   recvd-long short-command version safe-certname name-hash)))))))
+
+(def serialize-metadata (metadata-serializer))
 
 (defn metadata-rx [valid-commands]
   (re-pattern (str
@@ -108,20 +131,27 @@
                "_([0-9]+)_(.*)\\.json")))
 
 (defn metadata-parser
-  ([] (metadata-parser metadata-command-names))
-  ([valid-commands]
+  "Given an (optional) map between the command names that appear in metadata
+  strings and the command names used in the rest of PuppetDB, return a function
+  that parses a queue metadata string. If no map is provided, then the map
+  `metadata-command->puppetdb-command` defined in this namespace is used.
+  Note that the certname in this result will not be the same as the original
+  certname if the certname is long or contains filesystem special characters."
+  ([] (metadata-parser metadata-command->puppetdb-command))
+  ([metadata-command->puppetdb-command]
    ;; NOTE: changes here may affect the DLO, e.g. it currently assumes
    ;; the trailing .json.
-   (let [rx (metadata-rx valid-commands)]
+   (let [rx (metadata-rx (keys metadata-command->puppetdb-command))
+         md-cmd->pdb-cmd metadata-command->puppetdb-command]
      (fn [s]
-       (when-let [[_ stamp command version certname] (re-matches rx s)]
+       (when-let [[_ stamp md-command version certname] (re-matches rx s)]
          (and certname
               {:received (-> stamp
                              Long/parseLong
                              tcoerce/from-long
                              kitchensink/timestamp)
                :version (Long/parseLong version)
-               :command command
+               :command (get md-cmd->pdb-cmd md-command "unknown")
                :certname certname}))))))
 
 (def parse-metadata (metadata-parser))
@@ -129,7 +159,7 @@
 (defrecord CommandRef [id command version certname received callback annotations delete?])
 
 (defn cmdref->entry [{:keys [id command version certname received]}]
-  (stock/entry id (metadata-str received command version certname)))
+  (stock/entry id (serialize-metadata received command version certname)))
 
 (defn entry->cmdref [entry]
   (let [{:keys [received command version certname]} (-> entry
@@ -162,7 +192,7 @@
    (let [current-time (time/now)
          entry (stock/store q
                             command-stream
-                            (metadata-str current-time command version certname))]
+                            (serialize-metadata current-time command version certname))]
      (map->CommandRef {:id (stock/entry-id entry)
                        :command command
                        :version version

--- a/src/puppetlabs/puppetdb/queue.clj
+++ b/src/puppetlabs/puppetdb/queue.clj
@@ -58,14 +58,14 @@
       "-")))
 
 (defn max-certname-length
-  "Given the received-at time, command and command version for a metadata
-  string, returns the maximum allowable length (in bytes) of a certname in that
-  string. Note that this length is only achievable if the certname does not
-  need to be sanitized, since sanitized certnames always have a SHA1 hash
-  appended."
-  [received command version]
+  "Given the received-at time, metadata command name and command version for
+  a metadata string, returns the maximum allowable length (in bytes) of
+  a certname in that string. Note that this length is only achievable if the
+  certname does not need to be sanitized, since sanitized certnames always have
+  a SHA1 hash appended."
+  [received metadata-command version]
   (let [time-length (-> received tcoerce/to-long str utf8-length)
-        command-length (utf8-length command)
+        command-length (utf8-length metadata-command)
         version-length (utf8-length (str version))
         field-separators 3]
     (- 255 ; overall filename length limit
@@ -74,13 +74,13 @@
        5))) ; length of '.json' suffix in UTF-8
 
 (defn truncated-certname-length
-  "Given the received-at time, command, and command version that will be in
-  a metadata string, returns the length (in bytes) to truncate certnames to when
-  they are longer than the `max-certname-length` for the string or they contain
-  characters that must be sanitized. This is less than the string's
-  `max-certname-length` to leave space for the SHA1 hash."
-  [received command version]
-  (- (max-certname-length received command version)
+  "Given the received-at time, metadata command name, and command version that
+  will be in a metadata string, returns the length (in bytes) to truncate
+  certnames to when they are longer than the `max-certname-length` for the
+  string or they contain characters that must be sanitized. This is less than
+  the string's `max-certname-length` to leave space for the SHA1 hash."
+  [received metadata-command version]
+  (- (max-certname-length received metadata-command version)
      1 ; for the additional field separator between certname and hash
      constants/sha1-hex-length))
 
@@ -90,11 +90,11 @@
   replace any illegal filesystem characters and underscores with dashes, and
   will be truncated if the original version will cause the metadata string to
   exceed 255 characters."
-  [received command version certname]
+  [received metadata-command version certname]
   (let [cn-length (utf8-length certname)
-        trunc-length (truncated-certname-length received command version)
+        trunc-length (truncated-certname-length received metadata-command version)
         sanitized-certname (sanitize-certname certname)]
-    (if (or (> cn-length (max-certname-length received command version))
+    (if (or (> cn-length (max-certname-length received metadata-command version))
             (and (not= certname sanitized-certname)
                  (> cn-length trunc-length)))
       (utf8-truncate sanitized-certname trunc-length)

--- a/test/puppetlabs/puppetdb/command/dlo_test.clj
+++ b/test/puppetlabs/puppetdb/command/dlo_test.clj
@@ -49,16 +49,16 @@
     (are [cmd-info metadata-str] (= cmd-info (#'dlo/parse-cmd-filename metadata-str))
 
       {:received r0 :version 0 :command "replace catalog" :certname "foo"}
-      "0-0_replace catalog_0_foo.json"
+      "0-0_catalog_0_foo.json"
 
       {:received r0 :version 0 :command "replace catalog" :certname "foo.json"}
-      "0-0_replace catalog_0_foo.json.json"
+      "0-0_catalog_0_foo.json.json"
 
       {:received r10 :version 10 :command "replace catalog" :certname "foo"}
-      "10-10_replace catalog_10_foo.json"
+      "10-10_catalog_10_foo.json"
 
       {:received r10 :version 42 :command "replace catalog" :certname "foo"}
-      "10-10_replace catalog_42_foo.json"
+      "10-10_catalog_42_foo.json"
 
       {:received r10 :version 10 :command "unknown" :certname "foo"}
       "10-10_unknown_10_foo.json")

--- a/test/puppetlabs/puppetdb/queue_test.clj
+++ b/test/puppetlabs/puppetdb/queue_test.clj
@@ -22,56 +22,57 @@
   (doseq [bad-char (conj constants/filename-forbidden-characters \_)]
     (is (= "sanitize-me" (sanitize-certname (format "sanitize%cme" bad-char))))))
 
-(deftest test-metadata-str
+(deftest test-metadata-serializer
   (let [recvd (now)
         recvd-long (tcoerce/to-long recvd)
         cmd "replace facts"
+        cmd-abbrev (puppetdb-command->metadata-command cmd)
         cmd-ver 4]
 
     (testing "certnames are sanitized"
       (let [cname "foo_bar/baz"
             safe-cname "foo-bar-baz"
             cname-hash (kitchensink/utf8-string->sha1 cname)]
-        (is (= (format "%d_%s_%d_%s_%s.json" recvd-long cmd cmd-ver safe-cname cname-hash)
-               (metadata-str recvd cmd cmd-ver cname)))))
+        (is (= (format "%d_%s_%d_%s_%s.json" recvd-long cmd-abbrev cmd-ver safe-cname cname-hash)
+               (serialize-metadata recvd cmd cmd-ver cname)))))
 
     (testing "long certnames are truncated"
       (let [long-cname (apply str "trol" (repeat 1000 "lo"))
-            trunc-cname (subs long-cname 0 (truncated-certname-length recvd cmd cmd-ver))
+            trunc-cname (subs long-cname 0 (truncated-certname-length recvd cmd-abbrev cmd-ver))
             cname-hash (kitchensink/utf8-string->sha1 long-cname)]
-        (is (= (format "%d_%s_%d_%s_%s.json" recvd-long cmd cmd-ver trunc-cname cname-hash)
-               (metadata-str recvd cmd cmd-ver long-cname)))
-        (is (<= (utf8-length (metadata-str recvd cmd cmd-ver long-cname)) 255))))
+        (is (= (format "%d_%s_%d_%s_%s.json" recvd-long cmd-abbrev cmd-ver trunc-cname cname-hash)
+               (serialize-metadata recvd cmd cmd-ver long-cname)))
+        (is (<= (utf8-length (serialize-metadata recvd cmd cmd-ver long-cname)) 255))))
 
     (testing "multi-byte characters in UTF-8 are counted correctly"
       (let [cname-max-length (max-certname-length recvd cmd cmd-ver)
             disapproval-monster (apply str (repeat (inc (/ cname-max-length 4)) "ಠ_"))]
-        (is (<= (utf8-length (metadata-str recvd cmd cmd-ver disapproval-monster)) 255))))
+        (is (<= (utf8-length (serialize-metadata recvd cmd cmd-ver disapproval-monster)) 255))))
 
     (testing "sanitized certnames are truncated to leave room for hash"
-      (let [cname-trunc-length (truncated-certname-length recvd cmd cmd-ver)
+      (let [cname-trunc-length (truncated-certname-length recvd cmd-abbrev cmd-ver)
             tricky-cname (apply str "____" (repeat cname-trunc-length "o"))
             cname-hash (kitchensink/utf8-string->sha1 tricky-cname)
             trunc-cname (subs (sanitize-certname tricky-cname) 0 cname-trunc-length)]
-        (is (= (format "%d_%s_%d_%s_%s.json" recvd-long cmd cmd-ver trunc-cname cname-hash)
-               (metadata-str recvd cmd cmd-ver tricky-cname)))
-        (is (<= (utf8-length (metadata-str recvd cmd cmd-ver tricky-cname)) 255))))
+        (is (= (format "%d_%s_%d_%s_%s.json" recvd-long cmd-abbrev cmd-ver trunc-cname cname-hash)
+               (serialize-metadata recvd cmd cmd-ver tricky-cname)))
+        (is (<= (utf8-length (serialize-metadata recvd cmd cmd-ver tricky-cname)) 255))))
 
     (testing "short & safe certnames are preserved and the hash is omitted"
       (let [cname "bender.myowncasino.moon"]
-        (is (= (format "%d_%s_%d_%s.json" recvd-long cmd cmd-ver cname)
-               (metadata-str recvd cmd cmd-ver cname)))))))
+        (is (= (format "%d_%s_%d_%s.json" recvd-long cmd-abbrev cmd-ver cname)
+               (serialize-metadata recvd cmd cmd-ver cname)))))))
 
 (deftest test-metadata
   (tqueue/with-stockpile q
     (let [now (time/now)
           ;; Sleep to ensure the command has a different time
           _ (Thread/sleep 1)
-          cmdref (store-command q "my command" 1 "foo.com" (-> "{\"message\": \"payload\"}"
-                                                               (.getBytes "UTF-8")
-                                                               java.io.ByteArrayInputStream.))
+          cmdref (store-command q "replace facts" 1 "foo.com" (-> "{\"message\": \"payload\"}"
+                                                                (.getBytes "UTF-8")
+                                                                java.io.ByteArrayInputStream.))
            command (cmdref->cmd q cmdref)]
-      (is (= {:command "my command"
+      (is (= {:command "replace facts"
               :version 1
               :certname "foo.com"
               :payload {:message "payload"}}


### PR DESCRIPTION
(**NB**: this commit depends on #2065)

Replace `puppetdb.queue/metadata-command-names` with a map called
`metadata-command->puppetdb-comand` that defines the mapping between
the command names that can appear in the queue metadata that forms the
message filenames and the command names used by the rest of PuppetDB.
The inverse mapping is dynamically constructed under the var
`puppetdb-command->metadata-command`.

Replace `puppetdb.queue/metadata-str` with `metadata-serializer`, which
takes a map from PuppetDB command names to the metadata command names
and returns a function with the same signature as `metadata-str`; viz.
taking all the queue metadata components and returning a metadata
string. The only differences are that the returned function looks up the
command name it's given in the translation map and puts the metadata
name it finds there in the metadata string, and that if this lookup
fails then an IllegalArgumentException is thrown.

Bind a metadata serializer with the default translation map of
`queue/puppetdb-command->metadata-command` to `queue/serialize-metadata`

Change `metadata-parser` to take a translation map rather than
a sequential collection comand names, have the returned function perform
the inverse mapping from the metadata command name back to the PuppetDB
command name, and to add a docstring to `metadata-parser`.

Add `parse-metadata` and `serialize-metadata` vars to the
`puppetdb.command.dlo` namespace that add an "unknown" -> "unknown"
entry to both translation maps, since the DLO uses that command name as
a fallback when the message is so garbled that the command name cannot
be recovered. Consequently, change all invocations of
`queue/metadata-str` in the DLO to call `dlo/serialize-metadata`, and
likewise `queue/metadata-parser` to `dlo/parse-metadata`.

Change `puppetdb.command.dlo/discard-cmdref` to create its own queue
metadat string and use `stock/entry` directly in order to create
a stockpile entry for the discarded cmdref, rather than using
`queue/cmdref->entry`, as the latter creates a metadata string using
only the default command names & metadata abbreviations, so it will now
throw an error if the discarded cmdref's command is "unknown".

Update tests to align with the new function names and arguments, as well
as the abbreviated command names in queue metadata strings.

Clarify that `puppetdb.queue/embeddable-certname` and the two
functions it calls to determine the certname length all take the
metadata command name, rather than the command name that the rest of
PuppetDB uses.

Remove a redundant check for a ".json" suffix on the filename from
`puppetdb.command.dlo/metrics-for-dir`, since the metadata parser also
performs this check, and can handle random strings that aren't the form
it expects, so there's no need to do this pre-screening.