### PR TITLE
(maint) pre_suite: update before keyring install

### DIFF
--- a/acceptance/setup/pre_suite/15_setup_repos.rb
+++ b/acceptance/setup/pre_suite/15_setup_repos.rb
@@ -8,8 +8,8 @@ def initialize_repo_on_host(host, os)
       on host, "curl -O http://apt.puppetlabs.com/puppetlabs-release-$(lsb_release -sc).deb"
       on host, "dpkg -i puppetlabs-release-$(lsb_release -sc).deb"
     end
-      on host, "apt-get install debian-archive-keyring"
       on host, "apt-get update"
+      on host, "apt-get install debian-archive-keyring"
   when :redhat
     if options[:type] == 'aio' then
       /^(el|centos)-(\d+)-(.+)$/.match(host.platform)


### PR DESCRIPTION
This seems likely to be the right thing to do in general, and may
address recent keyring install failures (missing package).