### PR TITLE
(maint) .travis.yml: require sudo explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: clojure
 lein: lein2
 
+# Always explicitly set sudo.  Otherwise travis' defaults may vary
+# based on when the repository testing was enabled.
+sudo: required
+
 jdk:
   - openjdk7
   - oraclejdk8


### PR DESCRIPTION
We already require it, but haven't had to specify it because it's the
default for puppetlabs/puppetdb on travis ("default for repositories
enabled before 2015").

Without this explicit setting, anyone who tries to set up their own
travis build will end up defaulting to "sudo: false", which won't work.