### PR TITLE
(PDB-3026) Move the clj -> json byte stream function

### DIFF
--- a/src/puppetlabs/puppetdb/amq_migration.clj
+++ b/src/puppetlabs/puppetdb/amq_migration.clj
@@ -72,19 +72,6 @@
         (throw (Exception. (i18n/trs "Only read {0}/{1} bytes from incoming message" n len))))
       buf)))
 
-(defn coerce-clj->json-byte-stream
-  "Converts clojure data to JSON serialized bytes on a
-  ByteArrayInputStream. Cheshire will only output to writers and
-  stockpile will only accept input streams, so some conversion needs
-  to be done in this fn"
-  [payload]
-  (with-open [baos (java.io.ByteArrayOutputStream.)]
-    (with-open [osw (java.io.OutputStreamWriter. baos java.nio.charset.StandardCharsets/UTF_8)]
-      (json/generate-stream payload osw))
-    (-> baos
-        .toByteArray
-        java.io.ByteArrayInputStream.)))
-
 (defn convert-old-command-format
   "Converts from the command format that didn't include the certname
   in the toplevel key list and had all the command data with the
@@ -95,7 +82,7 @@
      :version version
      :certname (or (get-in old-command [:payload :certname])
                    (get-in old-command [:payload :name]))
-     :payload (coerce-clj->json-byte-stream (:payload old-command))}))
+     :payload (json/coerce-clj->json-byte-stream (:payload old-command))}))
 
 (def upgrade-message-schema
   {:command s/Str

--- a/src/puppetlabs/puppetdb/cheshire.clj
+++ b/src/puppetlabs/puppetdb/cheshire.clj
@@ -181,6 +181,7 @@
 ;; Alias (apply io/writer ...) to avoid reflection
 (defn ^Writer writer [f options]
   (apply io/writer f options))
+
 (defn spit-json
   "Similar to clojure.core/spit, but writes the Clojure
    datastructure as JSON to `f`"
@@ -188,3 +189,16 @@
   (with-open [writer (writer f options)]
     (generate-pretty-stream obj writer))
   nil)
+
+(defn coerce-clj->json-byte-stream
+  "Converts clojure data to JSON serialized bytes on a
+  ByteArrayInputStream. Cheshire will only output to writers and
+  stockpile will only accept input streams, so some conversion needs
+  to be done in this fn"
+  [payload]
+  (with-open [baos (java.io.ByteArrayOutputStream.)]
+    (with-open [osw (java.io.OutputStreamWriter. baos java.nio.charset.StandardCharsets/UTF_8)]
+      (generate-stream payload osw))
+    (-> baos
+        .toByteArray
+        java.io.ByteArrayInputStream.)))

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -397,7 +397,7 @@
 (defn make-cmd-processed-message [cmd ex]
   (conj
    (conj (select-keys cmd [:id :command :version])
-         [:producer-timestamp (get-in cmd [:payload :payload :producer_timestamp])])
+         [:producer-timestamp (get-in cmd [:payload :producer_timestamp])])
    (when ex
      [:exception ex])))
 


### PR DESCRIPTION
This function is useful in extensions, so this commit moves it from
amq-migration to cheshire. This commit also fixes up an issue with the
maps being enqueued in the response-mult, causing the extensions tests
to break.