### PR TITLE
(PDB-3073) Add support for querying resource events by corrective_change flag

### DIFF
--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -682,7 +682,7 @@
              ;; these fields allow NULL, which causes a change in semantics when
              ;; wrapped in a NOT(...) clause, so we have to be very explicit
              ;; about the NULL case.
-             [(field :guard #{"property" "message" "file" "line" "containing_class"})]
+             [(field :guard #{"property" "message" "file" "line" "containing_class" "corrective_change"})]
              (if-not (nil? value)
                {:where (format "resource_events.%s = ? AND resource_events.%s IS NOT NULL" field field)
                 :params [value] }

--- a/test/puppetlabs/puppetdb/testutils/events.clj
+++ b/test/puppetlabs/puppetdb/testutils/events.clj
@@ -4,7 +4,8 @@
             [puppetlabs.puppetdb.jdbc :as jdbc]
             [clojure.walk :as walk]
             [puppetlabs.puppetdb.utils :refer [assoc-when]]
-            [clj-time.coerce :refer [to-timestamp to-string]]))
+            [clj-time.coerce :refer [to-timestamp to-string]]
+            [puppetlabs.puppetdb.scf.storage :as scf-store]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Utility functions for massaging results and example data into formats that
@@ -22,9 +23,9 @@
              :configuration_version (:configuration_version report)
              :run_start_time (to-timestamp (:start_time report))
              :run_end_time (to-timestamp (:end_time report))
-             :report_receive_time (to-timestamp (:receive_time report))
-             ;; corrective_change is nil in FOSS
-             :corrective_change nil)
+             :report_receive_time (to-timestamp (:receive_time report)))
+      ;; corrective_change is nil in FOSS
+      (cond-> (not @scf-store/store-corrective-change?) (assoc :corrective_change nil))
       ;; we need to convert the datetime fields from the examples to timestamp objects
       ;; in order to compare them.
       (update :timestamp to-timestamp)


### PR DESCRIPTION
There is a need to query `events` by `corrective_change` flag in PE. This PR enables that.

Currently, there is no INDEX in `resource_events` for the `corrective_change` flag.  Since we always query `events` by `status` and `corrective_change` fields at the same time `resource_events_status_idx` seems to be sufficient. However, a combined index `CREATE INDEX xyz_idx ON resource_events (status, corrective_change)` would be ideal. @senior , @wkalt What is your policy concerning new INDEXes?