### PR TITLE
(PDB-3067) Improve command logging

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -222,9 +222,10 @@
       (finally
         (clear-clean-status!)))))
 
-(defn- clean-puppetdb [context config what]
+(defn- clean-puppetdb
   "Implements the PuppetDBServer clean method, see the protocol for
   further information."
+  [context config what]
   (let [lock (:clean-lock context)]
     (when (.tryLock lock)
       (try

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -138,7 +138,8 @@
     (jdbc/with-transacted-connection' db :repeatable-read
       (scf-storage/maybe-activate-node! certname producer-timestamp)
       (scf-storage/replace-catalog! catalog received))
-    (log/infof "[%s] [%s] %s" id (command-names :replace-catalog) certname)))
+    (log/infof (i18n/trs "[%s-%d] '%s' command processed for %s")
+               id (tcoerce/to-long received) (command-names :replace-catalog) certname)))
 
 (defn replace-catalog [{:keys [payload received version] :as command} db]
   (let [validated-payload (upon-error-throw-fatality
@@ -150,13 +151,14 @@
 ;; Fact replacement
 
 (defn replace-facts*
-  [{:keys [payload id] :as command} db]
+  [{:keys [payload id received] :as command} db]
   (let [{:keys [certname values] :as fact-data} payload
         producer-timestamp (:producer_timestamp fact-data)]
     (jdbc/with-transacted-connection' db :repeatable-read
       (scf-storage/maybe-activate-node! certname producer-timestamp)
       (scf-storage/replace-facts! fact-data))
-    (log/infof "[%s] [%s] %s" id (command-names :replace-facts) certname)))
+    (log/infof (i18n/trs "[%s-%d] '%s' command processed for %s")
+               id (tcoerce/to-long received) (command-names :replace-facts) certname)))
 
 (defn replace-facts [{:keys [payload version received] :as command} db]
   (let [validated-payload (upon-error-throw-fatality
@@ -184,14 +186,15 @@
       deactivate-node-wire-v2->wire-3))
 
 (defn deactivate-node*
-  [{:keys [id payload]} db]
+  [{:keys [id received payload]} db]
   (let [certname (:certname payload)
         producer-timestamp (to-timestamp (:producer_timestamp payload (now)))]
     (jdbc/with-transacted-connection db
       (when-not (scf-storage/certname-exists? certname)
         (scf-storage/add-certname! certname))
       (scf-storage/deactivate-node! certname producer-timestamp))
-    (log/infof "[%s] [%s] %s" id (command-names :deactivate-node) certname)))
+    (log/infof (i18n/trs "[%s-%d] '%s' command processed for %s")
+               id (tcoerce/to-long received) (command-names :deactivate-node) certname)))
 
 (defn deactivate-node [{:keys [payload version] :as command} db]
   (-> command
@@ -210,8 +213,9 @@
     (jdbc/with-transacted-connection db
       (scf-storage/maybe-activate-node! certname producer-timestamp)
       (scf-storage/add-report! report received))
-    (log/infof "[%s] [%s] puppet v%s - %s"
+    (log/infof (i18n/trs "[%s-%d] '%s' puppet v%s command processed for %s")
                id
+               (tcoerce/to-long received)
                (command-names :store-report)
                puppet_version
                certname)))


### PR DESCRIPTION
(**NB:** these commits depend on #2077 and should be merged after it.)

Change the message identifier in the command namespace's log/info
invocations to be a concatenation of the stockpile ID and the timestamp
the message was received at, in order to guarantee uniqueness across
restarts (as the stockpile ID may reset).

Change the overall structure of the logged message in the same form so
it's clear *what* is being logged.

When a command is placed on the queue, log its ID, command name, and
certname at the debug level, similarly to the logging after the command is
processed.