### PR TITLE
(PDB-3066) Detect queue upgrade end via sentinel

### DIFF
--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -314,8 +314,8 @@
 
 (defn upgrade-activemq [config enqueue-fn dlo]
   (when (mig/needs-upgrade? config)
-    (mig/activemq->stockpile config enqueue-fn dlo)
-    (mig/lock-upgrade config)))
+    (when (mig/activemq->stockpile config enqueue-fn dlo)
+      (mig/lock-upgrade config))))
 
 (defservice command-service
   PuppetDBCommandDispatcher


### PR DESCRIPTION
Before beginning to transfer messages from activemq to stockpile, send
an "end-of-line" tracer command that when received later should indicate
the end of the queue.

In the unlikely (and unsupported) downgrade case, older versions of
puppetdb should just reject the sentinel as garbage.