### PR TITLE
(PDB-3077) Add service reload and logback size-based rotation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
    :password :env/nexus_jenkins_password
    :sign-releases false})
 
-(def tk-version "1.4.1")
+(def tk-version "1.5.1")
 (def tk-jetty9-version "1.5.9")
 (def ks-version "1.3.1")
 (def tk-status-version "0.5.0")
@@ -82,7 +82,7 @@
                  [puppetlabs/trapperkeeper-metrics "0.2.0" :exclusions [ring/ring-defaults org.slf4j/slf4j-api]]
                  [prismatic/schema "1.1.2"]
                  [trptcolin/versioneer "0.2.0"]
-                 [puppetlabs/trapperkeeper-status ~tk-status-version]
+                 [puppetlabs/trapperkeeper-status ~tk-status-version :exclusions [org.slf4j/slf4j-api]]
                  [org.clojure/tools.macro "0.1.5"]
                  [com.novemberain/pantomime "2.1.0"]
                  [fast-zip-visit "1.0.2"]
@@ -142,7 +142,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "0.5.1"
+                      :plugins [[puppetlabs/lein-ezbake "1.0.0"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}

--- a/project.clj
+++ b/project.clj
@@ -113,7 +113,8 @@
                        :group "puppetdb"
                        :build-type "foss"
                        :main-namespace "puppetlabs.puppetdb.main"
-                       :repo-target "PC1"}
+                       :repo-target "PC1"
+                       :logrotate-enabled false}
                 :config-dir "ext/config/foss"
                 }
 

--- a/resources/ext/config/logback.xml
+++ b/resources/ext/config/logback.xml
@@ -10,8 +10,8 @@
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
-            <maxFileSize>10MB</maxFileSize>
+            <!-- each file should be at most 200MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>200MB</maxFileSize>
             <maxHistory>90</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
@@ -36,8 +36,8 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- rollover daily -->
             <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-status-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
-            <maxFileSize>10MB</maxFileSize>
+            <!-- each file should be at most 200MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>200MB</maxFileSize>
             <maxHistory>90</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>

--- a/resources/ext/config/logback.xml
+++ b/resources/ext/config/logback.xml
@@ -30,6 +30,28 @@
     <logger name="org.apache.activemq.store.kahadb.MessageDatabase"
         level="info"/>
 
+    <appender name="STATUS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/var/log/puppetlabs/puppetdb/puppetdb-status.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- rollover daily -->
+            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-status-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <!-- note that this will only log the JSON message (%m) and a newline (%n)-->
+            <pattern>%m%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- without additivity="false", the status log messages will be sent to every other appender as well-->
+    <logger name="puppetlabs.trapperkeeper.services.status.status-debug-logging" additivity="false">
+        <appender-ref ref="STATUS"/>
+    </logger>
+
     <root level="info">
         <appender-ref ref="${logappender:-DUMMY}" />
         <appender-ref ref="F1" />

--- a/resources/ext/config/logback.xml
+++ b/resources/ext/config/logback.xml
@@ -7,10 +7,13 @@
 
     <appender name="F1" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/var/log/puppetlabs/puppetdb/puppetdb.log</file>
-
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>10MB</maxFileSize>
             <maxHistory>90</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
             <pattern>%d %-5p [%c{2}] %m%n</pattern>

--- a/resources/ext/config/request-logging.xml
+++ b/resources/ext/config/request-logging.xml
@@ -1,6 +1,14 @@
 <configuration debug="false">
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/var/log/puppetlabs/puppetdb/puppetdb-access.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-access-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
         <encoder>
             <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D</pattern>
         </encoder>

--- a/resources/ext/config/request-logging.xml
+++ b/resources/ext/config/request-logging.xml
@@ -4,8 +4,8 @@
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-access-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
-            <maxFileSize>10MB</maxFileSize>
+            <!-- each file should be at most 200MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>200MB</maxFileSize>
             <maxHistory>90</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>


### PR DESCRIPTION
This PR bumps the Trapperkeeper and lein-ezbake dependencies up to 1.5.1 and 1.0.0, respectively, in order for PuppetDB packages to be built with support for service reload functionality (built on top of SIGHUP).  This PR also includes some logback configuration changes to support moving to logback file-size based log rotation and disabling the logic in ezbake that previously enabled log rotation via logrotate.