### PR TITLE
(PDB-3071) Log a warning if retired server/port config items are in use.

### DIFF
--- a/puppet/lib/puppet/util/puppetdb/config.rb
+++ b/puppet/lib/puppet/util/puppetdb/config.rb
@@ -39,6 +39,8 @@ module Puppet::Util::Puppetdb
           section = $1
           result[section] ||= {}
 
+        when /^\s*(server|port)\s*=.*$/
+          Puppet.warning("Setting '#{line.chomp}' is retired: use 'server_urls' instead. Defaulting to 'server_urls=https://puppetdb:8081'.")
         when /^\s*(\w+)\s*=\s*(\S+|[\S+\s*\,\s*\S]+)\s*$/
           raise "Setting '#{line}' is illegal outside of section in PuppetDB config #{config_file}:#{number}" unless section
           result[section][$1] = $2


### PR DESCRIPTION
It's relatively common for users to miss the retirement of server/port
when upgrading from versions of PDB that supported it. This has the
effect of defaulting their server/port to puppetdb:8081, producing agent
run failures that log a puppetdb hostname different from what they
believe they've configured.

This patch logs warnings when server and port are detected in the config
file. I think it would be preferable to remove the defaulting behavior
and throw an error when server_urls is not present, but I don't have a
sense of whether anyone relies on the defaulting today.