### PR TITLE
(PDB-3060) `concurrent-writes` setting

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -620,6 +620,17 @@ tuned based on what you see in the performance dashboard.][dashboard]
 
 This setting defaults to half the number of cores in your system.
 
+### `concurrent-writes`
+
+This sets a limit on the number of threads that can write to the disk at
+any one time. The default value is the smaller number of half the number
+of CPU cores and 4.
+
+If your load is low, your disk is fast (i.e. an SSD), and commands
+aren't being processed quickly enough, then you could increasing this
+value in order to alleviate that, but this is unlikely to be the
+bottleneck for command processing.
+
 ### `dlo-compression-threshold`
 
 **Note**: This setting is deprecated and ignored by PuppetDB. It will be removed

--- a/resources/ext/config/conf.d/config.ini
+++ b/resources/ext/config/conf.d/config.ini
@@ -11,3 +11,6 @@ logging-config = /etc/puppetlabs/puppetdb/logback.xml
 [command-processing]
 # How many command-processing threads to use, defaults to (CPUs / 2)
 # threads = 4
+
+# How many threads can write to disk at once, defaults to min(CPUs / 2, 4)
+# concurrent-writes = 4

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -145,7 +145,7 @@
     {:threads (pls/defaulted-maybe s/Int half-the-cores)
      :max-command-size (pls/defaulted-maybe s/Int (default-max-command-size))
      :reject-large-commands (pls/defaulted-maybe String "false")
-     :concurrent-writes (pls/defaulted-maybe s/Int 100)
+     :concurrent-writes (pls/defaulted-maybe s/Int (min half-the-cores 4))
 
      ;; Deprecated
      :dlo-compression-threshold (pls/defaulted-maybe String "1d")


### PR DESCRIPTION
Change the default value for the concurrent writes configuration setting
from 100 to the minimum of half the CPU coresb (rounded up) and 4.

Add documentation for the command processing `concurrent-writes`
configuration setting to the configuration documentation file, and add
some commented-out lines to the default `config.ini` file that set its
value and explain what it's for.