### PR TITLE
(PDB-3058) version 6 reports incorrectly rejected

### DIFF
--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -10,9 +10,14 @@
             [puppetlabs.puppetdb.scf.storage :as scf-store]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.catalogs :as catalog]
-            [puppetlabs.puppetdb.examples.reports :as report-examples]
+            [puppetlabs.puppetdb.examples.reports :refer [v4-report
+                                                          v5-report
+                                                          v6-report
+                                                          v7-report
+                                                          v8-report]]
             [puppetlabs.puppetdb.scf.hash :as shash]
             [puppetlabs.puppetdb.testutils.db :refer [*db* with-test-db]]
+            [schema.core :as s]
             [puppetlabs.trapperkeeper.testutils.logging :refer [atom-logger]]
             [clj-time.format :as tfmt]
             [puppetlabs.puppetdb.cli.services :as cli-svc]
@@ -1335,27 +1340,6 @@
 ;; Report Command Tests
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(def v8-report
-  (-> (:basic report-examples/reports)
-      reports/report-query->wire-v8))
-
-(def v7-report
-  (-> v8-report
-      (dissoc :producer :noop_pending)))
-
-(def v6-report
-  (-> v7-report
-      (dissoc :catalog_uuid :cached_catalog_status :code_id)))
-
-(def v5-report
-  (-> (:basic report-examples/reports)
-      reports/report-query->wire-v5))
-
-(def v4-report
-  (-> v5-report
-      (dissoc :producer_timestamp :metrics :logs :noop)
-      utils/underscore->dash-keys))
 
 (def store-report-name (command-names :store-report))
 

--- a/test/puppetlabs/puppetdb/reports_test.clj
+++ b/test/puppetlabs/puppetdb/reports_test.clj
@@ -1,6 +1,10 @@
 (ns puppetlabs.puppetdb.reports-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.puppetdb.examples.reports :refer :all]
+            [puppetlabs.puppetdb.examples.reports :refer [reports
+                                                          v4-report
+                                                          v5-report
+                                                          v6-report
+                                                          v7-report]]
             [puppetlabs.puppetdb.reports :refer :all]
             [schema.core :as s]
             [com.rpl.specter :as sp]
@@ -32,62 +36,27 @@
        (sp/transform [:resource-events sp/ALL sp/ALL]
                      #(update % 0 utils/underscores->dashes))))
 
-(def v8-example-report
-  (-> reports
-      :basic
-      report-query->wire-v8))
-
-(def v7-example-report
-  (-> v8-example-report
-      (dissoc :producer :corrective_change :noop_pending)))
-
-(def v6-example-report
-  (-> v7-example-report
-      (dissoc :code_id :catalog_uuid :cached_catalog_status)))
-
-(def v5-example-report
-  (-> reports
-      :basic
-      (dissoc :code_id :catalog_uuid :cached_catalog_status :producer :corrective_change)
-      report-query->wire-v5))
-
-(def v4-example-report
-  (-> v5-example-report
-      underscore->dash-report-keys
-      (dissoc :logs :metrics :noop :producer-timestamp)))
-
 (deftest test-v7-conversion
-  (let [v7-report v7-example-report
-        v8-report (wire-v7->wire-v8 v7-report)]
-
-    (is (s/validate report-v7-wireformat-schema v7-report))
+  (let [v8-report (wire-v7->wire-v8 v7-report)]
     (is (s/validate report-wireformat-schema v8-report))))
 
 (deftest test-v6-conversion
-  (let [v6-report v6-example-report
-        v8-report (wire-v6->wire-v8 v6-report)]
-
-    (is (s/validate report-v6-wireformat-schema v6-report))
+  (let [v8-report (wire-v6->wire-v8 v6-report)]
     (is (s/validate report-wireformat-schema v8-report))))
 
 (deftest test-v5-conversion
-  (let [v5-report v5-example-report
-        v8-report (wire-v5->wire-v8 v5-report)]
-
-    (is (s/validate report-v5-wireformat-schema v5-report))
+  (let [v8-report (wire-v5->wire-v8 v5-report)]
     (is (s/validate report-wireformat-schema v8-report))))
 
 (deftest test-v4-conversion
   (let [current-time (now)
-        v8-report (wire-v4->wire-v8 v4-example-report current-time)]
-
-    (is (s/validate report-v4-wireformat-schema v4-example-report))
+        v8-report (wire-v4->wire-v8 v4-report current-time)]
     (is (s/validate report-wireformat-schema v8-report))
     (is (= current-time (:producer_timestamp v8-report)))))
 
 (deftest test-v3-conversion
   (let [current-time (now)
-        v3-report (dissoc v4-example-report :status)
+        v3-report (dissoc v4-report :status)
         v8-report (wire-v3->wire-v8 v3-report current-time)]
     (is (s/validate report-v3-wireformat-schema v3-report))
     (is (s/validate report-wireformat-schema v8-report))


### PR DESCRIPTION
This was a schema error introduced with the corrective_change feature.
The main operational impact was that users upgrading from 3.2.x to 4.2
with enqueued data would have their commands fail on restart.

This commit corrects the schema to accept v6 reports, and also does a
bit of test cleanup so we won't have this problem again. Specifically it
consolidates synthesis of old command versions under the example reports
namespace and causes test compilation to fail if the synthetic reports
are invalid.