### PR TITLE
(PDB-3077) Upgrade to lein-ezbake 1.1.2, fix Debian startup problems

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -143,7 +143,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "1.0.0"
+                      :plugins [[puppetlabs/lein-ezbake "1.1.2"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}

--- a/resources/ext/cli/config-migration
+++ b/resources/ext/cli/config-migration
@@ -99,6 +99,7 @@ function replaceline {
   tmp="$3.tmp.$(date +%s)"
   sed "s/$1/$(echo "$2" | sed -e 's/[\/&]/\\&/g')/g" "$3" > "$tmp"
   mv "$tmp" "$3"
+  chmod 644 "$3"
 }
 
 # This funtion gives a generic error message if a given path or file isn't found

--- a/resources/ext/cli/ssl-setup.erb
+++ b/resources/ext/cli/ssl-setup.erb
@@ -101,6 +101,7 @@ function replaceline {
   tmp=$3.tmp.`date +%s`
   sed "s/$1/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g" $3 > $tmp
   mv $tmp $3
+  chmod 644 $3
 }
 
 # This function comments out a line in a file, based on a regexp


### PR DESCRIPTION
This commit upgrades the lein-ezbake dependency from 1.0.0 to 1.1.2.
This is needed to fix problems with the PuppetDB service not starting
properly on Debian-based platforms due to a permissions issue around the
use of the service rundir.  The rundir problem was previously introduced
by the bump to lein-ezbake 1.0.0.

In the newer ezbake release, subcommands run with a umask of 027.  This
commit includes a couple of explicit chmod calls in the migration and
ssl-setup subcommands which ensure that any modified config files are
still world-readable.  World-readability is required for these files in
order for the puppetdb service, running as user puppetdb, to be able to
still read the config files, which are owned by root:root.