### PR TITLE
(MAINT) Bump beaker to 2.50.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :acceptance do
     gem 'beaker', *location_for(beaker_version)
   else
     # use the pinned version
-    gem 'beaker', '~> 2.43.0'
+    gem 'beaker', '~> 2.50.0'
   end
   # This forces google-api-client to not download retirable 2.0.0 which lacks
   # ruby 1.9.x support.


### PR DESCRIPTION
Previously, PuppetDB's Gemfile was picking up beaker version 2.43.0.
This was transitively picking up hocon version 0.9.5.  puppetserver
recently added some variable interpolation to the puppetserver.conf
file.  Some fixes in hocon 1.0 and later are needed in order for the
interpolation to be handled correctly.

This commit bumps the beaker dependency in the Gemfile to ~> 2.50.0,
which transitively will cause test jobs to pick up a newer hocon gem
dependency, >= 1.0.