### PR TITLE
(PDB-2810) Update benchmark sample data

### DIFF
--- a/resources/puppetlabs/puppetdb/benchmark/samples/catalogs/host-0.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/catalogs/host-0.json
@@ -7943,5 +7943,8 @@
   "certname" : "host-0",
   "hash" : "d3299d0dfa96afc41ae74c430ab1f42df75ebd07",
   "environment" : "production",
-  "version" : "1425333104"
+  "version" : "1425333104",
+  "producer" : "puppetmaster1",
+  "catalog_uuid" : "4794d936-2151-4625-9476-150ff4245391",
+  "code_id" : "8f0023fde6ce1ae69a8cbbc4f59d2d39f2f369e7"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/catalogs/host-1.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/catalogs/host-1.json
@@ -7948,5 +7948,8 @@
   "certname" : "host-1",
   "hash" : "304a1b7afdd74fa113a6c1b54847f9f3e5bc0cfb",
   "environment" : "production",
-  "version" : "1425333104"
+  "version" : "1425333104",
+  "producer" : "puppetmaster1",
+  "catalog_uuid" : "80c65ab5-559c-4835-a59b-399da0310d5b",
+  "code_id" : "69aa00ba5711ce321e9aab1d66a75c30f3140ac5"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/catalogs/host-2.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/catalogs/host-2.json
@@ -7926,5 +7926,8 @@
   "certname" : "host-2",
   "hash" : "d5efb5a2283f61d63cb295e63126e698b026c517",
   "environment" : "production",
-  "version" : "1425333104"
+  "version" : "1425333104",
+  "producer" : "puppetmaster1",
+  "catalog_uuid" : "30a0b9c4-b039-447d-b8f2-c0cb84d0a1f7",
+  "code_id" : "a3f761afad29291f42e0ae2b5b50527a426bb070"
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/facts/pg1.vm.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/facts/pg1.vm.json
@@ -1,5 +1,6 @@
 {
   "certname" : "pg1.vm",
+  "producer" : "puppetmaster1",
   "values" : {
     "mtu_eth0" : "1500",
     "path" : "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/facts/pg2.vm.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/facts/pg2.vm.json
@@ -1,5 +1,6 @@
 {
   "certname" : "pg2.vm",
+  "producer" : "puppetmaster1",
   "producer_timestamp" : "2015-03-02T21:51:45.395Z",
   "values" : {
     "mtu_eth0" : "1500",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/facts/puppetdb1.vm.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/facts/puppetdb1.vm.json
@@ -1,5 +1,6 @@
 {
   "certname" : "puppetdb1.vm",
+  "producer" : "puppetmaster1",
   "producer_timestamp" : "2015-03-02T21:51:45.395Z",
   "values" : {
     "mtu_eth0" : "1500",

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-304bebf8e5fc109ced84e8b086f9bcf8324f3d78.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-304bebf8e5fc109ced84e8b086f9bcf8324f3d78.json
@@ -1,268 +1,2235 @@
 {
-    "cached_catalog_status": "on_failure",
-    "certname": "pg1.vm",
-    "configuration_version": "1423833741",
-    "end_time": "2015-02-13T13:22:52.014Z",
-    "environment": "production",
-    "corrective_change": false,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 0.29 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:22:54.288+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 3,
-            "message": "defined 'message' as 'foo'",
-            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
-            "tags": [
-                "notice",
-                "notify",
-                "foo",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:22:54.117+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "foo",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:22:54.116+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423833741'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:22:54.054+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for pg1.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:22:53.904+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:22:51.695+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:22:51.23+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:22:51.192+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.000493414
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 0.800477095
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.013962715
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.02031697
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 8.1892e-05
-        },
-        {
-            "category": "time",
-            "name": "gnupg_key",
-            "value": 0.009883399
-        },
-        {
-            "category": "time",
-            "name": "ini_setting",
-            "value": 0.000383931
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.001923986
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.018245457000000003
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.000532156
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.071825341
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 0.938319936
-        },
-        {
-            "category": "time",
-            "name": "vcsrepo",
-            "value": 0.00019358
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 47
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 1
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 1
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 1
-        }
-    ],
-    "noop": true,
-    "puppet_version": "3.7.4",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "defined 'message' as 'foo'",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "success",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:22:54.116Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 3,
-            "resource_title": "foo",
-            "corrective_change": false,
-            "resource_type": "Notify",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:22:54.116Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:22:51.075Z",
-    "catalog_uuid": "2e59e974-7d40-4e41-bb81-20d91e2c2679",
-    "producer": "foo.com",
-    "code_id": "5ce7eda4-a281-49d5-94e9-edb4b3b1d0b5",
-    "status": "changed",
-    "transaction_uuid": "6906e9f2-d15a-414d-928c-ec1eac4b5e92"
+  "corrective_change" : false,
+  "code_id" : "5ce7eda4-a281-49d5-94e9-edb4b3b1d0b5",
+  "noop" : true,
+  "certname" : "pg1.vm",
+  "puppet_version" : "3.7.4",
+  "cached_catalog_status" : "on_failure",
+  "transaction_uuid" : "6906e9f2-d15a-414d-928c-ec1eac4b5e92",
+  "configuration_version" : "1423833741",
+  "status" : "changed",
+  "producer" : "foo.com",
+  "catalog_uuid" : "2e59e974-7d40-4e41-bb81-20d91e2c2679",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 0.29 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:22:54.288+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 3,
+    "message" : "defined 'message' as 'foo'",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
+    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:22:54.117+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "foo",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:22:54.116+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423833741'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:22:54.054+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for pg1.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:22:53.904+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:22:51.695+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:22:51.23+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:22:51.192+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:22:52.014Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:22:51.075Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 4.93414E-4
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 0.800477095
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.013962715
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.02031697
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 8.1892E-5
+  }, {
+    "category" : "time",
+    "name" : "gnupg_key",
+    "value" : 0.009883399
+  }, {
+    "category" : "time",
+    "name" : "ini_setting",
+    "value" : 3.83931E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 0.001923986
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.018245457000000003
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 5.32156E-4
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.071825341
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 0.938319936
+  }, {
+    "category" : "time",
+    "name" : "vcsrepo",
+    "value" : 1.9358E-4
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 47
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 1
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 1
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 1
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "b",
+    "resource_type" : "tEIUCq7Qg",
+    "events" : [ ],
+    "line" : 860,
+    "file" : "J90vafPdY",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "RMaI",
+    "resource_type" : "atvN",
+    "events" : [ ],
+    "line" : 421,
+    "file" : "x",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-327147ee71a6e67db76112add34d49c674f97b4f.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-327147ee71a6e67db76112add34d49c674f97b4f.json
@@ -1,573 +1,2351 @@
 {
-    "cached_catalog_status": "on_failure",
-    "certname": "pg1.vm",
-    "configuration_version": "1423833650",
-    "end_time": "2015-02-13T13:21:04.382Z",
-    "environment": "production",
-    "corrective_change": false,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 0.35 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:21:06.7+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 2 events",
-            "source": "Stage[main]",
-            "tags": [
-                "notice",
-                "completed_stage",
-                "main"
-            ],
-            "time": "2015-02-13T13:21:06.647+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 4 events",
-            "source": "Class[Loadtest]",
-            "tags": [
-                "notice",
-                "completed_class",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:21:06.64+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Concat::Fragment[tmpfile]",
-            "tags": [
-                "notice",
-                "completed_concat::fragment",
-                "completed_concat",
-                "fragment",
-                "tmpfile"
-            ],
-            "time": "2015-02-13T13:21:06.613+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Concat[/tmp/file]",
-            "tags": [
-                "notice",
-                "completed_concat"
-            ],
-            "time": "2015-02-13T13:21:06.612+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 187,
-            "message": "Would have triggered 'refresh' from 2 events",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-            "tags": [
-                "notice",
-                "exec",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:06.608+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "info",
-            "line": 113,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-            "tags": [
-                "info",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:06.589+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "notice",
-            "line": 113,
-            "message": "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
-            "tags": [
-                "notice",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:06.589+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "notice",
-            "line": 113,
-            "message": "\n--- /var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile\t2015-02-13 13:05:05.021459942 +0000\n+++ /tmp/puppet-file20150213-9820-1huuxni\t2015-02-13 13:21:06.573472904 +0000\n@@ -1 +1 @@\n-test contents\n\\ No newline at end of file\n+test contents foo\n\\ No newline at end of file\n",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
-            "tags": [
-                "notice",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "content"
-            ],
-            "time": "2015-02-13T13:21:06.588+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Concat::Fragment[tmpfile2]",
-            "tags": [
-                "notice",
-                "completed_concat::fragment",
-                "completed_concat",
-                "fragment",
-                "tmpfile2"
-            ],
-            "time": "2015-02-13T13:21:06.577+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "info",
-            "line": 113,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-            "tags": [
-                "info",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile2",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:06.576+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "notice",
-            "line": 113,
-            "message": "current_value absent, should be file (noop)",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
-            "tags": [
-                "notice",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile2",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:06.575+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 3,
-            "message": "current_value absent, should be foo (noop)",
-            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
-            "tags": [
-                "notice",
-                "notify",
-                "foo",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:06.489+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Motd]",
-            "tags": [
-                "notice",
-                "completed_class",
-                "motd"
-            ],
-            "time": "2015-02-13T13:21:06.445+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "level": "notice",
-            "line": 33,
-            "message": "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}a3bfa10444570ab20a2f7d563592294d (noop)",
-            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
-            "tags": [
-                "notice",
-                "file",
-                "class",
-                "motd",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:06.444+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "level": "notice",
-            "line": 33,
-            "message": "\n--- /etc/motd\t2015-02-13 13:06:12.997460859 +0000\n+++ /tmp/puppet-file20150213-9820-vsqcg9\t2015-02-13 13:21:06.425472902 +0000\n@@ -1 +1,3 @@\n-Welcome to my test host!\n\\ No newline at end of file\n+The operating system is Debian\n+The free memory is 203.97 MB\n+The domain is vm\n",
-            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
-            "tags": [
-                "notice",
-                "file",
-                "class",
-                "motd",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "content"
-            ],
-            "time": "2015-02-13T13:21:06.443+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423833650'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:06.412+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for pg1.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:06.268+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:03.917+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:03.481+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:03.442+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.0005503540000000001
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 0.882534088
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.016960151
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.043997192
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 9.3244e-05
-        },
-        {
-            "category": "time",
-            "name": "gnupg_key",
-            "value": 0.011448235
-        },
-        {
-            "category": "time",
-            "name": "ini_setting",
-            "value": 0.000385746
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.00134731
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.019649724000000004
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.000575223
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.078253771
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 1.056010572
-        },
-        {
-            "category": "time",
-            "name": "vcsrepo",
-            "value": 0.000215534
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 4
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 47
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "noop",
-            "value": 4
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 4
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 0
-        }
-    ],
-    "noop": true,
-    "puppet_version": "3.7.4",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Motd",
-                "File[/etc/motd]"
-            ],
-            "events": [
-                {
-                    "message": "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}a3bfa10444570ab20a2f7d563592294d (noop)",
-                    "new_value": "{md5}a3bfa10444570ab20a2f7d563592294d",
-                    "old_value": "{md5}a3f731187a6aaaa23d4a7b244f223f33",
+  "corrective_change" : false,
+  "code_id" : "6764b61b-6f2a-4187-85e8-cef3e29cda5e",
+  "noop" : true,
+  "certname" : "pg1.vm",
+  "puppet_version" : "3.7.4",
+  "cached_catalog_status" : "on_failure",
+  "transaction_uuid" : "d00ab23c-bd14-42a5-b5ef-855ceede8a40",
+  "configuration_version" : "1423833650",
+  "status" : "unchanged",
+  "producer" : "foo.com",
+  "catalog_uuid" : "90de2540-d70e-40bb-a264-c84e5a95bbef",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 0.35 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:21:06.7+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 2 events",
+    "source" : "Stage[main]",
+    "tags" : [ "notice", "completed_stage", "main" ],
+    "time" : "2015-02-13T13:21:06.647+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 4 events",
+    "source" : "Class[Loadtest]",
+    "tags" : [ "notice", "completed_class", "loadtest" ],
+    "time" : "2015-02-13T13:21:06.64+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Concat::Fragment[tmpfile]",
+    "tags" : [ "notice", "completed_concat::fragment", "completed_concat", "fragment", "tmpfile" ],
+    "time" : "2015-02-13T13:21:06.613+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Concat[/tmp/file]",
+    "tags" : [ "notice", "completed_concat" ],
+    "time" : "2015-02-13T13:21:06.612+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 187,
+    "message" : "Would have triggered 'refresh' from 2 events",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+    "tags" : [ "notice", "exec", "concat", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:06.608+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "info",
+    "line" : 113,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+    "tags" : [ "info", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:06.589+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "notice",
+    "line" : 113,
+    "message" : "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
+    "tags" : [ "notice", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:06.589+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "notice",
+    "line" : 113,
+    "message" : "\n--- /var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile\t2015-02-13 13:05:05.021459942 +0000\n+++ /tmp/puppet-file20150213-9820-1huuxni\t2015-02-13 13:21:06.573472904 +0000\n@@ -1 +1 @@\n-test contents\n\\ No newline at end of file\n+test contents foo\n\\ No newline at end of file\n",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
+    "tags" : [ "notice", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm", "content" ],
+    "time" : "2015-02-13T13:21:06.588+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Concat::Fragment[tmpfile2]",
+    "tags" : [ "notice", "completed_concat::fragment", "completed_concat", "fragment", "tmpfile2" ],
+    "time" : "2015-02-13T13:21:06.577+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "info",
+    "line" : 113,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+    "tags" : [ "info", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:06.576+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "notice",
+    "line" : 113,
+    "message" : "current_value absent, should be file (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
+    "tags" : [ "notice", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:06.575+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 3,
+    "message" : "current_value absent, should be foo (noop)",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
+    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:06.489+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Motd]",
+    "tags" : [ "notice", "completed_class", "motd" ],
+    "time" : "2015-02-13T13:21:06.445+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
+    "level" : "notice",
+    "line" : 33,
+    "message" : "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}a3bfa10444570ab20a2f7d563592294d (noop)",
+    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
+    "tags" : [ "notice", "file", "class", "motd", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:06.444+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
+    "level" : "notice",
+    "line" : 33,
+    "message" : "\n--- /etc/motd\t2015-02-13 13:06:12.997460859 +0000\n+++ /tmp/puppet-file20150213-9820-vsqcg9\t2015-02-13 13:21:06.425472902 +0000\n@@ -1 +1,3 @@\n-Welcome to my test host!\n\\ No newline at end of file\n+The operating system is Debian\n+The free memory is 203.97 MB\n+The domain is vm\n",
+    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
+    "tags" : [ "notice", "file", "class", "motd", "loadtest", "node", "pg1.vm", "content" ],
+    "time" : "2015-02-13T13:21:06.443+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423833650'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:06.412+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for pg1.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:06.268+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:03.917+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:03.481+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:03.442+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:21:04.382Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:21:03.326Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 5.503540000000001E-4
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 0.882534088
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.016960151
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.043997192
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 9.3244E-5
+  }, {
+    "category" : "time",
+    "name" : "gnupg_key",
+    "value" : 0.011448235
+  }, {
+    "category" : "time",
+    "name" : "ini_setting",
+    "value" : 3.85746E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 0.00134731
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.019649724000000004
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 5.75223E-4
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.078253771
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 1.056010572
+  }, {
+    "category" : "time",
+    "name" : "vcsrepo",
+    "value" : 2.15534E-4
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 4
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 47
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "noop",
+    "value" : 4
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 4
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 0
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [  {
+                    "message": null,
+                    "new_value": "bar",
+                    "old_value": "foo",
                     "property": "content",
-                    "status": "noop",
+                    "status": "success",
                     "corrective_change": false,
-                    "timestamp": "2015-02-13T13:21:06.444Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "corrective_change": false,
-            "line": 33,
-            "resource_title": "/etc/motd",
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:21:06.444Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be foo (noop)",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:21:06.488Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 3,
-            "corrective_change": false,
-            "resource_title": "foo",
-            "resource_type": "Notify",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:21:06.488Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat::Fragment[tmpfile2]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be file (noop)",
-                    "new_value": "file",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:21:06.575Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "line": 113,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:21:06.575Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat::Fragment[tmpfile]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]"
-            ],
-            "events": [
-                {
-                    "message": "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)",
-                    "new_value": "{md5}3a010064e9f94f26236ba1167c7ee125",
-                    "old_value": "{md5}df14e44b311152c34358a675ae34afe0",
-                    "property": "content",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:21:06.589Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "line": 113,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:21:06.589Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:21:03.326Z",
-    "status": "unchanged",
-    "catalog_uuid": "90de2540-d70e-40bb-a264-c84e5a95bbef",
-    "producer": "foo.com",
-    "code_id": "6764b61b-6f2a-4187-85e8-cef3e29cda5e",
-    "transaction_uuid": "d00ab23c-bd14-42a5-b5ef-855ceede8a40"
+                    "timestamp": "2015-02-13T13:23:50.136Z"
+                }],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "b",
+    "resource_type" : "tEIUCq7Qg",
+    "events" : [ ],
+    "line" : 860,
+    "file" : "J90vafPdY",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "RMaI",
+    "resource_type" : "atvN",
+    "events" : [ ],
+    "line" : 421,
+    "file" : "x",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-339914cdb0a7a9a7ca4c9c310ab96ba20649376f.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-339914cdb0a7a9a7ca4c9c310ab96ba20649376f.json
@@ -1,2773 +1,3631 @@
 {
-    "cached_catalog_status": "not_used",
-    "certname": "pg1.vm",
-    "configuration_version": "1423833650",
-    "end_time": "2015-02-13T13:21:14.240Z",
-    "environment": "production",
-    "corrective_change": false,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 0.39 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:21:16.622+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Stored state in 0.04 seconds",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.622+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Storing state",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.578+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Finishing transaction 10519500",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.578+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 2 events",
-            "source": "Stage[main]",
-            "tags": [
-                "notice",
-                "completed_stage",
-                "main"
-            ],
-            "time": "2015-02-13T13:21:16.577+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "debug",
-            "line": 71,
-            "message": "Nothing to manage: no ensure and the resource doesn't exist",
-            "source": "/Package[gunicorn]",
-            "tags": [
-                "debug",
-                "package",
-                "gunicorn",
-                "class",
-                "python::install",
-                "python",
-                "install",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.572+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "The container Stage[main] will propagate my refresh event",
-            "source": "Class[Loadtest]",
-            "tags": [
-                "debug",
-                "completed_class",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:21:16.57+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 4 events",
-            "source": "Class[Loadtest]",
-            "tags": [
-                "notice",
-                "completed_class",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:21:16.569+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Executing '/etc/init.d/snmpd status'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.547+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "The container Class[Loadtest] will propagate my refresh event",
-            "source": "Concat::Fragment[tmpfile]",
-            "tags": [
-                "debug",
-                "completed_concat::fragment",
-                "completed_concat",
-                "fragment",
-                "tmpfile"
-            ],
-            "time": "2015-02-13T13:21:16.545+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Concat::Fragment[tmpfile]",
-            "tags": [
-                "notice",
-                "completed_concat::fragment",
-                "completed_concat",
-                "fragment",
-                "tmpfile"
-            ],
-            "time": "2015-02-13T13:21:16.544+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "The container Class[Loadtest] will propagate my refresh event",
-            "source": "Concat[/tmp/file]",
-            "tags": [
-                "debug",
-                "completed_concat"
-            ],
-            "time": "2015-02-13T13:21:16.544+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Concat[/tmp/file]",
-            "tags": [
-                "notice",
-                "completed_concat"
-            ],
-            "time": "2015-02-13T13:21:16.543+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "debug",
-            "line": 187,
-            "message": "The container Concat[/tmp/file] will propagate my refresh event",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-            "tags": [
-                "debug",
-                "exec",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.541+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 187,
-            "message": "Would have triggered 'refresh' from 2 events",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-            "tags": [
-                "notice",
-                "exec",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.54+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Executing '/var/lib/puppet/concat/bin/concatfragments.sh -o \"/var/lib/puppet/concat/_tmp_file/fragments.concat.out\" -d \"/var/lib/puppet/concat/_tmp_file\" -t'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.526+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Executing check '/var/lib/puppet/concat/bin/concatfragments.sh -o \"/var/lib/puppet/concat/_tmp_file/fragments.concat.out\" -d \"/var/lib/puppet/concat/_tmp_file\" -t'",
-            "source": "Exec[concat_/tmp/file](provider=posix)",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.525+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "debug",
-            "line": 113,
-            "message": "The container Concat::Fragment[tmpfile] will propagate my refresh event",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-            "tags": [
-                "debug",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.524+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "info",
-            "line": 113,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-            "tags": [
-                "info",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.523+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "notice",
-            "line": 113,
-            "message": "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
-            "tags": [
-                "notice",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.523+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "notice",
-            "line": 113,
-            "message": "\n--- /var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile\t2015-02-13 13:05:05.021459942 +0000\n+++ /tmp/puppet-file20150213-10108-1ebmfcz\t2015-02-13 13:21:16.509473038 +0000\n@@ -1 +1 @@\n-test contents\n\\ No newline at end of file\n+test contents foo\n\\ No newline at end of file\n",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
-            "tags": [
-                "notice",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "content"
-            ],
-            "time": "2015-02-13T13:21:16.522+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Executing 'diff -u /var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile /tmp/puppet-file20150213-10108-1ebmfcz'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.513+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "The container Class[Loadtest] will propagate my refresh event",
-            "source": "Concat::Fragment[tmpfile2]",
-            "tags": [
-                "debug",
-                "completed_concat::fragment",
-                "completed_concat",
-                "fragment",
-                "tmpfile2"
-            ],
-            "time": "2015-02-13T13:21:16.511+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Concat::Fragment[tmpfile2]",
-            "tags": [
-                "notice",
-                "completed_concat::fragment",
-                "completed_concat",
-                "fragment",
-                "tmpfile2"
-            ],
-            "time": "2015-02-13T13:21:16.511+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "debug",
-            "line": 113,
-            "message": "The container Concat::Fragment[tmpfile2] will propagate my refresh event",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-            "tags": [
-                "debug",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile2",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.51+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "info",
-            "line": 113,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-            "tags": [
-                "info",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile2",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.509+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "notice",
-            "line": 113,
-            "message": "current_value absent, should be file (noop)",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
-            "tags": [
-                "notice",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile2",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.508+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Executing 'gpg --list-keys --with-colons 20BC0A86'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.47+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Executing '/etc/init.d/ntp status'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.433+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Executing '/etc/init.d/cron status'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.395+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "debug",
-            "line": 3,
-            "message": "The container Class[Loadtest] will propagate my refresh event",
-            "source": "/Stage[main]/Loadtest/Notify[foo]",
-            "tags": [
-                "debug",
-                "notify",
-                "foo",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.394+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 3,
-            "message": "current_value absent, should be foo (noop)",
-            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
-            "tags": [
-                "notice",
-                "notify",
-                "foo",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.393+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Executing '/usr/bin/apt-cache policy etckeeper'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.375+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Executing '/usr/bin/dpkg-query -W --showformat '${Status} ${Package} ${Version}\\n''",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.352+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Prefetching apt resources for package",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.351+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "The container Stage[main] will propagate my refresh event",
-            "source": "Class[Motd]",
-            "tags": [
-                "debug",
-                "completed_class",
-                "motd"
-            ],
-            "time": "2015-02-13T13:21:16.35+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Motd]",
-            "tags": [
-                "notice",
-                "completed_class",
-                "motd"
-            ],
-            "time": "2015-02-13T13:21:16.349+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "level": "debug",
-            "line": 33,
-            "message": "The container Class[Motd] will propagate my refresh event",
-            "source": "/Stage[main]/Motd/File[/etc/motd]",
-            "tags": [
-                "debug",
-                "file",
-                "class",
-                "motd",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.349+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "level": "notice",
-            "line": 33,
-            "message": "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}6e10c92cc7cd37f8033108d9555eb33a (noop)",
-            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
-            "tags": [
-                "notice",
-                "file",
-                "class",
-                "motd",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.348+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "level": "notice",
-            "line": 33,
-            "message": "\n--- /etc/motd\t2015-02-13 13:06:12.997460859 +0000\n+++ /tmp/puppet-file20150213-10108-1epr0sd\t2015-02-13 13:21:16.333473035 +0000\n@@ -1 +1,3 @@\n-Welcome to my test host!\n\\ No newline at end of file\n+The operating system is Debian\n+The free memory is 204.09 MB\n+The domain is vm\n",
-            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
-            "tags": [
-                "notice",
-                "file",
-                "class",
-                "motd",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "content"
-            ],
-            "time": "2015-02-13T13:21:16.347+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Executing 'diff -u /etc/motd /tmp/puppet-file20150213-10108-1epr0sd'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.338+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Caching connection for https://puppet:8140",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.335+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Using cached connection for https://puppet:8140",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.327+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "file_metadata supports formats: pson b64_zlib_yaml yaml raw",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.327+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Network::Format[msgpack]: feature msgpack is missing",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.326+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Failed to load library 'msgpack' for feature 'msgpack'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.325+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423833650'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:16.316+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "debug",
-            "line": 113,
-            "message": "Autorequiring File[/var/lib/puppet/concat/_tmp_file/fragments]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-            "tags": [
-                "debug",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile2",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.305+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "debug",
-            "line": 113,
-            "message": "Autorequiring File[/var/lib/puppet/concat/_tmp_file/fragments]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-            "tags": [
-                "debug",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.304+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "debug",
-            "line": 187,
-            "message": "Autorequiring File[/var/lib/puppet/concat/bin/concatfragments.sh]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-            "tags": [
-                "debug",
-                "exec",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.304+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "debug",
-            "line": 164,
-            "message": "Autorequiring File[/var/lib/puppet/concat/_tmp_file]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]",
-            "tags": [
-                "debug",
-                "file",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.303+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "debug",
-            "line": 159,
-            "message": "Autorequiring File[/var/lib/puppet/concat/_tmp_file]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]",
-            "tags": [
-                "debug",
-                "file",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.302+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "debug",
-            "line": 149,
-            "message": "Autorequiring File[/var/lib/puppet/concat/_tmp_file]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
-            "tags": [
-                "debug",
-                "file",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.301+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "debug",
-            "line": 144,
-            "message": "Autorequiring File[/var/lib/puppet/concat]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
-            "tags": [
-                "debug",
-                "file",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.3+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/setup.pp",
-            "level": "debug",
-            "line": 60,
-            "message": "Autorequiring File[/var/lib/puppet/concat]",
-            "source": "/Stage[main]/Concat::Setup/File[/var/lib/puppet/concat/bin]",
-            "tags": [
-                "debug",
-                "file",
-                "class",
-                "concat::setup",
-                "concat",
-                "setup",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.3+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/setup.pp",
-            "level": "debug",
-            "line": 53,
-            "message": "Autorequiring File[/var/lib/puppet/concat/bin]",
-            "source": "/Stage[main]/Concat::Setup/File[/var/lib/puppet/concat/bin/concatfragments.sh]",
-            "tags": [
-                "debug",
-                "file",
-                "class",
-                "concat::setup",
-                "concat",
-                "setup",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.299+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "debug",
-            "line": 69,
-            "message": "Autorequiring Package[gnupg]",
-            "source": "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]",
-            "tags": [
-                "debug",
-                "gnupg_key",
-                "hkp_server_20bc0a86",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.298+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "debug",
-            "line": 11,
-            "message": "Autorequiring Package[git]",
-            "source": "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
-            "tags": [
-                "debug",
-                "vcsrepo",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.295+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "debug",
-            "line": 113,
-            "message": "subscribes to Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/notify",
-            "tags": [
-                "debug",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile2",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "notify"
-            ],
-            "time": "2015-02-13T13:21:16.294+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "debug",
-            "line": 113,
-            "message": "subscribes to Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/notify",
-            "tags": [
-                "debug",
-                "file",
-                "concat::fragment",
-                "concat",
-                "fragment",
-                "tmpfile",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "notify"
-            ],
-            "time": "2015-02-13T13:21:16.293+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "debug",
-            "line": 187,
-            "message": "subscribes to File[/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/notify",
-            "tags": [
-                "debug",
-                "exec",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "notify"
-            ],
-            "time": "2015-02-13T13:21:16.292+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "debug",
-            "line": 187,
-            "message": "subscribes to File[/var/lib/puppet/concat/_tmp_file]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/subscribe",
-            "tags": [
-                "debug",
-                "exec",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "subscribe"
-            ],
-            "time": "2015-02-13T13:21:16.291+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "debug",
-            "line": 187,
-            "message": "requires File[/var/lib/puppet/concat/_tmp_file/fragments.concat]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/require",
-            "tags": [
-                "debug",
-                "exec",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "require"
-            ],
-            "time": "2015-02-13T13:21:16.29+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "debug",
-            "line": 187,
-            "message": "requires File[/var/lib/puppet/concat/_tmp_file/fragments]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/require",
-            "tags": [
-                "debug",
-                "exec",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "require"
-            ],
-            "time": "2015-02-13T13:21:16.29+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "debug",
-            "line": 187,
-            "message": "requires File[/var/lib/puppet/concat/_tmp_file]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/require",
-            "tags": [
-                "debug",
-                "exec",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "require"
-            ],
-            "time": "2015-02-13T13:21:16.289+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "debug",
-            "line": 149,
-            "message": "subscribes to Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/notify",
-            "tags": [
-                "debug",
-                "file",
-                "concat",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "notify"
-            ],
-            "time": "2015-02-13T13:21:16.289+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/init.pp",
-            "level": "debug",
-            "line": 92,
-            "message": "requires Anchor[python::end]",
-            "source": "/Stage[main]/Python::Config/before",
-            "tags": [
-                "debug",
-                "class",
-                "python::config",
-                "python",
-                "config",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "before"
-            ],
-            "time": "2015-02-13T13:21:16.288+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/init.pp",
-            "level": "debug",
-            "line": 91,
-            "message": "requires Class[Python::Config]",
-            "source": "/Stage[main]/Python::Install/before",
-            "tags": [
-                "debug",
-                "class",
-                "python::install",
-                "python",
-                "install",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "before"
-            ],
-            "time": "2015-02-13T13:21:16.287+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/init.pp",
-            "level": "debug",
-            "line": 90,
-            "message": "requires Class[Python::Install]",
-            "source": "/Stage[main]/Python/Anchor[python::begin]/before",
-            "tags": [
-                "debug",
-                "anchor",
-                "python::begin",
-                "python",
-                "begin",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "before"
-            ],
-            "time": "2015-02-13T13:21:16.286+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "debug",
-            "line": 517,
-            "message": "requires File[var-net-snmp]",
-            "source": "/Stage[main]/Snmp/Service[snmpd]/require",
-            "tags": [
-                "debug",
-                "service",
-                "snmpd",
-                "class",
-                "snmp",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "require"
-            ],
-            "time": "2015-02-13T13:21:16.286+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "debug",
-            "line": 517,
-            "message": "requires Package[snmpd]",
-            "source": "/Stage[main]/Snmp/Service[snmpd]/require",
-            "tags": [
-                "debug",
-                "service",
-                "snmpd",
-                "class",
-                "snmp",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "require"
-            ],
-            "time": "2015-02-13T13:21:16.285+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "debug",
-            "line": 453,
-            "message": "subscribes to Service[snmpd]",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]/notify",
-            "tags": [
-                "debug",
-                "file",
-                "snmptrapd.conf",
-                "class",
-                "snmp",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "notify"
-            ],
-            "time": "2015-02-13T13:21:16.284+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "debug",
-            "line": 453,
-            "message": "requires Package[snmpd]",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]/require",
-            "tags": [
-                "debug",
-                "file",
-                "snmptrapd.conf",
-                "class",
-                "snmp",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "require"
-            ],
-            "time": "2015-02-13T13:21:16.283+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "debug",
-            "line": 441,
-            "message": "subscribes to Service[snmpd]",
-            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]/notify",
-            "tags": [
-                "debug",
-                "file",
-                "snmpd.sysconfig",
-                "class",
-                "snmp",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "notify"
-            ],
-            "time": "2015-02-13T13:21:16.282+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "debug",
-            "line": 441,
-            "message": "requires Package[snmpd]",
-            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]/require",
-            "tags": [
-                "debug",
-                "file",
-                "snmpd.sysconfig",
-                "class",
-                "snmp",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "require"
-            ],
-            "time": "2015-02-13T13:21:16.282+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "debug",
-            "line": 429,
-            "message": "subscribes to Service[snmpd]",
-            "source": "/Stage[main]/Snmp/File[snmpd.conf]/notify",
-            "tags": [
-                "debug",
-                "file",
-                "snmpd.conf",
-                "class",
-                "snmp",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "notify"
-            ],
-            "time": "2015-02-13T13:21:16.281+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "debug",
-            "line": 429,
-            "message": "requires Package[snmpd]",
-            "source": "/Stage[main]/Snmp/File[snmpd.conf]/require",
-            "tags": [
-                "debug",
-                "file",
-                "snmpd.conf",
-                "class",
-                "snmp",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "require"
-            ],
-            "time": "2015-02-13T13:21:16.28+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "debug",
-            "line": 410,
-            "message": "requires Package[snmpd]",
-            "source": "/Stage[main]/Snmp/File[var-net-snmp]/require",
-            "tags": [
-                "debug",
-                "file",
-                "var-net-snmp",
-                "class",
-                "snmp",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "require"
-            ],
-            "time": "2015-02-13T13:21:16.279+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "level": "debug",
-            "line": 85,
-            "message": "requires Package[snmp-client]",
-            "source": "/Stage[main]/Snmp::Client/File[snmp.conf]/require",
-            "tags": [
-                "debug",
-                "file",
-                "snmp.conf",
-                "class",
-                "snmp::client",
-                "snmp",
-                "client",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "require"
-            ],
-            "time": "2015-02-13T13:21:16.279+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/init.pp",
-            "level": "debug",
-            "line": 61,
-            "message": "requires Anchor[ntp::end]",
-            "source": "/Stage[main]/Ntp::Service/before",
-            "tags": [
-                "debug",
-                "class",
-                "ntp::service",
-                "ntp",
-                "service",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "before"
-            ],
-            "time": "2015-02-13T13:21:16.278+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/init.pp",
-            "level": "debug",
-            "line": 60,
-            "message": "subscribes to Class[Ntp::Service]",
-            "source": "/Stage[main]/Ntp::Config/notify",
-            "tags": [
-                "debug",
-                "class",
-                "ntp::config",
-                "ntp",
-                "config",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "notify"
-            ],
-            "time": "2015-02-13T13:21:16.277+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/init.pp",
-            "level": "debug",
-            "line": 59,
-            "message": "requires Class[Ntp::Config]",
-            "source": "/Stage[main]/Ntp::Install/before",
-            "tags": [
-                "debug",
-                "class",
-                "ntp::install",
-                "ntp",
-                "install",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "before"
-            ],
-            "time": "2015-02-13T13:21:16.276+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/init.pp",
-            "level": "debug",
-            "line": 58,
-            "message": "requires Class[Ntp::Install]",
-            "source": "/Stage[main]/Ntp/Anchor[ntp::begin]/before",
-            "tags": [
-                "debug",
-                "anchor",
-                "ntp::begin",
-                "ntp",
-                "begin",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "before"
-            ],
-            "time": "2015-02-13T13:21:16.271+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loaded state in 0.04 seconds",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.269+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Creating default schedules",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.207+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/gnupg/manifests/install.pp",
-            "level": "debug",
-            "line": 4,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[gnupg]",
-            "tags": [
-                "debug",
-                "package",
-                "gnupg",
-                "class",
-                "gnupg::install",
-                "install",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.19+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "debug",
-            "line": 71,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[gunicorn]",
-            "tags": [
-                "debug",
-                "package",
-                "gunicorn",
-                "class",
-                "python::install",
-                "python",
-                "install",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.187+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "debug",
-            "line": 62,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[python]",
-            "tags": [
-                "debug",
-                "package",
-                "python",
-                "class",
-                "python::install",
-                "install",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.186+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "debug",
-            "line": 61,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[python-dev]",
-            "tags": [
-                "debug",
-                "package",
-                "python-dev",
-                "class",
-                "python::install",
-                "python",
-                "install",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.185+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "debug",
-            "line": 60,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[python-pip]",
-            "tags": [
-                "debug",
-                "package",
-                "python-pip",
-                "class",
-                "python::install",
-                "python",
-                "install",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.184+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "debug",
-            "line": 59,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[python-virtualenv]",
-            "tags": [
-                "debug",
-                "package",
-                "python-virtualenv",
-                "class",
-                "python::install",
-                "python",
-                "install",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.183+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "debug",
-            "line": 405,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[snmpd]",
-            "tags": [
-                "debug",
-                "package",
-                "snmpd",
-                "class",
-                "snmp",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.177+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "level": "debug",
-            "line": 76,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[snmp-client]",
-            "tags": [
-                "debug",
-                "package",
-                "snmp-client",
-                "class",
-                "snmp::client",
-                "snmp",
-                "client",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.175+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/git/manifests/init.pp",
-            "level": "debug",
-            "line": 12,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[git]",
-            "tags": [
-                "debug",
-                "package",
-                "git",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.172+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "debug",
-            "line": 41,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[etckeeper]",
-            "tags": [
-                "debug",
-                "package",
-                "etckeeper",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.17+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Vcsrepo::ProviderCvs: file cvs does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.165+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Vcsrepo::ProviderHg: file hg does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.164+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Vcsrepo::ProviderSvn: file svn does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.163+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Vcsrepo::ProviderBzr: file bzr does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.163+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/install.pp",
-            "level": "debug",
-            "line": 4,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[ntp]",
-            "tags": [
-                "debug",
-                "package",
-                "ntp",
-                "class",
-                "ntp::install",
-                "install",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:16.159+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Service::ProviderRunit: file /usr/bin/sv does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.155+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Service::ProviderGentoo: file /sbin/rc-update does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.155+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Service::ProviderLaunchd: file /bin/launchctl does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.154+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Service::ProviderUpstart: 0 confines (of 2) were true",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.154+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Service::ProviderOpenrc: file /bin/rc-status does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.153+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Service::ProviderDaemontools: file /usr/bin/svc does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.153+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Service::ProviderRedhat: file /sbin/chkconfig does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.152+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Service::ProviderSystemd: file systemctl does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:16.152+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for pg1.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:16.135+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Caching connection for https://puppet:8140",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:15.783+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Using cached connection for https://puppet:8140",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:15.35+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "catalog supports formats: pson b64_zlib_yaml yaml dot raw",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:15.349+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Network::Format[msgpack]: feature msgpack is missing",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:15.349+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Failed to load library 'msgpack' for feature 'msgpack'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:15.348+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Executing '/usr/bin/dpkg-query -W --showformat '${Status} ${Package} ${Version}\\n' python'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:15.302+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[python]",
-            "tags": [
-                "debug",
-                "package",
-                "python"
-            ],
-            "time": "2015-02-13T13:21:14.371+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[python-pip]",
-            "tags": [
-                "debug",
-                "package",
-                "python-pip"
-            ],
-            "time": "2015-02-13T13:21:14.369+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
-            "source": "/Package[virtualenv]",
-            "tags": [
-                "debug",
-                "package",
-                "virtualenv"
-            ],
-            "time": "2015-02-13T13:21:14.368+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderPacman: file /usr/bin/pacman does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.367+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderPkg: file /usr/bin/pkg does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.366+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderZypper: file /usr/bin/zypper does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.366+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderAptrpm: file rpm does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.365+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderSunfreeware: file pkg-get does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.365+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderHpux: file /usr/sbin/swinstall does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.364+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderNim: file /usr/sbin/nimclient does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.364+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderUrpmi: file urpmi does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.363+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderUp2date: file /usr/sbin/up2date-nox does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.362+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderRug: file /usr/bin/rug does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.362+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderPortupgrade: file /usr/local/sbin/portupgrade does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.362+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderYum: file yum does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.361+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderRpm: file rpm does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.361+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderFink: file /sw/bin/fink does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.36+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderPorts: file /usr/local/sbin/portupgrade does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.359+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderFreebsd: file /usr/sbin/pkg_info does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.359+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderOpenbsd: file pkg_info does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.358+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderOpkg: file opkg does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.358+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderPkgin: file pkgin does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.357+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderSun: file /usr/bin/pkginfo does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.357+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderPortage: file /usr/bin/emerge does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.356+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Type::Package::ProviderAix: file /usr/bin/lslpp does not exist",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:14.355+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/puppet_vardir.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.849+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/root_home.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.849+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/ip6tables_version.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.849+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/git_version.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.848+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/facter_dot_d.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.848+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/iptables_version.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.847+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/python_version.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.847+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/git_exec_path.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.846+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/apt_package_updates.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.846+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/git_html_path.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.846+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/pip_version.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.845+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/virtualenv_version.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.845+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/concat_basedir.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.844+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/apt_security_updates.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.844+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/apt_updates.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.843+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/pe_version.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.843+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading facts from /var/lib/puppet/lib/facter/iptables_persistent_version.rb",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.842+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:13.842+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Loading external facts from /var/lib/puppet/facts.d",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.841+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Finishing transaction 11350920",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.82+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Caching connection for https://puppet:8140",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.6+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Using cached connection for https://puppet:8140",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.56+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "file_metadata supports formats: pson b64_zlib_yaml yaml raw",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.559+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Network::Format[msgpack]: feature msgpack is missing",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.559+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Failed to load library 'msgpack' for feature 'msgpack'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.558+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:13.401+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Finishing transaction 21451200",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.4+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Caching connection for https://puppet:8140",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.398+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Using cached connection for https://puppet:8140",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.39+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "file_metadata supports formats: pson b64_zlib_yaml yaml raw",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.389+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Network::Format[msgpack]: feature msgpack is missing",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.389+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Failed to load library 'msgpack' for feature 'msgpack'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.388+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:13.365+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Caching connection for https://puppet:8140",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.35+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Starting connection for https://puppet:8140",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.305+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Using cached certificate_revocation_list for ca",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.305+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Creating new connection for https://puppet:8140",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.304+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Using cached certificate for pg1.vm",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.304+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Using cached certificate for ca",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.303+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "node supports formats: pson b64_zlib_yaml yaml raw",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.302+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Puppet::Network::Format[msgpack]: feature msgpack is missing",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.301+00:00"
-        },
-        {
-            "file": null,
-            "level": "debug",
-            "line": null,
-            "message": "Failed to load library 'msgpack' for feature 'msgpack'",
-            "source": "Puppet",
-            "tags": [
-                "debug"
-            ],
-            "time": "2015-02-13T13:21:13.301+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.000524479
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 0.809646404
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.015701975
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.04500305600000001
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 0.000115401
-        },
-        {
-            "category": "time",
-            "name": "gnupg_key",
-            "value": 0.0245873
-        },
-        {
-            "category": "time",
-            "name": "ini_setting",
-            "value": 0.000374412
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.00119644
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.018980525999999994
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.00055239
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.085381164
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 1.0023958039999998
-        },
-        {
-            "category": "time",
-            "name": "vcsrepo",
-            "value": 0.000332257
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 4
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 47
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "noop",
-            "value": 4
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 4
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 0
-        }
-    ],
-    "noop": true,
-    "puppet_version": "3.7.4",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Motd",
-                "File[/etc/motd]"
-            ],
-            "events": [
-                {
-                    "message": "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}6e10c92cc7cd37f8033108d9555eb33a (noop)",
-                    "new_value": "{md5}6e10c92cc7cd37f8033108d9555eb33a",
-                    "old_value": "{md5}a3f731187a6aaaa23d4a7b244f223f33",
-                    "property": "content",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:21:16.348Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "line": 33,
-            "resource_title": "/etc/motd",
-            "resource_type": "File",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:21:16.348Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be foo (noop)",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:21:16.393Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 3,
-            "resource_title": "foo",
-            "resource_type": "Notify",
-            "skipped": false,
-            "corrective_change": false,
-            "timestamp": "2015-02-13T13:21:16.393Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat::Fragment[tmpfile2]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be file (noop)",
-                    "new_value": "file",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:21:16.508Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "line": 113,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:21:16.508Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat::Fragment[tmpfile]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]"
-            ],
-            "events": [
-                {
-                    "message": "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)",
-                    "new_value": "{md5}3a010064e9f94f26236ba1167c7ee125",
-                    "old_value": "{md5}df14e44b311152c34358a675ae34afe0",
-                    "property": "content",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:21:16.523Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "line": 113,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
-            "resource_type": "File",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:21:16.523Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:21:13.238Z",
-    "status": "unchanged",
-    "catalog_uuid": "dcedddbf-25be-43fa-bf6d-a8ffdf765c73",
-    "producer": "foo.com",
-    "code_id": "b6187ff7-0e4f-4400-818d-8ee1dfd0fe38",
-    "transaction_uuid": "ac63fb6f-d191-4d8a-94af-995ccaadb7dd"
+  "corrective_change" : false,
+  "code_id" : "b6187ff7-0e4f-4400-818d-8ee1dfd0fe38",
+  "noop" : true,
+  "certname" : "pg1.vm",
+  "puppet_version" : "3.7.4",
+  "cached_catalog_status" : "not_used",
+  "transaction_uuid" : "ac63fb6f-d191-4d8a-94af-995ccaadb7dd",
+  "configuration_version" : "1423833650",
+  "status" : "unchanged",
+  "producer" : "foo.com",
+  "catalog_uuid" : "dcedddbf-25be-43fa-bf6d-a8ffdf765c73",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 0.39 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:21:16.622+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Stored state in 0.04 seconds",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.622+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Storing state",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.578+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Finishing transaction 10519500",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.578+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 2 events",
+    "source" : "Stage[main]",
+    "tags" : [ "notice", "completed_stage", "main" ],
+    "time" : "2015-02-13T13:21:16.577+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "debug",
+    "line" : 71,
+    "message" : "Nothing to manage: no ensure and the resource doesn't exist",
+    "source" : "/Package[gunicorn]",
+    "tags" : [ "debug", "package", "gunicorn", "class", "python::install", "python", "install", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.572+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "The container Stage[main] will propagate my refresh event",
+    "source" : "Class[Loadtest]",
+    "tags" : [ "debug", "completed_class", "loadtest" ],
+    "time" : "2015-02-13T13:21:16.57+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 4 events",
+    "source" : "Class[Loadtest]",
+    "tags" : [ "notice", "completed_class", "loadtest" ],
+    "time" : "2015-02-13T13:21:16.569+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Executing '/etc/init.d/snmpd status'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.547+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "The container Class[Loadtest] will propagate my refresh event",
+    "source" : "Concat::Fragment[tmpfile]",
+    "tags" : [ "debug", "completed_concat::fragment", "completed_concat", "fragment", "tmpfile" ],
+    "time" : "2015-02-13T13:21:16.545+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Concat::Fragment[tmpfile]",
+    "tags" : [ "notice", "completed_concat::fragment", "completed_concat", "fragment", "tmpfile" ],
+    "time" : "2015-02-13T13:21:16.544+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "The container Class[Loadtest] will propagate my refresh event",
+    "source" : "Concat[/tmp/file]",
+    "tags" : [ "debug", "completed_concat" ],
+    "time" : "2015-02-13T13:21:16.544+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Concat[/tmp/file]",
+    "tags" : [ "notice", "completed_concat" ],
+    "time" : "2015-02-13T13:21:16.543+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "debug",
+    "line" : 187,
+    "message" : "The container Concat[/tmp/file] will propagate my refresh event",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.541+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 187,
+    "message" : "Would have triggered 'refresh' from 2 events",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+    "tags" : [ "notice", "exec", "concat", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.54+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Executing '/var/lib/puppet/concat/bin/concatfragments.sh -o \"/var/lib/puppet/concat/_tmp_file/fragments.concat.out\" -d \"/var/lib/puppet/concat/_tmp_file\" -t'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.526+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Executing check '/var/lib/puppet/concat/bin/concatfragments.sh -o \"/var/lib/puppet/concat/_tmp_file/fragments.concat.out\" -d \"/var/lib/puppet/concat/_tmp_file\" -t'",
+    "source" : "Exec[concat_/tmp/file](provider=posix)",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.525+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "debug",
+    "line" : 113,
+    "message" : "The container Concat::Fragment[tmpfile] will propagate my refresh event",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+    "tags" : [ "debug", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.524+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "info",
+    "line" : 113,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+    "tags" : [ "info", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.523+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "notice",
+    "line" : 113,
+    "message" : "current_value {md5}df14e44b311152c34358a675ae34afe0, should be {md5}3a010064e9f94f26236ba1167c7ee125 (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
+    "tags" : [ "notice", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.523+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "notice",
+    "line" : 113,
+    "message" : "\n--- /var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile\t2015-02-13 13:05:05.021459942 +0000\n+++ /tmp/puppet-file20150213-10108-1ebmfcz\t2015-02-13 13:21:16.509473038 +0000\n@@ -1 +1 @@\n-test contents\n\\ No newline at end of file\n+test contents foo\n\\ No newline at end of file\n",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/content",
+    "tags" : [ "notice", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm", "content" ],
+    "time" : "2015-02-13T13:21:16.522+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Executing 'diff -u /var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile /tmp/puppet-file20150213-10108-1ebmfcz'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.513+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "The container Class[Loadtest] will propagate my refresh event",
+    "source" : "Concat::Fragment[tmpfile2]",
+    "tags" : [ "debug", "completed_concat::fragment", "completed_concat", "fragment", "tmpfile2" ],
+    "time" : "2015-02-13T13:21:16.511+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Concat::Fragment[tmpfile2]",
+    "tags" : [ "notice", "completed_concat::fragment", "completed_concat", "fragment", "tmpfile2" ],
+    "time" : "2015-02-13T13:21:16.511+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "debug",
+    "line" : 113,
+    "message" : "The container Concat::Fragment[tmpfile2] will propagate my refresh event",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+    "tags" : [ "debug", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.51+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "info",
+    "line" : 113,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+    "tags" : [ "info", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.509+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "notice",
+    "line" : 113,
+    "message" : "current_value absent, should be file (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
+    "tags" : [ "notice", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.508+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Executing 'gpg --list-keys --with-colons 20BC0A86'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.47+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Executing '/etc/init.d/ntp status'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.433+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Executing '/etc/init.d/cron status'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.395+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "debug",
+    "line" : 3,
+    "message" : "The container Class[Loadtest] will propagate my refresh event",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]",
+    "tags" : [ "debug", "notify", "foo", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.394+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 3,
+    "message" : "current_value absent, should be foo (noop)",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
+    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.393+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Executing '/usr/bin/apt-cache policy etckeeper'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.375+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Executing '/usr/bin/dpkg-query -W --showformat '${Status} ${Package} ${Version}\\n''",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.352+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Prefetching apt resources for package",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.351+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "The container Stage[main] will propagate my refresh event",
+    "source" : "Class[Motd]",
+    "tags" : [ "debug", "completed_class", "motd" ],
+    "time" : "2015-02-13T13:21:16.35+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Motd]",
+    "tags" : [ "notice", "completed_class", "motd" ],
+    "time" : "2015-02-13T13:21:16.349+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
+    "level" : "debug",
+    "line" : 33,
+    "message" : "The container Class[Motd] will propagate my refresh event",
+    "source" : "/Stage[main]/Motd/File[/etc/motd]",
+    "tags" : [ "debug", "file", "class", "motd", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.349+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
+    "level" : "notice",
+    "line" : 33,
+    "message" : "current_value {md5}a3f731187a6aaaa23d4a7b244f223f33, should be {md5}6e10c92cc7cd37f8033108d9555eb33a (noop)",
+    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
+    "tags" : [ "notice", "file", "class", "motd", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.348+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
+    "level" : "notice",
+    "line" : 33,
+    "message" : "\n--- /etc/motd\t2015-02-13 13:06:12.997460859 +0000\n+++ /tmp/puppet-file20150213-10108-1epr0sd\t2015-02-13 13:21:16.333473035 +0000\n@@ -1 +1,3 @@\n-Welcome to my test host!\n\\ No newline at end of file\n+The operating system is Debian\n+The free memory is 204.09 MB\n+The domain is vm\n",
+    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
+    "tags" : [ "notice", "file", "class", "motd", "loadtest", "node", "pg1.vm", "content" ],
+    "time" : "2015-02-13T13:21:16.347+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Executing 'diff -u /etc/motd /tmp/puppet-file20150213-10108-1epr0sd'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.338+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Caching connection for https://puppet:8140",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.335+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Using cached connection for https://puppet:8140",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.327+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "file_metadata supports formats: pson b64_zlib_yaml yaml raw",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.327+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Network::Format[msgpack]: feature msgpack is missing",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.326+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Failed to load library 'msgpack' for feature 'msgpack'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.325+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423833650'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:16.316+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "debug",
+    "line" : 113,
+    "message" : "Autorequiring File[/var/lib/puppet/concat/_tmp_file/fragments]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+    "tags" : [ "debug", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.305+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "debug",
+    "line" : 113,
+    "message" : "Autorequiring File[/var/lib/puppet/concat/_tmp_file/fragments]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+    "tags" : [ "debug", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.304+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "debug",
+    "line" : 187,
+    "message" : "Autorequiring File[/var/lib/puppet/concat/bin/concatfragments.sh]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.304+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "debug",
+    "line" : 164,
+    "message" : "Autorequiring File[/var/lib/puppet/concat/_tmp_file]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]",
+    "tags" : [ "debug", "file", "concat", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.303+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "debug",
+    "line" : 159,
+    "message" : "Autorequiring File[/var/lib/puppet/concat/_tmp_file]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]",
+    "tags" : [ "debug", "file", "concat", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.302+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "debug",
+    "line" : 149,
+    "message" : "Autorequiring File[/var/lib/puppet/concat/_tmp_file]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
+    "tags" : [ "debug", "file", "concat", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.301+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "debug",
+    "line" : 144,
+    "message" : "Autorequiring File[/var/lib/puppet/concat]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
+    "tags" : [ "debug", "file", "concat", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.3+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/setup.pp",
+    "level" : "debug",
+    "line" : 60,
+    "message" : "Autorequiring File[/var/lib/puppet/concat]",
+    "source" : "/Stage[main]/Concat::Setup/File[/var/lib/puppet/concat/bin]",
+    "tags" : [ "debug", "file", "class", "concat::setup", "concat", "setup", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.3+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/setup.pp",
+    "level" : "debug",
+    "line" : 53,
+    "message" : "Autorequiring File[/var/lib/puppet/concat/bin]",
+    "source" : "/Stage[main]/Concat::Setup/File[/var/lib/puppet/concat/bin/concatfragments.sh]",
+    "tags" : [ "debug", "file", "class", "concat::setup", "concat", "setup", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.299+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "debug",
+    "line" : 69,
+    "message" : "Autorequiring Package[gnupg]",
+    "source" : "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]",
+    "tags" : [ "debug", "gnupg_key", "hkp_server_20bc0a86", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.298+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "debug",
+    "line" : 11,
+    "message" : "Autorequiring Package[git]",
+    "source" : "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
+    "tags" : [ "debug", "vcsrepo", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.295+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "debug",
+    "line" : 113,
+    "message" : "subscribes to Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/notify",
+    "tags" : [ "debug", "file", "concat::fragment", "concat", "fragment", "tmpfile2", "class", "loadtest", "node", "pg1.vm", "notify" ],
+    "time" : "2015-02-13T13:21:16.294+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "debug",
+    "line" : 113,
+    "message" : "subscribes to Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/notify",
+    "tags" : [ "debug", "file", "concat::fragment", "concat", "fragment", "tmpfile", "class", "loadtest", "node", "pg1.vm", "notify" ],
+    "time" : "2015-02-13T13:21:16.293+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "debug",
+    "line" : 187,
+    "message" : "subscribes to File[/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/notify",
+    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm", "notify" ],
+    "time" : "2015-02-13T13:21:16.292+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "debug",
+    "line" : 187,
+    "message" : "subscribes to File[/var/lib/puppet/concat/_tmp_file]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/subscribe",
+    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm", "subscribe" ],
+    "time" : "2015-02-13T13:21:16.291+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "debug",
+    "line" : 187,
+    "message" : "requires File[/var/lib/puppet/concat/_tmp_file/fragments.concat]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/require",
+    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm", "require" ],
+    "time" : "2015-02-13T13:21:16.29+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "debug",
+    "line" : 187,
+    "message" : "requires File[/var/lib/puppet/concat/_tmp_file/fragments]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/require",
+    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm", "require" ],
+    "time" : "2015-02-13T13:21:16.29+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "debug",
+    "line" : 187,
+    "message" : "requires File[/var/lib/puppet/concat/_tmp_file]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/require",
+    "tags" : [ "debug", "exec", "concat", "class", "loadtest", "node", "pg1.vm", "require" ],
+    "time" : "2015-02-13T13:21:16.289+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "debug",
+    "line" : 149,
+    "message" : "subscribes to Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/notify",
+    "tags" : [ "debug", "file", "concat", "class", "loadtest", "node", "pg1.vm", "notify" ],
+    "time" : "2015-02-13T13:21:16.289+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/init.pp",
+    "level" : "debug",
+    "line" : 92,
+    "message" : "requires Anchor[python::end]",
+    "source" : "/Stage[main]/Python::Config/before",
+    "tags" : [ "debug", "class", "python::config", "python", "config", "loadtest", "node", "pg1.vm", "before" ],
+    "time" : "2015-02-13T13:21:16.288+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/init.pp",
+    "level" : "debug",
+    "line" : 91,
+    "message" : "requires Class[Python::Config]",
+    "source" : "/Stage[main]/Python::Install/before",
+    "tags" : [ "debug", "class", "python::install", "python", "install", "loadtest", "node", "pg1.vm", "before" ],
+    "time" : "2015-02-13T13:21:16.287+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/init.pp",
+    "level" : "debug",
+    "line" : 90,
+    "message" : "requires Class[Python::Install]",
+    "source" : "/Stage[main]/Python/Anchor[python::begin]/before",
+    "tags" : [ "debug", "anchor", "python::begin", "python", "begin", "class", "loadtest", "node", "pg1.vm", "before" ],
+    "time" : "2015-02-13T13:21:16.286+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 517,
+    "message" : "requires File[var-net-snmp]",
+    "source" : "/Stage[main]/Snmp/Service[snmpd]/require",
+    "tags" : [ "debug", "service", "snmpd", "class", "snmp", "loadtest", "node", "pg1.vm", "require" ],
+    "time" : "2015-02-13T13:21:16.286+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 517,
+    "message" : "requires Package[snmpd]",
+    "source" : "/Stage[main]/Snmp/Service[snmpd]/require",
+    "tags" : [ "debug", "service", "snmpd", "class", "snmp", "loadtest", "node", "pg1.vm", "require" ],
+    "time" : "2015-02-13T13:21:16.285+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 453,
+    "message" : "subscribes to Service[snmpd]",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]/notify",
+    "tags" : [ "debug", "file", "snmptrapd.conf", "class", "snmp", "loadtest", "node", "pg1.vm", "notify" ],
+    "time" : "2015-02-13T13:21:16.284+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 453,
+    "message" : "requires Package[snmpd]",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]/require",
+    "tags" : [ "debug", "file", "snmptrapd.conf", "class", "snmp", "loadtest", "node", "pg1.vm", "require" ],
+    "time" : "2015-02-13T13:21:16.283+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 441,
+    "message" : "subscribes to Service[snmpd]",
+    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]/notify",
+    "tags" : [ "debug", "file", "snmpd.sysconfig", "class", "snmp", "loadtest", "node", "pg1.vm", "notify" ],
+    "time" : "2015-02-13T13:21:16.282+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 441,
+    "message" : "requires Package[snmpd]",
+    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]/require",
+    "tags" : [ "debug", "file", "snmpd.sysconfig", "class", "snmp", "loadtest", "node", "pg1.vm", "require" ],
+    "time" : "2015-02-13T13:21:16.282+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 429,
+    "message" : "subscribes to Service[snmpd]",
+    "source" : "/Stage[main]/Snmp/File[snmpd.conf]/notify",
+    "tags" : [ "debug", "file", "snmpd.conf", "class", "snmp", "loadtest", "node", "pg1.vm", "notify" ],
+    "time" : "2015-02-13T13:21:16.281+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 429,
+    "message" : "requires Package[snmpd]",
+    "source" : "/Stage[main]/Snmp/File[snmpd.conf]/require",
+    "tags" : [ "debug", "file", "snmpd.conf", "class", "snmp", "loadtest", "node", "pg1.vm", "require" ],
+    "time" : "2015-02-13T13:21:16.28+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 410,
+    "message" : "requires Package[snmpd]",
+    "source" : "/Stage[main]/Snmp/File[var-net-snmp]/require",
+    "tags" : [ "debug", "file", "var-net-snmp", "class", "snmp", "loadtest", "node", "pg1.vm", "require" ],
+    "time" : "2015-02-13T13:21:16.279+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
+    "level" : "debug",
+    "line" : 85,
+    "message" : "requires Package[snmp-client]",
+    "source" : "/Stage[main]/Snmp::Client/File[snmp.conf]/require",
+    "tags" : [ "debug", "file", "snmp.conf", "class", "snmp::client", "snmp", "client", "loadtest", "node", "pg1.vm", "require" ],
+    "time" : "2015-02-13T13:21:16.279+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 61,
+    "message" : "requires Anchor[ntp::end]",
+    "source" : "/Stage[main]/Ntp::Service/before",
+    "tags" : [ "debug", "class", "ntp::service", "ntp", "service", "loadtest", "node", "pg1.vm", "before" ],
+    "time" : "2015-02-13T13:21:16.278+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 60,
+    "message" : "subscribes to Class[Ntp::Service]",
+    "source" : "/Stage[main]/Ntp::Config/notify",
+    "tags" : [ "debug", "class", "ntp::config", "ntp", "config", "loadtest", "node", "pg1.vm", "notify" ],
+    "time" : "2015-02-13T13:21:16.277+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 59,
+    "message" : "requires Class[Ntp::Config]",
+    "source" : "/Stage[main]/Ntp::Install/before",
+    "tags" : [ "debug", "class", "ntp::install", "ntp", "install", "loadtest", "node", "pg1.vm", "before" ],
+    "time" : "2015-02-13T13:21:16.276+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 58,
+    "message" : "requires Class[Ntp::Install]",
+    "source" : "/Stage[main]/Ntp/Anchor[ntp::begin]/before",
+    "tags" : [ "debug", "anchor", "ntp::begin", "ntp", "begin", "class", "loadtest", "node", "pg1.vm", "before" ],
+    "time" : "2015-02-13T13:21:16.271+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loaded state in 0.04 seconds",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.269+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Creating default schedules",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.207+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/gnupg/manifests/install.pp",
+    "level" : "debug",
+    "line" : 4,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[gnupg]",
+    "tags" : [ "debug", "package", "gnupg", "class", "gnupg::install", "install", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.19+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "debug",
+    "line" : 71,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[gunicorn]",
+    "tags" : [ "debug", "package", "gunicorn", "class", "python::install", "python", "install", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.187+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "debug",
+    "line" : 62,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[python]",
+    "tags" : [ "debug", "package", "python", "class", "python::install", "install", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.186+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "debug",
+    "line" : 61,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[python-dev]",
+    "tags" : [ "debug", "package", "python-dev", "class", "python::install", "python", "install", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.185+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "debug",
+    "line" : 60,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[python-pip]",
+    "tags" : [ "debug", "package", "python-pip", "class", "python::install", "python", "install", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.184+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "debug",
+    "line" : 59,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[python-virtualenv]",
+    "tags" : [ "debug", "package", "python-virtualenv", "class", "python::install", "python", "install", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.183+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "debug",
+    "line" : 405,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[snmpd]",
+    "tags" : [ "debug", "package", "snmpd", "class", "snmp", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.177+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
+    "level" : "debug",
+    "line" : 76,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[snmp-client]",
+    "tags" : [ "debug", "package", "snmp-client", "class", "snmp::client", "snmp", "client", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.175+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/git/manifests/init.pp",
+    "level" : "debug",
+    "line" : 12,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[git]",
+    "tags" : [ "debug", "package", "git", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.172+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "debug",
+    "line" : 41,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[etckeeper]",
+    "tags" : [ "debug", "package", "etckeeper", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.17+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Vcsrepo::ProviderCvs: file cvs does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.165+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Vcsrepo::ProviderHg: file hg does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.164+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Vcsrepo::ProviderSvn: file svn does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.163+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Vcsrepo::ProviderBzr: file bzr does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.163+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/install.pp",
+    "level" : "debug",
+    "line" : 4,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[ntp]",
+    "tags" : [ "debug", "package", "ntp", "class", "ntp::install", "install", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:16.159+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Service::ProviderRunit: file /usr/bin/sv does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.155+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Service::ProviderGentoo: file /sbin/rc-update does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.155+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Service::ProviderLaunchd: file /bin/launchctl does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.154+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Service::ProviderUpstart: 0 confines (of 2) were true",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.154+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Service::ProviderOpenrc: file /bin/rc-status does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.153+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Service::ProviderDaemontools: file /usr/bin/svc does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.153+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Service::ProviderRedhat: file /sbin/chkconfig does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.152+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Service::ProviderSystemd: file systemctl does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:16.152+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for pg1.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:16.135+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Caching connection for https://puppet:8140",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:15.783+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Using cached connection for https://puppet:8140",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:15.35+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "catalog supports formats: pson b64_zlib_yaml yaml dot raw",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:15.349+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Network::Format[msgpack]: feature msgpack is missing",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:15.349+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Failed to load library 'msgpack' for feature 'msgpack'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:15.348+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Executing '/usr/bin/dpkg-query -W --showformat '${Status} ${Package} ${Version}\\n' python'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:15.302+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[python]",
+    "tags" : [ "debug", "package", "python" ],
+    "time" : "2015-02-13T13:21:14.371+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[python-pip]",
+    "tags" : [ "debug", "package", "python-pip" ],
+    "time" : "2015-02-13T13:21:14.369+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Provider apt does not support features virtual_packages; not managing attribute allow_virtual",
+    "source" : "/Package[virtualenv]",
+    "tags" : [ "debug", "package", "virtualenv" ],
+    "time" : "2015-02-13T13:21:14.368+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderPacman: file /usr/bin/pacman does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.367+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderPkg: file /usr/bin/pkg does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.366+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderZypper: file /usr/bin/zypper does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.366+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderAptrpm: file rpm does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.365+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderSunfreeware: file pkg-get does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.365+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderHpux: file /usr/sbin/swinstall does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.364+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderNim: file /usr/sbin/nimclient does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.364+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderUrpmi: file urpmi does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.363+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderUp2date: file /usr/sbin/up2date-nox does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.362+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderRug: file /usr/bin/rug does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.362+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderPortupgrade: file /usr/local/sbin/portupgrade does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.362+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderYum: file yum does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.361+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderRpm: file rpm does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.361+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderFink: file /sw/bin/fink does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.36+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderPorts: file /usr/local/sbin/portupgrade does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.359+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderFreebsd: file /usr/sbin/pkg_info does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.359+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderOpenbsd: file pkg_info does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.358+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderOpkg: file opkg does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.358+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderPkgin: file pkgin does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.357+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderSun: file /usr/bin/pkginfo does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.357+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderPortage: file /usr/bin/emerge does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.356+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Type::Package::ProviderAix: file /usr/bin/lslpp does not exist",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:14.355+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/puppet_vardir.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.849+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/root_home.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.849+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/ip6tables_version.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.849+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/git_version.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.848+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/facter_dot_d.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.848+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/iptables_version.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.847+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/python_version.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.847+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/git_exec_path.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.846+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/apt_package_updates.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.846+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/git_html_path.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.846+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/pip_version.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.845+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/virtualenv_version.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.845+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/concat_basedir.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.844+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/apt_security_updates.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.844+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/apt_updates.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.843+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/pe_version.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.843+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading facts from /var/lib/puppet/lib/facter/iptables_persistent_version.rb",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.842+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:13.842+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Loading external facts from /var/lib/puppet/facts.d",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.841+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Finishing transaction 11350920",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.82+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Caching connection for https://puppet:8140",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.6+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Using cached connection for https://puppet:8140",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.56+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "file_metadata supports formats: pson b64_zlib_yaml yaml raw",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.559+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Network::Format[msgpack]: feature msgpack is missing",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.559+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Failed to load library 'msgpack' for feature 'msgpack'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.558+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:13.401+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Finishing transaction 21451200",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.4+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Caching connection for https://puppet:8140",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.398+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Using cached connection for https://puppet:8140",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.39+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "file_metadata supports formats: pson b64_zlib_yaml yaml raw",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.389+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Network::Format[msgpack]: feature msgpack is missing",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.389+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Failed to load library 'msgpack' for feature 'msgpack'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.388+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:13.365+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Caching connection for https://puppet:8140",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.35+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Starting connection for https://puppet:8140",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.305+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Using cached certificate_revocation_list for ca",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.305+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Creating new connection for https://puppet:8140",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.304+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Using cached certificate for pg1.vm",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.304+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Using cached certificate for ca",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.303+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "node supports formats: pson b64_zlib_yaml yaml raw",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.302+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Puppet::Network::Format[msgpack]: feature msgpack is missing",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.301+00:00"
+  }, {
+    "file" : null,
+    "level" : "debug",
+    "line" : null,
+    "message" : "Failed to load library 'msgpack' for feature 'msgpack'",
+    "source" : "Puppet",
+    "tags" : [ "debug" ],
+    "time" : "2015-02-13T13:21:13.301+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:21:14.240Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:21:13.238Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 5.24479E-4
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 0.809646404
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.015701975
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.04500305600000001
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 1.15401E-4
+  }, {
+    "category" : "time",
+    "name" : "gnupg_key",
+    "value" : 0.0245873
+  }, {
+    "category" : "time",
+    "name" : "ini_setting",
+    "value" : 3.74412E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 0.00119644
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.018980525999999994
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 5.5239E-4
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.085381164
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 1.0023958039999998
+  }, {
+    "category" : "time",
+    "name" : "vcsrepo",
+    "value" : 3.32257E-4
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 4
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 47
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "noop",
+    "value" : 4
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 4
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 0
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "b",
+    "resource_type" : "tEIUCq7Qg",
+    "events" : [ ],
+    "line" : 860,
+    "file" : "J90vafPdY",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "RMaI",
+    "resource_type" : "atvN",
+    "events" : [ ],
+    "line" : 421,
+    "file" : "x",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-9956b77aba1f29fe276978cd68d4c169f2e34d69.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-9956b77aba1f29fe276978cd68d4c169f2e34d69.json
@@ -1,328 +1,2251 @@
 {
-    "cached_catalog_status": "not_used",
-    "certname": "pg1.vm",
-    "configuration_version": "1423833650",
-    "end_time": "2015-02-13T13:21:49.346Z",
-    "environment": "production",
-    "corrective_change": true,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 0.31 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:21:52.273+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 3,
-            "message": "defined 'message' as 'foo'",
-            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
-            "tags": [
-                "notice",
-                "notify",
-                "foo",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:52.096+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "foo",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:21:52.095+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "level": "notice",
-            "line": 33,
-            "message": "content changed '{md5}02d304aace03a918311acc96cd339cc3' to '{md5}ed132dbd31efba0f517dda09d5fbb9b6'",
-            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
-            "tags": [
-                "notice",
-                "file",
-                "class",
-                "motd",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:21:52.053+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "level": "notice",
-            "line": 33,
-            "message": "\n--- /etc/motd\t2015-02-13 13:21:23.741473135 +0000\n+++ /tmp/puppet-file20150213-10724-1gn0ewj\t2015-02-13 13:21:52.037473517 +0000\n@@ -1,3 +1,3 @@\n The operating system is Debian\n-The free memory is 204.07 MB\n+The free memory is 202.91 MB\n The domain is vm\n",
-            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
-            "tags": [
-                "notice",
-                "file",
-                "class",
-                "motd",
-                "loadtest",
-                "node",
-                "pg1.vm",
-                "content"
-            ],
-            "time": "2015-02-13T13:21:52.051+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423833650'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:52.022+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for pg1.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:51.874+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:49.041+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:48.395+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:21:48.332+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.00044813199999999996
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 0.993234538
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.014644488
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.031661835
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 8.5529e-05
-        },
-        {
-            "category": "time",
-            "name": "gnupg_key",
-            "value": 0.010125739
-        },
-        {
-            "category": "time",
-            "name": "ini_setting",
-            "value": 0.000355716
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.001868988
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.017718799
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.000512278
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.073210798
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 1.1441704209999999
-        },
-        {
-            "category": "time",
-            "name": "vcsrepo",
-            "value": 0.000303581
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 2
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 2
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 47
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 2
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 2
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 2
-        }
-    ],
-    "noop": false,
-    "puppet_version": "3.7.4",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Motd",
-                "File[/etc/motd]"
-            ],
-            "events": [
-                {
-                    "message": "content changed '{md5}02d304aace03a918311acc96cd339cc3' to '{md5}ed132dbd31efba0f517dda09d5fbb9b6'",
-                    "new_value": "{md5}ed132dbd31efba0f517dda09d5fbb9b6",
-                    "old_value": "{md5}02d304aace03a918311acc96cd339cc3",
-                    "property": "content",
-                    "status": "success",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:21:52.052Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "line": 33,
-            "resource_title": "/etc/motd",
-            "corrective_change": true,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:21:52.052Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "defined 'message' as 'foo'",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "success",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:21:52.095Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 3,
-            "resource_title": "foo",
-            "corrective_change": false,
-            "resource_type": "Notify",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:21:52.095Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:21:48.201Z",
-    "status": "changed",
-    "catalog_uuid": "a86149f6-e0fd-46e4-9080-f873002837bb",
-    "producer": "foo.com",
-    "code_id": "75ffb3e4-ae64-4a58-9017-1d84563852b2",
-    "transaction_uuid": "af8d1c1c-f1b9-450a-949d-f6990cf24d63"
+  "corrective_change" : true,
+  "code_id" : "75ffb3e4-ae64-4a58-9017-1d84563852b2",
+  "noop" : false,
+  "certname" : "pg1.vm",
+  "puppet_version" : "3.7.4",
+  "cached_catalog_status" : "not_used",
+  "transaction_uuid" : "af8d1c1c-f1b9-450a-949d-f6990cf24d63",
+  "configuration_version" : "1423833650",
+  "status" : "changed",
+  "producer" : "foo.com",
+  "catalog_uuid" : "a86149f6-e0fd-46e4-9080-f873002837bb",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 0.31 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:21:52.273+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 3,
+    "message" : "defined 'message' as 'foo'",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
+    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:52.096+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "foo",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:21:52.095+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
+    "level" : "notice",
+    "line" : 33,
+    "message" : "content changed '{md5}02d304aace03a918311acc96cd339cc3' to '{md5}ed132dbd31efba0f517dda09d5fbb9b6'",
+    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
+    "tags" : [ "notice", "file", "class", "motd", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:21:52.053+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
+    "level" : "notice",
+    "line" : 33,
+    "message" : "\n--- /etc/motd\t2015-02-13 13:21:23.741473135 +0000\n+++ /tmp/puppet-file20150213-10724-1gn0ewj\t2015-02-13 13:21:52.037473517 +0000\n@@ -1,3 +1,3 @@\n The operating system is Debian\n-The free memory is 204.07 MB\n+The free memory is 202.91 MB\n The domain is vm\n",
+    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
+    "tags" : [ "notice", "file", "class", "motd", "loadtest", "node", "pg1.vm", "content" ],
+    "time" : "2015-02-13T13:21:52.051+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423833650'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:52.022+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for pg1.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:51.874+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:49.041+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:48.395+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:21:48.332+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:21:49.346Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:21:48.201Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 4.4813199999999996E-4
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 0.993234538
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.014644488
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.031661835
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 8.5529E-5
+  }, {
+    "category" : "time",
+    "name" : "gnupg_key",
+    "value" : 0.010125739
+  }, {
+    "category" : "time",
+    "name" : "ini_setting",
+    "value" : 3.55716E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 0.001868988
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.017718799
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 5.12278E-4
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.073210798
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 1.1441704209999999
+  }, {
+    "category" : "time",
+    "name" : "vcsrepo",
+    "value" : 3.03581E-4
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 2
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 2
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 47
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 2
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 2
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 2
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "b",
+    "resource_type" : "tEIUCq7Qg",
+    "events" : [ ],
+    "line" : 860,
+    "file" : "J90vafPdY",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "RMaI",
+    "resource_type" : "atvN",
+    "events" : [ ],
+    "line" : 421,
+    "file" : "x",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-a454ec51cbadba8c31beb9c1d66e90e9482ff4a6.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg1.vm-a454ec51cbadba8c31beb9c1d66e90e9482ff4a6.json
@@ -1,268 +1,2235 @@
 {
-    "cached_catalog_status": "not_used",
-    "certname": "pg1.vm",
-    "configuration_version": "1423833741",
-    "end_time": "2015-02-13T13:22:42.965Z",
-    "environment": "production",
-    "corrective_change": false,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 0.30 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:22:45.298+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 3,
-            "message": "defined 'message' as 'foo'",
-            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
-            "tags": [
-                "notice",
-                "notify",
-                "foo",
-                "class",
-                "loadtest",
-                "node",
-                "pg1.vm"
-            ],
-            "time": "2015-02-13T13:22:45.122+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "foo",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:22:45.121+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423833741'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:22:45.06+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for pg1.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:22:44.906+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:22:42.642+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:22:42.172+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:22:42.133+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.000612874
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 0.806047949
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.015268704
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.020647922999999995
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 8.8499e-05
-        },
-        {
-            "category": "time",
-            "name": "gnupg_key",
-            "value": 0.01052339
-        },
-        {
-            "category": "time",
-            "name": "ini_setting",
-            "value": 0.00037523
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.001848423
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.018125949000000002
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.0005236080000000001
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.071202317
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 0.945464791
-        },
-        {
-            "category": "time",
-            "name": "vcsrepo",
-            "value": 0.000199925
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 47
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 1
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 1
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 1
-        }
-    ],
-    "noop": false,
-    "puppet_version": "3.7.4",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "defined 'message' as 'foo'",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "success",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:22:45.121Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 3,
-            "corrective_change": false,
-            "resource_title": "foo",
-            "resource_type": "Notify",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:22:45.121Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:22:42.019Z",
-    "status": "changed",
-    "catalog_uuid": "065ebf9f-8592-4f83-8537-d270a69dd91e",
-    "producer": "foo.com",
-    "code_id": "9d1df9cd-99e6-4f8e-8536-5d892aca3600",
-    "transaction_uuid": "8659eaf5-90a6-41d7-8898-6b0aec08d106"
+  "corrective_change" : false,
+  "code_id" : "9d1df9cd-99e6-4f8e-8536-5d892aca3600",
+  "noop" : false,
+  "certname" : "pg1.vm",
+  "puppet_version" : "3.7.4",
+  "cached_catalog_status" : "not_used",
+  "transaction_uuid" : "8659eaf5-90a6-41d7-8898-6b0aec08d106",
+  "configuration_version" : "1423833741",
+  "status" : "changed",
+  "producer" : "foo.com",
+  "catalog_uuid" : "065ebf9f-8592-4f83-8537-d270a69dd91e",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 0.30 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:22:45.298+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 3,
+    "message" : "defined 'message' as 'foo'",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
+    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "pg1.vm" ],
+    "time" : "2015-02-13T13:22:45.122+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "foo",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:22:45.121+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423833741'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:22:45.06+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for pg1.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:22:44.906+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:22:42.642+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:22:42.172+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:22:42.133+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:22:42.965Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:22:42.019Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 6.12874E-4
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 0.806047949
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.015268704
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.020647922999999995
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 8.8499E-5
+  }, {
+    "category" : "time",
+    "name" : "gnupg_key",
+    "value" : 0.01052339
+  }, {
+    "category" : "time",
+    "name" : "ini_setting",
+    "value" : 3.7523E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 0.001848423
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.018125949000000002
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 5.236080000000001E-4
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.071202317
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 0.945464791
+  }, {
+    "category" : "time",
+    "name" : "vcsrepo",
+    "value" : 1.99925E-4
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 47
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 1
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 1
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 1
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "b",
+    "resource_type" : "tEIUCq7Qg",
+    "events" : [ ],
+    "line" : 860,
+    "file" : "J90vafPdY",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "RMaI",
+    "resource_type" : "atvN",
+    "events" : [ ],
+    "line" : 421,
+    "file" : "x",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-193c2a3ae8b277158dbb1073a35290b406c3c073.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-193c2a3ae8b277158dbb1073a35290b406c3c073.json
@@ -1,1994 +1,2713 @@
 {
-    "cached_catalog_status": "on_failure",
-    "certname": "pg2.vm",
-    "configuration_version": "1423834124",
-    "end_time": "2015-02-13T13:29:29.626Z",
-    "environment": "production",
-    "corrective_change": false,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 2.08 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.78+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 8 events",
-            "source": "Stage[main]",
-            "tags": [
-                "main",
-                "completed_stage",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.748+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 8 events",
-            "source": "Class[Loadtest]",
-            "tags": [
-                "completed_class",
-                "loadtest",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.746+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "err",
-            "line": 11,
-            "message": "Provider git is not functional on this host",
-            "source": "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
-            "tags": [
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "err",
-                "vcsrepo",
-                "node"
-            ],
-            "time": "2015-02-13T13:29:33.746+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 2 events",
-            "source": "Class[Snmp::Client]",
-            "tags": [
-                "completed_class",
-                "snmp",
-                "snmp::client",
-                "client",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.745+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "level": "notice",
-            "line": 85,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp::Client/File[snmp.conf]/ensure",
-            "tags": [
-                "class",
-                "snmp",
-                "pg2.vm",
-                "snmp.conf",
-                "loadtest",
-                "file",
-                "node",
-                "snmp::client",
-                "client",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.744+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 3 events",
-            "source": "Class[Python::Install]",
-            "tags": [
-                "completed_class",
-                "python::install",
-                "install",
-                "python",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.741+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "notice",
-            "line": 59,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Python::Install/Package[python-virtualenv]/ensure",
-            "tags": [
-                "class",
-                "python::install",
-                "pg2.vm",
-                "python-virtualenv",
-                "install",
-                "python",
-                "loadtest",
-                "node",
-                "package",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.738+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "notice",
-            "line": 61,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Python::Install/Package[python-devel]/ensure",
-            "tags": [
-                "python-devel",
-                "class",
-                "python::install",
-                "pg2.vm",
-                "install",
-                "python",
-                "loadtest",
-                "node",
-                "package",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.688+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "notice",
-            "line": 60,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Python::Install/Package[python-pip]/ensure",
-            "tags": [
-                "class",
-                "python-pip",
-                "python::install",
-                "pg2.vm",
-                "install",
-                "python",
-                "loadtest",
-                "node",
-                "package",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.66+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Git]",
-            "tags": [
-                "completed_class",
-                "git",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.409+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/git/manifests/init.pp",
-            "level": "notice",
-            "line": 12,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Git/Package[git]/ensure",
-            "tags": [
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "git",
-                "node",
-                "package",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.407+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 8 events",
-            "source": "Class[Snmp]",
-            "tags": [
-                "completed_class",
-                "snmp",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.224+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 517,
-            "message": "Unscheduling refresh on Service[snmpd]",
-            "source": "/Stage[main]/Snmp/Service[snmpd]",
-            "tags": [
-                "snmpd",
-                "class",
-                "info",
-                "snmp",
-                "pg2.vm",
-                "loadtest",
-                "service",
-                "node"
-            ],
-            "time": "2015-02-13T13:29:33.222+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 517,
-            "message": "current_value stopped, should be running (noop)",
-            "source": "/Stage[main]/Snmp/Service[snmpd]/ensure",
-            "tags": [
-                "snmpd",
-                "class",
-                "snmp",
-                "pg2.vm",
-                "loadtest",
-                "service",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.221+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 429,
-            "message": "Scheduling refresh of Service[snmpd]",
-            "source": "/Stage[main]/Snmp/File[snmpd.conf]",
-            "tags": [
-                "class",
-                "info",
-                "snmp",
-                "pg2.vm",
-                "loadtest",
-                "snmpd.conf",
-                "file",
-                "node"
-            ],
-            "time": "2015-02-13T13:29:33.124+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 429,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/File[snmpd.conf]/ensure",
-            "tags": [
-                "class",
-                "snmp",
-                "pg2.vm",
-                "loadtest",
-                "snmpd.conf",
-                "file",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.123+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Concat::Fragment[tmpfile]",
-            "tags": [
-                "completed_concat::fragment",
-                "fragment",
-                "completed_concat",
-                "tmpfile",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.121+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 6 events",
-            "source": "Concat[/tmp/file]",
-            "tags": [
-                "completed_concat",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.119+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "err",
-            "line": 169,
-            "message": "Could not evaluate: Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/tmp/file]",
-            "tags": [
-                "concat",
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "err",
-                "file",
-                "node"
-            ],
-            "time": "2015-02-13T13:29:33.117+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 187,
-            "message": "Would have triggered 'refresh' from 4 events",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-            "tags": [
-                "concat",
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "node",
-                "exec",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.114+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 187,
-            "message": "current_value notrun, should be 0 (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/returns",
-            "tags": [
-                "concat",
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "node",
-                "exec",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.113+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "info",
-            "line": 113,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-            "tags": [
-                "concat::fragment",
-                "class",
-                "concat",
-                "info",
-                "pg2.vm",
-                "fragment",
-                "loadtest",
-                "tmpfile",
-                "file",
-                "node"
-            ],
-            "time": "2015-02-13T13:29:33.046+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "notice",
-            "line": 113,
-            "message": "current_value absent, should be file (noop)",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/ensure",
-            "tags": [
-                "concat::fragment",
-                "class",
-                "concat",
-                "pg2.vm",
-                "fragment",
-                "loadtest",
-                "tmpfile",
-                "file",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.045+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Concat::Fragment[tmpfile2]",
-            "tags": [
-                "completed_concat::fragment",
-                "tmpfile2",
-                "fragment",
-                "completed_concat",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:33.042+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "info",
-            "line": 113,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-            "tags": [
-                "concat::fragment",
-                "class",
-                "concat",
-                "info",
-                "pg2.vm",
-                "tmpfile2",
-                "fragment",
-                "loadtest",
-                "file",
-                "node"
-            ],
-            "time": "2015-02-13T13:29:32.973+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "notice",
-            "line": 113,
-            "message": "current_value absent, should be file (noop)",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
-            "tags": [
-                "concat::fragment",
-                "class",
-                "concat",
-                "pg2.vm",
-                "tmpfile2",
-                "fragment",
-                "loadtest",
-                "file",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.973+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "info",
-            "line": 149,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
-            "tags": [
-                "concat",
-                "class",
-                "info",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "node"
-            ],
-            "time": "2015-02-13T13:29:32.972+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 149,
-            "message": "current_value absent, should be directory (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/ensure",
-            "tags": [
-                "concat",
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.971+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 476,
-            "message": "Would have triggered 'refresh' from 2 events",
-            "source": "/Stage[main]/Snmp/Service[snmptrapd]",
-            "tags": [
-                "class",
-                "snmp",
-                "pg2.vm",
-                "snmptrapd",
-                "loadtest",
-                "service",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.967+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 164,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]/ensure",
-            "tags": [
-                "concat",
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.716+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 159,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]/ensure",
-            "tags": [
-                "concat",
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.715+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "info",
-            "line": 144,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
-            "tags": [
-                "concat",
-                "class",
-                "info",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "node"
-            ],
-            "time": "2015-02-13T13:29:32.714+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 144,
-            "message": "current_value absent, should be directory (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]/ensure",
-            "tags": [
-                "concat",
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.714+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 453,
-            "message": "Scheduling refresh of Service[snmptrapd]",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]",
-            "tags": [
-                "snmptrapd.conf",
-                "class",
-                "info",
-                "snmp",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "node"
-            ],
-            "time": "2015-02-13T13:29:32.712+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 453,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]/ensure",
-            "tags": [
-                "snmptrapd.conf",
-                "class",
-                "snmp",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.711+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 69,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]/ensure",
-            "tags": [
-                "gnupg_key",
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "hkp_server_20bc0a86",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.444+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Ntp::Service]",
-            "tags": [
-                "completed_class",
-                "ntp",
-                "service",
-                "ntp::service",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.418+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
-            "level": "info",
-            "line": 9,
-            "message": "Unscheduling refresh on Service[ntp]",
-            "source": "/Stage[main]/Ntp::Service/Service[ntp]",
-            "tags": [
-                "ntp",
-                "class",
-                "info",
-                "pg2.vm",
-                "loadtest",
-                "service",
-                "node",
-                "ntp::service"
-            ],
-            "time": "2015-02-13T13:29:32.416+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
-            "level": "notice",
-            "line": 9,
-            "message": "current_value stopped, should be running (noop)",
-            "source": "/Stage[main]/Ntp::Service/Service[ntp]/ensure",
-            "tags": [
-                "ntp",
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "service",
-                "node",
-                "ntp::service",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.416+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 410,
-            "message": "current_value absent, should be directory (noop)",
-            "source": "/Stage[main]/Snmp/File[var-net-snmp]/ensure",
-            "tags": [
-                "class",
-                "var-net-snmp",
-                "snmp",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.336+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 45,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Loadtest/Ini_setting[sample setting]/ensure",
-            "tags": [
-                "class",
-                "ini_setting",
-                "pg2.vm",
-                "loadtest",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.334+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Service[ntp]",
-            "source": "Class[Ntp::Service]",
-            "tags": [
-                "ntp",
-                "info",
-                "admissible_class",
-                "service",
-                "ntp::service"
-            ],
-            "time": "2015-02-13T13:29:32.333+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Ntp::Service]",
-            "tags": [
-                "ntp",
-                "admissible_class",
-                "service",
-                "ntp::service",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.333+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Class[Ntp::Service]",
-            "source": "Class[Ntp::Config]",
-            "tags": [
-                "completed_class",
-                "ntp",
-                "info",
-                "ntp::config",
-                "config"
-            ],
-            "time": "2015-02-13T13:29:32.332+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Ntp::Config]",
-            "tags": [
-                "completed_class",
-                "ntp",
-                "ntp::config",
-                "config",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.331+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
-            "level": "notice",
-            "line": 14,
-            "message": "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
-            "source": "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
-            "tags": [
-                "class",
-                "ntp",
-                "pg2.vm",
-                "ntp::config",
-                "loadtest",
-                "file",
-                "node",
-                "config",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.328+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
-            "level": "notice",
-            "line": 14,
-            "message": "\n--- /etc/ntp.conf\t2013-07-15 10:18:47.000000000 +0100\n+++ /tmp/puppet-file20150213-62287-xahzaj-0\t2015-02-13 13:29:32.296877887 +0000\n@@ -1,53 +1,19 @@\n-# For more information about this file, see the man pages\n-# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).\n+# ntp.conf: Managed by puppet.\n+#\n+# Keep ntpd from panicking in the event of a large clock skew\n+# when a VM guest is suspended and resumed.\n+tinker panic 0\n \n-driftfile /var/lib/ntp/drift\n \n # Permit time synchronization with our time source, but do not\n # permit the source to query or modify the service on this system.\n-restrict default kod nomodify notrap nopeer noquery\n-restrict -6 default kod nomodify notrap nopeer noquery\n+restrict 127.0.0.1\n+\n \n-# Permit all access over the loopback interface.  This could\n-# be tightened as well, but to do so would effect some of\n-# the administrative functions.\n-restrict 127.0.0.1 \n-restrict -6 ::1\n-\n-# Hosts on local network are less restricted.\n-#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap\n-\n-# Use public servers from the pool.ntp.org project.\n-# Please consider joining the pool (http://www.pool.ntp.org/join.html).\n-server 0.centos.pool.ntp.org iburst\n-server 1.centos.pool.ntp.org iburst\n-server 2.centos.pool.ntp.org iburst\n-server 3.centos.pool.ntp.org iburst\n-\n-#broadcast 192.168.1.255 autokey\t# broadcast server\n-#broadcastclient\t\t\t# broadcast client\n-#broadcast 224.0.1.1 autokey\t\t# multicast server\n-#multicastclient 224.0.1.1\t\t# multicast client\n-#manycastserver 239.255.254.254\t\t# manycast server\n-#manycastclient 239.255.254.254 autokey # manycast client\n-\n-# Enable public key cryptography.\n-#crypto\n-\n-includefile /etc/ntp/crypto/pw\n-\n-# Key file containing the keys and key identifiers used when operating\n-# with symmetric key cryptography. \n-keys /etc/ntp/keys\n-\n-# Specify the key identifiers which are trusted.\n-#trustedkey 4 8 42\n+server ntp.pool.org\n \n-# Specify the key identifier to use with the ntpdc utility.\n-#requestkey 8\n \n-# Specify the key identifier to use with the ntpq utility.\n-#controlkey 8\n+# Driftfile.\n+driftfile /var/lib/ntp/drift\n+\n \n-# Enable writing of statistics records.\n-#statistics clockstats cryptostats loopstats peerstats\n",
-            "source": "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
-            "tags": [
-                "class",
-                "ntp",
-                "pg2.vm",
-                "ntp::config",
-                "loadtest",
-                "file",
-                "node",
-                "config",
-                "content",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.324+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 441,
-            "message": "Scheduling refresh of Service[snmpd]",
-            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]",
-            "tags": [
-                "snmpd.sysconfig",
-                "class",
-                "info",
-                "snmp",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "node"
-            ],
-            "time": "2015-02-13T13:29:32.293+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 441,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]/ensure",
-            "tags": [
-                "snmpd.sysconfig",
-                "class",
-                "snmp",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.292+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 465,
-            "message": "Scheduling refresh of Service[snmptrapd]",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.sysconfig]",
-            "tags": [
-                "class",
-                "info",
-                "snmp",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "node",
-                "snmptrapd.sysconfig"
-            ],
-            "time": "2015-02-13T13:29:32.285+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 465,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.sysconfig]/ensure",
-            "tags": [
-                "class",
-                "snmp",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "node",
-                "snmptrapd.sysconfig",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.285+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "info",
-            "line": 4,
-            "message": "Unscheduling refresh on Service[cron]",
-            "source": "/Stage[main]/Loadtest/Service[cron]",
-            "tags": [
-                "class",
-                "info",
-                "pg2.vm",
-                "loadtest",
-                "service",
-                "cron",
-                "node"
-            ],
-            "time": "2015-02-13T13:29:32.281+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 4,
-            "message": "current_value stopped, should be running (noop)",
-            "source": "/Stage[main]/Loadtest/Service[cron]/ensure",
-            "tags": [
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "service",
-                "cron",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.28+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 3,
-            "message": "current_value absent, should be foo (noop)",
-            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
-            "tags": [
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "foo",
-                "node",
-                "notify",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.178+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 405,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/Package[snmpd]/ensure",
-            "tags": [
-                "snmpd",
-                "class",
-                "snmp",
-                "pg2.vm",
-                "loadtest",
-                "node",
-                "package",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.176+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 41,
-            "message": "current_value absent, should be latest (noop)",
-            "source": "/Stage[main]/Loadtest/Package[etckeeper]/ensure",
-            "tags": [
-                "etckeeper",
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "node",
-                "package",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.134+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "level": "notice",
-            "line": 76,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp::Client/Package[snmp-client]/ensure",
-            "tags": [
-                "snmp-client",
-                "class",
-                "snmp",
-                "pg2.vm",
-                "loadtest",
-                "node",
-                "snmp::client",
-                "package",
-                "client",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:32.09+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Motd]",
-            "tags": [
-                "completed_class",
-                "motd",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:31.93+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "level": "notice",
-            "line": 33,
-            "message": "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
-            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
-            "tags": [
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "motd",
-                "node",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:31.924+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "level": "notice",
-            "line": 33,
-            "message": "\n--- /etc/motd\t2010-01-12 13:28:22.000000000 +0000\n+++ /tmp/puppet-file20150213-62287-jf1btv-0\t2015-02-13 13:29:31.882877889 +0000\n@@ -0,0 +1 @@\n+Welcome to my test host!\n\\ No newline at end of file\n",
-            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
-            "tags": [
-                "class",
-                "pg2.vm",
-                "loadtest",
-                "file",
-                "motd",
-                "node",
-                "content",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:31.923+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423834124'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:31.774+00:00"
-        },
-        {
-            "file": null,
-            "level": "warning",
-            "line": null,
-            "message": "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
-            "source": "Puppet",
-            "tags": [
-                "warning"
-            ],
-            "time": "2015-02-13T13:29:31.381+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for pg2.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:31.286+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:29.241+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:26.991+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:26.912+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.001046
-        },
-        {
-            "category": "time",
-            "name": "augeas",
-            "value": 0.049918
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 1.2285521030426
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.454854
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.232939
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 0.000135
-        },
-        {
-            "category": "time",
-            "name": "gnupg_key",
-            "value": 0.024507
-        },
-        {
-            "category": "time",
-            "name": "ini_setting",
-            "value": 0.000665
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.00084
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.25077
-        },
-        {
-            "category": "time",
-            "name": "postgresql_conf",
-            "value": 0.000628
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.002515
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.532835
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 2.7802041030426
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 2
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 29
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 88
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 1
-        },
-        {
-            "category": "events",
-            "name": "noop",
-            "value": 28
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 29
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 0
-        }
-    ],
-    "noop": true,
-    "puppet_version": "3.7.1",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp::Client",
-                "File[snmp.conf]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:33.744Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "line": 85,
-            "corrective_change": false,
-            "resource_title": "snmp.conf",
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:33.744Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.716Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 164,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.716Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp::Client",
-                "Package[snmp-client]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.090Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "line": 76,
-            "resource_title": "snmp-client",
-            "corrective_change": false,
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.090Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat::Fragment[tmpfile2]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be file (noop)",
-                    "new_value": "file",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.973Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "line": 113,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
-            "resource_type": "File",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.973Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Package[etckeeper]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be latest (noop)",
-                    "new_value": "latest",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.134Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 41,
-            "corrective_change": false,
-            "resource_title": "etckeeper",
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.134Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Motd",
-                "File[/etc/motd]"
-            ],
-            "events": [
-                {
-                    "message": "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
-                    "new_value": "{md5}a3f731187a6aaaa23d4a7b244f223f33",
-                    "old_value": "{md5}d41d8cd98f00b204e9800998ecf8427e",
+  "corrective_change" : false,
+  "code_id" : "01167c6f-95ce-4163-98d8-60ae9b5fbf15",
+  "noop" : true,
+  "certname" : "pg2.vm",
+  "puppet_version" : "3.7.1",
+  "cached_catalog_status" : "on_failure",
+  "transaction_uuid" : "1fb6bf81-0b2a-488c-b1d7-610a81b06b27",
+  "configuration_version" : "1423834124",
+  "status" : "failed",
+  "producer" : "foo.com",
+  "catalog_uuid" : "974b0567-11bf-4600-a659-e293f14d0a03",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 2.08 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:29:33.78+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 8 events",
+    "source" : "Stage[main]",
+    "tags" : [ "main", "completed_stage", "notice" ],
+    "time" : "2015-02-13T13:29:33.748+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 8 events",
+    "source" : "Class[Loadtest]",
+    "tags" : [ "completed_class", "loadtest", "notice" ],
+    "time" : "2015-02-13T13:29:33.746+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "err",
+    "line" : 11,
+    "message" : "Provider git is not functional on this host",
+    "source" : "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
+    "tags" : [ "class", "pg2.vm", "loadtest", "err", "vcsrepo", "node" ],
+    "time" : "2015-02-13T13:29:33.746+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 2 events",
+    "source" : "Class[Snmp::Client]",
+    "tags" : [ "completed_class", "snmp", "snmp::client", "client", "notice" ],
+    "time" : "2015-02-13T13:29:33.745+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
+    "level" : "notice",
+    "line" : 85,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp::Client/File[snmp.conf]/ensure",
+    "tags" : [ "class", "snmp", "pg2.vm", "snmp.conf", "loadtest", "file", "node", "snmp::client", "client", "notice" ],
+    "time" : "2015-02-13T13:29:33.744+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 3 events",
+    "source" : "Class[Python::Install]",
+    "tags" : [ "completed_class", "python::install", "install", "python", "notice" ],
+    "time" : "2015-02-13T13:29:33.741+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "notice",
+    "line" : 59,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Python::Install/Package[python-virtualenv]/ensure",
+    "tags" : [ "class", "python::install", "pg2.vm", "python-virtualenv", "install", "python", "loadtest", "node", "package", "notice" ],
+    "time" : "2015-02-13T13:29:33.738+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "notice",
+    "line" : 61,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Python::Install/Package[python-devel]/ensure",
+    "tags" : [ "python-devel", "class", "python::install", "pg2.vm", "install", "python", "loadtest", "node", "package", "notice" ],
+    "time" : "2015-02-13T13:29:33.688+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "notice",
+    "line" : 60,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Python::Install/Package[python-pip]/ensure",
+    "tags" : [ "class", "python-pip", "python::install", "pg2.vm", "install", "python", "loadtest", "node", "package", "notice" ],
+    "time" : "2015-02-13T13:29:33.66+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Git]",
+    "tags" : [ "completed_class", "git", "notice" ],
+    "time" : "2015-02-13T13:29:33.409+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/git/manifests/init.pp",
+    "level" : "notice",
+    "line" : 12,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Git/Package[git]/ensure",
+    "tags" : [ "class", "pg2.vm", "loadtest", "git", "node", "package", "notice" ],
+    "time" : "2015-02-13T13:29:33.407+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 8 events",
+    "source" : "Class[Snmp]",
+    "tags" : [ "completed_class", "snmp", "notice" ],
+    "time" : "2015-02-13T13:29:33.224+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 517,
+    "message" : "Unscheduling refresh on Service[snmpd]",
+    "source" : "/Stage[main]/Snmp/Service[snmpd]",
+    "tags" : [ "snmpd", "class", "info", "snmp", "pg2.vm", "loadtest", "service", "node" ],
+    "time" : "2015-02-13T13:29:33.222+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 517,
+    "message" : "current_value stopped, should be running (noop)",
+    "source" : "/Stage[main]/Snmp/Service[snmpd]/ensure",
+    "tags" : [ "snmpd", "class", "snmp", "pg2.vm", "loadtest", "service", "node", "notice" ],
+    "time" : "2015-02-13T13:29:33.221+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 429,
+    "message" : "Scheduling refresh of Service[snmpd]",
+    "source" : "/Stage[main]/Snmp/File[snmpd.conf]",
+    "tags" : [ "class", "info", "snmp", "pg2.vm", "loadtest", "snmpd.conf", "file", "node" ],
+    "time" : "2015-02-13T13:29:33.124+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 429,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/File[snmpd.conf]/ensure",
+    "tags" : [ "class", "snmp", "pg2.vm", "loadtest", "snmpd.conf", "file", "node", "notice" ],
+    "time" : "2015-02-13T13:29:33.123+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Concat::Fragment[tmpfile]",
+    "tags" : [ "completed_concat::fragment", "fragment", "completed_concat", "tmpfile", "notice" ],
+    "time" : "2015-02-13T13:29:33.121+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 6 events",
+    "source" : "Concat[/tmp/file]",
+    "tags" : [ "completed_concat", "notice" ],
+    "time" : "2015-02-13T13:29:33.119+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "err",
+    "line" : 169,
+    "message" : "Could not evaluate: Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/tmp/file]",
+    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "err", "file", "node" ],
+    "time" : "2015-02-13T13:29:33.117+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 187,
+    "message" : "Would have triggered 'refresh' from 4 events",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "node", "exec", "notice" ],
+    "time" : "2015-02-13T13:29:33.114+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 187,
+    "message" : "current_value notrun, should be 0 (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/returns",
+    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "node", "exec", "notice" ],
+    "time" : "2015-02-13T13:29:33.113+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "info",
+    "line" : 113,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+    "tags" : [ "concat::fragment", "class", "concat", "info", "pg2.vm", "fragment", "loadtest", "tmpfile", "file", "node" ],
+    "time" : "2015-02-13T13:29:33.046+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "notice",
+    "line" : 113,
+    "message" : "current_value absent, should be file (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/ensure",
+    "tags" : [ "concat::fragment", "class", "concat", "pg2.vm", "fragment", "loadtest", "tmpfile", "file", "node", "notice" ],
+    "time" : "2015-02-13T13:29:33.045+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Concat::Fragment[tmpfile2]",
+    "tags" : [ "completed_concat::fragment", "tmpfile2", "fragment", "completed_concat", "notice" ],
+    "time" : "2015-02-13T13:29:33.042+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "info",
+    "line" : 113,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+    "tags" : [ "concat::fragment", "class", "concat", "info", "pg2.vm", "tmpfile2", "fragment", "loadtest", "file", "node" ],
+    "time" : "2015-02-13T13:29:32.973+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "notice",
+    "line" : 113,
+    "message" : "current_value absent, should be file (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
+    "tags" : [ "concat::fragment", "class", "concat", "pg2.vm", "tmpfile2", "fragment", "loadtest", "file", "node", "notice" ],
+    "time" : "2015-02-13T13:29:32.973+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "info",
+    "line" : 149,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
+    "tags" : [ "concat", "class", "info", "pg2.vm", "loadtest", "file", "node" ],
+    "time" : "2015-02-13T13:29:32.972+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 149,
+    "message" : "current_value absent, should be directory (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/ensure",
+    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "file", "node", "notice" ],
+    "time" : "2015-02-13T13:29:32.971+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 476,
+    "message" : "Would have triggered 'refresh' from 2 events",
+    "source" : "/Stage[main]/Snmp/Service[snmptrapd]",
+    "tags" : [ "class", "snmp", "pg2.vm", "snmptrapd", "loadtest", "service", "node", "notice" ],
+    "time" : "2015-02-13T13:29:32.967+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 164,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]/ensure",
+    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "file", "node", "notice" ],
+    "time" : "2015-02-13T13:29:32.716+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 159,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]/ensure",
+    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "file", "node", "notice" ],
+    "time" : "2015-02-13T13:29:32.715+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "info",
+    "line" : 144,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
+    "tags" : [ "concat", "class", "info", "pg2.vm", "loadtest", "file", "node" ],
+    "time" : "2015-02-13T13:29:32.714+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 144,
+    "message" : "current_value absent, should be directory (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]/ensure",
+    "tags" : [ "concat", "class", "pg2.vm", "loadtest", "file", "node", "notice" ],
+    "time" : "2015-02-13T13:29:32.714+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 453,
+    "message" : "Scheduling refresh of Service[snmptrapd]",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]",
+    "tags" : [ "snmptrapd.conf", "class", "info", "snmp", "pg2.vm", "loadtest", "file", "node" ],
+    "time" : "2015-02-13T13:29:32.712+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 453,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]/ensure",
+    "tags" : [ "snmptrapd.conf", "class", "snmp", "pg2.vm", "loadtest", "file", "node", "notice" ],
+    "time" : "2015-02-13T13:29:32.711+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 69,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]/ensure",
+    "tags" : [ "gnupg_key", "class", "pg2.vm", "loadtest", "hkp_server_20bc0a86", "node", "notice" ],
+    "time" : "2015-02-13T13:29:32.444+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Ntp::Service]",
+    "tags" : [ "completed_class", "ntp", "service", "ntp::service", "notice" ],
+    "time" : "2015-02-13T13:29:32.418+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
+    "level" : "info",
+    "line" : 9,
+    "message" : "Unscheduling refresh on Service[ntp]",
+    "source" : "/Stage[main]/Ntp::Service/Service[ntp]",
+    "tags" : [ "ntp", "class", "info", "pg2.vm", "loadtest", "service", "node", "ntp::service" ],
+    "time" : "2015-02-13T13:29:32.416+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
+    "level" : "notice",
+    "line" : 9,
+    "message" : "current_value stopped, should be running (noop)",
+    "source" : "/Stage[main]/Ntp::Service/Service[ntp]/ensure",
+    "tags" : [ "ntp", "class", "pg2.vm", "loadtest", "service", "node", "ntp::service", "notice" ],
+    "time" : "2015-02-13T13:29:32.416+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 410,
+    "message" : "current_value absent, should be directory (noop)",
+    "source" : "/Stage[main]/Snmp/File[var-net-snmp]/ensure",
+    "tags" : [ "class", "var-net-snmp", "snmp", "pg2.vm", "loadtest", "file", "node", "notice" ],
+    "time" : "2015-02-13T13:29:32.336+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 45,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Loadtest/Ini_setting[sample setting]/ensure",
+    "tags" : [ "class", "ini_setting", "pg2.vm", "loadtest", "node", "notice" ],
+    "time" : "2015-02-13T13:29:32.334+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Service[ntp]",
+    "source" : "Class[Ntp::Service]",
+    "tags" : [ "ntp", "info", "admissible_class", "service", "ntp::service" ],
+    "time" : "2015-02-13T13:29:32.333+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Ntp::Service]",
+    "tags" : [ "ntp", "admissible_class", "service", "ntp::service", "notice" ],
+    "time" : "2015-02-13T13:29:32.333+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Class[Ntp::Service]",
+    "source" : "Class[Ntp::Config]",
+    "tags" : [ "completed_class", "ntp", "info", "ntp::config", "config" ],
+    "time" : "2015-02-13T13:29:32.332+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Ntp::Config]",
+    "tags" : [ "completed_class", "ntp", "ntp::config", "config", "notice" ],
+    "time" : "2015-02-13T13:29:32.331+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
+    "level" : "notice",
+    "line" : 14,
+    "message" : "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
+    "source" : "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
+    "tags" : [ "class", "ntp", "pg2.vm", "ntp::config", "loadtest", "file", "node", "config", "notice" ],
+    "time" : "2015-02-13T13:29:32.328+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
+    "level" : "notice",
+    "line" : 14,
+    "message" : "\n--- /etc/ntp.conf\t2013-07-15 10:18:47.000000000 +0100\n+++ /tmp/puppet-file20150213-62287-xahzaj-0\t2015-02-13 13:29:32.296877887 +0000\n@@ -1,53 +1,19 @@\n-# For more information about this file, see the man pages\n-# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).\n+# ntp.conf: Managed by puppet.\n+#\n+# Keep ntpd from panicking in the event of a large clock skew\n+# when a VM guest is suspended and resumed.\n+tinker panic 0\n \n-driftfile /var/lib/ntp/drift\n \n # Permit time synchronization with our time source, but do not\n # permit the source to query or modify the service on this system.\n-restrict default kod nomodify notrap nopeer noquery\n-restrict -6 default kod nomodify notrap nopeer noquery\n+restrict 127.0.0.1\n+\n \n-# Permit all access over the loopback interface.  This could\n-# be tightened as well, but to do so would effect some of\n-# the administrative functions.\n-restrict 127.0.0.1 \n-restrict -6 ::1\n-\n-# Hosts on local network are less restricted.\n-#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap\n-\n-# Use public servers from the pool.ntp.org project.\n-# Please consider joining the pool (http://www.pool.ntp.org/join.html).\n-server 0.centos.pool.ntp.org iburst\n-server 1.centos.pool.ntp.org iburst\n-server 2.centos.pool.ntp.org iburst\n-server 3.centos.pool.ntp.org iburst\n-\n-#broadcast 192.168.1.255 autokey\t# broadcast server\n-#broadcastclient\t\t\t# broadcast client\n-#broadcast 224.0.1.1 autokey\t\t# multicast server\n-#multicastclient 224.0.1.1\t\t# multicast client\n-#manycastserver 239.255.254.254\t\t# manycast server\n-#manycastclient 239.255.254.254 autokey # manycast client\n-\n-# Enable public key cryptography.\n-#crypto\n-\n-includefile /etc/ntp/crypto/pw\n-\n-# Key file containing the keys and key identifiers used when operating\n-# with symmetric key cryptography. \n-keys /etc/ntp/keys\n-\n-# Specify the key identifiers which are trusted.\n-#trustedkey 4 8 42\n+server ntp.pool.org\n \n-# Specify the key identifier to use with the ntpdc utility.\n-#requestkey 8\n \n-# Specify the key identifier to use with the ntpq utility.\n-#controlkey 8\n+# Driftfile.\n+driftfile /var/lib/ntp/drift\n+\n \n-# Enable writing of statistics records.\n-#statistics clockstats cryptostats loopstats peerstats\n",
+    "source" : "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
+    "tags" : [ "class", "ntp", "pg2.vm", "ntp::config", "loadtest", "file", "node", "config", "content", "notice" ],
+    "time" : "2015-02-13T13:29:32.324+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 441,
+    "message" : "Scheduling refresh of Service[snmpd]",
+    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]",
+    "tags" : [ "snmpd.sysconfig", "class", "info", "snmp", "pg2.vm", "loadtest", "file", "node" ],
+    "time" : "2015-02-13T13:29:32.293+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 441,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]/ensure",
+    "tags" : [ "snmpd.sysconfig", "class", "snmp", "pg2.vm", "loadtest", "file", "node", "notice" ],
+    "time" : "2015-02-13T13:29:32.292+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 465,
+    "message" : "Scheduling refresh of Service[snmptrapd]",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.sysconfig]",
+    "tags" : [ "class", "info", "snmp", "pg2.vm", "loadtest", "file", "node", "snmptrapd.sysconfig" ],
+    "time" : "2015-02-13T13:29:32.285+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 465,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.sysconfig]/ensure",
+    "tags" : [ "class", "snmp", "pg2.vm", "loadtest", "file", "node", "snmptrapd.sysconfig", "notice" ],
+    "time" : "2015-02-13T13:29:32.285+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "info",
+    "line" : 4,
+    "message" : "Unscheduling refresh on Service[cron]",
+    "source" : "/Stage[main]/Loadtest/Service[cron]",
+    "tags" : [ "class", "info", "pg2.vm", "loadtest", "service", "cron", "node" ],
+    "time" : "2015-02-13T13:29:32.281+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 4,
+    "message" : "current_value stopped, should be running (noop)",
+    "source" : "/Stage[main]/Loadtest/Service[cron]/ensure",
+    "tags" : [ "class", "pg2.vm", "loadtest", "service", "cron", "node", "notice" ],
+    "time" : "2015-02-13T13:29:32.28+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 3,
+    "message" : "current_value absent, should be foo (noop)",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
+    "tags" : [ "class", "pg2.vm", "loadtest", "foo", "node", "notify", "notice" ],
+    "time" : "2015-02-13T13:29:32.178+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 405,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/Package[snmpd]/ensure",
+    "tags" : [ "snmpd", "class", "snmp", "pg2.vm", "loadtest", "node", "package", "notice" ],
+    "time" : "2015-02-13T13:29:32.176+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 41,
+    "message" : "current_value absent, should be latest (noop)",
+    "source" : "/Stage[main]/Loadtest/Package[etckeeper]/ensure",
+    "tags" : [ "etckeeper", "class", "pg2.vm", "loadtest", "node", "package", "notice" ],
+    "time" : "2015-02-13T13:29:32.134+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
+    "level" : "notice",
+    "line" : 76,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp::Client/Package[snmp-client]/ensure",
+    "tags" : [ "snmp-client", "class", "snmp", "pg2.vm", "loadtest", "node", "snmp::client", "package", "client", "notice" ],
+    "time" : "2015-02-13T13:29:32.09+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Motd]",
+    "tags" : [ "completed_class", "motd", "notice" ],
+    "time" : "2015-02-13T13:29:31.93+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
+    "level" : "notice",
+    "line" : 33,
+    "message" : "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
+    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
+    "tags" : [ "class", "pg2.vm", "loadtest", "file", "motd", "node", "notice" ],
+    "time" : "2015-02-13T13:29:31.924+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
+    "level" : "notice",
+    "line" : 33,
+    "message" : "\n--- /etc/motd\t2010-01-12 13:28:22.000000000 +0000\n+++ /tmp/puppet-file20150213-62287-jf1btv-0\t2015-02-13 13:29:31.882877889 +0000\n@@ -0,0 +1 @@\n+Welcome to my test host!\n\\ No newline at end of file\n",
+    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
+    "tags" : [ "class", "pg2.vm", "loadtest", "file", "motd", "node", "content", "notice" ],
+    "time" : "2015-02-13T13:29:31.923+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423834124'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:31.774+00:00"
+  }, {
+    "file" : null,
+    "level" : "warning",
+    "line" : null,
+    "message" : "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
+    "source" : "Puppet",
+    "tags" : [ "warning" ],
+    "time" : "2015-02-13T13:29:31.381+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for pg2.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:31.286+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:29.241+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:26.991+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:26.912+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:29:29.626Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:29:26.846Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 0.001046
+  }, {
+    "category" : "time",
+    "name" : "augeas",
+    "value" : 0.049918
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 1.2285521030426
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.454854
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.232939
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 1.35E-4
+  }, {
+    "category" : "time",
+    "name" : "gnupg_key",
+    "value" : 0.024507
+  }, {
+    "category" : "time",
+    "name" : "ini_setting",
+    "value" : 6.65E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 8.4E-4
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.25077
+  }, {
+    "category" : "time",
+    "name" : "postgresql_conf",
+    "value" : 6.28E-4
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 0.002515
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.532835
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 2.7802041030426
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 2
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 29
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 88
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 1
+  }, {
+    "category" : "events",
+    "name" : "noop",
+    "value" : 28
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 29
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 0
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "hdyu",
+    "resource_type" : "ZID",
+    "events" : [ ],
+    "line" : 400,
+    "file" : "JlvbbGQ2Fx",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ {
+                    "message": null,
+                    "new_value": "bar",
+                    "old_value": "foo",
                     "property": "content",
-                    "status": "noop",
+                    "status": "success",
                     "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:31.924Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "line": 33,
-            "resource_title": "/etc/motd",
-            "resource_type": "File",
-            "skipped": false,
-            "corrective_change": false,
-            "timestamp": "2015-02-13T13:29:31.924Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/tmp/file]"
-            ],
-            "events": [
-                {
-                    "message": "Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-                    "new_value": null,
-                    "old_value": null,
-                    "property": null,
-                    "status": "failure",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:33.118Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 169,
-            "resource_title": "/tmp/file",
-            "resource_type": "File",
-            "skipped": false,
-            "corrective_change": false,
-            "timestamp": "2015-02-13T13:29:33.118Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be foo (noop)",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.178Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 3,
-            "resource_title": "foo",
-            "corrective_change": false,
-            "resource_type": "Notify",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.178Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[snmptrapd.sysconfig]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.284Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 465,
-            "resource_title": "snmptrapd.sysconfig",
-            "resource_type": "File",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.284Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat::Fragment[tmpfile]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be file (noop)",
-                    "new_value": "file",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:33.045Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "line": 113,
-            "corrective_change": false,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:33.045Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[var-net-snmp]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be directory (noop)",
-                    "new_value": "directory",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.336Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 410,
-            "resource_title": "var-net-snmp",
-            "resource_type": "File",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.336Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Python::Install",
-                "Package[python-pip]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:33.660Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "line": 60,
-            "resource_title": "python-pip",
-            "resource_type": "Package",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:33.660Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "Service[snmpd]"
-            ],
-            "events": [
-                {
-                    "message": "current_value stopped, should be running (noop)",
-                    "new_value": "running",
-                    "old_value": "stopped",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:33.221Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 517,
-            "resource_title": "snmpd",
-            "corrective_change": false,
-            "resource_type": "Service",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:33.221Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[snmpd.sysconfig]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.292Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 441,
-            "resource_title": "snmpd.sysconfig",
-            "resource_type": "File",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.292Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Git",
-                "Package[git]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:33.407Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/git/manifests/init.pp",
-            "line": 12,
-            "resource_title": "git",
-            "corrective_change": false,
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:33.407Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Python::Install",
-                "Package[python-virtualenv]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:33.738Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "corrective_change": false,
-            "line": 59,
-            "resource_title": "python-virtualenv",
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:33.738Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "Package[snmpd]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.175Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 405,
-            "resource_title": "snmpd",
-            "resource_type": "Package",
-            "skipped": false,
-            "corrective_change": false,
-            "timestamp": "2015-02-13T13:29:32.175Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Ntp::Service",
-                "Service[ntp]"
-            ],
-            "events": [
-                {
-                    "message": "current_value stopped, should be running (noop)",
-                    "new_value": "running",
-                    "old_value": "stopped",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.416Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
-            "line": 9,
-            "resource_title": "ntp",
-            "corrective_change": false,
-            "resource_type": "Service",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.416Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Python::Install",
-                "Package[python-devel]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:33.687Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "line": 61,
-            "corrective_change": false,
-            "resource_title": "python-devel",
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:33.687Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[snmptrapd.conf]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.711Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 453,
-            "resource_title": "snmptrapd.conf",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.711Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/var/lib/puppet/concat/_tmp_file]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be directory (noop)",
-                    "new_value": "directory",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.713Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 144,
-            "corrective_change": false,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file",
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.713Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Gnupg_key[hkp_server_20BC0A86]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.444Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 69,
-            "resource_title": "hkp_server_20BC0A86",
-            "corrective_change": false,
-            "resource_type": "Gnupg_key",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.444Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be directory (noop)",
-                    "new_value": "directory",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.971Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 149,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.971Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments.concat]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.715Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 159,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat",
-            "resource_type": "File",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.715Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[snmpd.conf]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:33.123Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 429,
-            "corrective_change": false,
-            "resource_title": "snmpd.conf",
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:33.123Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "Exec[concat_/tmp/file]"
-            ],
-            "events": [
-                {
-                    "message": "current_value notrun, should be 0 (noop)",
-                    "new_value": [
-                        "0"
-                    ],
-                    "old_value": "notrun",
-                    "property": "returns",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:33.112Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 187,
-            "resource_title": "concat_/tmp/file",
-            "corrective_change": false,
-            "resource_type": "Exec",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:33.112Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Ini_setting[sample setting]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.334Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 45,
-            "corrective_change": false,
-            "resource_title": "sample setting",
-            "resource_type": "Ini_setting",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.334Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Service[cron]"
-            ],
-            "events": [
-                {
-                    "message": "current_value stopped, should be running (noop)",
-                    "new_value": "running",
-                    "old_value": "stopped",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.280Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 4,
-            "resource_title": "cron",
-            "corrective_change": false,
-            "resource_type": "Service",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.280Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Ntp::Config",
-                "File[/etc/ntp.conf]"
-            ],
-            "events": [
-                {
-                    "message": "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
-                    "new_value": "{md5}eb918d28434c9fefcc05875c29c3ba1a",
-                    "old_value": "{md5}7fda24f62b1c7ae951db0f746dc6e0cc",
-                    "property": "content",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:32.328Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
-            "line": 14,
-            "resource_title": "/etc/ntp.conf",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:32.328Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:29:26.846Z",
-    "status": "failed",
-    "catalog_uuid": "974b0567-11bf-4600-a659-e293f14d0a03",
-    "producer": "foo.com",
-    "code_id": "01167c6f-95ce-4163-98d8-60ae9b5fbf15",
-    "transaction_uuid": "1fb6bf81-0b2a-488c-b1d7-610a81b06b27"
+                    "timestamp": "2015-02-13T13:23:50.136Z"
+                }],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-19fce4fd5281b1df9b42d58c808fecb2a783da3b.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-19fce4fd5281b1df9b42d58c808fecb2a783da3b.json
@@ -1,1994 +1,2705 @@
 {
-    "cached_catalog_status": "not_used",
-    "certname": "pg2.vm",
-    "configuration_version": "1423834124",
-    "end_time": "2015-02-13T13:28:44.696Z",
-    "environment": "production",
-    "corrective_change": true,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 2.19 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:28:48.73+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 8 events",
-            "source": "Stage[main]",
-            "tags": [
-                "completed_stage",
-                "main",
-                "notice"
-            ],
-            "time": "2015-02-13T13:28:48.698+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 8 events",
-            "source": "Class[Loadtest]",
-            "tags": [
-                "completed_class",
-                "loadtest",
-                "notice"
-            ],
-            "time": "2015-02-13T13:28:48.697+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "err",
-            "line": 11,
-            "message": "Provider git is not functional on this host",
-            "source": "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
-            "tags": [
-                "pg2.vm",
-                "vcsrepo",
-                "loadtest",
-                "class",
-                "node",
-                "err"
-            ],
-            "time": "2015-02-13T13:28:48.696+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 2 events",
-            "source": "Class[Snmp::Client]",
-            "tags": [
-                "completed_class",
-                "client",
-                "snmp",
-                "snmp::client",
-                "notice"
-            ],
-            "time": "2015-02-13T13:28:48.695+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "level": "notice",
-            "line": 85,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp::Client/File[snmp.conf]/ensure",
-            "tags": [
-                "pg2.vm",
-                "client",
-                "file",
-                "loadtest",
-                "class",
-                "snmp",
-                "snmp.conf",
-                "snmp::client",
-                "notice",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:48.694+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 3 events",
-            "source": "Class[Python::Install]",
-            "tags": [
-                "completed_class",
-                "notice",
-                "python::install",
-                "install",
-                "python"
-            ],
-            "time": "2015-02-13T13:28:48.691+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "notice",
-            "line": 59,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Python::Install/Package[python-virtualenv]/ensure",
-            "tags": [
-                "pg2.vm",
-                "python-virtualenv",
-                "loadtest",
-                "class",
-                "notice",
-                "python::install",
-                "install",
-                "node",
-                "package",
-                "python"
-            ],
-            "time": "2015-02-13T13:28:48.688+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "notice",
-            "line": 61,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Python::Install/Package[python-devel]/ensure",
-            "tags": [
-                "pg2.vm",
-                "python-devel",
-                "loadtest",
-                "class",
-                "notice",
-                "python::install",
-                "install",
-                "node",
-                "package",
-                "python"
-            ],
-            "time": "2015-02-13T13:28:48.637+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "notice",
-            "line": 60,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Python::Install/Package[python-pip]/ensure",
-            "tags": [
-                "pg2.vm",
-                "python-pip",
-                "loadtest",
-                "class",
-                "notice",
-                "python::install",
-                "install",
-                "node",
-                "package",
-                "python"
-            ],
-            "time": "2015-02-13T13:28:48.609+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Git]",
-            "tags": [
-                "completed_class",
-                "git",
-                "notice"
-            ],
-            "time": "2015-02-13T13:28:48.353+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/git/manifests/init.pp",
-            "level": "notice",
-            "line": 12,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Git/Package[git]/ensure",
-            "tags": [
-                "pg2.vm",
-                "git",
-                "loadtest",
-                "class",
-                "notice",
-                "node",
-                "package"
-            ],
-            "time": "2015-02-13T13:28:48.351+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 8 events",
-            "source": "Class[Snmp]",
-            "tags": [
-                "completed_class",
-                "snmp",
-                "notice"
-            ],
-            "time": "2015-02-13T13:28:48.168+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 517,
-            "message": "Unscheduling refresh on Service[snmpd]",
-            "source": "/Stage[main]/Snmp/Service[snmpd]",
-            "tags": [
-                "pg2.vm",
-                "info",
-                "snmpd",
-                "loadtest",
-                "class",
-                "snmp",
-                "service",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:48.166+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 517,
-            "message": "current_value stopped, should be running (noop)",
-            "source": "/Stage[main]/Snmp/Service[snmpd]/ensure",
-            "tags": [
-                "pg2.vm",
-                "snmpd",
-                "loadtest",
-                "class",
-                "snmp",
-                "notice",
-                "service",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:48.164+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 429,
-            "message": "Scheduling refresh of Service[snmpd]",
-            "source": "/Stage[main]/Snmp/File[snmpd.conf]",
-            "tags": [
-                "pg2.vm",
-                "snmpd.conf",
-                "info",
-                "file",
-                "loadtest",
-                "class",
-                "snmp",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:48.068+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 429,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/File[snmpd.conf]/ensure",
-            "tags": [
-                "pg2.vm",
-                "snmpd.conf",
-                "file",
-                "loadtest",
-                "class",
-                "snmp",
-                "notice",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:48.067+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Concat::Fragment[tmpfile]",
-            "tags": [
-                "tmpfile",
-                "fragment",
-                "completed_concat",
-                "completed_concat::fragment",
-                "notice"
-            ],
-            "time": "2015-02-13T13:28:48.064+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 6 events",
-            "source": "Concat[/tmp/file]",
-            "tags": [
-                "completed_concat",
-                "notice"
-            ],
-            "time": "2015-02-13T13:28:48.062+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "err",
-            "line": 169,
-            "message": "Could not evaluate: Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/tmp/file]",
-            "tags": [
-                "pg2.vm",
-                "file",
-                "loadtest",
-                "class",
-                "concat",
-                "node",
-                "err"
-            ],
-            "time": "2015-02-13T13:28:48.06+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 187,
-            "message": "Would have triggered 'refresh' from 4 events",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-            "tags": [
-                "pg2.vm",
-                "exec",
-                "loadtest",
-                "class",
-                "notice",
-                "concat",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:48.057+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 187,
-            "message": "current_value notrun, should be 0 (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/returns",
-            "tags": [
-                "pg2.vm",
-                "exec",
-                "loadtest",
-                "class",
-                "notice",
-                "concat",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:48.056+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "info",
-            "line": 113,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-            "tags": [
-                "concat::fragment",
-                "pg2.vm",
-                "tmpfile",
-                "info",
-                "file",
-                "loadtest",
-                "fragment",
-                "class",
-                "node",
-                "concat"
-            ],
-            "time": "2015-02-13T13:28:47.989+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "notice",
-            "line": 113,
-            "message": "current_value absent, should be file (noop)",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/ensure",
-            "tags": [
-                "concat::fragment",
-                "pg2.vm",
-                "tmpfile",
-                "file",
-                "loadtest",
-                "fragment",
-                "class",
-                "notice",
-                "node",
-                "concat"
-            ],
-            "time": "2015-02-13T13:28:47.989+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Concat::Fragment[tmpfile2]",
-            "tags": [
-                "fragment",
-                "completed_concat",
-                "tmpfile2",
-                "completed_concat::fragment",
-                "notice"
-            ],
-            "time": "2015-02-13T13:28:47.986+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "info",
-            "line": 113,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-            "tags": [
-                "concat::fragment",
-                "pg2.vm",
-                "info",
-                "file",
-                "loadtest",
-                "fragment",
-                "class",
-                "tmpfile2",
-                "node",
-                "concat"
-            ],
-            "time": "2015-02-13T13:28:47.985+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "notice",
-            "line": 113,
-            "message": "current_value absent, should be file (noop)",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
-            "tags": [
-                "concat::fragment",
-                "pg2.vm",
-                "file",
-                "loadtest",
-                "fragment",
-                "class",
-                "tmpfile2",
-                "notice",
-                "node",
-                "concat"
-            ],
-            "time": "2015-02-13T13:28:47.982+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "info",
-            "line": 149,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
-            "tags": [
-                "pg2.vm",
-                "info",
-                "file",
-                "loadtest",
-                "class",
-                "concat",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.919+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 149,
-            "message": "current_value absent, should be directory (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/ensure",
-            "tags": [
-                "pg2.vm",
-                "file",
-                "loadtest",
-                "class",
-                "notice",
-                "concat",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.919+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 476,
-            "message": "Would have triggered 'refresh' from 2 events",
-            "source": "/Stage[main]/Snmp/Service[snmptrapd]",
-            "tags": [
-                "pg2.vm",
-                "loadtest",
-                "class",
-                "snmp",
-                "snmptrapd",
-                "notice",
-                "service",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.915+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 164,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]/ensure",
-            "tags": [
-                "pg2.vm",
-                "file",
-                "loadtest",
-                "class",
-                "notice",
-                "concat",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.705+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 159,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]/ensure",
-            "tags": [
-                "pg2.vm",
-                "file",
-                "loadtest",
-                "class",
-                "notice",
-                "concat",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.703+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "info",
-            "line": 144,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
-            "tags": [
-                "pg2.vm",
-                "info",
-                "file",
-                "loadtest",
-                "class",
-                "concat",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.702+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 144,
-            "message": "current_value absent, should be directory (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]/ensure",
-            "tags": [
-                "pg2.vm",
-                "file",
-                "loadtest",
-                "class",
-                "notice",
-                "concat",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.702+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 453,
-            "message": "Scheduling refresh of Service[snmptrapd]",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]",
-            "tags": [
-                "pg2.vm",
-                "snmptrapd.conf",
-                "info",
-                "file",
-                "loadtest",
-                "class",
-                "snmp",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.699+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 453,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]/ensure",
-            "tags": [
-                "pg2.vm",
-                "snmptrapd.conf",
-                "file",
-                "loadtest",
-                "class",
-                "snmp",
-                "notice",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.699+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 69,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]/ensure",
-            "tags": [
-                "pg2.vm",
-                "hkp_server_20bc0a86",
-                "loadtest",
-                "class",
-                "notice",
-                "node",
-                "gnupg_key"
-            ],
-            "time": "2015-02-13T13:28:47.439+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Ntp::Service]",
-            "tags": [
-                "completed_class",
-                "ntp",
-                "ntp::service",
-                "notice",
-                "service"
-            ],
-            "time": "2015-02-13T13:28:47.396+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
-            "level": "info",
-            "line": 9,
-            "message": "Unscheduling refresh on Service[ntp]",
-            "source": "/Stage[main]/Ntp::Service/Service[ntp]",
-            "tags": [
-                "ntp",
-                "pg2.vm",
-                "ntp::service",
-                "info",
-                "loadtest",
-                "class",
-                "node",
-                "service"
-            ],
-            "time": "2015-02-13T13:28:47.394+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
-            "level": "notice",
-            "line": 9,
-            "message": "current_value stopped, should be running (noop)",
-            "source": "/Stage[main]/Ntp::Service/Service[ntp]/ensure",
-            "tags": [
-                "ntp",
-                "pg2.vm",
-                "ntp::service",
-                "loadtest",
-                "class",
-                "notice",
-                "node",
-                "service"
-            ],
-            "time": "2015-02-13T13:28:47.393+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 410,
-            "message": "current_value absent, should be directory (noop)",
-            "source": "/Stage[main]/Snmp/File[var-net-snmp]/ensure",
-            "tags": [
-                "pg2.vm",
-                "file",
-                "loadtest",
-                "var-net-snmp",
-                "class",
-                "snmp",
-                "notice",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.234+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 45,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Loadtest/Ini_setting[sample setting]/ensure",
-            "tags": [
-                "pg2.vm",
-                "loadtest",
-                "class",
-                "ini_setting",
-                "notice",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.231+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Service[ntp]",
-            "source": "Class[Ntp::Service]",
-            "tags": [
-                "ntp",
-                "ntp::service",
-                "info",
-                "admissible_class",
-                "service"
-            ],
-            "time": "2015-02-13T13:28:47.23+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Ntp::Service]",
-            "tags": [
-                "ntp",
-                "ntp::service",
-                "notice",
-                "admissible_class",
-                "service"
-            ],
-            "time": "2015-02-13T13:28:47.229+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Class[Ntp::Service]",
-            "source": "Class[Ntp::Config]",
-            "tags": [
-                "completed_class",
-                "ntp",
-                "config",
-                "info",
-                "ntp::config"
-            ],
-            "time": "2015-02-13T13:28:47.229+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Ntp::Config]",
-            "tags": [
-                "completed_class",
-                "ntp",
-                "config",
-                "notice",
-                "ntp::config"
-            ],
-            "time": "2015-02-13T13:28:47.228+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
-            "level": "notice",
-            "line": 14,
-            "message": "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
-            "source": "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
-            "tags": [
-                "ntp",
-                "config",
-                "pg2.vm",
-                "file",
-                "loadtest",
-                "class",
-                "notice",
-                "node",
-                "ntp::config"
-            ],
-            "time": "2015-02-13T13:28:47.225+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
-            "level": "notice",
-            "line": 14,
-            "message": "\n--- /etc/ntp.conf\t2013-07-15 10:18:47.000000000 +0100\n+++ /tmp/puppet-file20150213-61500-1so4rsh-0\t2015-02-13 13:28:47.197877918 +0000\n@@ -1,53 +1,19 @@\n-# For more information about this file, see the man pages\n-# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).\n+# ntp.conf: Managed by puppet.\n+#\n+# Keep ntpd from panicking in the event of a large clock skew\n+# when a VM guest is suspended and resumed.\n+tinker panic 0\n \n-driftfile /var/lib/ntp/drift\n \n # Permit time synchronization with our time source, but do not\n # permit the source to query or modify the service on this system.\n-restrict default kod nomodify notrap nopeer noquery\n-restrict -6 default kod nomodify notrap nopeer noquery\n+restrict 127.0.0.1\n+\n \n-# Permit all access over the loopback interface.  This could\n-# be tightened as well, but to do so would effect some of\n-# the administrative functions.\n-restrict 127.0.0.1 \n-restrict -6 ::1\n-\n-# Hosts on local network are less restricted.\n-#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap\n-\n-# Use public servers from the pool.ntp.org project.\n-# Please consider joining the pool (http://www.pool.ntp.org/join.html).\n-server 0.centos.pool.ntp.org iburst\n-server 1.centos.pool.ntp.org iburst\n-server 2.centos.pool.ntp.org iburst\n-server 3.centos.pool.ntp.org iburst\n-\n-#broadcast 192.168.1.255 autokey\t# broadcast server\n-#broadcastclient\t\t\t# broadcast client\n-#broadcast 224.0.1.1 autokey\t\t# multicast server\n-#multicastclient 224.0.1.1\t\t# multicast client\n-#manycastserver 239.255.254.254\t\t# manycast server\n-#manycastclient 239.255.254.254 autokey # manycast client\n-\n-# Enable public key cryptography.\n-#crypto\n-\n-includefile /etc/ntp/crypto/pw\n-\n-# Key file containing the keys and key identifiers used when operating\n-# with symmetric key cryptography. \n-keys /etc/ntp/keys\n-\n-# Specify the key identifiers which are trusted.\n-#trustedkey 4 8 42\n+server ntp.pool.org\n \n-# Specify the key identifier to use with the ntpdc utility.\n-#requestkey 8\n \n-# Specify the key identifier to use with the ntpq utility.\n-#controlkey 8\n+# Driftfile.\n+driftfile /var/lib/ntp/drift\n+\n \n-# Enable writing of statistics records.\n-#statistics clockstats cryptostats loopstats peerstats\n",
-            "source": "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
-            "tags": [
-                "ntp",
-                "config",
-                "pg2.vm",
-                "file",
-                "loadtest",
-                "class",
-                "content",
-                "notice",
-                "node",
-                "ntp::config"
-            ],
-            "time": "2015-02-13T13:28:47.221+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 441,
-            "message": "Scheduling refresh of Service[snmpd]",
-            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]",
-            "tags": [
-                "pg2.vm",
-                "info",
-                "file",
-                "loadtest",
-                "snmpd.sysconfig",
-                "class",
-                "snmp",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.191+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 441,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]/ensure",
-            "tags": [
-                "pg2.vm",
-                "file",
-                "loadtest",
-                "snmpd.sysconfig",
-                "class",
-                "snmp",
-                "notice",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.191+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 465,
-            "message": "Scheduling refresh of Service[snmptrapd]",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.sysconfig]",
-            "tags": [
-                "pg2.vm",
-                "info",
-                "file",
-                "loadtest",
-                "class",
-                "snmp",
-                "snmptrapd.sysconfig",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.182+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 465,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.sysconfig]/ensure",
-            "tags": [
-                "pg2.vm",
-                "file",
-                "loadtest",
-                "class",
-                "snmp",
-                "snmptrapd.sysconfig",
-                "notice",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.182+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "info",
-            "line": 4,
-            "message": "Unscheduling refresh on Service[cron]",
-            "source": "/Stage[main]/Loadtest/Service[cron]",
-            "tags": [
-                "pg2.vm",
-                "info",
-                "loadtest",
-                "class",
-                "service",
-                "cron",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.178+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 4,
-            "message": "current_value stopped, should be running (noop)",
-            "source": "/Stage[main]/Loadtest/Service[cron]/ensure",
-            "tags": [
-                "pg2.vm",
-                "loadtest",
-                "class",
-                "notice",
-                "service",
-                "cron",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.177+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 3,
-            "message": "current_value absent, should be foo (noop)",
-            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
-            "tags": [
-                "foo",
-                "pg2.vm",
-                "notify",
-                "loadtest",
-                "class",
-                "notice",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:47.072+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 405,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/Package[snmpd]/ensure",
-            "tags": [
-                "pg2.vm",
-                "snmpd",
-                "loadtest",
-                "class",
-                "snmp",
-                "notice",
-                "node",
-                "package"
-            ],
-            "time": "2015-02-13T13:28:47.069+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 41,
-            "message": "current_value absent, should be latest (noop)",
-            "source": "/Stage[main]/Loadtest/Package[etckeeper]/ensure",
-            "tags": [
-                "pg2.vm",
-                "loadtest",
-                "etckeeper",
-                "class",
-                "notice",
-                "node",
-                "package"
-            ],
-            "time": "2015-02-13T13:28:47.026+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "level": "notice",
-            "line": 76,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp::Client/Package[snmp-client]/ensure",
-            "tags": [
-                "pg2.vm",
-                "snmp-client",
-                "client",
-                "loadtest",
-                "class",
-                "snmp",
-                "snmp::client",
-                "notice",
-                "node",
-                "package"
-            ],
-            "time": "2015-02-13T13:28:46.98+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Motd]",
-            "tags": [
-                "completed_class",
-                "motd",
-                "notice"
-            ],
-            "time": "2015-02-13T13:28:46.803+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "level": "notice",
-            "line": 33,
-            "message": "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
-            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
-            "tags": [
-                "motd",
-                "pg2.vm",
-                "file",
-                "loadtest",
-                "class",
-                "notice",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:46.797+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "level": "notice",
-            "line": 33,
-            "message": "\n--- /etc/motd\t2010-01-12 13:28:22.000000000 +0000\n+++ /tmp/puppet-file20150213-61500-ay65od-0\t2015-02-13 13:28:46.727877920 +0000\n@@ -0,0 +1 @@\n+Welcome to my test host!\n\\ No newline at end of file\n",
-            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
-            "tags": [
-                "motd",
-                "pg2.vm",
-                "file",
-                "loadtest",
-                "class",
-                "content",
-                "notice",
-                "node"
-            ],
-            "time": "2015-02-13T13:28:46.795+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423834124'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:28:46.616+00:00"
-        },
-        {
-            "file": null,
-            "level": "warning",
-            "line": null,
-            "message": "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
-            "source": "Puppet",
-            "tags": [
-                "warning"
-            ],
-            "time": "2015-02-13T13:28:46.219+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for pg2.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:28:46.118+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:28:43.601+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:28:41.319+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:28:41.273+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.001149
-        },
-        {
-            "category": "time",
-            "name": "augeas",
-            "value": 0.050034
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 1.71986413002014
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.451339
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.322403
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 0.000129
-        },
-        {
-            "category": "time",
-            "name": "gnupg_key",
-            "value": 0.041761
-        },
-        {
-            "category": "time",
-            "name": "ini_setting",
-            "value": 0.000804
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.000886
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.257424
-        },
-        {
-            "category": "time",
-            "name": "postgresql_conf",
-            "value": 0.000636
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.053516
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.576265
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 3.47621013002014
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 2
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 29
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 88
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 1
-        },
-        {
-            "category": "events",
-            "name": "noop",
-            "value": 28
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 29
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 0
-        }
-    ],
-    "noop": true,
-    "puppet_version": "3.7.1",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Ini_setting[sample setting]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.231Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 45,
-            "resource_title": "sample setting",
-            "corrective_change": true,
-            "resource_type": "Ini_setting",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.231Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Service[cron]"
-            ],
-            "events": [
-                {
-                    "message": "current_value stopped, should be running (noop)",
-                    "new_value": "running",
-                    "old_value": "stopped",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.177Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 4,
-            "corrective_change": true,
-            "resource_title": "cron",
-            "resource_type": "Service",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.177Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Python::Install",
-                "Package[python-virtualenv]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:48.688Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "line": 59,
-            "resource_title": "python-virtualenv",
-            "corrective_change": true,
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:48.688Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be foo (noop)",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.072Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "corrective_change": true,
-            "line": 3,
-            "resource_title": "foo",
-            "resource_type": "Notify",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.072Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be directory (noop)",
-                    "new_value": "directory",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.919Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "corrective_change": true,
-            "line": 149,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments",
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.919Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Python::Install",
-                "Package[python-devel]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:48.637Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "line": 61,
-            "corrective_change": true,
-            "resource_title": "python-devel",
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:48.637Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Python::Install",
-                "Package[python-pip]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:48.609Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "line": 60,
-            "corrective_change": true,
-            "resource_title": "python-pip",
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:48.609Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/var/lib/puppet/concat/_tmp_file]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be directory (noop)",
-                    "new_value": "directory",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.701Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 144,
-            "corrective_change": true,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file",
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.701Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "Service[snmpd]"
-            ],
-            "events": [
-                {
-                    "message": "current_value stopped, should be running (noop)",
-                    "new_value": "running",
-                    "old_value": "stopped",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:48.164Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 517,
-            "corrective_change": true,
-            "resource_title": "snmpd",
-            "resource_type": "Service",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:48.164Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Package[etckeeper]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be latest (noop)",
-                    "new_value": "latest",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.026Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 41,
-            "resource_title": "etckeeper",
-            "resource_type": "Package",
-            "corrective_change": true,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.026Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat::Fragment[tmpfile2]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be file (noop)",
-                    "new_value": "file",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.921Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "line": 113,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
-            "resource_type": "File",
-            "corrective_change": true,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.921Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.705Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 164,
-            "corrective_change": true,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.705Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Git",
-                "Package[git]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:48.351Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/git/manifests/init.pp",
-            "line": 12,
-            "resource_title": "git",
-            "resource_type": "Package",
-            "skipped": false,
-            "corrective_change": true,
-            "timestamp": "2015-02-13T13:28:48.351Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat::Fragment[tmpfile]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be file (noop)",
-                    "new_value": "file",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.989Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "line": 113,
-            "corrective_change": true,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.989Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "Exec[concat_/tmp/file]"
-            ],
-            "events": [
-                {
-                    "message": "current_value notrun, should be 0 (noop)",
-                    "new_value": [
-                        "0"
-                    ],
-                    "old_value": "notrun",
-                    "property": "returns",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:48.056Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 187,
-            "corrective_change": true,
-            "resource_title": "concat_/tmp/file",
-            "resource_type": "Exec",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:48.056Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments.concat]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.703Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 159,
-            "corrective_change": true,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat",
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.703Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[snmpd.conf]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:48.067Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 429,
-            "resource_title": "snmpd.conf",
-            "resource_type": "File",
-            "corrective_change": true,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:48.067Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp::Client",
-                "Package[snmp-client]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:46.980Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "line": 76,
-            "corrective_change": true,
-            "resource_title": "snmp-client",
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:46.980Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/tmp/file]"
-            ],
-            "events": [
-                {
-                    "message": "Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-                    "new_value": null,
-                    "old_value": null,
-                    "property": null,
-                    "status": "failure",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:48.062Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 169,
-            "resource_title": "/tmp/file",
-            "resource_type": "File",
-            "skipped": false,
-            "corrective_change": true,
-            "timestamp": "2015-02-13T13:28:48.062Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Ntp::Config",
-                "File[/etc/ntp.conf]"
-            ],
-            "events": [
-                {
-                    "message": "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
-                    "new_value": "{md5}eb918d28434c9fefcc05875c29c3ba1a",
-                    "old_value": "{md5}7fda24f62b1c7ae951db0f746dc6e0cc",
-                    "property": "content",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.224Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
-            "line": 14,
-            "resource_title": "/etc/ntp.conf",
-            "corrective_change": true,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.224Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[var-net-snmp]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be directory (noop)",
-                    "new_value": "directory",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.234Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 410,
-            "resource_title": "var-net-snmp",
-            "resource_type": "File",
-            "corrective_change": true,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.234Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "Package[snmpd]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.069Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 405,
-            "resource_title": "snmpd",
-            "resource_type": "Package",
-            "corrective_change": true,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.069Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Motd",
-                "File[/etc/motd]"
-            ],
-            "events": [
-                {
-                    "message": "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
-                    "new_value": "{md5}a3f731187a6aaaa23d4a7b244f223f33",
-                    "old_value": "{md5}d41d8cd98f00b204e9800998ecf8427e",
-                    "property": "content",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:46.797Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "line": 33,
-            "corrective_change": true,
-            "resource_title": "/etc/motd",
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:46.797Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Gnupg_key[hkp_server_20BC0A86]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.439Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 69,
-            "resource_title": "hkp_server_20BC0A86",
-            "corrective_change": true,
-            "resource_type": "Gnupg_key",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.439Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Ntp::Service",
-                "Service[ntp]"
-            ],
-            "events": [
-                {
-                    "message": "current_value stopped, should be running (noop)",
-                    "new_value": "running",
-                    "old_value": "stopped",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.393Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
-            "line": 9,
-            "resource_title": "ntp",
-            "resource_type": "Service",
-            "corrective_change": true,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.393Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[snmptrapd.sysconfig]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.182Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 465,
-            "resource_title": "snmptrapd.sysconfig",
-            "corrective_change": true,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.182Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[snmpd.sysconfig]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.191Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 441,
-            "resource_title": "snmpd.sysconfig",
-            "resource_type": "File",
-            "corrective_change": true,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:47.191Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp::Client",
-                "File[snmp.conf]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:48.694Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "line": 85,
-            "resource_title": "snmp.conf",
-            "corrective_change": true,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:28:48.694Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[snmptrapd.conf]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:28:47.699Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 453,
-            "resource_title": "snmptrapd.conf",
-            "resource_type": "File",
-            "skipped": false,
-            "corrective_change": true,
-            "timestamp": "2015-02-13T13:28:47.699Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:28:41.219Z",
-    "status": "failed",
-    "catalog_uuid": "a1bec548-67cf-4588-a2df-2f357f496cf4",
-    "producer": "foo.com",
-    "code_id": "06c0074c-139d-4795-a45a-5d31acc0b07f",
-    "transaction_uuid": "1fe685d2-cf15-46ba-8a07-84854c584703"
+  "corrective_change" : true,
+  "code_id" : "06c0074c-139d-4795-a45a-5d31acc0b07f",
+  "noop" : true,
+  "certname" : "pg2.vm",
+  "puppet_version" : "3.7.1",
+  "cached_catalog_status" : "not_used",
+  "transaction_uuid" : "1fe685d2-cf15-46ba-8a07-84854c584703",
+  "configuration_version" : "1423834124",
+  "status" : "failed",
+  "producer" : "foo.com",
+  "catalog_uuid" : "a1bec548-67cf-4588-a2df-2f357f496cf4",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 2.19 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:28:48.73+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 8 events",
+    "source" : "Stage[main]",
+    "tags" : [ "completed_stage", "main", "notice" ],
+    "time" : "2015-02-13T13:28:48.698+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 8 events",
+    "source" : "Class[Loadtest]",
+    "tags" : [ "completed_class", "loadtest", "notice" ],
+    "time" : "2015-02-13T13:28:48.697+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "err",
+    "line" : 11,
+    "message" : "Provider git is not functional on this host",
+    "source" : "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
+    "tags" : [ "pg2.vm", "vcsrepo", "loadtest", "class", "node", "err" ],
+    "time" : "2015-02-13T13:28:48.696+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 2 events",
+    "source" : "Class[Snmp::Client]",
+    "tags" : [ "completed_class", "client", "snmp", "snmp::client", "notice" ],
+    "time" : "2015-02-13T13:28:48.695+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
+    "level" : "notice",
+    "line" : 85,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp::Client/File[snmp.conf]/ensure",
+    "tags" : [ "pg2.vm", "client", "file", "loadtest", "class", "snmp", "snmp.conf", "snmp::client", "notice", "node" ],
+    "time" : "2015-02-13T13:28:48.694+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 3 events",
+    "source" : "Class[Python::Install]",
+    "tags" : [ "completed_class", "notice", "python::install", "install", "python" ],
+    "time" : "2015-02-13T13:28:48.691+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "notice",
+    "line" : 59,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Python::Install/Package[python-virtualenv]/ensure",
+    "tags" : [ "pg2.vm", "python-virtualenv", "loadtest", "class", "notice", "python::install", "install", "node", "package", "python" ],
+    "time" : "2015-02-13T13:28:48.688+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "notice",
+    "line" : 61,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Python::Install/Package[python-devel]/ensure",
+    "tags" : [ "pg2.vm", "python-devel", "loadtest", "class", "notice", "python::install", "install", "node", "package", "python" ],
+    "time" : "2015-02-13T13:28:48.637+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "notice",
+    "line" : 60,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Python::Install/Package[python-pip]/ensure",
+    "tags" : [ "pg2.vm", "python-pip", "loadtest", "class", "notice", "python::install", "install", "node", "package", "python" ],
+    "time" : "2015-02-13T13:28:48.609+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Git]",
+    "tags" : [ "completed_class", "git", "notice" ],
+    "time" : "2015-02-13T13:28:48.353+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/git/manifests/init.pp",
+    "level" : "notice",
+    "line" : 12,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Git/Package[git]/ensure",
+    "tags" : [ "pg2.vm", "git", "loadtest", "class", "notice", "node", "package" ],
+    "time" : "2015-02-13T13:28:48.351+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 8 events",
+    "source" : "Class[Snmp]",
+    "tags" : [ "completed_class", "snmp", "notice" ],
+    "time" : "2015-02-13T13:28:48.168+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 517,
+    "message" : "Unscheduling refresh on Service[snmpd]",
+    "source" : "/Stage[main]/Snmp/Service[snmpd]",
+    "tags" : [ "pg2.vm", "info", "snmpd", "loadtest", "class", "snmp", "service", "node" ],
+    "time" : "2015-02-13T13:28:48.166+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 517,
+    "message" : "current_value stopped, should be running (noop)",
+    "source" : "/Stage[main]/Snmp/Service[snmpd]/ensure",
+    "tags" : [ "pg2.vm", "snmpd", "loadtest", "class", "snmp", "notice", "service", "node" ],
+    "time" : "2015-02-13T13:28:48.164+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 429,
+    "message" : "Scheduling refresh of Service[snmpd]",
+    "source" : "/Stage[main]/Snmp/File[snmpd.conf]",
+    "tags" : [ "pg2.vm", "snmpd.conf", "info", "file", "loadtest", "class", "snmp", "node" ],
+    "time" : "2015-02-13T13:28:48.068+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 429,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/File[snmpd.conf]/ensure",
+    "tags" : [ "pg2.vm", "snmpd.conf", "file", "loadtest", "class", "snmp", "notice", "node" ],
+    "time" : "2015-02-13T13:28:48.067+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Concat::Fragment[tmpfile]",
+    "tags" : [ "tmpfile", "fragment", "completed_concat", "completed_concat::fragment", "notice" ],
+    "time" : "2015-02-13T13:28:48.064+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 6 events",
+    "source" : "Concat[/tmp/file]",
+    "tags" : [ "completed_concat", "notice" ],
+    "time" : "2015-02-13T13:28:48.062+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "err",
+    "line" : 169,
+    "message" : "Could not evaluate: Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/tmp/file]",
+    "tags" : [ "pg2.vm", "file", "loadtest", "class", "concat", "node", "err" ],
+    "time" : "2015-02-13T13:28:48.06+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 187,
+    "message" : "Would have triggered 'refresh' from 4 events",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+    "tags" : [ "pg2.vm", "exec", "loadtest", "class", "notice", "concat", "node" ],
+    "time" : "2015-02-13T13:28:48.057+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 187,
+    "message" : "current_value notrun, should be 0 (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/returns",
+    "tags" : [ "pg2.vm", "exec", "loadtest", "class", "notice", "concat", "node" ],
+    "time" : "2015-02-13T13:28:48.056+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "info",
+    "line" : 113,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+    "tags" : [ "concat::fragment", "pg2.vm", "tmpfile", "info", "file", "loadtest", "fragment", "class", "node", "concat" ],
+    "time" : "2015-02-13T13:28:47.989+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "notice",
+    "line" : 113,
+    "message" : "current_value absent, should be file (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/ensure",
+    "tags" : [ "concat::fragment", "pg2.vm", "tmpfile", "file", "loadtest", "fragment", "class", "notice", "node", "concat" ],
+    "time" : "2015-02-13T13:28:47.989+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Concat::Fragment[tmpfile2]",
+    "tags" : [ "fragment", "completed_concat", "tmpfile2", "completed_concat::fragment", "notice" ],
+    "time" : "2015-02-13T13:28:47.986+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "info",
+    "line" : 113,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+    "tags" : [ "concat::fragment", "pg2.vm", "info", "file", "loadtest", "fragment", "class", "tmpfile2", "node", "concat" ],
+    "time" : "2015-02-13T13:28:47.985+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "notice",
+    "line" : 113,
+    "message" : "current_value absent, should be file (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
+    "tags" : [ "concat::fragment", "pg2.vm", "file", "loadtest", "fragment", "class", "tmpfile2", "notice", "node", "concat" ],
+    "time" : "2015-02-13T13:28:47.982+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "info",
+    "line" : 149,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
+    "tags" : [ "pg2.vm", "info", "file", "loadtest", "class", "concat", "node" ],
+    "time" : "2015-02-13T13:28:47.919+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 149,
+    "message" : "current_value absent, should be directory (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/ensure",
+    "tags" : [ "pg2.vm", "file", "loadtest", "class", "notice", "concat", "node" ],
+    "time" : "2015-02-13T13:28:47.919+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 476,
+    "message" : "Would have triggered 'refresh' from 2 events",
+    "source" : "/Stage[main]/Snmp/Service[snmptrapd]",
+    "tags" : [ "pg2.vm", "loadtest", "class", "snmp", "snmptrapd", "notice", "service", "node" ],
+    "time" : "2015-02-13T13:28:47.915+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 164,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]/ensure",
+    "tags" : [ "pg2.vm", "file", "loadtest", "class", "notice", "concat", "node" ],
+    "time" : "2015-02-13T13:28:47.705+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 159,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]/ensure",
+    "tags" : [ "pg2.vm", "file", "loadtest", "class", "notice", "concat", "node" ],
+    "time" : "2015-02-13T13:28:47.703+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "info",
+    "line" : 144,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
+    "tags" : [ "pg2.vm", "info", "file", "loadtest", "class", "concat", "node" ],
+    "time" : "2015-02-13T13:28:47.702+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 144,
+    "message" : "current_value absent, should be directory (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]/ensure",
+    "tags" : [ "pg2.vm", "file", "loadtest", "class", "notice", "concat", "node" ],
+    "time" : "2015-02-13T13:28:47.702+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 453,
+    "message" : "Scheduling refresh of Service[snmptrapd]",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]",
+    "tags" : [ "pg2.vm", "snmptrapd.conf", "info", "file", "loadtest", "class", "snmp", "node" ],
+    "time" : "2015-02-13T13:28:47.699+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 453,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]/ensure",
+    "tags" : [ "pg2.vm", "snmptrapd.conf", "file", "loadtest", "class", "snmp", "notice", "node" ],
+    "time" : "2015-02-13T13:28:47.699+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 69,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]/ensure",
+    "tags" : [ "pg2.vm", "hkp_server_20bc0a86", "loadtest", "class", "notice", "node", "gnupg_key" ],
+    "time" : "2015-02-13T13:28:47.439+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Ntp::Service]",
+    "tags" : [ "completed_class", "ntp", "ntp::service", "notice", "service" ],
+    "time" : "2015-02-13T13:28:47.396+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
+    "level" : "info",
+    "line" : 9,
+    "message" : "Unscheduling refresh on Service[ntp]",
+    "source" : "/Stage[main]/Ntp::Service/Service[ntp]",
+    "tags" : [ "ntp", "pg2.vm", "ntp::service", "info", "loadtest", "class", "node", "service" ],
+    "time" : "2015-02-13T13:28:47.394+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
+    "level" : "notice",
+    "line" : 9,
+    "message" : "current_value stopped, should be running (noop)",
+    "source" : "/Stage[main]/Ntp::Service/Service[ntp]/ensure",
+    "tags" : [ "ntp", "pg2.vm", "ntp::service", "loadtest", "class", "notice", "node", "service" ],
+    "time" : "2015-02-13T13:28:47.393+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 410,
+    "message" : "current_value absent, should be directory (noop)",
+    "source" : "/Stage[main]/Snmp/File[var-net-snmp]/ensure",
+    "tags" : [ "pg2.vm", "file", "loadtest", "var-net-snmp", "class", "snmp", "notice", "node" ],
+    "time" : "2015-02-13T13:28:47.234+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 45,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Loadtest/Ini_setting[sample setting]/ensure",
+    "tags" : [ "pg2.vm", "loadtest", "class", "ini_setting", "notice", "node" ],
+    "time" : "2015-02-13T13:28:47.231+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Service[ntp]",
+    "source" : "Class[Ntp::Service]",
+    "tags" : [ "ntp", "ntp::service", "info", "admissible_class", "service" ],
+    "time" : "2015-02-13T13:28:47.23+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Ntp::Service]",
+    "tags" : [ "ntp", "ntp::service", "notice", "admissible_class", "service" ],
+    "time" : "2015-02-13T13:28:47.229+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Class[Ntp::Service]",
+    "source" : "Class[Ntp::Config]",
+    "tags" : [ "completed_class", "ntp", "config", "info", "ntp::config" ],
+    "time" : "2015-02-13T13:28:47.229+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Ntp::Config]",
+    "tags" : [ "completed_class", "ntp", "config", "notice", "ntp::config" ],
+    "time" : "2015-02-13T13:28:47.228+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
+    "level" : "notice",
+    "line" : 14,
+    "message" : "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
+    "source" : "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
+    "tags" : [ "ntp", "config", "pg2.vm", "file", "loadtest", "class", "notice", "node", "ntp::config" ],
+    "time" : "2015-02-13T13:28:47.225+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
+    "level" : "notice",
+    "line" : 14,
+    "message" : "\n--- /etc/ntp.conf\t2013-07-15 10:18:47.000000000 +0100\n+++ /tmp/puppet-file20150213-61500-1so4rsh-0\t2015-02-13 13:28:47.197877918 +0000\n@@ -1,53 +1,19 @@\n-# For more information about this file, see the man pages\n-# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).\n+# ntp.conf: Managed by puppet.\n+#\n+# Keep ntpd from panicking in the event of a large clock skew\n+# when a VM guest is suspended and resumed.\n+tinker panic 0\n \n-driftfile /var/lib/ntp/drift\n \n # Permit time synchronization with our time source, but do not\n # permit the source to query or modify the service on this system.\n-restrict default kod nomodify notrap nopeer noquery\n-restrict -6 default kod nomodify notrap nopeer noquery\n+restrict 127.0.0.1\n+\n \n-# Permit all access over the loopback interface.  This could\n-# be tightened as well, but to do so would effect some of\n-# the administrative functions.\n-restrict 127.0.0.1 \n-restrict -6 ::1\n-\n-# Hosts on local network are less restricted.\n-#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap\n-\n-# Use public servers from the pool.ntp.org project.\n-# Please consider joining the pool (http://www.pool.ntp.org/join.html).\n-server 0.centos.pool.ntp.org iburst\n-server 1.centos.pool.ntp.org iburst\n-server 2.centos.pool.ntp.org iburst\n-server 3.centos.pool.ntp.org iburst\n-\n-#broadcast 192.168.1.255 autokey\t# broadcast server\n-#broadcastclient\t\t\t# broadcast client\n-#broadcast 224.0.1.1 autokey\t\t# multicast server\n-#multicastclient 224.0.1.1\t\t# multicast client\n-#manycastserver 239.255.254.254\t\t# manycast server\n-#manycastclient 239.255.254.254 autokey # manycast client\n-\n-# Enable public key cryptography.\n-#crypto\n-\n-includefile /etc/ntp/crypto/pw\n-\n-# Key file containing the keys and key identifiers used when operating\n-# with symmetric key cryptography. \n-keys /etc/ntp/keys\n-\n-# Specify the key identifiers which are trusted.\n-#trustedkey 4 8 42\n+server ntp.pool.org\n \n-# Specify the key identifier to use with the ntpdc utility.\n-#requestkey 8\n \n-# Specify the key identifier to use with the ntpq utility.\n-#controlkey 8\n+# Driftfile.\n+driftfile /var/lib/ntp/drift\n+\n \n-# Enable writing of statistics records.\n-#statistics clockstats cryptostats loopstats peerstats\n",
+    "source" : "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
+    "tags" : [ "ntp", "config", "pg2.vm", "file", "loadtest", "class", "content", "notice", "node", "ntp::config" ],
+    "time" : "2015-02-13T13:28:47.221+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 441,
+    "message" : "Scheduling refresh of Service[snmpd]",
+    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]",
+    "tags" : [ "pg2.vm", "info", "file", "loadtest", "snmpd.sysconfig", "class", "snmp", "node" ],
+    "time" : "2015-02-13T13:28:47.191+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 441,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]/ensure",
+    "tags" : [ "pg2.vm", "file", "loadtest", "snmpd.sysconfig", "class", "snmp", "notice", "node" ],
+    "time" : "2015-02-13T13:28:47.191+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 465,
+    "message" : "Scheduling refresh of Service[snmptrapd]",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.sysconfig]",
+    "tags" : [ "pg2.vm", "info", "file", "loadtest", "class", "snmp", "snmptrapd.sysconfig", "node" ],
+    "time" : "2015-02-13T13:28:47.182+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 465,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.sysconfig]/ensure",
+    "tags" : [ "pg2.vm", "file", "loadtest", "class", "snmp", "snmptrapd.sysconfig", "notice", "node" ],
+    "time" : "2015-02-13T13:28:47.182+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "info",
+    "line" : 4,
+    "message" : "Unscheduling refresh on Service[cron]",
+    "source" : "/Stage[main]/Loadtest/Service[cron]",
+    "tags" : [ "pg2.vm", "info", "loadtest", "class", "service", "cron", "node" ],
+    "time" : "2015-02-13T13:28:47.178+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 4,
+    "message" : "current_value stopped, should be running (noop)",
+    "source" : "/Stage[main]/Loadtest/Service[cron]/ensure",
+    "tags" : [ "pg2.vm", "loadtest", "class", "notice", "service", "cron", "node" ],
+    "time" : "2015-02-13T13:28:47.177+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 3,
+    "message" : "current_value absent, should be foo (noop)",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
+    "tags" : [ "foo", "pg2.vm", "notify", "loadtest", "class", "notice", "node" ],
+    "time" : "2015-02-13T13:28:47.072+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 405,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/Package[snmpd]/ensure",
+    "tags" : [ "pg2.vm", "snmpd", "loadtest", "class", "snmp", "notice", "node", "package" ],
+    "time" : "2015-02-13T13:28:47.069+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 41,
+    "message" : "current_value absent, should be latest (noop)",
+    "source" : "/Stage[main]/Loadtest/Package[etckeeper]/ensure",
+    "tags" : [ "pg2.vm", "loadtest", "etckeeper", "class", "notice", "node", "package" ],
+    "time" : "2015-02-13T13:28:47.026+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
+    "level" : "notice",
+    "line" : 76,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp::Client/Package[snmp-client]/ensure",
+    "tags" : [ "pg2.vm", "snmp-client", "client", "loadtest", "class", "snmp", "snmp::client", "notice", "node", "package" ],
+    "time" : "2015-02-13T13:28:46.98+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Motd]",
+    "tags" : [ "completed_class", "motd", "notice" ],
+    "time" : "2015-02-13T13:28:46.803+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
+    "level" : "notice",
+    "line" : 33,
+    "message" : "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
+    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
+    "tags" : [ "motd", "pg2.vm", "file", "loadtest", "class", "notice", "node" ],
+    "time" : "2015-02-13T13:28:46.797+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
+    "level" : "notice",
+    "line" : 33,
+    "message" : "\n--- /etc/motd\t2010-01-12 13:28:22.000000000 +0000\n+++ /tmp/puppet-file20150213-61500-ay65od-0\t2015-02-13 13:28:46.727877920 +0000\n@@ -0,0 +1 @@\n+Welcome to my test host!\n\\ No newline at end of file\n",
+    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
+    "tags" : [ "motd", "pg2.vm", "file", "loadtest", "class", "content", "notice", "node" ],
+    "time" : "2015-02-13T13:28:46.795+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423834124'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:28:46.616+00:00"
+  }, {
+    "file" : null,
+    "level" : "warning",
+    "line" : null,
+    "message" : "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
+    "source" : "Puppet",
+    "tags" : [ "warning" ],
+    "time" : "2015-02-13T13:28:46.219+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for pg2.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:28:46.118+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:28:43.601+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:28:41.319+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:28:41.273+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:28:44.696Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:28:41.219Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 0.001149
+  }, {
+    "category" : "time",
+    "name" : "augeas",
+    "value" : 0.050034
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 1.71986413002014
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.451339
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.322403
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 1.29E-4
+  }, {
+    "category" : "time",
+    "name" : "gnupg_key",
+    "value" : 0.041761
+  }, {
+    "category" : "time",
+    "name" : "ini_setting",
+    "value" : 8.04E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 8.86E-4
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.257424
+  }, {
+    "category" : "time",
+    "name" : "postgresql_conf",
+    "value" : 6.36E-4
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 0.053516
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.576265
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 3.47621013002014
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 2
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 29
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 88
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 1
+  }, {
+    "category" : "events",
+    "name" : "noop",
+    "value" : 28
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 29
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 0
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "hdyu",
+    "resource_type" : "ZID",
+    "events" : [ ],
+    "line" : 400,
+    "file" : "JlvbbGQ2Fx",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-34ecfe5dcfebc9510d159d2ec010d6e1f9094fb1.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-34ecfe5dcfebc9510d159d2ec010d6e1f9094fb1.json
@@ -1,748 +1,2373 @@
 {
-    "cached_catalog_status": "not_used",
-    "certname": "pg2.vm",
-    "configuration_version": "1423833741",
-    "end_time": "2015-02-13T13:26:57.691Z",
-    "environment": "production",
-    "corrective_change": true,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 4.55 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:27:01.557+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-            "level": "notice",
-            "line": 41,
-            "message": "Triggered 'refresh' from 1 events",
-            "source": "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::end]",
-            "tags": [
-                "node",
-                "notice",
-                "postgresql::server::service::end",
-                "postgresql",
-                "postgresql::server",
-                "anchor",
-                "postgresql::server::service",
-                "server",
-                "pg2.vm",
-                "end",
-                "class",
-                "service"
-            ],
-            "time": "2015-02-13T13:27:01.513+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/validate_db_connection.pp",
-            "level": "notice",
-            "line": 51,
-            "message": "Triggered 'refresh' from 1 events",
-            "source": "/Stage[main]/Postgresql::Server::Service/Postgresql::Validate_db_connection[validate_service_is_running]/Exec[validate postgres connection for /postgres]",
-            "tags": [
-                "node",
-                "notice",
-                "validate_service_is_running",
-                "postgresql",
-                "postgresql::server",
-                "postgresql::server::service",
-                "server",
-                "validate_db_connection",
-                "pg2.vm",
-                "exec",
-                "class",
-                "postgresql::validate_db_connection",
-                "service"
-            ],
-            "time": "2015-02-13T13:27:01.509+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Exec[validate postgres connection for /postgres]",
-            "source": "Postgresql::Validate_db_connection[validate_service_is_running]",
-            "tags": [
-                "admissible_postgresql",
-                "validate_service_is_running",
-                "validate_db_connection",
-                "admissible_postgresql::validate_db_connection",
-                "info"
-            ],
-            "time": "2015-02-13T13:27:01.378+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-            "level": "info",
-            "line": 14,
-            "message": "Unscheduling refresh on Service[postgresqld]",
-            "source": "/Stage[main]/Postgresql::Server::Service/Service[postgresqld]",
-            "tags": [
-                "node",
-                "postgresqld",
-                "postgresql",
-                "postgresql::server",
-                "postgresql::server::service",
-                "server",
-                "pg2.vm",
-                "info",
-                "class",
-                "service"
-            ],
-            "time": "2015-02-13T13:27:01.376+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-            "level": "notice",
-            "line": 14,
-            "message": "ensure changed 'stopped' to 'running'",
-            "source": "/Stage[main]/Postgresql::Server::Service/Service[postgresqld]/ensure",
-            "tags": [
-                "node",
-                "notice",
-                "postgresqld",
-                "postgresql",
-                "postgresql::server",
-                "postgresql::server::service",
-                "server",
-                "pg2.vm",
-                "class",
-                "service"
-            ],
-            "time": "2015-02-13T13:27:01.375+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-            "level": "notice",
-            "line": 12,
-            "message": "Triggered 'refresh' from 1 events",
-            "source": "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::begin]",
-            "tags": [
-                "node",
-                "notice",
-                "begin",
-                "postgresql::server::service::begin",
-                "postgresql",
-                "postgresql::server",
-                "anchor",
-                "postgresql::server::service",
-                "server",
-                "pg2.vm",
-                "class",
-                "service"
-            ],
-            "time": "2015-02-13T13:26:59.222+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Anchor[postgresql::server::service::begin]",
-            "source": "Class[Postgresql::Server::Service]",
-            "tags": [
-                "admissible_class",
-                "postgresql",
-                "postgresql::server::service",
-                "server",
-                "info",
-                "service"
-            ],
-            "time": "2015-02-13T13:26:59.221+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Anchor[postgresql::server::service::end]",
-            "source": "Class[Postgresql::Server::Service]",
-            "tags": [
-                "admissible_class",
-                "postgresql",
-                "postgresql::server::service",
-                "server",
-                "info",
-                "service"
-            ],
-            "time": "2015-02-13T13:26:59.22+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Postgresql::Validate_db_connection[validate_service_is_running]",
-            "source": "Class[Postgresql::Server::Service]",
-            "tags": [
-                "admissible_class",
-                "postgresql",
-                "postgresql::server::service",
-                "server",
-                "info",
-                "service"
-            ],
-            "time": "2015-02-13T13:26:59.22+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Service[postgresqld]",
-            "source": "Class[Postgresql::Server::Service]",
-            "tags": [
-                "admissible_class",
-                "postgresql",
-                "postgresql::server::service",
-                "server",
-                "info",
-                "service"
-            ],
-            "time": "2015-02-13T13:26:59.22+00:00"
-        },
-        {
-            "file": "/etc/puppet/manifests/site.pp",
-            "level": "notice",
-            "line": 6,
-            "message": "defined 'message' as 'foo'",
-            "source": "/Stage[main]/Main/Node[pg2.vm]/Notify[foo]/message",
-            "tags": [
-                "node",
-                "notice",
-                "foo",
-                "pg2.vm",
-                "class",
-                "notify"
-            ],
-            "time": "2015-02-13T13:26:58.976+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "foo",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:26:58.976+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "level": "info",
-            "line": 105,
-            "message": "Scheduling refresh of Class[Postgresql::Server::Service]",
-            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]",
-            "tags": [
-                "node",
-                "postgresql::server::config",
-                "postgresql::server::config_entry",
-                "postgresql_conf",
-                "data_directory",
-                "postgresql::server",
-                "postgresql",
-                "server",
-                "pg2.vm",
-                "config_entry",
-                "config",
-                "info",
-                "class"
-            ],
-            "time": "2015-02-13T13:26:58.824+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Computing checksum on file /var/lib/pgsql/data/postgresql.conf",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:26:58.815+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "level": "notice",
-            "line": 105,
-            "message": "created",
-            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]/ensure",
-            "tags": [
-                "node",
-                "notice",
-                "postgresql::server::config",
-                "postgresql::server::config_entry",
-                "postgresql_conf",
-                "data_directory",
-                "postgresql::server",
-                "postgresql",
-                "server",
-                "pg2.vm",
-                "config_entry",
-                "config",
-                "class"
-            ],
-            "time": "2015-02-13T13:26:58.814+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "level": "info",
-            "line": 90,
-            "message": "Scheduling refresh of Class[Postgresql::Server::Service]",
-            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]",
-            "tags": [
-                "node",
-                "postgresql::server::config",
-                "postgresql::server::config_entry",
-                "data_directory",
-                "postgresql::server",
-                "postgresql",
-                "augeas",
-                "server",
-                "pg2.vm",
-                "config_entry",
-                "config",
-                "info",
-                "class"
-            ],
-            "time": "2015-02-13T13:26:58.806+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "level": "notice",
-            "line": 90,
-            "message": "executed successfully",
-            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]/returns",
-            "tags": [
-                "node",
-                "notice",
-                "postgresql::server::config",
-                "postgresql::server::config_entry",
-                "data_directory",
-                "postgresql::server",
-                "postgresql",
-                "augeas",
-                "server",
-                "pg2.vm",
-                "config_entry",
-                "config",
-                "class"
-            ],
-            "time": "2015-02-13T13:26:58.805+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "\n--- /etc/sysconfig/pgsql/postgresql\t2014-09-18 15:48:23.129826040 +0100\n+++ /etc/sysconfig/pgsql/postgresql.augnew\t2015-02-13 13:26:58.619877991 +0000\n@@ -1,2 +1,3 @@\n \n PGPORT=5432\n+PGDATA=/var/lib/pgsql/data\n",
-            "source": "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql](provider=augeas)",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:26:58.78+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config.pp",
-            "level": "notice",
-            "line": 120,
-            "message": "created",
-            "source": "/Stage[main]/Postgresql::Server::Config/File[/etc/sysconfig/pgsql/postgresql-8.4]/ensure",
-            "tags": [
-                "node",
-                "notice",
-                "postgresql::server::config",
-                "file",
-                "postgresql::server",
-                "postgresql",
-                "server",
-                "pg2.vm",
-                "config",
-                "class"
-            ],
-            "time": "2015-02-13T13:26:58.583+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "level": "notice",
-            "line": 83,
-            "message": "executed successfully",
-            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Exec[postgresql_data_directory]/returns",
-            "tags": [
-                "node",
-                "notice",
-                "postgresql_data_directory",
-                "postgresql::server::config",
-                "postgresql::server::config_entry",
-                "data_directory",
-                "postgresql::server",
-                "postgresql",
-                "server",
-                "pg2.vm",
-                "config_entry",
-                "config",
-                "exec",
-                "class"
-            ],
-            "time": "2015-02-13T13:26:58.57+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423833741'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:26:57.059+00:00"
-        },
-        {
-            "file": null,
-            "level": "warning",
-            "line": null,
-            "message": "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
-            "source": "Puppet",
-            "tags": [
-                "warning"
-            ],
-            "time": "2015-02-13T13:26:56.789+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for pg2.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:26:56.714+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:26:54.936+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:26:52.669+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:26:52.621+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.000567
-        },
-        {
-            "category": "time",
-            "name": "augeas",
-            "value": 0.250754
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 0.956570863723755
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 1.549255
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.202946
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 0.000101
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.00144
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.001022
-        },
-        {
-            "category": "time",
-            "name": "postgresql_conf",
-            "value": 0.01103
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.000922
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 2.152731
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 5.12733886372376
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 6
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 6
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 3
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 50
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 6
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 6
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 6
-        }
-    ],
-    "noop": true,
-    "puppet_version": "3.7.1",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Postgresql::Server::Config",
-                "Postgresql::Server::Config_entry[data_directory]",
-                "Exec[postgresql_data_directory]"
-            ],
-            "events": [
-                {
-                    "message": "executed successfully",
-                    "new_value": [
-                        "0"
-                    ],
-                    "old_value": "notrun",
-                    "property": "returns",
-                    "status": "success",
-                    "corrective_change": true,
-                    "timestamp": "2015-02-13T13:26:57.409Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "line": 83,
-            "corrective_change": true,
-            "resource_title": "postgresql_data_directory",
-            "resource_type": "Exec",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:26:57.409Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Postgresql::Server::Config",
-                "File[/etc/sysconfig/pgsql/postgresql-8.4]"
-            ],
-            "events": [
-                {
-                    "message": "created",
-                    "new_value": "link",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "success",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:26:58.573Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config.pp",
-            "line": 120,
-            "resource_title": "/etc/sysconfig/pgsql/postgresql-8.4",
-            "resource_type": "File",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:26:58.573Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Postgresql::Server::Config",
-                "Postgresql::Server::Config_entry[data_directory]",
-                "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]"
-            ],
-            "events": [
-                {
-                    "message": "executed successfully",
-                    "new_value": 0,
-                    "old_value": "need_to_run",
-                    "property": "returns",
-                    "status": "success",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:26:58.781Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "line": 90,
-            "corrective_change": false,
-            "resource_title": "override PGDATA in /etc/sysconfig/pgsql/postgresql",
-            "resource_type": "Augeas",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:26:58.781Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Postgresql::Server::Config",
-                "Postgresql::Server::Config_entry[data_directory]",
-                "Postgresql_conf[data_directory]"
-            ],
-            "events": [
-                {
-                    "message": "created",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "success",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:26:58.814Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "line": 105,
-            "resource_title": "data_directory",
-            "resource_type": "Postgresql_conf",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:26:58.814Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Main",
-                "Node[pg2.vm]",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "defined 'message' as 'foo'",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "success",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:26:58.975Z"
-                }
-            ],
-            "file": "/etc/puppet/manifests/site.pp",
-            "line": 6,
-            "resource_title": "foo",
-            "corrective_change": false,
-            "resource_type": "Notify",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:26:58.975Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Postgresql::Server::Service",
-                "Service[postgresqld]"
-            ],
-            "events": [
-                {
-                    "message": "ensure changed 'stopped' to 'running'",
-                    "new_value": "running",
-                    "old_value": "stopped",
-                    "property": "ensure",
-                    "status": "success",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:26:59.281Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-            "line": 14,
-            "corrective_change": false,
-            "resource_title": "postgresqld",
-            "resource_type": "Service",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:26:59.281Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:26:52.564Z",
-    "status": "changed",
-    "catalog_uuid": "f9e15df3-bbfb-404c-80bd-f29ecdbe5283",
-    "producer": "foo.com",
-    "code_id": "8589ce99-5690-4900-a249-a052e044ca11",
-    "transaction_uuid": "9df4e7ce-5646-4178-8ff8-db6add84e9fc"
+  "corrective_change" : true,
+  "code_id" : "8589ce99-5690-4900-a249-a052e044ca11",
+  "noop" : true,
+  "certname" : "pg2.vm",
+  "puppet_version" : "3.7.1",
+  "cached_catalog_status" : "not_used",
+  "transaction_uuid" : "9df4e7ce-5646-4178-8ff8-db6add84e9fc",
+  "configuration_version" : "1423833741",
+  "status" : "changed",
+  "producer" : "foo.com",
+  "catalog_uuid" : "f9e15df3-bbfb-404c-80bd-f29ecdbe5283",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 4.55 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:27:01.557+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+    "level" : "notice",
+    "line" : 41,
+    "message" : "Triggered 'refresh' from 1 events",
+    "source" : "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::end]",
+    "tags" : [ "node", "notice", "postgresql::server::service::end", "postgresql", "postgresql::server", "anchor", "postgresql::server::service", "server", "pg2.vm", "end", "class", "service" ],
+    "time" : "2015-02-13T13:27:01.513+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/validate_db_connection.pp",
+    "level" : "notice",
+    "line" : 51,
+    "message" : "Triggered 'refresh' from 1 events",
+    "source" : "/Stage[main]/Postgresql::Server::Service/Postgresql::Validate_db_connection[validate_service_is_running]/Exec[validate postgres connection for /postgres]",
+    "tags" : [ "node", "notice", "validate_service_is_running", "postgresql", "postgresql::server", "postgresql::server::service", "server", "validate_db_connection", "pg2.vm", "exec", "class", "postgresql::validate_db_connection", "service" ],
+    "time" : "2015-02-13T13:27:01.509+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Exec[validate postgres connection for /postgres]",
+    "source" : "Postgresql::Validate_db_connection[validate_service_is_running]",
+    "tags" : [ "admissible_postgresql", "validate_service_is_running", "validate_db_connection", "admissible_postgresql::validate_db_connection", "info" ],
+    "time" : "2015-02-13T13:27:01.378+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+    "level" : "info",
+    "line" : 14,
+    "message" : "Unscheduling refresh on Service[postgresqld]",
+    "source" : "/Stage[main]/Postgresql::Server::Service/Service[postgresqld]",
+    "tags" : [ "node", "postgresqld", "postgresql", "postgresql::server", "postgresql::server::service", "server", "pg2.vm", "info", "class", "service" ],
+    "time" : "2015-02-13T13:27:01.376+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+    "level" : "notice",
+    "line" : 14,
+    "message" : "ensure changed 'stopped' to 'running'",
+    "source" : "/Stage[main]/Postgresql::Server::Service/Service[postgresqld]/ensure",
+    "tags" : [ "node", "notice", "postgresqld", "postgresql", "postgresql::server", "postgresql::server::service", "server", "pg2.vm", "class", "service" ],
+    "time" : "2015-02-13T13:27:01.375+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+    "level" : "notice",
+    "line" : 12,
+    "message" : "Triggered 'refresh' from 1 events",
+    "source" : "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::begin]",
+    "tags" : [ "node", "notice", "begin", "postgresql::server::service::begin", "postgresql", "postgresql::server", "anchor", "postgresql::server::service", "server", "pg2.vm", "class", "service" ],
+    "time" : "2015-02-13T13:26:59.222+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Anchor[postgresql::server::service::begin]",
+    "source" : "Class[Postgresql::Server::Service]",
+    "tags" : [ "admissible_class", "postgresql", "postgresql::server::service", "server", "info", "service" ],
+    "time" : "2015-02-13T13:26:59.221+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Anchor[postgresql::server::service::end]",
+    "source" : "Class[Postgresql::Server::Service]",
+    "tags" : [ "admissible_class", "postgresql", "postgresql::server::service", "server", "info", "service" ],
+    "time" : "2015-02-13T13:26:59.22+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Postgresql::Validate_db_connection[validate_service_is_running]",
+    "source" : "Class[Postgresql::Server::Service]",
+    "tags" : [ "admissible_class", "postgresql", "postgresql::server::service", "server", "info", "service" ],
+    "time" : "2015-02-13T13:26:59.22+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Service[postgresqld]",
+    "source" : "Class[Postgresql::Server::Service]",
+    "tags" : [ "admissible_class", "postgresql", "postgresql::server::service", "server", "info", "service" ],
+    "time" : "2015-02-13T13:26:59.22+00:00"
+  }, {
+    "file" : "/etc/puppet/manifests/site.pp",
+    "level" : "notice",
+    "line" : 6,
+    "message" : "defined 'message' as 'foo'",
+    "source" : "/Stage[main]/Main/Node[pg2.vm]/Notify[foo]/message",
+    "tags" : [ "node", "notice", "foo", "pg2.vm", "class", "notify" ],
+    "time" : "2015-02-13T13:26:58.976+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "foo",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:26:58.976+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+    "level" : "info",
+    "line" : 105,
+    "message" : "Scheduling refresh of Class[Postgresql::Server::Service]",
+    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]",
+    "tags" : [ "node", "postgresql::server::config", "postgresql::server::config_entry", "postgresql_conf", "data_directory", "postgresql::server", "postgresql", "server", "pg2.vm", "config_entry", "config", "info", "class" ],
+    "time" : "2015-02-13T13:26:58.824+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Computing checksum on file /var/lib/pgsql/data/postgresql.conf",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:26:58.815+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+    "level" : "notice",
+    "line" : 105,
+    "message" : "created",
+    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]/ensure",
+    "tags" : [ "node", "notice", "postgresql::server::config", "postgresql::server::config_entry", "postgresql_conf", "data_directory", "postgresql::server", "postgresql", "server", "pg2.vm", "config_entry", "config", "class" ],
+    "time" : "2015-02-13T13:26:58.814+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+    "level" : "info",
+    "line" : 90,
+    "message" : "Scheduling refresh of Class[Postgresql::Server::Service]",
+    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]",
+    "tags" : [ "node", "postgresql::server::config", "postgresql::server::config_entry", "data_directory", "postgresql::server", "postgresql", "augeas", "server", "pg2.vm", "config_entry", "config", "info", "class" ],
+    "time" : "2015-02-13T13:26:58.806+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+    "level" : "notice",
+    "line" : 90,
+    "message" : "executed successfully",
+    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]/returns",
+    "tags" : [ "node", "notice", "postgresql::server::config", "postgresql::server::config_entry", "data_directory", "postgresql::server", "postgresql", "augeas", "server", "pg2.vm", "config_entry", "config", "class" ],
+    "time" : "2015-02-13T13:26:58.805+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "\n--- /etc/sysconfig/pgsql/postgresql\t2014-09-18 15:48:23.129826040 +0100\n+++ /etc/sysconfig/pgsql/postgresql.augnew\t2015-02-13 13:26:58.619877991 +0000\n@@ -1,2 +1,3 @@\n \n PGPORT=5432\n+PGDATA=/var/lib/pgsql/data\n",
+    "source" : "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql](provider=augeas)",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:26:58.78+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/config.pp",
+    "level" : "notice",
+    "line" : 120,
+    "message" : "created",
+    "source" : "/Stage[main]/Postgresql::Server::Config/File[/etc/sysconfig/pgsql/postgresql-8.4]/ensure",
+    "tags" : [ "node", "notice", "postgresql::server::config", "file", "postgresql::server", "postgresql", "server", "pg2.vm", "config", "class" ],
+    "time" : "2015-02-13T13:26:58.583+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+    "level" : "notice",
+    "line" : 83,
+    "message" : "executed successfully",
+    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Exec[postgresql_data_directory]/returns",
+    "tags" : [ "node", "notice", "postgresql_data_directory", "postgresql::server::config", "postgresql::server::config_entry", "data_directory", "postgresql::server", "postgresql", "server", "pg2.vm", "config_entry", "config", "exec", "class" ],
+    "time" : "2015-02-13T13:26:58.57+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423833741'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:26:57.059+00:00"
+  }, {
+    "file" : null,
+    "level" : "warning",
+    "line" : null,
+    "message" : "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
+    "source" : "Puppet",
+    "tags" : [ "warning" ],
+    "time" : "2015-02-13T13:26:56.789+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for pg2.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:26:56.714+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:26:54.936+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:26:52.669+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:26:52.621+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:26:57.691Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:26:52.564Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 5.67E-4
+  }, {
+    "category" : "time",
+    "name" : "augeas",
+    "value" : 0.250754
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 0.956570863723755
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 1.549255
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.202946
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 1.01E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 0.00144
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.001022
+  }, {
+    "category" : "time",
+    "name" : "postgresql_conf",
+    "value" : 0.01103
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 9.22E-4
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 2.152731
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 5.12733886372376
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 6
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 6
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 3
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 50
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 6
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 6
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 6
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "hdyu",
+    "resource_type" : "ZID",
+    "events" : [ ],
+    "line" : 400,
+    "file" : "JlvbbGQ2Fx",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-b73c37f620703406b5666e7c919afff00c511f1e.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-b73c37f620703406b5666e7c919afff00c511f1e.json
@@ -1,274 +1,2229 @@
 {
-    "cached_catalog_status": "not_used",
-    "certname": "pg2.vm",
-    "configuration_version": "1423833741",
-    "end_time": "2015-02-13T13:27:14.717Z",
-    "environment": "production",
-    "corrective_change": false,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 1.17 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:27:18.498+00:00"
-        },
-        {
-            "file": "/etc/puppet/manifests/site.pp",
-            "level": "notice",
-            "line": 6,
-            "message": "defined 'message' as 'foo'",
-            "source": "/Stage[main]/Main/Node[pg2.vm]/Notify[foo]/message",
-            "tags": [
-                "node",
-                "notify",
-                "notice",
-                "class",
-                "foo",
-                "pg2.vm"
-            ],
-            "time": "2015-02-13T13:27:17.957+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "foo",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:27:17.956+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423833741'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:27:17.38+00:00"
-        },
-        {
-            "file": null,
-            "level": "warning",
-            "line": null,
-            "message": "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
-            "source": "Puppet",
-            "tags": [
-                "warning"
-            ],
-            "time": "2015-02-13T13:27:17.108+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for pg2.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:27:17.037+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:27:15.24+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:27:13.024+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:27:12.945+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.000462
-        },
-        {
-            "category": "time",
-            "name": "augeas",
-            "value": 0.050606
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 0.944538116455078
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.566681
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.176818
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 0.0001
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.000768
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.000995
-        },
-        {
-            "category": "time",
-            "name": "postgresql_conf",
-            "value": 0.000886
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.000759
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.08334
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 1.82595311645508
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 50
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 1
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 1
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 1
-        }
-    ],
-    "noop": true,
-    "puppet_version": "3.7.1",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Main",
-                "Node[pg2.vm]",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "defined 'message' as 'foo'",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "success",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:27:17.956Z"
-                }
-            ],
-            "file": "/etc/puppet/manifests/site.pp",
-            "line": 6,
-            "resource_title": "foo",
-            "corrective_change": false,
-            "resource_type": "Notify",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:27:17.956Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:27:12.891Z",
-    "status": "changed",
-    "catalog_uuid": "b7505625-6d8d-4014-beea-b67b785b8b6b",
-    "producer": "foo.com",
-    "code_id": "87680666-21a4-43b1-8c23-cc69f1832d74",
-    "transaction_uuid": "5c4f17ad-d6df-4514-881b-e31ef107076e"
+  "corrective_change" : false,
+  "code_id" : "87680666-21a4-43b1-8c23-cc69f1832d74",
+  "noop" : true,
+  "certname" : "pg2.vm",
+  "puppet_version" : "3.7.1",
+  "cached_catalog_status" : "not_used",
+  "transaction_uuid" : "5c4f17ad-d6df-4514-881b-e31ef107076e",
+  "configuration_version" : "1423833741",
+  "status" : "changed",
+  "producer" : "foo.com",
+  "catalog_uuid" : "b7505625-6d8d-4014-beea-b67b785b8b6b",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 1.17 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:27:18.498+00:00"
+  }, {
+    "file" : "/etc/puppet/manifests/site.pp",
+    "level" : "notice",
+    "line" : 6,
+    "message" : "defined 'message' as 'foo'",
+    "source" : "/Stage[main]/Main/Node[pg2.vm]/Notify[foo]/message",
+    "tags" : [ "node", "notify", "notice", "class", "foo", "pg2.vm" ],
+    "time" : "2015-02-13T13:27:17.957+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "foo",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:27:17.956+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423833741'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:27:17.38+00:00"
+  }, {
+    "file" : null,
+    "level" : "warning",
+    "line" : null,
+    "message" : "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
+    "source" : "Puppet",
+    "tags" : [ "warning" ],
+    "time" : "2015-02-13T13:27:17.108+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for pg2.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:27:17.037+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:27:15.24+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:27:13.024+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:27:12.945+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:27:14.717Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:27:12.891Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 4.62E-4
+  }, {
+    "category" : "time",
+    "name" : "augeas",
+    "value" : 0.050606
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 0.944538116455078
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.566681
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.176818
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 1.0E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 7.68E-4
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 9.95E-4
+  }, {
+    "category" : "time",
+    "name" : "postgresql_conf",
+    "value" : 8.86E-4
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 7.59E-4
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.08334
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 1.82595311645508
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 50
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 1
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 1
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 1
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "hdyu",
+    "resource_type" : "ZID",
+    "events" : [ ],
+    "line" : 400,
+    "file" : "JlvbbGQ2Fx",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-bb3cea0e4f72a38fde935e93a9efca44e540ec3c.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-bb3cea0e4f72a38fde935e93a9efca44e540ec3c.json
@@ -1,2068 +1,2753 @@
 {
-    "cached_catalog_status": "not_used",
-    "certname": "pg2.vm",
-    "configuration_version": "1423834124",
-    "end_time": "2015-02-13T13:29:04.147Z",
-    "environment": "production",
-    "corrective_change": false,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 1.98 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:10.931+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 8 events",
-            "source": "Stage[main]",
-            "tags": [
-                "main",
-                "completed_stage",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:10.897+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 8 events",
-            "source": "Class[Loadtest]",
-            "tags": [
-                "notice",
-                "completed_class",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.895+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "err",
-            "line": 11,
-            "message": "Provider git is not functional on this host",
-            "source": "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
-            "tags": [
-                "class",
-                "vcsrepo",
-                "node",
-                "pg2.vm",
-                "err",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.894+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 2 events",
-            "source": "Class[Snmp::Client]",
-            "tags": [
-                "snmp",
-                "client",
-                "snmp::client",
-                "notice",
-                "completed_class"
-            ],
-            "time": "2015-02-13T13:29:10.893+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "level": "notice",
-            "line": 85,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp::Client/File[snmp.conf]/ensure",
-            "tags": [
-                "snmp",
-                "class",
-                "node",
-                "snmp.conf",
-                "client",
-                "pg2.vm",
-                "snmp::client",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.892+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 3 events",
-            "source": "Class[Python::Install]",
-            "tags": [
-                "python",
-                "python::install",
-                "install",
-                "notice",
-                "completed_class"
-            ],
-            "time": "2015-02-13T13:29:10.888+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "notice",
-            "line": 59,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Python::Install/Package[python-virtualenv]/ensure",
-            "tags": [
-                "package",
-                "class",
-                "python",
-                "python-virtualenv",
-                "node",
-                "pg2.vm",
-                "python::install",
-                "install",
-                "notice",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.885+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "notice",
-            "line": 61,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Python::Install/Package[python-devel]/ensure",
-            "tags": [
-                "package",
-                "class",
-                "python",
-                "node",
-                "python-devel",
-                "pg2.vm",
-                "python::install",
-                "install",
-                "notice",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.82+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "level": "notice",
-            "line": 60,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Python::Install/Package[python-pip]/ensure",
-            "tags": [
-                "package",
-                "class",
-                "python",
-                "node",
-                "python-pip",
-                "pg2.vm",
-                "python::install",
-                "install",
-                "notice",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.787+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Git]",
-            "tags": [
-                "notice",
-                "git",
-                "completed_class"
-            ],
-            "time": "2015-02-13T13:29:10.506+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/git/manifests/init.pp",
-            "level": "notice",
-            "line": 12,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Git/Package[git]/ensure",
-            "tags": [
-                "package",
-                "class",
-                "node",
-                "pg2.vm",
-                "notice",
-                "git",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.504+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 8 events",
-            "source": "Class[Snmp]",
-            "tags": [
-                "snmp",
-                "notice",
-                "completed_class"
-            ],
-            "time": "2015-02-13T13:29:10.276+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 517,
-            "message": "Unscheduling refresh on Service[snmpd]",
-            "source": "/Stage[main]/Snmp/Service[snmpd]",
-            "tags": [
-                "snmpd",
-                "snmp",
-                "class",
-                "node",
-                "service",
-                "info",
-                "pg2.vm",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.276+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 517,
-            "message": "current_value stopped, should be running (noop)",
-            "source": "/Stage[main]/Snmp/Service[snmpd]/ensure",
-            "tags": [
-                "snmpd",
-                "snmp",
-                "class",
-                "node",
-                "service",
-                "pg2.vm",
-                "notice",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.275+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 429,
-            "message": "Scheduling refresh of Service[snmpd]",
-            "source": "/Stage[main]/Snmp/File[snmpd.conf]",
-            "tags": [
-                "snmp",
-                "class",
-                "snmpd.conf",
-                "node",
-                "info",
-                "pg2.vm",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.236+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 429,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/File[snmpd.conf]/ensure",
-            "tags": [
-                "snmp",
-                "class",
-                "snmpd.conf",
-                "node",
-                "pg2.vm",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.235+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Concat::Fragment[tmpfile]",
-            "tags": [
-                "fragment",
-                "completed_concat",
-                "completed_concat::fragment",
-                "tmpfile",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:10.234+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 6 events",
-            "source": "Concat[/tmp/file]",
-            "tags": [
-                "completed_concat",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:10.233+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "err",
-            "line": 169,
-            "message": "Could not evaluate: Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/tmp/file]",
-            "tags": [
-                "concat",
-                "class",
-                "node",
-                "pg2.vm",
-                "err",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.232+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 187,
-            "message": "Would have triggered 'refresh' from 4 events",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
-            "tags": [
-                "concat",
-                "class",
-                "node",
-                "exec",
-                "pg2.vm",
-                "notice",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.231+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 187,
-            "message": "current_value notrun, should be 0 (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/returns",
-            "tags": [
-                "concat",
-                "class",
-                "node",
-                "exec",
-                "pg2.vm",
-                "notice",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.23+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "info",
-            "line": 113,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
-            "tags": [
-                "concat",
-                "class",
-                "concat::fragment",
-                "fragment",
-                "node",
-                "info",
-                "tmpfile",
-                "pg2.vm",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.165+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "notice",
-            "line": 113,
-            "message": "current_value absent, should be file (noop)",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/ensure",
-            "tags": [
-                "concat",
-                "class",
-                "concat::fragment",
-                "fragment",
-                "node",
-                "tmpfile",
-                "pg2.vm",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.164+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Concat::Fragment[tmpfile2]",
-            "tags": [
-                "fragment",
-                "completed_concat",
-                "completed_concat::fragment",
-                "tmpfile2",
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:10.161+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "info",
-            "line": 113,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
-            "tags": [
-                "concat",
-                "class",
-                "concat::fragment",
-                "fragment",
-                "node",
-                "info",
-                "pg2.vm",
-                "tmpfile2",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.161+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "level": "notice",
-            "line": 113,
-            "message": "current_value absent, should be file (noop)",
-            "source": "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
-            "tags": [
-                "concat",
-                "class",
-                "concat::fragment",
-                "fragment",
-                "node",
-                "pg2.vm",
-                "tmpfile2",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.16+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "info",
-            "line": 149,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
-            "tags": [
-                "concat",
-                "class",
-                "node",
-                "info",
-                "pg2.vm",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.159+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 149,
-            "message": "current_value absent, should be directory (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/ensure",
-            "tags": [
-                "concat",
-                "class",
-                "node",
-                "pg2.vm",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.159+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 476,
-            "message": "Would have triggered 'refresh' from 2 events",
-            "source": "/Stage[main]/Snmp/Service[snmptrapd]",
-            "tags": [
-                "snmp",
-                "class",
-                "snmptrapd",
-                "node",
-                "service",
-                "pg2.vm",
-                "notice",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.155+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 164,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]/ensure",
-            "tags": [
-                "concat",
-                "class",
-                "node",
-                "pg2.vm",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.114+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 159,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]/ensure",
-            "tags": [
-                "concat",
-                "class",
-                "node",
-                "pg2.vm",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.112+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "info",
-            "line": 144,
-            "message": "Scheduling refresh of Exec[concat_/tmp/file]",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
-            "tags": [
-                "concat",
-                "class",
-                "node",
-                "info",
-                "pg2.vm",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.111+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "level": "notice",
-            "line": 144,
-            "message": "current_value absent, should be directory (noop)",
-            "source": "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]/ensure",
-            "tags": [
-                "concat",
-                "class",
-                "node",
-                "pg2.vm",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.11+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 453,
-            "message": "Scheduling refresh of Service[snmptrapd]",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]",
-            "tags": [
-                "snmp",
-                "class",
-                "node",
-                "info",
-                "pg2.vm",
-                "snmptrapd.conf",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.108+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 453,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.conf]/ensure",
-            "tags": [
-                "snmp",
-                "class",
-                "node",
-                "pg2.vm",
-                "snmptrapd.conf",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:10.108+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 69,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]/ensure",
-            "tags": [
-                "class",
-                "node",
-                "hkp_server_20bc0a86",
-                "gnupg_key",
-                "pg2.vm",
-                "notice",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.902+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Ntp::Service]",
-            "tags": [
-                "ntp",
-                "service",
-                "notice",
-                "completed_class",
-                "ntp::service"
-            ],
-            "time": "2015-02-13T13:29:09.873+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
-            "level": "info",
-            "line": 9,
-            "message": "Unscheduling refresh on Service[ntp]",
-            "source": "/Stage[main]/Ntp::Service/Service[ntp]",
-            "tags": [
-                "class",
-                "ntp",
-                "node",
-                "service",
-                "info",
-                "pg2.vm",
-                "ntp::service",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.872+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
-            "level": "notice",
-            "line": 9,
-            "message": "current_value stopped, should be running (noop)",
-            "source": "/Stage[main]/Ntp::Service/Service[ntp]/ensure",
-            "tags": [
-                "class",
-                "ntp",
-                "node",
-                "service",
-                "pg2.vm",
-                "notice",
-                "ntp::service",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.871+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 410,
-            "message": "current_value absent, should be directory (noop)",
-            "source": "/Stage[main]/Snmp/File[var-net-snmp]/ensure",
-            "tags": [
-                "snmp",
-                "class",
-                "var-net-snmp",
-                "node",
-                "pg2.vm",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.751+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 45,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Loadtest/Ini_setting[sample setting]/ensure",
-            "tags": [
-                "class",
-                "node",
-                "pg2.vm",
-                "notice",
-                "ini_setting",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.749+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Service[ntp]",
-            "source": "Class[Ntp::Service]",
-            "tags": [
-                "ntp",
-                "admissible_class",
-                "service",
-                "info",
-                "ntp::service"
-            ],
-            "time": "2015-02-13T13:29:09.747+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Ntp::Service]",
-            "tags": [
-                "ntp",
-                "admissible_class",
-                "service",
-                "notice",
-                "ntp::service"
-            ],
-            "time": "2015-02-13T13:29:09.747+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Class[Ntp::Service]",
-            "source": "Class[Ntp::Config]",
-            "tags": [
-                "ntp",
-                "ntp::config",
-                "config",
-                "info",
-                "completed_class"
-            ],
-            "time": "2015-02-13T13:29:09.746+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Ntp::Config]",
-            "tags": [
-                "ntp",
-                "ntp::config",
-                "config",
-                "notice",
-                "completed_class"
-            ],
-            "time": "2015-02-13T13:29:09.745+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
-            "level": "notice",
-            "line": 14,
-            "message": "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
-            "source": "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
-            "tags": [
-                "class",
-                "ntp",
-                "ntp::config",
-                "config",
-                "node",
-                "pg2.vm",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.741+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
-            "level": "notice",
-            "line": 14,
-            "message": "\n--- /etc/ntp.conf\t2013-07-15 10:18:47.000000000 +0100\n+++ /tmp/puppet-file20150213-61841-934rx4-0\t2015-02-13 13:29:09.708877903 +0000\n@@ -1,53 +1,19 @@\n-# For more information about this file, see the man pages\n-# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).\n+# ntp.conf: Managed by puppet.\n+#\n+# Keep ntpd from panicking in the event of a large clock skew\n+# when a VM guest is suspended and resumed.\n+tinker panic 0\n \n-driftfile /var/lib/ntp/drift\n \n # Permit time synchronization with our time source, but do not\n # permit the source to query or modify the service on this system.\n-restrict default kod nomodify notrap nopeer noquery\n-restrict -6 default kod nomodify notrap nopeer noquery\n+restrict 127.0.0.1\n+\n \n-# Permit all access over the loopback interface.  This could\n-# be tightened as well, but to do so would effect some of\n-# the administrative functions.\n-restrict 127.0.0.1 \n-restrict -6 ::1\n-\n-# Hosts on local network are less restricted.\n-#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap\n-\n-# Use public servers from the pool.ntp.org project.\n-# Please consider joining the pool (http://www.pool.ntp.org/join.html).\n-server 0.centos.pool.ntp.org iburst\n-server 1.centos.pool.ntp.org iburst\n-server 2.centos.pool.ntp.org iburst\n-server 3.centos.pool.ntp.org iburst\n-\n-#broadcast 192.168.1.255 autokey\t# broadcast server\n-#broadcastclient\t\t\t# broadcast client\n-#broadcast 224.0.1.1 autokey\t\t# multicast server\n-#multicastclient 224.0.1.1\t\t# multicast client\n-#manycastserver 239.255.254.254\t\t# manycast server\n-#manycastclient 239.255.254.254 autokey # manycast client\n-\n-# Enable public key cryptography.\n-#crypto\n-\n-includefile /etc/ntp/crypto/pw\n-\n-# Key file containing the keys and key identifiers used when operating\n-# with symmetric key cryptography. \n-keys /etc/ntp/keys\n-\n-# Specify the key identifiers which are trusted.\n-#trustedkey 4 8 42\n+server ntp.pool.org\n \n-# Specify the key identifier to use with the ntpdc utility.\n-#requestkey 8\n \n-# Specify the key identifier to use with the ntpq utility.\n-#controlkey 8\n+# Driftfile.\n+driftfile /var/lib/ntp/drift\n+\n \n-# Enable writing of statistics records.\n-#statistics clockstats cryptostats loopstats peerstats\n",
-            "source": "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
-            "tags": [
-                "class",
-                "ntp",
-                "ntp::config",
-                "config",
-                "node",
-                "pg2.vm",
-                "content",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.737+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 441,
-            "message": "Scheduling refresh of Service[snmpd]",
-            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]",
-            "tags": [
-                "snmp",
-                "class",
-                "node",
-                "info",
-                "pg2.vm",
-                "snmpd.sysconfig",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.703+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 441,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/File[snmpd.sysconfig]/ensure",
-            "tags": [
-                "snmp",
-                "class",
-                "node",
-                "pg2.vm",
-                "notice",
-                "snmpd.sysconfig",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.703+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "info",
-            "line": 465,
-            "message": "Scheduling refresh of Service[snmptrapd]",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.sysconfig]",
-            "tags": [
-                "snmp",
-                "class",
-                "snmptrapd.sysconfig",
-                "node",
-                "info",
-                "pg2.vm",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.694+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 465,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/File[snmptrapd.sysconfig]/ensure",
-            "tags": [
-                "snmp",
-                "class",
-                "snmptrapd.sysconfig",
-                "node",
-                "pg2.vm",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.693+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "info",
-            "line": 4,
-            "message": "Unscheduling refresh on Service[cron]",
-            "source": "/Stage[main]/Loadtest/Service[cron]",
-            "tags": [
-                "class",
-                "cron",
-                "node",
-                "service",
-                "info",
-                "pg2.vm",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.688+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 4,
-            "message": "current_value stopped, should be running (noop)",
-            "source": "/Stage[main]/Loadtest/Service[cron]/ensure",
-            "tags": [
-                "class",
-                "cron",
-                "node",
-                "service",
-                "pg2.vm",
-                "notice",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.687+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 3,
-            "message": "current_value absent, should be foo (noop)",
-            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
-            "tags": [
-                "class",
-                "node",
-                "notify",
-                "foo",
-                "pg2.vm",
-                "notice",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.523+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "level": "notice",
-            "line": 405,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp/Package[snmpd]/ensure",
-            "tags": [
-                "package",
-                "snmpd",
-                "snmp",
-                "class",
-                "node",
-                "pg2.vm",
-                "notice",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.521+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 41,
-            "message": "current_value absent, should be latest (noop)",
-            "source": "/Stage[main]/Loadtest/Package[etckeeper]/ensure",
-            "tags": [
-                "package",
-                "class",
-                "etckeeper",
-                "node",
-                "pg2.vm",
-                "notice",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.423+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "level": "notice",
-            "line": 76,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Snmp::Client/Package[snmp-client]/ensure",
-            "tags": [
-                "package",
-                "snmp",
-                "class",
-                "node",
-                "snmp-client",
-                "client",
-                "pg2.vm",
-                "snmp::client",
-                "notice",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.325+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Motd]",
-            "tags": [
-                "motd",
-                "notice",
-                "completed_class"
-            ],
-            "time": "2015-02-13T13:29:09.093+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "level": "notice",
-            "line": 33,
-            "message": "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
-            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
-            "tags": [
-                "class",
-                "node",
-                "motd",
-                "pg2.vm",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.09+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "level": "notice",
-            "line": 33,
-            "message": "\n--- /etc/motd\t2010-01-12 13:28:22.000000000 +0000\n+++ /tmp/puppet-file20150213-61841-isxd4q-0\t2015-02-13 13:29:09.073877903 +0000\n@@ -0,0 +1 @@\n+Welcome to my test host!\n\\ No newline at end of file\n",
-            "source": "/Stage[main]/Motd/File[/etc/motd]/content",
-            "tags": [
-                "class",
-                "node",
-                "motd",
-                "pg2.vm",
-                "content",
-                "notice",
-                "file",
-                "loadtest"
-            ],
-            "time": "2015-02-13T13:29:09.09+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423834124'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:09.021+00:00"
-        },
-        {
-            "file": null,
-            "level": "warning",
-            "line": null,
-            "message": "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
-            "source": "Puppet",
-            "tags": [
-                "warning"
-            ],
-            "time": "2015-02-13T13:29:08.608+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for pg2.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:08.547+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:02.517+00:00"
-        },
-        {
-            "file": null,
-            "level": "err",
-            "line": null,
-            "message": "Could not evaluate: Could not retrieve file metadata for puppet://puppet/plugins: Network is unreachable - connect(2)\nWrapped exception:\nNetwork is unreachable - connect(2)",
-            "source": "/File[/var/lib/puppet/lib]",
-            "tags": [
-                "plugin",
-                "err",
-                "file"
-            ],
-            "time": "2015-02-13T13:29:02.507+00:00"
-        },
-        {
-            "file": null,
-            "level": "err",
-            "line": null,
-            "message": "Failed to generate additional resources using 'eval_generate': Network is unreachable - connect(2)",
-            "source": "/File[/var/lib/puppet/lib]",
-            "tags": [
-                "plugin",
-                "err",
-                "file"
-            ],
-            "time": "2015-02-13T13:29:02.502+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:01.367+00:00"
-        },
-        {
-            "file": null,
-            "level": "err",
-            "line": null,
-            "message": "Could not evaluate: Could not retrieve file metadata for puppet://puppet/pluginfacts: Network is unreachable - connect(2)\nWrapped exception:\nNetwork is unreachable - connect(2)",
-            "source": "/File[/var/lib/puppet/facts.d]",
-            "tags": [
-                "pluginfacts",
-                "err",
-                "file"
-            ],
-            "time": "2015-02-13T13:29:01.367+00:00"
-        },
-        {
-            "file": null,
-            "level": "err",
-            "line": null,
-            "message": "Failed to generate additional resources using 'eval_generate': Network is unreachable - connect(2)",
-            "source": "/File[/var/lib/puppet/facts.d]",
-            "tags": [
-                "pluginfacts",
-                "err",
-                "file"
-            ],
-            "time": "2015-02-13T13:29:01.364+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:01.353+00:00"
-        },
-        {
-            "file": null,
-            "level": "warning",
-            "line": null,
-            "message": "Network is unreachable - connect(2)",
-            "source": "Puppet",
-            "tags": [
-                "warning"
-            ],
-            "time": "2015-02-13T13:29:01.352+00:00"
-        },
-        {
-            "file": null,
-            "level": "warning",
-            "line": null,
-            "message": "Unable to fetch my node definition, but the agent run will continue:",
-            "source": "Puppet",
-            "tags": [
-                "warning"
-            ],
-            "time": "2015-02-13T13:29:01.352+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.00119
-        },
-        {
-            "category": "time",
-            "name": "augeas",
-            "value": 0.0566330000000001
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 1.24377989768982
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.393671
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.302035
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 0.000469
-        },
-        {
-            "category": "time",
-            "name": "gnupg_key",
-            "value": 0.026254
-        },
-        {
-            "category": "time",
-            "name": "ini_setting",
-            "value": 0.000823
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.000611
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.450188
-        },
-        {
-            "category": "time",
-            "name": "postgresql_conf",
-            "value": 0.00068
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.001031
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.329234
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 2.80659889768982
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 2
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 29
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 88
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 1
-        },
-        {
-            "category": "events",
-            "name": "noop",
-            "value": 28
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 29
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 0
-        }
-    ],
-    "noop": true,
-    "puppet_version": "3.7.1",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat::Fragment[tmpfile]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be file (noop)",
-                    "new_value": "file",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.164Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "line": 113,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.164Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/var/lib/puppet/concat/_tmp_file]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be directory (noop)",
-                    "new_value": "directory",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.110Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 144,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file",
-            "resource_type": "File",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.110Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Ntp::Config",
-                "File[/etc/ntp.conf]"
-            ],
-            "events": [
-                {
-                    "message": "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
-                    "new_value": "{md5}eb918d28434c9fefcc05875c29c3ba1a",
-                    "old_value": "{md5}7fda24f62b1c7ae951db0f746dc6e0cc",
-                    "property": "content",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:09.741Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/ntp/manifests/config.pp",
-            "line": 14,
-            "resource_title": "/etc/ntp.conf",
-            "resource_type": "File",
-            "skipped": false,
-            "corrective_change": false,
-            "timestamp": "2015-02-13T13:29:09.741Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "Exec[concat_/tmp/file]"
-            ],
-            "events": [
-                {
-                    "message": "current_value notrun, should be 0 (noop)",
-                    "new_value": [
-                        "0"
-                    ],
-                    "old_value": "notrun",
-                    "property": "returns",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.230Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 187,
-            "resource_title": "concat_/tmp/file",
-            "corrective_change": false,
-            "resource_type": "Exec",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.230Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Python::Install",
-                "Package[python-virtualenv]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.885Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "line": 59,
-            "resource_title": "python-virtualenv",
-            "corrective_change": false,
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.885Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Git",
-                "Package[git]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.504Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/git/manifests/init.pp",
-            "line": 12,
-            "resource_title": "git",
-            "corrective_change": false,
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.504Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Package[etckeeper]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be latest (noop)",
-                    "new_value": "latest",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:09.423Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 41,
-            "resource_title": "etckeeper",
-            "corrective_change": false,
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:09.423Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp::Client",
-                "Package[snmp-client]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:09.325Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "line": 76,
-            "resource_title": "snmp-client",
-            "corrective_change": false,
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:09.325Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[var-net-snmp]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be directory (noop)",
-                    "new_value": "directory",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:09.751Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 410,
-            "corrective_change": false,
-            "resource_title": "var-net-snmp",
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:09.751Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "Package[snmpd]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:09.521Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 405,
-            "corrective_change": false,
-            "resource_title": "snmpd",
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:09.521Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be directory (noop)",
-                    "new_value": "directory",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.158Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 149,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.158Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "Service[snmpd]"
-            ],
-            "events": [
-                {
-                    "message": "current_value stopped, should be running (noop)",
-                    "new_value": "running",
-                    "old_value": "stopped",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.275Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 517,
-            "resource_title": "snmpd",
-            "corrective_change": false,
-            "resource_type": "Service",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.275Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Ntp::Service",
-                "Service[ntp]"
-            ],
-            "events": [
-                {
-                    "message": "current_value stopped, should be running (noop)",
-                    "new_value": "running",
-                    "old_value": "stopped",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:09.871Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/ntp/manifests/service.pp",
-            "line": 9,
-            "resource_title": "ntp",
-            "corrective_change": false,
-            "resource_type": "Service",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:09.871Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Python::Install",
-                "Package[python-devel]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.820Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "line": 61,
-            "resource_title": "python-devel",
-            "corrective_change": false,
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.820Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[snmpd.sysconfig]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:09.702Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 441,
-            "resource_title": "snmpd.sysconfig",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:09.702Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Motd",
-                "File[/etc/motd]"
-            ],
-            "events": [
-                {
-                    "message": "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
-                    "new_value": "{md5}a3f731187a6aaaa23d4a7b244f223f33",
-                    "old_value": "{md5}d41d8cd98f00b204e9800998ecf8427e",
-                    "property": "content",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:09.090Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/motd/manifests/init.pp",
-            "line": 33,
-            "resource_title": "/etc/motd",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:09.090Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[snmptrapd.conf]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.108Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 453,
-            "resource_title": "snmptrapd.conf",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.108Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[snmptrapd.sysconfig]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:09.693Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 465,
-            "resource_title": "snmptrapd.sysconfig",
-            "resource_type": "File",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:09.693Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat::Fragment[tmpfile2]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be file (noop)",
-                    "new_value": "file",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.160Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/fragment.pp",
-            "line": 113,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.160Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp::Client",
-                "File[snmp.conf]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.892Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/client.pp",
-            "line": 85,
-            "resource_title": "snmp.conf",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.892Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.114Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 164,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-            "resource_type": "File",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.114Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/tmp/file]"
-            ],
-            "events": [
-                {
-                    "message": "Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
-                    "new_value": null,
-                    "old_value": null,
-                    "property": null,
-                    "status": "failure",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.233Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 169,
-            "corrective_change": false,
-            "resource_title": "/tmp/file",
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.233Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Snmp",
-                "File[snmpd.conf]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.235Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/snmp/manifests/init.pp",
-            "line": 429,
-            "resource_title": "snmpd.conf",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.235Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be foo (noop)",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:09.523Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 3,
-            "resource_title": "foo",
-            "corrective_change": false,
-            "resource_type": "Notify",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:09.523Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Python::Install",
-                "Package[python-pip]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.786Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/python/manifests/install.pp",
-            "line": 60,
-            "resource_title": "python-pip",
-            "corrective_change": false,
-            "resource_type": "Package",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.786Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Ini_setting[sample setting]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:09.749Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 45,
-            "resource_title": "sample setting",
-            "corrective_change": false,
-            "resource_type": "Ini_setting",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:09.749Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Concat[/tmp/file]",
-                "File[/var/lib/puppet/concat/_tmp_file/fragments.concat]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:10.112Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/concat/manifests/init.pp",
-            "line": 159,
-            "resource_title": "/var/lib/puppet/concat/_tmp_file/fragments.concat",
-            "corrective_change": false,
-            "resource_type": "File",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:10.112Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Gnupg_key[hkp_server_20BC0A86]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:09.901Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 69,
-            "resource_title": "hkp_server_20BC0A86",
-            "corrective_change": false,
-            "resource_type": "Gnupg_key",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:09.901Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Service[cron]"
-            ],
-            "events": [
-                {
-                    "message": "current_value stopped, should be running (noop)",
-                    "new_value": "running",
-                    "old_value": "stopped",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:09.687Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 4,
-            "resource_title": "cron",
-            "corrective_change": false,
-            "resource_type": "Service",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:09.687Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:29:01.341Z",
-    "status": "failed",
-    "catalog_uuid": "48b574f9-fd1c-4d5d-9dc6-abb8b479e390",
-    "producer": "foo.com",
-    "code_id": "90102f12-0f34-429f-8280-3e7931295784",
-    "transaction_uuid": "f2b3642a-27e8-4311-a213-aad48859b9ac"
+  "corrective_change" : false,
+  "code_id" : "90102f12-0f34-429f-8280-3e7931295784",
+  "noop" : true,
+  "certname" : "pg2.vm",
+  "puppet_version" : "3.7.1",
+  "cached_catalog_status" : "not_used",
+  "transaction_uuid" : "f2b3642a-27e8-4311-a213-aad48859b9ac",
+  "configuration_version" : "1423834124",
+  "status" : "failed",
+  "producer" : "foo.com",
+  "catalog_uuid" : "48b574f9-fd1c-4d5d-9dc6-abb8b479e390",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 1.98 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:29:10.931+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 8 events",
+    "source" : "Stage[main]",
+    "tags" : [ "main", "completed_stage", "notice" ],
+    "time" : "2015-02-13T13:29:10.897+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 8 events",
+    "source" : "Class[Loadtest]",
+    "tags" : [ "notice", "completed_class", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.895+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "err",
+    "line" : 11,
+    "message" : "Provider git is not functional on this host",
+    "source" : "/Stage[main]/Loadtest/Vcsrepo[/srv/puppetdb]",
+    "tags" : [ "class", "vcsrepo", "node", "pg2.vm", "err", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.894+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 2 events",
+    "source" : "Class[Snmp::Client]",
+    "tags" : [ "snmp", "client", "snmp::client", "notice", "completed_class" ],
+    "time" : "2015-02-13T13:29:10.893+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
+    "level" : "notice",
+    "line" : 85,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp::Client/File[snmp.conf]/ensure",
+    "tags" : [ "snmp", "class", "node", "snmp.conf", "client", "pg2.vm", "snmp::client", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.892+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 3 events",
+    "source" : "Class[Python::Install]",
+    "tags" : [ "python", "python::install", "install", "notice", "completed_class" ],
+    "time" : "2015-02-13T13:29:10.888+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "notice",
+    "line" : 59,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Python::Install/Package[python-virtualenv]/ensure",
+    "tags" : [ "package", "class", "python", "python-virtualenv", "node", "pg2.vm", "python::install", "install", "notice", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.885+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "notice",
+    "line" : 61,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Python::Install/Package[python-devel]/ensure",
+    "tags" : [ "package", "class", "python", "node", "python-devel", "pg2.vm", "python::install", "install", "notice", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.82+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/python/manifests/install.pp",
+    "level" : "notice",
+    "line" : 60,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Python::Install/Package[python-pip]/ensure",
+    "tags" : [ "package", "class", "python", "node", "python-pip", "pg2.vm", "python::install", "install", "notice", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.787+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Git]",
+    "tags" : [ "notice", "git", "completed_class" ],
+    "time" : "2015-02-13T13:29:10.506+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/git/manifests/init.pp",
+    "level" : "notice",
+    "line" : 12,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Git/Package[git]/ensure",
+    "tags" : [ "package", "class", "node", "pg2.vm", "notice", "git", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.504+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 8 events",
+    "source" : "Class[Snmp]",
+    "tags" : [ "snmp", "notice", "completed_class" ],
+    "time" : "2015-02-13T13:29:10.276+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 517,
+    "message" : "Unscheduling refresh on Service[snmpd]",
+    "source" : "/Stage[main]/Snmp/Service[snmpd]",
+    "tags" : [ "snmpd", "snmp", "class", "node", "service", "info", "pg2.vm", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.276+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 517,
+    "message" : "current_value stopped, should be running (noop)",
+    "source" : "/Stage[main]/Snmp/Service[snmpd]/ensure",
+    "tags" : [ "snmpd", "snmp", "class", "node", "service", "pg2.vm", "notice", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.275+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 429,
+    "message" : "Scheduling refresh of Service[snmpd]",
+    "source" : "/Stage[main]/Snmp/File[snmpd.conf]",
+    "tags" : [ "snmp", "class", "snmpd.conf", "node", "info", "pg2.vm", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.236+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 429,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/File[snmpd.conf]/ensure",
+    "tags" : [ "snmp", "class", "snmpd.conf", "node", "pg2.vm", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.235+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Concat::Fragment[tmpfile]",
+    "tags" : [ "fragment", "completed_concat", "completed_concat::fragment", "tmpfile", "notice" ],
+    "time" : "2015-02-13T13:29:10.234+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 6 events",
+    "source" : "Concat[/tmp/file]",
+    "tags" : [ "completed_concat", "notice" ],
+    "time" : "2015-02-13T13:29:10.233+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "err",
+    "line" : 169,
+    "message" : "Could not evaluate: Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/_tmp_file/fragments.concat.out",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/tmp/file]",
+    "tags" : [ "concat", "class", "node", "pg2.vm", "err", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.232+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 187,
+    "message" : "Would have triggered 'refresh' from 4 events",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]",
+    "tags" : [ "concat", "class", "node", "exec", "pg2.vm", "notice", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.231+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 187,
+    "message" : "current_value notrun, should be 0 (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/Exec[concat_/tmp/file]/returns",
+    "tags" : [ "concat", "class", "node", "exec", "pg2.vm", "notice", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.23+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "info",
+    "line" : 113,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]",
+    "tags" : [ "concat", "class", "concat::fragment", "fragment", "node", "info", "tmpfile", "pg2.vm", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.165+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "notice",
+    "line" : 113,
+    "message" : "current_value absent, should be file (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile]/File[/var/lib/puppet/concat/_tmp_file/fragments/01_tmpfile]/ensure",
+    "tags" : [ "concat", "class", "concat::fragment", "fragment", "node", "tmpfile", "pg2.vm", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.164+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Concat::Fragment[tmpfile2]",
+    "tags" : [ "fragment", "completed_concat", "completed_concat::fragment", "tmpfile2", "notice" ],
+    "time" : "2015-02-13T13:29:10.161+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "info",
+    "line" : 113,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]",
+    "tags" : [ "concat", "class", "concat::fragment", "fragment", "node", "info", "pg2.vm", "tmpfile2", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.161+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/fragment.pp",
+    "level" : "notice",
+    "line" : 113,
+    "message" : "current_value absent, should be file (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat::Fragment[tmpfile2]/File[/var/lib/puppet/concat/_tmp_file/fragments/02_tmpfile2]/ensure",
+    "tags" : [ "concat", "class", "concat::fragment", "fragment", "node", "pg2.vm", "tmpfile2", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.16+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "info",
+    "line" : 149,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]",
+    "tags" : [ "concat", "class", "node", "info", "pg2.vm", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.159+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 149,
+    "message" : "current_value absent, should be directory (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments]/ensure",
+    "tags" : [ "concat", "class", "node", "pg2.vm", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.159+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 476,
+    "message" : "Would have triggered 'refresh' from 2 events",
+    "source" : "/Stage[main]/Snmp/Service[snmptrapd]",
+    "tags" : [ "snmp", "class", "snmptrapd", "node", "service", "pg2.vm", "notice", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.155+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 164,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat.out]/ensure",
+    "tags" : [ "concat", "class", "node", "pg2.vm", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.114+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 159,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file/fragments.concat]/ensure",
+    "tags" : [ "concat", "class", "node", "pg2.vm", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.112+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "info",
+    "line" : 144,
+    "message" : "Scheduling refresh of Exec[concat_/tmp/file]",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]",
+    "tags" : [ "concat", "class", "node", "info", "pg2.vm", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.111+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/concat/manifests/init.pp",
+    "level" : "notice",
+    "line" : 144,
+    "message" : "current_value absent, should be directory (noop)",
+    "source" : "/Stage[main]/Loadtest/Concat[/tmp/file]/File[/var/lib/puppet/concat/_tmp_file]/ensure",
+    "tags" : [ "concat", "class", "node", "pg2.vm", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.11+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 453,
+    "message" : "Scheduling refresh of Service[snmptrapd]",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]",
+    "tags" : [ "snmp", "class", "node", "info", "pg2.vm", "snmptrapd.conf", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.108+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 453,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.conf]/ensure",
+    "tags" : [ "snmp", "class", "node", "pg2.vm", "snmptrapd.conf", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:10.108+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 69,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Loadtest/Gnupg_key[hkp_server_20BC0A86]/ensure",
+    "tags" : [ "class", "node", "hkp_server_20bc0a86", "gnupg_key", "pg2.vm", "notice", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.902+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Ntp::Service]",
+    "tags" : [ "ntp", "service", "notice", "completed_class", "ntp::service" ],
+    "time" : "2015-02-13T13:29:09.873+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
+    "level" : "info",
+    "line" : 9,
+    "message" : "Unscheduling refresh on Service[ntp]",
+    "source" : "/Stage[main]/Ntp::Service/Service[ntp]",
+    "tags" : [ "class", "ntp", "node", "service", "info", "pg2.vm", "ntp::service", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.872+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/service.pp",
+    "level" : "notice",
+    "line" : 9,
+    "message" : "current_value stopped, should be running (noop)",
+    "source" : "/Stage[main]/Ntp::Service/Service[ntp]/ensure",
+    "tags" : [ "class", "ntp", "node", "service", "pg2.vm", "notice", "ntp::service", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.871+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 410,
+    "message" : "current_value absent, should be directory (noop)",
+    "source" : "/Stage[main]/Snmp/File[var-net-snmp]/ensure",
+    "tags" : [ "snmp", "class", "var-net-snmp", "node", "pg2.vm", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.751+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 45,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Loadtest/Ini_setting[sample setting]/ensure",
+    "tags" : [ "class", "node", "pg2.vm", "notice", "ini_setting", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.749+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Service[ntp]",
+    "source" : "Class[Ntp::Service]",
+    "tags" : [ "ntp", "admissible_class", "service", "info", "ntp::service" ],
+    "time" : "2015-02-13T13:29:09.747+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Ntp::Service]",
+    "tags" : [ "ntp", "admissible_class", "service", "notice", "ntp::service" ],
+    "time" : "2015-02-13T13:29:09.747+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Class[Ntp::Service]",
+    "source" : "Class[Ntp::Config]",
+    "tags" : [ "ntp", "ntp::config", "config", "info", "completed_class" ],
+    "time" : "2015-02-13T13:29:09.746+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Ntp::Config]",
+    "tags" : [ "ntp", "ntp::config", "config", "notice", "completed_class" ],
+    "time" : "2015-02-13T13:29:09.745+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
+    "level" : "notice",
+    "line" : 14,
+    "message" : "current_value {md5}7fda24f62b1c7ae951db0f746dc6e0cc, should be {md5}eb918d28434c9fefcc05875c29c3ba1a (noop)",
+    "source" : "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
+    "tags" : [ "class", "ntp", "ntp::config", "config", "node", "pg2.vm", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.741+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/ntp/manifests/config.pp",
+    "level" : "notice",
+    "line" : 14,
+    "message" : "\n--- /etc/ntp.conf\t2013-07-15 10:18:47.000000000 +0100\n+++ /tmp/puppet-file20150213-61841-934rx4-0\t2015-02-13 13:29:09.708877903 +0000\n@@ -1,53 +1,19 @@\n-# For more information about this file, see the man pages\n-# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).\n+# ntp.conf: Managed by puppet.\n+#\n+# Keep ntpd from panicking in the event of a large clock skew\n+# when a VM guest is suspended and resumed.\n+tinker panic 0\n \n-driftfile /var/lib/ntp/drift\n \n # Permit time synchronization with our time source, but do not\n # permit the source to query or modify the service on this system.\n-restrict default kod nomodify notrap nopeer noquery\n-restrict -6 default kod nomodify notrap nopeer noquery\n+restrict 127.0.0.1\n+\n \n-# Permit all access over the loopback interface.  This could\n-# be tightened as well, but to do so would effect some of\n-# the administrative functions.\n-restrict 127.0.0.1 \n-restrict -6 ::1\n-\n-# Hosts on local network are less restricted.\n-#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap\n-\n-# Use public servers from the pool.ntp.org project.\n-# Please consider joining the pool (http://www.pool.ntp.org/join.html).\n-server 0.centos.pool.ntp.org iburst\n-server 1.centos.pool.ntp.org iburst\n-server 2.centos.pool.ntp.org iburst\n-server 3.centos.pool.ntp.org iburst\n-\n-#broadcast 192.168.1.255 autokey\t# broadcast server\n-#broadcastclient\t\t\t# broadcast client\n-#broadcast 224.0.1.1 autokey\t\t# multicast server\n-#multicastclient 224.0.1.1\t\t# multicast client\n-#manycastserver 239.255.254.254\t\t# manycast server\n-#manycastclient 239.255.254.254 autokey # manycast client\n-\n-# Enable public key cryptography.\n-#crypto\n-\n-includefile /etc/ntp/crypto/pw\n-\n-# Key file containing the keys and key identifiers used when operating\n-# with symmetric key cryptography. \n-keys /etc/ntp/keys\n-\n-# Specify the key identifiers which are trusted.\n-#trustedkey 4 8 42\n+server ntp.pool.org\n \n-# Specify the key identifier to use with the ntpdc utility.\n-#requestkey 8\n \n-# Specify the key identifier to use with the ntpq utility.\n-#controlkey 8\n+# Driftfile.\n+driftfile /var/lib/ntp/drift\n+\n \n-# Enable writing of statistics records.\n-#statistics clockstats cryptostats loopstats peerstats\n",
+    "source" : "/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content",
+    "tags" : [ "class", "ntp", "ntp::config", "config", "node", "pg2.vm", "content", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.737+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 441,
+    "message" : "Scheduling refresh of Service[snmpd]",
+    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]",
+    "tags" : [ "snmp", "class", "node", "info", "pg2.vm", "snmpd.sysconfig", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.703+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 441,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/File[snmpd.sysconfig]/ensure",
+    "tags" : [ "snmp", "class", "node", "pg2.vm", "notice", "snmpd.sysconfig", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.703+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "info",
+    "line" : 465,
+    "message" : "Scheduling refresh of Service[snmptrapd]",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.sysconfig]",
+    "tags" : [ "snmp", "class", "snmptrapd.sysconfig", "node", "info", "pg2.vm", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.694+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 465,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/File[snmptrapd.sysconfig]/ensure",
+    "tags" : [ "snmp", "class", "snmptrapd.sysconfig", "node", "pg2.vm", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.693+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "info",
+    "line" : 4,
+    "message" : "Unscheduling refresh on Service[cron]",
+    "source" : "/Stage[main]/Loadtest/Service[cron]",
+    "tags" : [ "class", "cron", "node", "service", "info", "pg2.vm", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.688+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 4,
+    "message" : "current_value stopped, should be running (noop)",
+    "source" : "/Stage[main]/Loadtest/Service[cron]/ensure",
+    "tags" : [ "class", "cron", "node", "service", "pg2.vm", "notice", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.687+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 3,
+    "message" : "current_value absent, should be foo (noop)",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
+    "tags" : [ "class", "node", "notify", "foo", "pg2.vm", "notice", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.523+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/init.pp",
+    "level" : "notice",
+    "line" : 405,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp/Package[snmpd]/ensure",
+    "tags" : [ "package", "snmpd", "snmp", "class", "node", "pg2.vm", "notice", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.521+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 41,
+    "message" : "current_value absent, should be latest (noop)",
+    "source" : "/Stage[main]/Loadtest/Package[etckeeper]/ensure",
+    "tags" : [ "package", "class", "etckeeper", "node", "pg2.vm", "notice", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.423+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/snmp/manifests/client.pp",
+    "level" : "notice",
+    "line" : 76,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Snmp::Client/Package[snmp-client]/ensure",
+    "tags" : [ "package", "snmp", "class", "node", "snmp-client", "client", "pg2.vm", "snmp::client", "notice", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.325+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Motd]",
+    "tags" : [ "motd", "notice", "completed_class" ],
+    "time" : "2015-02-13T13:29:09.093+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
+    "level" : "notice",
+    "line" : 33,
+    "message" : "current_value {md5}d41d8cd98f00b204e9800998ecf8427e, should be {md5}a3f731187a6aaaa23d4a7b244f223f33 (noop)",
+    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
+    "tags" : [ "class", "node", "motd", "pg2.vm", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.09+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/motd/manifests/init.pp",
+    "level" : "notice",
+    "line" : 33,
+    "message" : "\n--- /etc/motd\t2010-01-12 13:28:22.000000000 +0000\n+++ /tmp/puppet-file20150213-61841-isxd4q-0\t2015-02-13 13:29:09.073877903 +0000\n@@ -0,0 +1 @@\n+Welcome to my test host!\n\\ No newline at end of file\n",
+    "source" : "/Stage[main]/Motd/File[/etc/motd]/content",
+    "tags" : [ "class", "node", "motd", "pg2.vm", "content", "notice", "file", "loadtest" ],
+    "time" : "2015-02-13T13:29:09.09+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423834124'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:09.021+00:00"
+  }, {
+    "file" : null,
+    "level" : "warning",
+    "line" : null,
+    "message" : "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
+    "source" : "Puppet",
+    "tags" : [ "warning" ],
+    "time" : "2015-02-13T13:29:08.608+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for pg2.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:08.547+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:02.517+00:00"
+  }, {
+    "file" : null,
+    "level" : "err",
+    "line" : null,
+    "message" : "Could not evaluate: Could not retrieve file metadata for puppet://puppet/plugins: Network is unreachable - connect(2)\nWrapped exception:\nNetwork is unreachable - connect(2)",
+    "source" : "/File[/var/lib/puppet/lib]",
+    "tags" : [ "plugin", "err", "file" ],
+    "time" : "2015-02-13T13:29:02.507+00:00"
+  }, {
+    "file" : null,
+    "level" : "err",
+    "line" : null,
+    "message" : "Failed to generate additional resources using 'eval_generate': Network is unreachable - connect(2)",
+    "source" : "/File[/var/lib/puppet/lib]",
+    "tags" : [ "plugin", "err", "file" ],
+    "time" : "2015-02-13T13:29:02.502+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:01.367+00:00"
+  }, {
+    "file" : null,
+    "level" : "err",
+    "line" : null,
+    "message" : "Could not evaluate: Could not retrieve file metadata for puppet://puppet/pluginfacts: Network is unreachable - connect(2)\nWrapped exception:\nNetwork is unreachable - connect(2)",
+    "source" : "/File[/var/lib/puppet/facts.d]",
+    "tags" : [ "pluginfacts", "err", "file" ],
+    "time" : "2015-02-13T13:29:01.367+00:00"
+  }, {
+    "file" : null,
+    "level" : "err",
+    "line" : null,
+    "message" : "Failed to generate additional resources using 'eval_generate': Network is unreachable - connect(2)",
+    "source" : "/File[/var/lib/puppet/facts.d]",
+    "tags" : [ "pluginfacts", "err", "file" ],
+    "time" : "2015-02-13T13:29:01.364+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:01.353+00:00"
+  }, {
+    "file" : null,
+    "level" : "warning",
+    "line" : null,
+    "message" : "Network is unreachable - connect(2)",
+    "source" : "Puppet",
+    "tags" : [ "warning" ],
+    "time" : "2015-02-13T13:29:01.352+00:00"
+  }, {
+    "file" : null,
+    "level" : "warning",
+    "line" : null,
+    "message" : "Unable to fetch my node definition, but the agent run will continue:",
+    "source" : "Puppet",
+    "tags" : [ "warning" ],
+    "time" : "2015-02-13T13:29:01.352+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:29:04.147Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:29:01.341Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 0.00119
+  }, {
+    "category" : "time",
+    "name" : "augeas",
+    "value" : 0.0566330000000001
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 1.24377989768982
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.393671
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.302035
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 4.69E-4
+  }, {
+    "category" : "time",
+    "name" : "gnupg_key",
+    "value" : 0.026254
+  }, {
+    "category" : "time",
+    "name" : "ini_setting",
+    "value" : 8.23E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 6.11E-4
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.450188
+  }, {
+    "category" : "time",
+    "name" : "postgresql_conf",
+    "value" : 6.8E-4
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 0.001031
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.329234
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 2.80659889768982
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 2
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 29
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 88
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 1
+  }, {
+    "category" : "events",
+    "name" : "noop",
+    "value" : 28
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 29
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 0
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "hdyu",
+    "resource_type" : "ZID",
+    "events" : [ ],
+    "line" : 400,
+    "file" : "JlvbbGQ2Fx",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-cfdc33f7bb68d2c25d3b3758f3dca50b851b96ea.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/pg2.vm-cfdc33f7bb68d2c25d3b3758f3dca50b851b96ea.json
@@ -1,819 +1,2425 @@
 {
-    "cached_catalog_status": "on_failure",
-    "certname": "pg2.vm",
-    "configuration_version": "1423833741",
-    "end_time": "2015-02-13T13:26:31.273Z",
-    "environment": "production",
-    "corrective_change": false,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 2.36 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:26:35.81+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 3 events",
-            "source": "Stage[main]",
-            "tags": [
-                "notice",
-                "completed_stage",
-                "main"
-            ],
-            "time": "2015-02-13T13:26:35.778+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 4 events",
-            "source": "Class[Postgresql::Server::Service]",
-            "tags": [
-                "completed_class",
-                "notice",
-                "server",
-                "service",
-                "postgresql::server::service",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:35.771+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-            "level": "notice",
-            "line": 41,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::end]",
-            "tags": [
-                "pg2.vm",
-                "node",
-                "anchor",
-                "postgresql::server",
-                "notice",
-                "server",
-                "service",
-                "end",
-                "postgresql::server::service",
-                "class",
-                "postgresql::server::service::end",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:35.77+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Postgresql::Validate_db_connection[validate_service_is_running]",
-            "tags": [
-                "completed_postgresql",
-                "completed_postgresql::validate_db_connection",
-                "notice",
-                "validate_service_is_running",
-                "validate_db_connection"
-            ],
-            "time": "2015-02-13T13:26:35.768+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/validate_db_connection.pp",
-            "level": "notice",
-            "line": 51,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "/Stage[main]/Postgresql::Server::Service/Postgresql::Validate_db_connection[validate_service_is_running]/Exec[validate postgres connection for /postgres]",
-            "tags": [
-                "pg2.vm",
-                "exec",
-                "node",
-                "postgresql::server",
-                "notice",
-                "server",
-                "postgresql::validate_db_connection",
-                "service",
-                "postgresql::server::service",
-                "validate_service_is_running",
-                "class",
-                "validate_db_connection",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:35.765+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Exec[validate postgres connection for /postgres]",
-            "source": "Postgresql::Validate_db_connection[validate_service_is_running]",
-            "tags": [
-                "admissible_postgresql::validate_db_connection",
-                "validate_service_is_running",
-                "validate_db_connection",
-                "admissible_postgresql",
-                "info"
-            ],
-            "time": "2015-02-13T13:26:35.578+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Postgresql::Validate_db_connection[validate_service_is_running]",
-            "tags": [
-                "admissible_postgresql::validate_db_connection",
-                "notice",
-                "validate_service_is_running",
-                "validate_db_connection",
-                "admissible_postgresql"
-            ],
-            "time": "2015-02-13T13:26:35.578+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-            "level": "notice",
-            "line": 14,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "/Stage[main]/Postgresql::Server::Service/Service[postgresqld]",
-            "tags": [
-                "pg2.vm",
-                "node",
-                "postgresql::server",
-                "notice",
-                "server",
-                "service",
-                "postgresqld",
-                "postgresql::server::service",
-                "class",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:35.576+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/service.pp",
-            "level": "notice",
-            "line": 12,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::begin]",
-            "tags": [
-                "begin",
-                "pg2.vm",
-                "postgresql::server::service::begin",
-                "node",
-                "anchor",
-                "postgresql::server",
-                "notice",
-                "server",
-                "service",
-                "postgresql::server::service",
-                "class",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:35.494+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Service[postgresqld]",
-            "source": "Class[Postgresql::Server::Service]",
-            "tags": [
-                "admissible_class",
-                "server",
-                "service",
-                "postgresql::server::service",
-                "info",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:35.492+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Anchor[postgresql::server::service::begin]",
-            "source": "Class[Postgresql::Server::Service]",
-            "tags": [
-                "admissible_class",
-                "server",
-                "service",
-                "postgresql::server::service",
-                "info",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:35.492+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Anchor[postgresql::server::service::end]",
-            "source": "Class[Postgresql::Server::Service]",
-            "tags": [
-                "admissible_class",
-                "server",
-                "service",
-                "postgresql::server::service",
-                "info",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:35.492+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Scheduling refresh of Postgresql::Validate_db_connection[validate_service_is_running]",
-            "source": "Class[Postgresql::Server::Service]",
-            "tags": [
-                "admissible_class",
-                "server",
-                "service",
-                "postgresql::server::service",
-                "info",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:35.492+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 2 events",
-            "source": "Class[Postgresql::Server::Service]",
-            "tags": [
-                "admissible_class",
-                "notice",
-                "server",
-                "service",
-                "postgresql::server::service",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:35.491+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 2 events",
-            "source": "Class[Postgresql::Server::Config]",
-            "tags": [
-                "config",
-                "postgresql::server::config",
-                "completed_class",
-                "notice",
-                "server",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:35.49+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Class[Main]",
-            "tags": [
-                "completed_class",
-                "notice",
-                "main"
-            ],
-            "time": "2015-02-13T13:26:35.191+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 1 events",
-            "source": "Node[pg2.vm]",
-            "tags": [
-                "pg2.vm",
-                "notice",
-                "completed_node"
-            ],
-            "time": "2015-02-13T13:26:35.126+00:00"
-        },
-        {
-            "file": "/etc/puppet/manifests/site.pp",
-            "level": "notice",
-            "line": 6,
-            "message": "current_value absent, should be foo (noop)",
-            "source": "/Stage[main]/Main/Node[pg2.vm]/Notify[foo]/message",
-            "tags": [
-                "pg2.vm",
-                "notify",
-                "node",
-                "foo",
-                "notice",
-                "class"
-            ],
-            "time": "2015-02-13T13:26:35.125+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Would have triggered 'refresh' from 3 events",
-            "source": "Postgresql::Server::Config_entry[data_directory]",
-            "tags": [
-                "data_directory",
-                "completed_postgresql",
-                "notice",
-                "server",
-                "config_entry",
-                "completed_postgresql::server::config_entry"
-            ],
-            "time": "2015-02-13T13:26:34.499+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "level": "info",
-            "line": 105,
-            "message": "Scheduling refresh of Class[Postgresql::Server::Service]",
-            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]",
-            "tags": [
-                "data_directory",
-                "config",
-                "pg2.vm",
-                "postgresql::server::config_entry",
-                "postgresql::server::config",
-                "node",
-                "postgresql::server",
-                "config_entry",
-                "server",
-                "postgresql_conf",
-                "class",
-                "info",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:34.498+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "level": "notice",
-            "line": 105,
-            "message": "current_value absent, should be present (noop)",
-            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]/ensure",
-            "tags": [
-                "data_directory",
-                "config",
-                "pg2.vm",
-                "postgresql::server::config_entry",
-                "postgresql::server::config",
-                "node",
-                "postgresql::server",
-                "notice",
-                "config_entry",
-                "server",
-                "postgresql_conf",
-                "class",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:34.498+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "level": "info",
-            "line": 90,
-            "message": "Scheduling refresh of Class[Postgresql::Server::Service]",
-            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]",
-            "tags": [
-                "data_directory",
-                "config",
-                "pg2.vm",
-                "augeas",
-                "postgresql::server::config_entry",
-                "postgresql::server::config",
-                "node",
-                "postgresql::server",
-                "config_entry",
-                "server",
-                "class",
-                "info",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:34.489+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "level": "notice",
-            "line": 90,
-            "message": "current_value need_to_run, should be 0 (noop)",
-            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]/returns",
-            "tags": [
-                "data_directory",
-                "config",
-                "pg2.vm",
-                "augeas",
-                "postgresql::server::config_entry",
-                "postgresql::server::config",
-                "node",
-                "postgresql::server",
-                "notice",
-                "config_entry",
-                "server",
-                "class",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:34.489+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "\n--- /etc/sysconfig/pgsql/postgresql\t2014-09-18 15:48:23.129826040 +0100\n+++ /etc/sysconfig/pgsql/postgresql.augnew\t2015-02-13 13:26:34.465878008 +0000\n@@ -1,2 +1,3 @@\n \n PGPORT=5432\n+PGDATA=/var/lib/pgsql/data\n",
-            "source": "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql](provider=augeas)",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:26:34.486+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config.pp",
-            "level": "notice",
-            "line": 120,
-            "message": "current_value absent, should be link (noop)",
-            "source": "/Stage[main]/Postgresql::Server::Config/File[/etc/sysconfig/pgsql/postgresql-8.4]/ensure",
-            "tags": [
-                "config",
-                "pg2.vm",
-                "postgresql::server::config",
-                "node",
-                "postgresql::server",
-                "notice",
-                "server",
-                "file",
-                "class",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:34.425+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "level": "notice",
-            "line": 83,
-            "message": "current_value notrun, should be 0 (noop)",
-            "source": "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Exec[postgresql_data_directory]/returns",
-            "tags": [
-                "postgresql_data_directory",
-                "data_directory",
-                "config",
-                "pg2.vm",
-                "postgresql::server::config_entry",
-                "postgresql::server::config",
-                "exec",
-                "node",
-                "postgresql::server",
-                "notice",
-                "config_entry",
-                "server",
-                "class",
-                "postgresql"
-            ],
-            "time": "2015-02-13T13:26:34.422+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423833741'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:26:33.496+00:00"
-        },
-        {
-            "file": null,
-            "level": "warning",
-            "line": null,
-            "message": "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
-            "source": "Puppet",
-            "tags": [
-                "warning"
-            ],
-            "time": "2015-02-13T13:26:33.119+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for pg2.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:26:33.01+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:26:30.946+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:26:28.652+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:26:28.606+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.000546
-        },
-        {
-            "category": "time",
-            "name": "augeas",
-            "value": 0.089285
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 1.24463891983032
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 1.178981
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.126266
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 0.000112
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.000667
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.001085
-        },
-        {
-            "category": "time",
-            "name": "postgresql_conf",
-            "value": 0.001515
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.000658
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.080169
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 2.72392291983032
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 5
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 50
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "noop",
-            "value": 5
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 5
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 0
-        }
-    ],
-    "noop": false,
-    "puppet_version": "3.7.1",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Postgresql::Server::Config",
-                "Postgresql::Server::Config_entry[data_directory]",
-                "Exec[postgresql_data_directory]"
-            ],
-            "events": [
-                {
-                    "message": "current_value notrun, should be 0 (noop)",
-                    "new_value": [
-                        "0"
-                    ],
-                    "old_value": "notrun",
-                    "property": "returns",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:26:34.422Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "line": 83,
-            "resource_title": "postgresql_data_directory",
-            "corrective_change": false,
-            "resource_type": "Exec",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:26:34.422Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Postgresql::Server::Config",
-                "File[/etc/sysconfig/pgsql/postgresql-8.4]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be link (noop)",
-                    "new_value": "link",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:26:34.425Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config.pp",
-            "line": 120,
-            "resource_title": "/etc/sysconfig/pgsql/postgresql-8.4",
-            "resource_type": "File",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:26:34.425Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Postgresql::Server::Config",
-                "Postgresql::Server::Config_entry[data_directory]",
-                "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]"
-            ],
-            "events": [
-                {
-                    "message": "current_value need_to_run, should be 0 (noop)",
-                    "new_value": 0,
-                    "old_value": "need_to_run",
-                    "property": "returns",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:26:34.488Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "line": 90,
-            "resource_title": "override PGDATA in /etc/sysconfig/pgsql/postgresql",
-            "corrective_change": false,
-            "resource_type": "Augeas",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:26:34.488Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Postgresql::Server::Config",
-                "Postgresql::Server::Config_entry[data_directory]",
-                "Postgresql_conf[data_directory]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be present (noop)",
-                    "new_value": "present",
-                    "old_value": "absent",
-                    "property": "ensure",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:26:34.498Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
-            "line": 105,
-            "resource_title": "data_directory",
-            "resource_type": "Postgresql_conf",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:26:34.498Z"
-        },
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Main",
-                "Node[pg2.vm]",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "current_value absent, should be foo (noop)",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "noop",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:26:35.125Z"
-                }
-            ],
-            "file": "/etc/puppet/manifests/site.pp",
-            "line": 6,
-            "resource_title": "foo",
-            "resource_type": "Notify",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:26:35.125Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:26:28.549Z",
-    "status": "unchanged",
-    "catalog_uuid": "7fd93195-cf36-4845-98a1-8fe460f32a1a",
-    "producer": "foo.com",
-    "code_id": "5a002ce2-643f-4147-ac17-5d7ca216ca8a",
-    "transaction_uuid": "441eb073-d81a-4c3d-9c75-8c4bb1ca1cd1"
+  "corrective_change" : false,
+  "code_id" : "5a002ce2-643f-4147-ac17-5d7ca216ca8a",
+  "noop" : false,
+  "certname" : "pg2.vm",
+  "puppet_version" : "3.7.1",
+  "cached_catalog_status" : "on_failure",
+  "transaction_uuid" : "441eb073-d81a-4c3d-9c75-8c4bb1ca1cd1",
+  "configuration_version" : "1423833741",
+  "status" : "unchanged",
+  "producer" : "foo.com",
+  "catalog_uuid" : "7fd93195-cf36-4845-98a1-8fe460f32a1a",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 2.36 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:26:35.81+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 3 events",
+    "source" : "Stage[main]",
+    "tags" : [ "notice", "completed_stage", "main" ],
+    "time" : "2015-02-13T13:26:35.778+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 4 events",
+    "source" : "Class[Postgresql::Server::Service]",
+    "tags" : [ "completed_class", "notice", "server", "service", "postgresql::server::service", "postgresql" ],
+    "time" : "2015-02-13T13:26:35.771+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+    "level" : "notice",
+    "line" : 41,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::end]",
+    "tags" : [ "pg2.vm", "node", "anchor", "postgresql::server", "notice", "server", "service", "end", "postgresql::server::service", "class", "postgresql::server::service::end", "postgresql" ],
+    "time" : "2015-02-13T13:26:35.77+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Postgresql::Validate_db_connection[validate_service_is_running]",
+    "tags" : [ "completed_postgresql", "completed_postgresql::validate_db_connection", "notice", "validate_service_is_running", "validate_db_connection" ],
+    "time" : "2015-02-13T13:26:35.768+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/validate_db_connection.pp",
+    "level" : "notice",
+    "line" : 51,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "/Stage[main]/Postgresql::Server::Service/Postgresql::Validate_db_connection[validate_service_is_running]/Exec[validate postgres connection for /postgres]",
+    "tags" : [ "pg2.vm", "exec", "node", "postgresql::server", "notice", "server", "postgresql::validate_db_connection", "service", "postgresql::server::service", "validate_service_is_running", "class", "validate_db_connection", "postgresql" ],
+    "time" : "2015-02-13T13:26:35.765+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Exec[validate postgres connection for /postgres]",
+    "source" : "Postgresql::Validate_db_connection[validate_service_is_running]",
+    "tags" : [ "admissible_postgresql::validate_db_connection", "validate_service_is_running", "validate_db_connection", "admissible_postgresql", "info" ],
+    "time" : "2015-02-13T13:26:35.578+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Postgresql::Validate_db_connection[validate_service_is_running]",
+    "tags" : [ "admissible_postgresql::validate_db_connection", "notice", "validate_service_is_running", "validate_db_connection", "admissible_postgresql" ],
+    "time" : "2015-02-13T13:26:35.578+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+    "level" : "notice",
+    "line" : 14,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "/Stage[main]/Postgresql::Server::Service/Service[postgresqld]",
+    "tags" : [ "pg2.vm", "node", "postgresql::server", "notice", "server", "service", "postgresqld", "postgresql::server::service", "class", "postgresql" ],
+    "time" : "2015-02-13T13:26:35.576+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/service.pp",
+    "level" : "notice",
+    "line" : 12,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "/Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::begin]",
+    "tags" : [ "begin", "pg2.vm", "postgresql::server::service::begin", "node", "anchor", "postgresql::server", "notice", "server", "service", "postgresql::server::service", "class", "postgresql" ],
+    "time" : "2015-02-13T13:26:35.494+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Service[postgresqld]",
+    "source" : "Class[Postgresql::Server::Service]",
+    "tags" : [ "admissible_class", "server", "service", "postgresql::server::service", "info", "postgresql" ],
+    "time" : "2015-02-13T13:26:35.492+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Anchor[postgresql::server::service::begin]",
+    "source" : "Class[Postgresql::Server::Service]",
+    "tags" : [ "admissible_class", "server", "service", "postgresql::server::service", "info", "postgresql" ],
+    "time" : "2015-02-13T13:26:35.492+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Anchor[postgresql::server::service::end]",
+    "source" : "Class[Postgresql::Server::Service]",
+    "tags" : [ "admissible_class", "server", "service", "postgresql::server::service", "info", "postgresql" ],
+    "time" : "2015-02-13T13:26:35.492+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Scheduling refresh of Postgresql::Validate_db_connection[validate_service_is_running]",
+    "source" : "Class[Postgresql::Server::Service]",
+    "tags" : [ "admissible_class", "server", "service", "postgresql::server::service", "info", "postgresql" ],
+    "time" : "2015-02-13T13:26:35.492+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 2 events",
+    "source" : "Class[Postgresql::Server::Service]",
+    "tags" : [ "admissible_class", "notice", "server", "service", "postgresql::server::service", "postgresql" ],
+    "time" : "2015-02-13T13:26:35.491+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 2 events",
+    "source" : "Class[Postgresql::Server::Config]",
+    "tags" : [ "config", "postgresql::server::config", "completed_class", "notice", "server", "postgresql" ],
+    "time" : "2015-02-13T13:26:35.49+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Class[Main]",
+    "tags" : [ "completed_class", "notice", "main" ],
+    "time" : "2015-02-13T13:26:35.191+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 1 events",
+    "source" : "Node[pg2.vm]",
+    "tags" : [ "pg2.vm", "notice", "completed_node" ],
+    "time" : "2015-02-13T13:26:35.126+00:00"
+  }, {
+    "file" : "/etc/puppet/manifests/site.pp",
+    "level" : "notice",
+    "line" : 6,
+    "message" : "current_value absent, should be foo (noop)",
+    "source" : "/Stage[main]/Main/Node[pg2.vm]/Notify[foo]/message",
+    "tags" : [ "pg2.vm", "notify", "node", "foo", "notice", "class" ],
+    "time" : "2015-02-13T13:26:35.125+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Would have triggered 'refresh' from 3 events",
+    "source" : "Postgresql::Server::Config_entry[data_directory]",
+    "tags" : [ "data_directory", "completed_postgresql", "notice", "server", "config_entry", "completed_postgresql::server::config_entry" ],
+    "time" : "2015-02-13T13:26:34.499+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+    "level" : "info",
+    "line" : 105,
+    "message" : "Scheduling refresh of Class[Postgresql::Server::Service]",
+    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]",
+    "tags" : [ "data_directory", "config", "pg2.vm", "postgresql::server::config_entry", "postgresql::server::config", "node", "postgresql::server", "config_entry", "server", "postgresql_conf", "class", "info", "postgresql" ],
+    "time" : "2015-02-13T13:26:34.498+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+    "level" : "notice",
+    "line" : 105,
+    "message" : "current_value absent, should be present (noop)",
+    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Postgresql_conf[data_directory]/ensure",
+    "tags" : [ "data_directory", "config", "pg2.vm", "postgresql::server::config_entry", "postgresql::server::config", "node", "postgresql::server", "notice", "config_entry", "server", "postgresql_conf", "class", "postgresql" ],
+    "time" : "2015-02-13T13:26:34.498+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+    "level" : "info",
+    "line" : 90,
+    "message" : "Scheduling refresh of Class[Postgresql::Server::Service]",
+    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]",
+    "tags" : [ "data_directory", "config", "pg2.vm", "augeas", "postgresql::server::config_entry", "postgresql::server::config", "node", "postgresql::server", "config_entry", "server", "class", "info", "postgresql" ],
+    "time" : "2015-02-13T13:26:34.489+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+    "level" : "notice",
+    "line" : 90,
+    "message" : "current_value need_to_run, should be 0 (noop)",
+    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql]/returns",
+    "tags" : [ "data_directory", "config", "pg2.vm", "augeas", "postgresql::server::config_entry", "postgresql::server::config", "node", "postgresql::server", "notice", "config_entry", "server", "class", "postgresql" ],
+    "time" : "2015-02-13T13:26:34.489+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "\n--- /etc/sysconfig/pgsql/postgresql\t2014-09-18 15:48:23.129826040 +0100\n+++ /etc/sysconfig/pgsql/postgresql.augnew\t2015-02-13 13:26:34.465878008 +0000\n@@ -1,2 +1,3 @@\n \n PGPORT=5432\n+PGDATA=/var/lib/pgsql/data\n",
+    "source" : "Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql](provider=augeas)",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:26:34.486+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/config.pp",
+    "level" : "notice",
+    "line" : 120,
+    "message" : "current_value absent, should be link (noop)",
+    "source" : "/Stage[main]/Postgresql::Server::Config/File[/etc/sysconfig/pgsql/postgresql-8.4]/ensure",
+    "tags" : [ "config", "pg2.vm", "postgresql::server::config", "node", "postgresql::server", "notice", "server", "file", "class", "postgresql" ],
+    "time" : "2015-02-13T13:26:34.425+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/postgresql/manifests/server/config_entry.pp",
+    "level" : "notice",
+    "line" : 83,
+    "message" : "current_value notrun, should be 0 (noop)",
+    "source" : "/Stage[main]/Postgresql::Server::Config/Postgresql::Server::Config_entry[data_directory]/Exec[postgresql_data_directory]/returns",
+    "tags" : [ "postgresql_data_directory", "data_directory", "config", "pg2.vm", "postgresql::server::config_entry", "postgresql::server::config", "exec", "node", "postgresql::server", "notice", "config_entry", "server", "class", "postgresql" ],
+    "time" : "2015-02-13T13:26:34.422+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423833741'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:26:33.496+00:00"
+  }, {
+    "file" : null,
+    "level" : "warning",
+    "line" : null,
+    "message" : "The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.\n   (at /usr/lib/ruby/site_ruby/1.8/puppet/type/package.rb:430:in `default')",
+    "source" : "Puppet",
+    "tags" : [ "warning" ],
+    "time" : "2015-02-13T13:26:33.119+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for pg2.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:26:33.01+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:26:30.946+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:26:28.652+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:26:28.606+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:26:31.273Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:26:28.549Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 5.46E-4
+  }, {
+    "category" : "time",
+    "name" : "augeas",
+    "value" : 0.089285
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 1.24463891983032
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 1.178981
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.126266
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 1.12E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 6.67E-4
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.001085
+  }, {
+    "category" : "time",
+    "name" : "postgresql_conf",
+    "value" : 0.001515
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 6.58E-4
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.080169
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 2.72392291983032
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 5
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 50
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "noop",
+    "value" : 5
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 5
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 0
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "hdyu",
+    "resource_type" : "ZID",
+    "events" : [ ],
+    "line" : 400,
+    "file" : "JlvbbGQ2Fx",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-02f72d7b1e2ded2074c4c3d6e2f415f6978d5932.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-02f72d7b1e2ded2074c4c3d6e2f415f6978d5932.json
@@ -1,268 +1,2223 @@
 {
-    "cached_catalog_status": "not_used",
-    "certname": "puppetdb1.vm",
-    "configuration_version": "1423833558",
-    "end_time": "2015-02-13T13:20:11.029Z",
-    "environment": "production",
-    "corrective_change": false,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 0.48 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:20:12.618+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 3,
-            "message": "defined 'message' as 'foo'",
-            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
-            "tags": [
-                "notice",
-                "notify",
-                "foo",
-                "class",
-                "loadtest",
-                "node",
-                "puppetdb1.vm"
-            ],
-            "time": "2015-02-13T13:20:12.32+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "foo",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:20:12.32+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423833558'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:20:12.2+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for puppetdb1.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:20:11.959+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:20:10.484+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:20:10.038+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:20:09.994+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.000543372
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 0.873328382
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.035544066
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.04061068300000001
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 6.2054e-05
-        },
-        {
-            "category": "time",
-            "name": "gnupg_key",
-            "value": 0.024042923
-        },
-        {
-            "category": "time",
-            "name": "ini_setting",
-            "value": 0.000357036
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.001911588
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.030850836
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.000600556
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.12383608900000001
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 1.131887902
-        },
-        {
-            "category": "time",
-            "name": "vcsrepo",
-            "value": 0.000200317
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 46
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 1
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 1
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 1
-        }
-    ],
-    "noop": false,
-    "puppet_version": "3.7.2",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "defined 'message' as 'foo'",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
+  "corrective_change" : false,
+  "code_id" : "3b415ed0-115b-4c73-a34f-883a7cf8b1a1",
+  "noop" : false,
+  "certname" : "puppetdb1.vm",
+  "puppet_version" : "3.7.2",
+  "cached_catalog_status" : "not_used",
+  "transaction_uuid" : "ed18c9ae-0998-483d-ba93-0e97b24b6ac1",
+  "configuration_version" : "1423833558",
+  "status" : "changed",
+  "producer" : "foo.com",
+  "catalog_uuid" : "ad67b622-ed6d-4336-80f3-88a1cef89d1d",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 0.48 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:20:12.618+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 3,
+    "message" : "defined 'message' as 'foo'",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
+    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "puppetdb1.vm" ],
+    "time" : "2015-02-13T13:20:12.32+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "foo",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:20:12.32+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423833558'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:20:12.2+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for puppetdb1.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:20:11.959+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:20:10.484+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:20:10.038+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:20:09.994+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:20:11.029Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:20:09.897Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 5.43372E-4
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 0.873328382
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.035544066
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.04061068300000001
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 6.2054E-5
+  }, {
+    "category" : "time",
+    "name" : "gnupg_key",
+    "value" : 0.024042923
+  }, {
+    "category" : "time",
+    "name" : "ini_setting",
+    "value" : 3.57036E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 0.001911588
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.030850836
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 6.00556E-4
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.12383608900000001
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 1.131887902
+  }, {
+    "category" : "time",
+    "name" : "vcsrepo",
+    "value" : 2.00317E-4
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 46
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 1
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 1
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 1
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ {
+                    "message": null,
+                    "new_value": "bar",
+                    "old_value": "foo",
+                    "property": "content",
                     "status": "success",
                     "corrective_change": false,
-                    "timestamp": "2015-02-13T13:20:12.320Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 3,
-            "resource_title": "foo",
-            "corrective_change": false,
-            "resource_type": "Notify",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:20:12.320Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:20:09.897Z",
-    "status": "changed",
-    "catalog_uuid": "ad67b622-ed6d-4336-80f3-88a1cef89d1d",
-    "producer": "foo.com",
-    "code_id": "3b415ed0-115b-4c73-a34f-883a7cf8b1a1",
-    "transaction_uuid": "ed18c9ae-0998-483d-ba93-0e97b24b6ac1"
+                    "timestamp": "2015-02-13T13:23:50.136Z"
+                }],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-05ce58a44a6441dc967559bf89fd82619068f72c.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-05ce58a44a6441dc967559bf89fd82619068f72c.json
@@ -1,268 +1,2215 @@
 {
-    "cached_catalog_status": "not_used",
-    "certname": "puppetdb1.vm",
-    "configuration_version": "1423834124",
-    "end_time": "2015-02-13T13:29:56.692Z",
-    "environment": "production",
-    "corrective_change": false,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 0.59 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:58.198+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 3,
-            "message": "defined 'message' as 'foo'",
-            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
-            "tags": [
-                "notice",
-                "notify",
-                "foo",
-                "class",
-                "loadtest",
-                "node",
-                "puppetdb1.vm"
-            ],
-            "time": "2015-02-13T13:29:57.796+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "foo",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:29:57.795+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423834124'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:57.688+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for puppetdb1.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:57.537+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:56.198+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:55.764+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:29:55.727+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.0007229879999999999
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 0.682468514
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.058694755
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.040055161
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 0.000137144
-        },
-        {
-            "category": "time",
-            "name": "gnupg_key",
-            "value": 0.051567308
-        },
-        {
-            "category": "time",
-            "name": "ini_setting",
-            "value": 0.000359073
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.001915414
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.03984193700000001
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.000518732
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.17672955
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 1.053324719
-        },
-        {
-            "category": "time",
-            "name": "vcsrepo",
-            "value": 0.000314143
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 47
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 1
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 1
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 1
-        }
-    ],
-    "noop": false,
-    "puppet_version": "3.7.2",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "defined 'message' as 'foo'",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "success",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:29:57.795Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 3,
-            "resource_title": "foo",
-            "corrective_change": false,
-            "resource_type": "Notify",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:29:57.795Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:29:55.639Z",
-    "status": "changed",
-    "catalog_uuid": "40cca17a-5367-400e-ae95-df85bd05daf0",
-    "producer": "foo.com",
-    "code_id": "e1f6c288-7510-451f-8f11-c9d9471f9441",
-    "transaction_uuid": "9e531f81-426c-4d91-8e10-649f067cf8a2"
+  "corrective_change" : false,
+  "code_id" : "e1f6c288-7510-451f-8f11-c9d9471f9441",
+  "noop" : false,
+  "certname" : "puppetdb1.vm",
+  "puppet_version" : "3.7.2",
+  "cached_catalog_status" : "not_used",
+  "transaction_uuid" : "9e531f81-426c-4d91-8e10-649f067cf8a2",
+  "configuration_version" : "1423834124",
+  "status" : "changed",
+  "producer" : "foo.com",
+  "catalog_uuid" : "40cca17a-5367-400e-ae95-df85bd05daf0",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 0.59 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:29:58.198+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 3,
+    "message" : "defined 'message' as 'foo'",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
+    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "puppetdb1.vm" ],
+    "time" : "2015-02-13T13:29:57.796+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "foo",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:29:57.795+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423834124'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:57.688+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for puppetdb1.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:57.537+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:56.198+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:55.764+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:29:55.727+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:29:56.692Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:29:55.639Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 7.229879999999999E-4
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 0.682468514
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.058694755
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.040055161
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 1.37144E-4
+  }, {
+    "category" : "time",
+    "name" : "gnupg_key",
+    "value" : 0.051567308
+  }, {
+    "category" : "time",
+    "name" : "ini_setting",
+    "value" : 3.59073E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 0.001915414
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.03984193700000001
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 5.18732E-4
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.17672955
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 1.053324719
+  }, {
+    "category" : "time",
+    "name" : "vcsrepo",
+    "value" : 3.14143E-4
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 47
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 1
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 1
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 1
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-5ba2c61aeb5f3ed8722e45f9c2c7b53d606e402e.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-5ba2c61aeb5f3ed8722e45f9c2c7b53d606e402e.json
@@ -1,268 +1,2215 @@
 {
-    "cached_catalog_status": "not_used",
-    "certname": "puppetdb1.vm",
-    "configuration_version": "1423834124",
-    "end_time": "2015-02-13T13:30:29.332Z",
-    "environment": "production",
-    "corrective_change": false,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 0.59 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:30:30.882+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 3,
-            "message": "defined 'message' as 'foo'",
-            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
-            "tags": [
-                "notice",
-                "notify",
-                "foo",
-                "class",
-                "loadtest",
-                "node",
-                "puppetdb1.vm"
-            ],
-            "time": "2015-02-13T13:30:30.478+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "foo",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:30:30.477+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423834124'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:30:30.373+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for puppetdb1.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:30:30.226+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:30:28.956+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:30:28.531+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:30:28.461+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.000522122
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 0.605934475
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.06095043
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.04168878300000001
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 6.7981e-05
-        },
-        {
-            "category": "time",
-            "name": "gnupg_key",
-            "value": 0.052758734
-        },
-        {
-            "category": "time",
-            "name": "ini_setting",
-            "value": 0.000427311
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.001462416
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.03715446999999999
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.000453319
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.178737151
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 0.980443806
-        },
-        {
-            "category": "time",
-            "name": "vcsrepo",
-            "value": 0.000286614
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 47
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 1
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 1
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 1
-        }
-    ],
-    "noop": false,
-    "puppet_version": "3.7.2",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "defined 'message' as 'foo'",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "success",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:30:30.477Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 3,
-            "resource_title": "foo",
-            "corrective_change": false,
-            "resource_type": "Notify",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:30:30.477Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:30:28.352Z",
-    "status": "changed",
-    "catalog_uuid": "fc0132b7-3c19-4084-840a-9c58cedf46de",
-    "producer": "foo.com",
-    "code_id": "d83f1aca-055d-45d5-9372-e88b115c810b",
-    "transaction_uuid": "3c99e9cc-bc56-45a5-bc71-e1b4fa2aff37"
+  "corrective_change" : false,
+  "code_id" : "d83f1aca-055d-45d5-9372-e88b115c810b",
+  "noop" : false,
+  "certname" : "puppetdb1.vm",
+  "puppet_version" : "3.7.2",
+  "cached_catalog_status" : "not_used",
+  "transaction_uuid" : "3c99e9cc-bc56-45a5-bc71-e1b4fa2aff37",
+  "configuration_version" : "1423834124",
+  "status" : "changed",
+  "producer" : "foo.com",
+  "catalog_uuid" : "fc0132b7-3c19-4084-840a-9c58cedf46de",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 0.59 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:30:30.882+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 3,
+    "message" : "defined 'message' as 'foo'",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
+    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "puppetdb1.vm" ],
+    "time" : "2015-02-13T13:30:30.478+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "foo",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:30:30.477+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423834124'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:30:30.373+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for puppetdb1.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:30:30.226+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:30:28.956+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:30:28.531+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:30:28.461+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:30:29.332Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:30:28.352Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 5.22122E-4
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 0.605934475
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.06095043
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.04168878300000001
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 6.7981E-5
+  }, {
+    "category" : "time",
+    "name" : "gnupg_key",
+    "value" : 0.052758734
+  }, {
+    "category" : "time",
+    "name" : "ini_setting",
+    "value" : 4.27311E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 0.001462416
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.03715446999999999
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 4.53319E-4
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.178737151
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 0.980443806
+  }, {
+    "category" : "time",
+    "name" : "vcsrepo",
+    "value" : 2.86614E-4
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 47
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 1
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 1
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 1
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-6eade546c696f0c045ec29f955bdb4d6a39a8291.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-6eade546c696f0c045ec29f955bdb4d6a39a8291.json
@@ -1,268 +1,2215 @@
 {
-    "cached_catalog_status": "not_used",
-    "certname": "puppetdb1.vm",
-    "configuration_version": "1423833741",
-    "end_time": "2015-02-13T13:23:55.758Z",
-    "environment": "production",
-    "corrective_change": true,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 0.48 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:23:57.259+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 3,
-            "message": "defined 'message' as 'foo'",
-            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
-            "tags": [
-                "notice",
-                "notify",
-                "foo",
-                "class",
-                "loadtest",
-                "node",
-                "puppetdb1.vm"
-            ],
-            "time": "2015-02-13T13:23:56.966+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "foo",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:23:56.965+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423833741'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:23:56.851+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for puppetdb1.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:23:56.685+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:23:55.455+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:23:55.039+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:23:55.001+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.00037396200000000004
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 0.61813028
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.035425543
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.040791153999999996
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 0.000106967
-        },
-        {
-            "category": "time",
-            "name": "gnupg_key",
-            "value": 0.023943093
-        },
-        {
-            "category": "time",
-            "name": "ini_setting",
-            "value": 0.000341525
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.001772577
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.029407727
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.000531606
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.12628271
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 0.8772784490000001
-        },
-        {
-            "category": "time",
-            "name": "vcsrepo",
-            "value": 0.000171305
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 47
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 1
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 1
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 1
-        }
-    ],
-    "noop": false,
-    "puppet_version": "3.7.2",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "defined 'message' as 'foo'",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "success",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:23:56.965Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 3,
-            "resource_title": "foo",
-            "corrective_change": false,
-            "resource_type": "Notify",
-            "skipped": false,
-            "timestamp": "2015-02-13T13:23:56.965Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:23:54.881Z",
-    "status": "changed",
-    "catalog_uuid": "bc71e138-e067-4150-995f-9273eaa81376",
-    "producer": "foo.com",
-    "code_id": "538e7abc-dd45-49fc-81e7-0034588344dd",
-    "transaction_uuid": "f0099317-b053-4b88-8c9c-198945c1b8a8"
+  "corrective_change" : true,
+  "code_id" : "538e7abc-dd45-49fc-81e7-0034588344dd",
+  "noop" : false,
+  "certname" : "puppetdb1.vm",
+  "puppet_version" : "3.7.2",
+  "cached_catalog_status" : "not_used",
+  "transaction_uuid" : "f0099317-b053-4b88-8c9c-198945c1b8a8",
+  "configuration_version" : "1423833741",
+  "status" : "changed",
+  "producer" : "foo.com",
+  "catalog_uuid" : "bc71e138-e067-4150-995f-9273eaa81376",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 0.48 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:23:57.259+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 3,
+    "message" : "defined 'message' as 'foo'",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
+    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "puppetdb1.vm" ],
+    "time" : "2015-02-13T13:23:56.966+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "foo",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:23:56.965+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423833741'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:23:56.851+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for puppetdb1.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:23:56.685+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:23:55.455+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:23:55.039+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:23:55.001+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:23:55.758Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:23:54.881Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 3.7396200000000004E-4
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 0.61813028
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.035425543
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.040791153999999996
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 1.06967E-4
+  }, {
+    "category" : "time",
+    "name" : "gnupg_key",
+    "value" : 0.023943093
+  }, {
+    "category" : "time",
+    "name" : "ini_setting",
+    "value" : 3.41525E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 0.001772577
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.029407727
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 5.31606E-4
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.12628271
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 0.8772784490000001
+  }, {
+    "category" : "time",
+    "name" : "vcsrepo",
+    "value" : 1.71305E-4
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 47
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 1
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 1
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 1
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  } ]
 }

--- a/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-9eeca12cedb235b2e8f616967bf1f46d3e1de812.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/reports/puppetdb1.vm-9eeca12cedb235b2e8f616967bf1f46d3e1de812.json
@@ -1,268 +1,2215 @@
 {
-    "cached_catalog_status": "on_failure",
-    "certname": "puppetdb1.vm",
-    "configuration_version": "1423833741",
-    "end_time": "2015-02-13T13:23:48.963Z",
-    "environment": "production",
-    "corrective_change": true,
-    "noop_pending": false,
-    "logs": [
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "Finished catalog run in 0.46 seconds",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:23:50.423+00:00"
-        },
-        {
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "level": "notice",
-            "line": 3,
-            "message": "defined 'message' as 'foo'",
-            "source": "/Stage[main]/Loadtest/Notify[foo]/message",
-            "tags": [
-                "notice",
-                "notify",
-                "foo",
-                "class",
-                "loadtest",
-                "node",
-                "puppetdb1.vm"
-            ],
-            "time": "2015-02-13T13:23:50.137+00:00"
-        },
-        {
-            "file": null,
-            "level": "notice",
-            "line": null,
-            "message": "foo",
-            "source": "Puppet",
-            "tags": [
-                "notice"
-            ],
-            "time": "2015-02-13T13:23:50.136+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Applying configuration version '1423833741'",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:23:50.025+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Caching catalog for puppetdb1.vm",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:23:49.878+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Loading facts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:23:48.611+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving plugin",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:23:48.197+00:00"
-        },
-        {
-            "file": null,
-            "level": "info",
-            "line": null,
-            "message": "Retrieving pluginfacts",
-            "source": "Puppet",
-            "tags": [
-                "info"
-            ],
-            "time": "2015-02-13T13:23:48.16+00:00"
-        }
-    ],
-    "metrics": [
-        {
-            "category": "time",
-            "name": "anchor",
-            "value": 0.00046438
-        },
-        {
-            "category": "time",
-            "name": "config_retrieval",
-            "value": 0.642441669
-        },
-        {
-            "category": "time",
-            "name": "exec",
-            "value": 0.035339224
-        },
-        {
-            "category": "time",
-            "name": "file",
-            "value": 0.03945806099999999
-        },
-        {
-            "category": "time",
-            "name": "filebucket",
-            "value": 7.8804e-05
-        },
-        {
-            "category": "time",
-            "name": "gnupg_key",
-            "value": 0.023286625
-        },
-        {
-            "category": "time",
-            "name": "ini_setting",
-            "value": 0.000322749
-        },
-        {
-            "category": "time",
-            "name": "notify",
-            "value": 0.001025265
-        },
-        {
-            "category": "time",
-            "name": "package",
-            "value": 0.029765502
-        },
-        {
-            "category": "time",
-            "name": "schedule",
-            "value": 0.000472722
-        },
-        {
-            "category": "time",
-            "name": "service",
-            "value": 0.117534308
-        },
-        {
-            "category": "time",
-            "name": "total",
-            "value": 0.890498771
-        },
-        {
-            "category": "time",
-            "name": "vcsrepo",
-            "value": 0.000309462
-        },
-        {
-            "category": "resources",
-            "name": "changed",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "failed",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "failed_to_restart",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "out_of_sync",
-            "value": 1
-        },
-        {
-            "category": "resources",
-            "name": "restarted",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "scheduled",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "skipped",
-            "value": 0
-        },
-        {
-            "category": "resources",
-            "name": "total",
-            "value": 47
-        },
-        {
-            "category": "events",
-            "name": "failure",
-            "value": 0
-        },
-        {
-            "category": "events",
-            "name": "success",
-            "value": 1
-        },
-        {
-            "category": "events",
-            "name": "total",
-            "value": 1
-        },
-        {
-            "category": "changes",
-            "name": "total",
-            "value": 1
-        }
-    ],
-    "noop": false,
-    "puppet_version": "3.7.2",
-    "report_format": 4,
-    "resources": [
-        {
-            "containment_path": [
-                "Stage[main]",
-                "Loadtest",
-                "Notify[foo]"
-            ],
-            "events": [
-                {
-                    "message": "defined 'message' as 'foo'",
-                    "new_value": "foo",
-                    "old_value": "absent",
-                    "property": "message",
-                    "status": "success",
-                    "corrective_change": false,
-                    "timestamp": "2015-02-13T13:23:50.136Z"
-                }
-            ],
-            "file": "/etc/puppet/modules/loadtest/manifests/init.pp",
-            "line": 3,
-            "resource_title": "foo",
-            "resource_type": "Notify",
-            "corrective_change": false,
-            "skipped": false,
-            "timestamp": "2015-02-13T13:23:50.136Z"
-        }
-    ],
-    "start_time": "2015-02-13T13:23:48.073Z",
-    "status": "changed",
-    "catalog_uuid": "76e7a26a-f7a2-44bc-b0fd-8db6edd8ec9e",
-    "producer": "foo.com",
-    "code_id": "87bf8011-918c-40b3-aded-cee4ec9d5536",
-    "transaction_uuid": "d6c4f3f3-afc5-41e6-8b1b-73e84400ca70"
+  "corrective_change" : true,
+  "code_id" : "87bf8011-918c-40b3-aded-cee4ec9d5536",
+  "noop" : false,
+  "certname" : "puppetdb1.vm",
+  "puppet_version" : "3.7.2",
+  "cached_catalog_status" : "on_failure",
+  "transaction_uuid" : "d6c4f3f3-afc5-41e6-8b1b-73e84400ca70",
+  "configuration_version" : "1423833741",
+  "status" : "changed",
+  "producer" : "foo.com",
+  "catalog_uuid" : "76e7a26a-f7a2-44bc-b0fd-8db6edd8ec9e",
+  "logs" : [ {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "Finished catalog run in 0.46 seconds",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:23:50.423+00:00"
+  }, {
+    "file" : "/etc/puppet/modules/loadtest/manifests/init.pp",
+    "level" : "notice",
+    "line" : 3,
+    "message" : "defined 'message' as 'foo'",
+    "source" : "/Stage[main]/Loadtest/Notify[foo]/message",
+    "tags" : [ "notice", "notify", "foo", "class", "loadtest", "node", "puppetdb1.vm" ],
+    "time" : "2015-02-13T13:23:50.137+00:00"
+  }, {
+    "file" : null,
+    "level" : "notice",
+    "line" : null,
+    "message" : "foo",
+    "source" : "Puppet",
+    "tags" : [ "notice" ],
+    "time" : "2015-02-13T13:23:50.136+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Applying configuration version '1423833741'",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:23:50.025+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Caching catalog for puppetdb1.vm",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:23:49.878+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Loading facts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:23:48.611+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving plugin",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:23:48.197+00:00"
+  }, {
+    "file" : null,
+    "level" : "info",
+    "line" : null,
+    "message" : "Retrieving pluginfacts",
+    "source" : "Puppet",
+    "tags" : [ "info" ],
+    "time" : "2015-02-13T13:23:48.16+00:00"
+  } ],
+  "noop_pending" : false,
+  "end_time" : "2015-02-13T13:23:48.963Z",
+  "environment" : "production",
+  "start_time" : "2015-02-13T13:23:48.073Z",
+  "metrics" : [ {
+    "category" : "time",
+    "name" : "anchor",
+    "value" : 4.6438E-4
+  }, {
+    "category" : "time",
+    "name" : "config_retrieval",
+    "value" : 0.642441669
+  }, {
+    "category" : "time",
+    "name" : "exec",
+    "value" : 0.035339224
+  }, {
+    "category" : "time",
+    "name" : "file",
+    "value" : 0.03945806099999999
+  }, {
+    "category" : "time",
+    "name" : "filebucket",
+    "value" : 7.8804E-5
+  }, {
+    "category" : "time",
+    "name" : "gnupg_key",
+    "value" : 0.023286625
+  }, {
+    "category" : "time",
+    "name" : "ini_setting",
+    "value" : 3.22749E-4
+  }, {
+    "category" : "time",
+    "name" : "notify",
+    "value" : 0.001025265
+  }, {
+    "category" : "time",
+    "name" : "package",
+    "value" : 0.029765502
+  }, {
+    "category" : "time",
+    "name" : "schedule",
+    "value" : 4.72722E-4
+  }, {
+    "category" : "time",
+    "name" : "service",
+    "value" : 0.117534308
+  }, {
+    "category" : "time",
+    "name" : "total",
+    "value" : 0.890498771
+  }, {
+    "category" : "time",
+    "name" : "vcsrepo",
+    "value" : 3.09462E-4
+  }, {
+    "category" : "resources",
+    "name" : "changed",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "failed",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "failed_to_restart",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "out_of_sync",
+    "value" : 1
+  }, {
+    "category" : "resources",
+    "name" : "restarted",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "scheduled",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "skipped",
+    "value" : 0
+  }, {
+    "category" : "resources",
+    "name" : "total",
+    "value" : 47
+  }, {
+    "category" : "events",
+    "name" : "failure",
+    "value" : 0
+  }, {
+    "category" : "events",
+    "name" : "success",
+    "value" : 1
+  }, {
+    "category" : "events",
+    "name" : "total",
+    "value" : 1
+  }, {
+    "category" : "changes",
+    "name" : "total",
+    "value" : 1
+  } ],
+  "report_format" : 4,
+  "resources" : [ {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/90_default-ssl-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::end",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 62,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default-ssl.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 232,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 120,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "main",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/80_default-ssl-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/conf.d",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 161,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/conf.d",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 154,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 21,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/90_default-access_log",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/cgid.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/50_default-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "worker",
+    "resource_type" : "Apache::Mpm",
+    "events" : [ ],
+    "line" : 68,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav_fs",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 191,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "Group",
+    "events" : [ ],
+    "line" : 118,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_mods",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 311,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp::begin",
+    "resource_type" : "Anchor",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 207,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/0_default-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin/concatfragments.sh",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 58,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 215,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Setenvif",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/apache2.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 299,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 147,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/70_default-ssl-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 39,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 179,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dav",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 37,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Mime",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-access_log",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 550,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/log/apache2",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 256,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Listen 80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_15-default.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/999_default-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/50_default-ssl-directories",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/80_default-serversignature",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 139,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Listen 80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/listen.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Alias",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 6,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/install.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "runtime",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 36,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_user.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 4,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-ssl",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 696,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_host",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "80",
+    "resource_type" : "Apache::Listen",
+    "events" : [ ],
+    "line" : 334,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 355,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Concat::Setup",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib::Stages",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/ntp.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 20,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/config.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 121,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/sites-available",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 200,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/0_default-ssl-apache-header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 5,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_app",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 40,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authn_file.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "auth_basic.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Settings",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav_fs.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "NameVirtualHost *:80",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/namevirtualhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/autoindex.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_Apache ports header",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime-support",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 19,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/var/www",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 246,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 209,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-directories",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 506,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 99,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "*:80",
+    "resource_type" : "Apache::Namevirtualhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Autoindex",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setenvif.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 11,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/setenvif.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-enabled/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Install",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 59,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 9,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dir.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 13,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/reqtimeout.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache ports header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 238,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments.concat",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 162,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-serversignature",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 537,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "setup",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 35,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 138,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default-ssl.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 442,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-docroot",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 462,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Stdlib",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/999_default-ssl-file_footer",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/70_default-logging",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 140,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-enabled",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 222,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/200_default-ssl-ssl",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_groupfile.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "env.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Cgid",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mime.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 14,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/mime.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 135,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/default_mods.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default",
+    "resource_type" : "Apache::Vhost",
+    "events" : [ ],
+    "line" : 339,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Dir",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 61,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default.conf/fragments/10_default-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Params",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy_infra",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 38,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-logging",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 529,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav_fs.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Service",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 130,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 176,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments.concat.out",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 167,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "ntp",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 15,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Ntp::Config",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 60,
+    "file" : "/home/wyatt/.puppet/modules/ntp/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "concat_/etc/apache2/ports.conf",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 199,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-ssl-file_footer",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 821,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Default_confd_files",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 315,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments/10_NameVirtualHost *_80",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dir.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "cgid.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "default-apache-header",
+    "resource_type" : "Concat::Fragment",
+    "events" : [ ],
+    "line" : 453,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/mods-available/worker.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 45,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/worker.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Worker",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : 317,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 18,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/alias.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "mkdir /etc/apache2/mods-enabled",
+    "resource_type" : "Exec",
+    "events" : [ ],
+    "line" : 184,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/ports.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 233,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Deflate",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "httpd",
+    "resource_type" : "Service",
+    "events" : [ ],
+    "line" : 43,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/service.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "apache2-mpm-worker",
+    "resource_type" : "Package",
+    "events" : [ ],
+    "line" : 53,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mpm.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "alias.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "negotiation.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 24,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/negotiation.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.load symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 109,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/_etc_apache2_ports.conf/fragments",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 157,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Reqtimeout",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deflate.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 23,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/deflate.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Mod::Negotiation",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "Apache::Version",
+    "resource_type" : "Class",
+    "events" : [ ],
+    "line" : null,
+    "file" : null,
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "dav",
+    "resource_type" : "Apache::Mod",
+    "events" : [ ],
+    "line" : 2,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod/dav.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/etc/apache2/sites-available/15-default-ssl.conf",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 214,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "authz_default.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "deploy",
+    "resource_type" : "Stage",
+    "events" : [ ],
+    "line" : 41,
+    "file" : "/home/wyatt/.puppet/modules/stdlib/manifests/stages.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "reqtimeout.conf symlink",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 127,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "www-data",
+    "resource_type" : "User",
+    "events" : [ ],
+    "line" : 111,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/init.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "autoindex.load",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 92,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/mod.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/bin",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 63,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/setup.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "15-default.conf",
+    "resource_type" : "Concat",
+    "events" : [ ],
+    "line" : 426,
+    "file" : "/home/wyatt/.puppet/modules/apache/manifests/vhost.pp",
+    "skipped" : false
+  }, {
+    "corrective_change" : null,
+    "containment_path" : [ "Stage[main]", "Loadtest", "Notify[foo]" ],
+    "timestamp" : "2016-10-14T10:07:38.735055076-05:00",
+    "resource_title" : "/home/wyatt/.puppet/var/concat/15-default-ssl.conf/fragments/10_default-ssl-docroot",
+    "resource_type" : "File",
+    "events" : [ ],
+    "line" : 123,
+    "file" : "/home/wyatt/.puppet/modules/concat/manifests/fragment.pp",
+    "skipped" : false
+  } ]
 }


### PR DESCRIPTION
The sample data included with PuppetDB that is used whenever you invoke
the benchmark tool without a dataset had become stale. Unchanged
resources for reports, producer, catalog_uuid and code_id are recent
additions that were missing from the sample data (and from the
randomization that benchmark does). This commit adds this new data.