### PR TITLE
(PDB-3077) Bump lein-ezbake dep to 1.1.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -143,7 +143,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "1.1.2"
+                      :plugins [[puppetlabs/lein-ezbake "1.1.3"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}


### PR DESCRIPTION
This commit bumps the lein-ezbake plugin dependency from 1.1.2
to 1.1.3.  This change re-adds the XXOutOfMemoryError java
command line arg which had unintentionally been dropped as part
of the ezbake bump for service reload functionality done for
PDB-3077.