### PR TITLE
(PDB-3082) Add new queue metrics

### DIFF
--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -2,7 +2,7 @@
   "Ring middleware"
   (:require [puppetlabs.i18n.core :as i18n]
             [puppetlabs.kitchensink.core :as kitchensink]
-            [puppetlabs.puppetdb.jdbc :as jdbc]
+            [puppetlabs.puppetdb.jdbc :as jdbc :refer [with-transacted-connection]]
             [puppetlabs.puppetdb.query-eng :as qe]
             [puppetlabs.puppetdb.utils.metrics :refer [multitime!]]
             [puppetlabs.puppetdb.http :as http]
@@ -14,7 +14,6 @@
             [clojure.set :as set]
             [pantomime.media :as media]
             [puppetlabs.puppetdb.metrics.core :as metrics]
-            [puppetlabs.puppetdb.jdbc :refer [with-transacted-connection]]
             [metrics.timers :refer [timer time!]]
             [metrics.meters :refer [meter mark!]]
             [clojure.walk :refer [keywordize-keys]]


### PR DESCRIPTION
Add three new metrics to the mq metrics registry:
  * `size`: a histogram of the size of received commands as reported by
    the HTTP request's Content-Length header.
  * `awaiting-retry`: a count of the number of commands that are
    currently waiting to be re-inserted into the queue.
  * `queue-time`: a histogram of the time in seconds that messages
    waited in the queue before being processed.