### PR TITLE
(PDB-2986) Update non-internationalized logging messages to use i18n

### DIFF
--- a/src/puppetlabs/puppetdb/admin.clj
+++ b/src/puppetlabs/puppetdb/admin.clj
@@ -47,7 +47,7 @@
       :else
       (http/json-response
        {:kind "conflict"
-        :msg (i18n/trs "Another cleanup is already in progress")
+        :msg (i18n/tru "Another cleanup is already in progress")
         :details nil}
        http/status-conflict))))
 

--- a/src/puppetlabs/puppetdb/archive.clj
+++ b/src/puppetlabs/puppetdb/archive.clj
@@ -20,7 +20,8 @@
             GzipCompressorInputStream])
   (:require [clojure.java.io :refer :all]
             [clj-time.core :refer [now]]
-            [clj-time.coerce :refer [to-date]]))
+            [clj-time.coerce :refer [to-date]]
+            [puppetlabs.i18n.core :refer [tru]]))
 
 ;; A simple type for writing tar/gz streams
 (defrecord TarGzWriter [tar-stream tar-writer gzip-stream]
@@ -50,9 +51,8 @@
    out
    :else
    (throw (IOException.
-           (format (str "Unable to convert type '%s' to an OutputStream; "
-                        "expected String, File, or OutputStream")
-                   (type out))))))
+           (tru "Unable to convert type ''{0}'' to an OutputStream; expected String, File, or OutputStream"
+                (type out))))))
 
 (defn- get-instream
   "Private helper function for coercing an object into an `InputStream`.  Currently
@@ -67,9 +67,8 @@
    in
    :else
    (throw (IOException.
-           (format (str "Unable to convert type '%s' to an InputStream; "
-                        "expected String, File, or InputStream")
-                   (type in))))))
+           (tru "Unable to convert type ''{0}'' to an InputStream; expected String, File, or InputStream"
+                (type in))))))
 
 (defn tarball-writer
   "Returns a `TarGzWriter` object, which can be used to write entries to a

--- a/src/puppetlabs/puppetdb/catalogs.clj
+++ b/src/puppetlabs/puppetdb/catalogs.clj
@@ -93,7 +93,8 @@
             [puppetlabs.puppetdb.time :refer [to-timestamp]]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.kitchensink.core :as kitchensink]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [puppetlabs.i18n.core :refer [trs]]))
 
 (def ^:const catalog-version
   "Constant representing the version number of the PuppetDB
@@ -310,7 +311,10 @@
     (when-let [invalid-tag (first
                             (remove #(re-find tag-pattern %) (:tags resource)))]
       (throw (IllegalArgumentException.
-              (format "Resource '%s' has an invalid tag '%s'. Tags must match the pattern /%s/." resource-spec invalid-tag tag-pattern)))))
+              (str
+               (trs "Resource ''{0}'' has an invalid tag ''{1}''." resource-spec invalid-tag)
+               " "
+               (trs "Tags must match the pattern /{0}/." tag-pattern))))))
   catalog)
 
 (defn validate-edges
@@ -324,10 +328,10 @@
           resource [source target]]
     (when-not (resources resource)
       (throw (IllegalArgumentException.
-              (format "Edge '%s' refers to resource '%s', which doesn't exist in the catalog." edge resource))))
+              (trs "Edge ''{0}'' refers to resource ''{1}'', which doesn't exist in the catalog." edge resource))))
     (when-not (valid-relationships relationship)
       (throw (IllegalArgumentException.
-              (format "Edge '%s' has invalid relationship type '%s'" edge relationship)))))
+              (trs "Edge ''{0}'' has invalid relationship type ''{1}''" edge relationship)))))
   catalog)
 
 (defn validate-keys
@@ -340,9 +344,11 @@
           extra-keys (set/difference present-keys valid-catalog-attrs)
           missing-keys (set/difference valid-catalog-attrs present-keys)]
       (when (seq extra-keys)
-        (throw (IllegalArgumentException. (format "Catalog has unexpected keys: %s" (string/join ", " (map name extra-keys))))))
+        (throw (IllegalArgumentException.
+                (trs "Catalog has unexpected keys: {0}" (string/join ", " (map name extra-keys))))))
       (when (seq missing-keys)
-        (throw (IllegalArgumentException. (format "Catalog is missing keys: %s" (string/join ", " (map name missing-keys)))))))
+        (throw (IllegalArgumentException.
+                (trs "Catalog is missing keys: {0}" (string/join ", " (map name missing-keys)))))))
     catalog))
 
 (defn validate
@@ -377,12 +383,14 @@
            version
 
            [(_ :guard map?) (_ :guard (complement number?))]
-           (throw (IllegalArgumentException. (format "Catalog version '%s' is not a legal version number" version)))
+           (throw (IllegalArgumentException.
+                   (trs "Catalog version ''{0}'' is not a legal version number" version)))
 
            ;; At this point, catalog can't be a string or a map (regardless of
            ;; what version is), so there's our problem!
            :else
-           (throw (IllegalArgumentException. (format "Catalog must be specified as a string or a map, not '%s'" (class catalog)))))))
+           (throw (IllegalArgumentException.
+                   (trs "Catalog must be specified as a string or a map, not ''{0}''" (class catalog)))))))
 
 (defmethod parse-catalog String
   [catalog version received-time]
@@ -437,7 +445,8 @@
 
 (defmethod parse-catalog :default
   [catalog version _]
-  (throw (IllegalArgumentException. (format "Unknown catalog version '%s'" version))))
+  (throw (IllegalArgumentException.
+          (trs "Unknown catalog version ''{0}''" version))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Catalog Query -> Wire format conversions

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -6,7 +6,7 @@
    and the format expected by the rest of the application."
   (:import [java.security KeyStore]
            [org.joda.time Minutes Days Period])
-  (:require [puppetlabs.i18n.core :as i18n]
+  (:require [puppetlabs.i18n.core :refer [trs]]
             [clojure.tools.logging :as log]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.trapperkeeper.bootstrap :as tk-bootstrap]
@@ -34,7 +34,8 @@
 (defn warn-unknown-keys
   [schema data]
   (doseq [k (pls/unknown-keys schema data)]
-    (log/warnf "The configuration item `%s` does not exist and should be removed from the config." k)))
+    (log/warn
+     (trs "The configuration item `{0}` does not exist and should be removed from the config." k))))
 
 (defn warn-and-validate
   "Warns a user about unknown configurations items, removes them and validates the config."
@@ -388,8 +389,8 @@
     (doseq [[svc route] filtered-web-router-config]
       (when (get-in config-data [:web-router-service svc])
         (utils/println-err
-         (i18n/trs "Configuring the route for `{0}` is not allowed. The default route is `{1}` and server is `{2}`."
-                   svc (:route route) (:server route)))))
+         (trs "Configuring the route for `{0}` is not allowed. The default route is `{1}` and server is `{2}`."
+              svc (:route route) (:server route)))))
     ;; We override the users settings as to make the above routes *not*
     ;; configurable
     (-> config-data

--- a/src/puppetlabs/puppetdb/dashboard.clj
+++ b/src/puppetlabs/puppetdb/dashboard.clj
@@ -3,7 +3,8 @@
             [puppetlabs.puppetdb.middleware :as mid]
             [puppetlabs.trapperkeeper.core :refer [defservice]]
             [ring.util.response :as rr]
-            [puppetlabs.comidi :as cmdi]))
+            [puppetlabs.comidi :as cmdi]
+            [puppetlabs.i18n.core :refer [trs]]))
 
 (def dashboard-routes
   (cmdi/context "/"
@@ -14,6 +15,6 @@
   [[:WebroutingService add-ring-handler get-route]]
 
   (start [this context]
-         (log/info "Redirecting / to the PuppetDB dashboard")
+         (log/info (trs "Redirecting / to the PuppetDB dashboard"))
          (add-ring-handler this (mid/make-pdb-handler dashboard-routes))
          context))

--- a/src/puppetlabs/puppetdb/export.clj
+++ b/src/puppetlabs/puppetdb/export.clj
@@ -17,7 +17,8 @@
             [clj-time.format :as time-fmt]
             [clj-time.coerce :as time-coerce]
             [puppetlabs.puppetdb.schema :as pls]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [puppetlabs.i18n.core :refer [trs]]))
 
 (def export-metadata-file-name "export-metadata.json")
 (def query-api-version :v4)
@@ -94,10 +95,10 @@
 (defn export!
   ([outfile query-fn] (export! outfile query-fn nil))
   ([outfile query-fn anonymize-profile]
-   (log/info "Export triggered for PuppetDB")
+   (log/info (trs "Export triggered for PuppetDB"))
    (with-open [tar-writer (archive/tarball-writer outfile)]
      (utils/add-tar-entry
       tar-writer {:file-suffix [export-metadata-file-name]
                   :contents (json/generate-pretty-string {:timestamp (now) :command_versions latest-command-versions})})
      (export!* tar-writer query-fn anonymize-profile))
-   (log/infof "Finished exporting PuppetDB")))
+   (log/info (trs "Finished exporting PuppetDB"))))

--- a/src/puppetlabs/puppetdb/http.clj
+++ b/src/puppetlabs/puppetdb/http.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.puppetdb.http
   (:import [org.apache.http.impl EnglishReasonPhraseCatalog]
            [java.io IOException Writer])
-  (:require [puppetlabs.i18n.core :as i18n]
+  (:require [puppetlabs.i18n.core :refer [tru trs]]
             [ring.util.response :as rr]
             [ring.util.io :as rio]
             [puppetlabs.puppetdb.cheshire :as json]
@@ -140,7 +140,7 @@
   ([error]
      (error-response error status-bad-request))
   ([error code]
-   (log/debug error (i18n/trs "Caught HTTP processing exception"))
+   (log/debug error (trs "Caught HTTP processing exception"))
    (-> (if (instance? Throwable error)
          (.getMessage error)
          (str error))
@@ -150,7 +150,7 @@
 
 (defn denied-response
   [msg status]
-  (-> (i18n/tru "Permission denied: {0}" msg)
+  (-> (tru "Permission denied: {0}" msg)
       (error-response status)))
 
 (defn must-accept-type
@@ -161,7 +161,7 @@
   (fn [{:keys [headers] :as req}]
     (if (acceptable-content-type content-type (headers "accept"))
       (f req)
-      (error-response (i18n/tru "must accept {0}" content-type)
+      (error-response (tru "must accept {0}" content-type)
                       status-not-acceptable))))
 
 (defn uri-segments
@@ -223,9 +223,9 @@
           (catch IOException e#
             ;; IOException includes things like broken pipes due to
             ;; client disconnect, so no need to spam the log normally.
-            (log/debug e# (i18n/trs "Error streaming response")))
+            (log/debug e# (trs "Error streaming response")))
           (catch Exception e#
-            (log/error e# (i18n/trs "Error streaming response"))))))))
+            (log/error e# (trs "Error streaming response"))))))))
 
 (defn parse-boolean-query-param
   "Utility method for parsing a query parameter whose value is expected to be
@@ -283,7 +283,7 @@
 (defn status-not-found-response
   "Produces a json response for when an entity (catalog/nodes/environment/...) is not found."
   [type id]
-  (json-response {:error (i18n/tru "No information is known about {0} {1}" type id)} status-not-found))
+  (json-response {:error (tru "No information is known about {0} {1}" type id)} status-not-found))
 
 (defn bad-request-response
   "Produce a json 400 response with an :error key holding message."

--- a/src/puppetlabs/puppetdb/http/handlers.clj
+++ b/src/puppetlabs/puppetdb/http/handlers.clj
@@ -15,7 +15,8 @@
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.utils :refer [assoc-when]]
-            [clojure.walk :refer [keywordize-keys]]))
+            [clojure.walk :refer [keywordize-keys]]
+            [puppetlabs.i18n.core :refer [trs]]))
 
 (def params-schema {(s/optional-key :optional) [s/Str]
                     (s/optional-key :required) [s/Str]})
@@ -58,7 +59,7 @@
             (-> (http-q/query-handler version)
                 (http-q/extract-query-pql {:optional (conj paging/query-params "ast_only")
                                            :required ["query"]})
-                (http/experimental-warning "The root endpoint is experimental"))))
+                (http/experimental-warning (trs "The root endpoint is experimental")))))
 
 (defn report-data-responder
   "Respond with either metrics or logs for a given report hash.

--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -8,7 +8,7 @@
             [clojure.core.match :as cm]
             [puppetlabs.puppetdb.query-eng :as qeng]
             [clojure.set :as set]
-            [puppetlabs.i18n.core :as i18n]
+            [puppetlabs.i18n.core :refer [trs tru]]
             [puppetlabs.kitchensink.core :as kitchensink]
             [schema.core :as s]
             [puppetlabs.puppetdb.http :as http]
@@ -233,14 +233,14 @@
       [p]
       (kitchensink/excludes-some params (:required param-spec))
       (throw (IllegalArgumentException.
-               (str "Missing required query parameter '" p "'")))
+              (tru "Missing required query parameter ''{0}''" p)))
 
       (let [diff (set/difference (kitchensink/keyset params)
                                  (set (:required param-spec))
                                  (set (:optional param-spec)))]
         (seq diff))
       (throw (IllegalArgumentException.
-               (str "Unsupported query parameter '" (first p) "'")))
+               (tru "Unsupported query parameter ''{0}''" (first p))))
 
       :else
       params)))
@@ -289,7 +289,7 @@
    (case (:request-method req)
      :get (get-req->query req parse-fn)
      :post (post-req->query req parse-fn)
-     (throw (IllegalArgumentException. "PuppetDB queries must be made via GET/POST")))
+     (throw (IllegalArgumentException. (tru "PuppetDB queries must be made via GET/POST"))))
    param-spec))
 
 (defn extract-query
@@ -332,8 +332,8 @@
            end   (to-timestamp distinct_end_time)]
        (when (some nil? [start end])
          (throw (IllegalArgumentException.
-                 (str "query parameters 'distinct_start_time' and 'distinct_end_time' must be valid datetime strings: "
-                      distinct_start_time " " distinct_end_time))))
+                 (tru "query parameters ''distinct_start_time'' and ''distinct_end_time'' must be valid datetime strings: {0} {1}"
+                      distinct_start_time distinct_end_time))))
        (merge params
               {:distinct_resources (boolean distinct_resources)
                :distinct_start_time start
@@ -341,11 +341,13 @@
 
      #{:distinct_start_time :distinct_end_time}
      (throw
-       (IllegalArgumentException.
-         "'distinct_resources' query parameter must accompany parameters 'distinct_start_time' and 'distinct_end_time'"))
+      (IllegalArgumentException.
+       (tru
+        "''distinct_resources'' query parameter must accompany parameters ''distinct_start_time'' and ''distinct_end_time''")))
      (throw
-       (IllegalArgumentException.
-         "'distinct_resources' query parameter requires accompanying parameters 'distinct_start_time' and 'distinct_end_time'")))))
+      (IllegalArgumentException.
+       (tru
+        "''distinct_resources'' query parameter requires accompanying parameters ''distinct_start_time'' and ''distinct_end_time''"))))))
 
 (defn narrow-globals
   "Reduces the number of globals to limit their reach in the codebase"

--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -3,8 +3,7 @@
 
    Consolidates our disparate REST endpoints into a single Ring
    application."
-  (:require [clojure.tools.logging :as log]
-            [puppetlabs.puppetdb.http :as http]
+  (:require [puppetlabs.puppetdb.http :as http]
             [puppetlabs.puppetdb.middleware :refer [wrap-with-globals
                                                     wrap-with-metrics
                                                     wrap-with-illegal-argument-catch
@@ -13,13 +12,14 @@
                                                     make-pdb-handler]]
             [ring.util.response :as rr]
             [puppetlabs.comidi :as cmdi]
-            [puppetlabs.puppetdb.http.handlers :as handlers]))
+            [puppetlabs.puppetdb.http.handlers :as handlers]
+            [puppetlabs.i18n.core :refer [trs tru]]))
 
 (defn- refuse-retired-api
   [version]
   (constantly
    (http/error-response
-    (format "The %s API has been retired; please use v4" version)
+    (tru "The {0} API has been retired; please use v4" version)
     404)))
 
 (defn retired-api-route

--- a/src/puppetlabs/puppetdb/import.clj
+++ b/src/puppetlabs/puppetdb/import.clj
@@ -14,7 +14,8 @@
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.schema :refer [defn-validated]]
-            [puppetlabs.puppetdb.utils :as utils]))
+            [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.i18n.core :refer [trs tru]]))
 
 (defn make-certname-matcher
   "Returns a function that find a certname in the `file-path` for the
@@ -64,17 +65,17 @@
     (case command-type
       "catalogs"
       (do
-        (log/infof "Importing catalog from archive entry '%s'" path)
+        (log/info (trs "Importing catalog from archive entry ''{0}''" path))
         (command-fn' :replace-catalog
                      (:replace_catalog command-versions)))
       "reports"
       (do
-        (log/infof "Importing report from archive entry '%s'" path)
+        (log/info (trs "Importing report from archive entry ''{0}''" path))
         (command-fn' :store-report
                     (:store_report command-versions)))
       "facts"
       (do
-        (log/infof "Importing facts from archive entry '%s'" path)
+        (log/info (trs "Importing facts from archive entry ''{0}''" path))
         (command-fn' :replace-facts
                      (:replace_facts command-versions)))
       nil)))
@@ -90,8 +91,7 @@
           (:command_versions %)]}
   (when-not (archive/find-entry tar-reader metadata-path)
     (throw (IllegalStateException.
-            (format "Unable to find export metadata file '%s' in archive"
-                    metadata-path))))
+            (tru "Unable to find export metadata file ''{0}'' in archive" metadata-path))))
   (utils/read-json-content tar-reader true))
 
 (defn import!

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -11,7 +11,8 @@
             [puppetlabs.puppetdb.jdbc.internal :refer [limit-result-set!]]
             [puppetlabs.puppetdb.schema :as pls]
             [schema.core :as s]
-            [clojure.math.numeric-tower :as math]))
+            [clojure.math.numeric-tower :as math]
+            [puppetlabs.i18n.core :refer [trs]]))
 
 (def ^:dynamic *db* nil)
 
@@ -258,17 +259,17 @@
   (cond
    (zero? remaining)
    (do
-     (log/warn "Caught exception. Last attempt, throwing exception.")
+     (log/warn (trs "Caught exception. Last attempt, throwing exception."))
      (throw exception))
 
    :else
    (do
-     (log/debugf "Caught %s: '%s'. SQL Error code: '%s'. Attempt: %s of %s."
-                 (.getName (class exception))
-                 (.getMessage exception)
-                 (.getSQLState exception)
-                 (inc current)
-                 (+ current remaining))
+     (log/debug (trs "Caught {0}: ''{1}''. SQL Error code: ''{2}''. Attempt: {3} of {4}."
+                     (.getName (class exception))
+                     (.getMessage exception)
+                     (.getSQLState exception)
+                     (inc current)
+                     (+ current remaining)))
      (exponential-sleep! current 1.3)
      false)))
 

--- a/src/puppetlabs/puppetdb/jdbc/internal.clj
+++ b/src/puppetlabs/puppetdb/jdbc/internal.clj
@@ -2,18 +2,15 @@
   "JDBC helper functions
 
    *External code should not call any of these functions directly, as they are*
-   *subject to change without notice.*")
+   *subject to change without notice.*"
+  (:require [puppetlabs.i18n.core :refer [tru]]))
 
 (defn limit-exception
   "Helper method; simply throws an exception with a message explaining
   that a query result limit was exceeded."
   [limit]
-  ;; TODO: tempted to create a custom exception for this, or at least
-  ;; some kind of general-purpose PuppetDBException
   (IllegalStateException.
-   (format
-    "Query returns more than the maximum number of results (max: %s)"
-    limit)))
+   (tru "Query returns more than the maximum number of results (max: {0})" limit)))
 
 
 (defn limit-result-set!

--- a/src/puppetlabs/puppetdb/meta.clj
+++ b/src/puppetlabs/puppetdb/meta.clj
@@ -11,7 +11,8 @@
             [puppetlabs.comidi :as cmdi]
             [bidi.schema :as bidi-schema]
             [puppetlabs.puppetdb.schema :as pls]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [puppetlabs.i18n.core :refer [trs tru]]))
 
 (defn current-version-fn
   "Returns a function that always returns a JSON object with the running
@@ -20,7 +21,8 @@
   (fn [_]
     (if version
       (http/json-response {:version version})
-      (http/error-response "Could not find version" 404))))
+      (http/error-response
+       (tru "Could not find version") 404))))
 
 (defn latest-version-fn
   "Returns a function returning the latest version of PuppetDB as a JSON
@@ -42,14 +44,15 @@
           (try+
            (http/json-response (v/update-info update-server scf-read-db))
            (catch map? {m :message}
-             (log/debug m (format "Could not retrieve update information (%s)"
-                                  update-server))
-             (http/error-response "Could not find version" 404))))
+             (log/debug m
+                        (trs "Could not retrieve update information ({0})"
+                             update-server))
+             (http/error-response (tru "Could not find version") 404))))
 
         (catch java.io.IOException e
-          (log/debugf "Error when checking for latest version: %s" e)
+          (log/debug e (trs "Error when checking for latest version") )
           (http/error-response
-           (format "Error when checking for latest version: %s" e)))))))
+           (tru "Error when checking for latest version: {0}" (.getMessage e))))))))
 
 (pls/defn-validated meta-routes :- bidi-schema/RoutePair
   [get-shared-globals :- (s/pred fn?)

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -17,7 +17,8 @@
             [puppetlabs.puppetdb.config :as conf]
             [puppetlabs.puppetdb.middleware :as mid]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.puppetdb.status :as pdb-status]))
+            [puppetlabs.puppetdb.status :as pdb-status]
+            [puppetlabs.i18n.core :refer [trs tru]]))
 
 
 (defn resource-request-handler [req]
@@ -26,9 +27,9 @@
 (defn maint-mode-handler [maint-mode-fn]
   (fn [req]
     (when (maint-mode-fn)
-      (log/info "HTTP request received while in maintenance mode")
+      (log/info (trs "HTTP request received while in maintenance mode"))
       {:status 503
-       :body "PuppetDB is currently down. Try again later."})))
+       :body (tru "PuppetDB is currently down. Try again later.")})))
 
 (defn wrap-with-context [uri route]
   (compojure/context uri [] route))
@@ -62,7 +63,7 @@
     (maint-mode-handler maint-mode-fn)
     (apply compojure/routes
            (concat app-routes
-                   [(route/not-found "Not Found")]))))
+                   [(route/not-found (tru "Not Found"))]))))
 
 (defprotocol MaintenanceMode
   (enable-maint-mode [this])
@@ -107,7 +108,7 @@
               cert-whitelist (get-in config [:puppetdb :certificate-whitelist])]
           (set-url-prefix query-prefix)
 
-          (log/info "Starting PuppetDB, entering maintenance mode")
+          (log/info (trs "Starting PuppetDB, entering maintenance mode"))
           (add-ring-handler
            this
            (-> (pdb-app context-root
@@ -127,7 +128,7 @@
                                              (pdb-status/status-details config shared-globals maint-mode?)))))
         context)
   (start [this context]
-         (log/info "PuppetDB finished starting, disabling maintenance mode")
+         (log/info (trs "PuppetDB finished starting, disabling maintenance mode"))
          (disable-maint-mode)
          context)
 

--- a/src/puppetlabs/puppetdb/pql.clj
+++ b/src/puppetlabs/puppetdb/pql.clj
@@ -7,7 +7,8 @@
             [instaparse.print :as print]
             [puppetlabs.i18n.core :as i18n]
             [puppetlabs.puppetdb.cheshire :as json]
-            [puppetlabs.puppetdb.pql.transform :as transform]))
+            [puppetlabs.puppetdb.pql.transform :as transform]
+            [puppetlabs.i18n.core :refer [trs tru]]))
 
 (defn transform
   "Transform parsed PQL to AST."
@@ -21,7 +22,7 @@
 (defn pql->ast
   "Convert a PQL string to AST format."
   [pql]
-  (log/warn (i18n/trs "The syntax for PQL is still experimental, and may change in the future."))
+  (log/warn (trs "The syntax for PQL is still experimental, and may change in the future."))
   (transform (parse pql)))
 
 (defn print-reason
@@ -29,7 +30,7 @@
   [r]
   (cond
     (:NOT r)
-    (format "NOT %s" (:NOT r))
+    (format (tru "NOT {0}" (:NOT r)))
     (:char-range r)
     (print/char-range->str r)
     (instance? java.util.regex.Pattern r)
@@ -40,18 +41,18 @@
 (defn pprint-failure
   "Takes an augmented failure object and prints the error message"
   [{:keys [line column text reason]}]
-  (let [opening (format "PQL parse error at line %d, column %d:\n\n%s\n%s\n\n"
-                        line column text (failure/marker column))
+  (let [opening (tru "PQL parse error at line {0}, column {1}:\n\n{2}\n{3}\n\n"
+                     line column text (failure/marker column))
         full-reasons (distinct (map :expecting
                                     (filter :full reason)))
         partial-reasons (distinct (map :expecting
                                        (filter (complement :full) reason)))
         total (+ (count full-reasons) (count partial-reasons))
         expected (cond (zero? total) nil
-                       (= 1 total) "Expected:\n"
-                       :else "Expected one of:\n\n")
+                       (= 1 total) (tru "Expected:\n")
+                       :else (tru "Expected one of:\n\n"))
         freasons (join (for [r full-reasons]
-                         (format "%s (followed by end-of-string)" (print-reason r))))
+                         (tru "{0} (followed by end-of-string)" (print-reason r))))
         preasons (join
                   (for [r partial-reasons]
                     (format "%s\n" (print-reason r))))]

--- a/src/puppetlabs/puppetdb/query/event_counts.clj
+++ b/src/puppetlabs/puppetdb/query/event_counts.clj
@@ -6,7 +6,8 @@
             [puppetlabs.puppetdb.query.paging :as paging]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.query-eng.engine :as qe]
-            [puppetlabs.puppetdb.scf.storage :refer [store-corrective-change?]]))
+            [puppetlabs.puppetdb.scf.storage :refer [store-corrective-change?]]
+            [puppetlabs.i18n.core :refer [tru]]))
 
 (defn- get-group-by
   "Given the value to summarize by, return the appropriate database field to be used in the SQL query.
@@ -19,7 +20,7 @@
     "certname" ["certname"]
     "containing_class" ["containing_class"]
     "resource" ["resource_type" "resource_title"]
-    (throw (IllegalArgumentException. (format "Unsupported value for 'summarize_by': '%s'" summarize_by)))))
+    (throw (IllegalArgumentException. (tru "Unsupported value for ''summarize_by'': ''{0}''" summarize_by)))))
 
 (def ^:private fields-basic ["failures" "skips" "successes" "noops"])
 (def ^:private fields-with-correctives ["failures" "skips" "intentional_successes" "corrective_successes" "intentional_noops" "corrective_noops"])
@@ -53,7 +54,7 @@
     "resource"  sql
     "certname"  (let [field-string (if (= group-by ["certname"]) "" (str ", " (string/join ", " group-by)))]
                   (format "SELECT DISTINCT certname, status, corrective_change%s FROM (%s) distinct_events" field-string sql))
-    (throw (IllegalArgumentException. (format "Unsupported value for 'count_by': '%s'" count-by)))))
+    (throw (IllegalArgumentException. (tru "Unsupported value for ''count_by'': ''{0}''" count-by)))))
 
 (defn- event-counts-columns
   [group-by]

--- a/src/puppetlabs/puppetdb/query/paging.clj
+++ b/src/puppetlabs/puppetdb/query/paging.clj
@@ -13,7 +13,8 @@
                                                                  parse-int]]
             [puppetlabs.puppetdb.honeysql :as h]
             [puppetlabs.puppetdb.schema :as pls]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [puppetlabs.i18n.core :refer [trs tru]]))
 
 (def query-params ["query" "limit" "offset" "order_by" "include_total"])
 (def count-header "X-Records")
@@ -62,8 +63,7 @@
     (json/parse-strict-string order_by true)
     (catch JsonParseException e
       (throw (IllegalArgumentException.
-              (str "Illegal value '" order_by "' for :order_by; expected a JSON "
-                   "array of maps.")
+              (tru "Illegal value ''{0}'' for :order_by; expected a JSON array of maps." order_by)
               e)))))
 
 (defn parse-order-str
@@ -84,8 +84,7 @@
           ((every-pred sequential? #(every? map? %)) order_by))
     order_by
     (throw (IllegalArgumentException.
-            (str "Illegal value '" order_by "' for :order_by; expected "
-                 "an array of maps.")))))
+            (tru "Illegal value ''{0}'' for :order_by; expected an array of maps." order_by)))))
 
 (defn parse-required-order-by-fields
   "Validates that each map in the order_by list contains the required
@@ -99,14 +98,13 @@
                            (fn [x] (when-not (contains? x :field) x))
                            order_by)]
     (throw (IllegalArgumentException.
-            (str "Illegal value '" bad-order-by "' in :order_by; "
-                 "missing required key 'field'."))))
+            (tru "Illegal value ''{0}'' in :order_by; missing required key 'field'."))))
   (when-let [bad-order-by (some
                            (fn [x] (when-not (valid-order-str? (:order x)) x))
                            order_by)]
     (throw (IllegalArgumentException.
-            (str "Illegal value '" bad-order-by "' in :order_by; "
-                 "'order' must be either 'asc' or 'desc'"))))
+            (tru "Illegal value ''{0}'' in :order_by; ''order'' must be either ''asc'' or ''desc''"
+                 bad-order-by))))
   (map
    (fn [x]
      [(keyword (:field x)) (parse-order-str (:order x))])
@@ -121,10 +119,9 @@
                          (fn [x] (when (keys (dissoc x :field :order)) x))
                          order_by)]
     (throw (IllegalArgumentException.
-            (str "Illegal value '" bad-order-by "' in :order_by; "
-                 "unknown key '"
-                 (-> bad-order-by (dissoc :field :order) keys first name)
-                 "'.")))
+            (tru "Illegal value ''{0}'' in :order_by; unknown key ''{1}''."
+                 bad-order-by
+                 (-> bad-order-by (dissoc :field :order) keys first name))))
     order_by))
 
 (defn parse-order-by
@@ -176,8 +173,7 @@
   (let [l (coerce-to-int limit)]
     (if ((some-fn nil? neg? zero?) l)
       (throw (IllegalArgumentException.
-              (format (str "Illegal value '%s' for :limit;"
-                           " expected a positive non-zero integer.") limit)))
+              (tru "Illegal value ''{0}'' for :limit; expected a positive non-zero integer." limit)))
       l)))
 
 (pls/defn-validated parse-limit :- (s/maybe s/Int)
@@ -197,8 +193,7 @@
   (let [o (coerce-to-int offset)]
     (if ((some-fn nil? neg?) o)
       (throw (IllegalArgumentException.
-              (format (str "Illegal value '%s' for :offset;"
-                           " expected a non-negative integer.") offset)))
+              (tru "Illegal value ''{0}'' for :offset; expected a non-negative integer." offset)))
       o)))
 
 (defn parse-offset
@@ -219,9 +214,9 @@
   (doseq [field (map first (:order_by paging-options))]
     (when-not (seq-contains? columns field)
       (throw (IllegalArgumentException.
-               (format "Unrecognized column '%s' specified in :order_by; Supported columns are '%s'"
-                       (name field)
-                       (string/join "', '" (map name columns)))))))
+               (tru "Unrecognized column ''{0}'' specified in :order_by; Supported columns are ''{1}''"
+                    (name field)
+                    (string/join "', '" (map name columns)))))))
   paging-options)
 
 (defn requires-paging?

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -4,7 +4,7 @@
             [clojure.java.jdbc :as sql]
             [clojure.tools.logging :as log]
             [clojure.set :refer [rename-keys]]
-            [puppetlabs.i18n.core :as i18n]
+            [puppetlabs.i18n.core :refer [trs tru]]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.query.paging :as paging]
             [puppetlabs.puppetdb.cheshire :as json]
@@ -67,8 +67,8 @@
   (if-let [munge-result (get-in @entity-fn-idx [entity :munge])]
     munge-result
     (throw (IllegalArgumentException.
-            (i18n/tru "Invalid entity ''{0}'' in query"
-                      (utils/dashes->underscores (name entity)))))))
+            (tru "Invalid entity ''{0}'' in query"
+                 (utils/dashes->underscores (name entity)))))))
 
 (defn orderable-columns
   [query-rec]
@@ -200,18 +200,19 @@
       (catch com.fasterxml.jackson.core.JsonParseException e
         (log/error
          e
-         (i18n/trs "Error executing query ''{0}'' with query options ''{1}''. Returning a 400 error code."
-                   query query-options))
+         (trs "Error executing query ''{0}'' with query options ''{1}''. Returning a 400 error code."
+              query query-options))
         (http/error-response e))
       (catch IllegalArgumentException e
         (log/error
          e
-         (i18n/trs "Error executing query ''{0}'' with query options ''{1}''. Returning a 400 error code."
-                   query query-options))
+         (trs
+          "Error executing query ''{0}'' with query options ''{1}''. Returning a 400 error code."
+          query query-options))
         (http/error-response e))
       (catch org.postgresql.util.PSQLException e
         (if (= (.getSQLState e) "2201B")
-          (do (log/debug e (i18n/trs "Caught PSQL processing exception"))
+          (do (log/debug e (trs "Caught PSQL processing exception"))
               (http/error-response (.getMessage e)))
           (throw e))))))
 

--- a/src/puppetlabs/puppetdb/queue.clj
+++ b/src/puppetlabs/puppetdb/queue.clj
@@ -8,7 +8,7 @@
             [puppetlabs.stockpile.queue :as stock]
             [clj-time.coerce :as tcoerce]
             [clojure.tools.logging :as log]
-            [puppetlabs.i18n.core :as i18n]
+            [puppetlabs.i18n.core :refer [trs tru]]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.command.constants :as command-constants]
             [puppetlabs.puppetdb.constants :as constants]
@@ -114,7 +114,7 @@
   ([puppetdb-command->metadata-command]
    (fn [received command version certname]
      (when-not (puppetdb-command->metadata-command command)
-       (throw (IllegalArgumentException. (format "unknown command '%s'" command))))
+       (throw (IllegalArgumentException. (trs "unknown command ''{0}''" command))))
      (let [certname (or certname "unknown-host")
            recvd-long (tcoerce/to-long received)
            short-command (puppetdb-command->metadata-command command)
@@ -199,13 +199,11 @@
      ;; then rethrow the exception for logging at the "top level".
      (try
        (Files/delete stream-data)
-       (-> "Cleaned up orphaned command temp file: {0}"
-           (i18n/trs (pr-str (str stream-data)))
-           (log/warn))
+       (log/warn (trs "Cleaned up orphaned command temp file: {0}"
+                      (pr-str (str stream-data))))
        (catch Exception ex
-         (-> "Unable to clean up orphaned command temp file: {0}"
-             (i18n/trs (pr-str (str stream-data)))
-             (log/warn ex))))
+         (log/warn (trs "Unable to clean up orphaned command temp file: {0}"
+                        (pr-str (str stream-data))))))
      (throw+))
 
    (catch [:kind ::path-cleanup-failure-after-error] {:keys [path exception]}
@@ -215,9 +213,8 @@
      ;; Don't try to delete the path again, just log the path with the
      ;; removal exception, and then rethrow the exception for logging
      ;; at the "top level".
-     (-> "Unable to remove temp file while trying to store incoming command: {0}"
-         (i18n/trs (pr-str (str path)))
-         (log/warn exception))
+     (log/warn (trs "Unable to remove temp file while trying to store incoming command: {0}"
+                    (pr-str (str path))))
      (throw+))))
 
 (defn store-command
@@ -257,7 +254,7 @@
 
   (add!* [this item]
     (when-not (instance? CommandRef item)
-      (throw (IllegalArgumentException. (str "Cannot enqueue item of type " (class item)))))
+      (throw (IllegalArgumentException. (trs "Cannot enqueue item of type {0}" (class item)))))
 
     (let [^CommandRef cmdref item
           command-type (:command cmdref)

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1255,9 +1255,9 @@
   (try
     (f)
     (catch java.sql.SQLException e
-      (log/error e "Caught SQLException during migration")
+      (log/error e (trs "Caught SQLException during migration"))
       (when-let [next (.getNextException e)]
-        (log/error next "Unravelled exception"))
+        (log/error next (trs "Unravelled exception")))
       (binding [*out* *err*] (flush)) (flush)
       (System/exit 1))))
 
@@ -1314,7 +1314,7 @@
         (sutils/analyze-small-tables small-tables)
         true)
       (do
-        (log/info "There are no pending migrations")
+        (log/info (trs "There are no pending migrations"))
         false))))
 
 ;; SPECIAL INDEX HANDLING
@@ -1323,11 +1323,11 @@
   "Create trgm indexes if they do not currently exist."
   []
   (when-not (sutils/index-exists? "fact_paths_path_trgm")
-    (log/info "Creating additional index `fact_paths_path_trgm`")
+    (log/info (trs "Creating additional index `fact_paths_path_trgm`"))
     (jdbc/do-commands
      "CREATE INDEX fact_paths_path_trgm ON fact_paths USING gist (path gist_trgm_ops)"))
   (when-not (sutils/index-exists? "fact_values_string_trgm")
-    (log/info "Creating additional index `fact_values_string_trgm`")
+    (log/info (trs "Creating additional index `fact_values_string_trgm`"))
     (jdbc/do-commands
      "CREATE INDEX fact_values_string_trgm ON fact_values USING gin (value_string gin_trgm_ops)")))
 
@@ -1339,9 +1339,8 @@
       (trgm-indexes!)
       (log/warn
        (str
-        "Missing PostgreSQL extension `pg_trgm`\n\n"
-        "We are unable to create the recommended pg_trgm indexes due to\n"
-        "the extension not being installed correctly. Run the command:\n\n"
-        "    CREATE EXTENSION pg_trgm;\n\n"
-        "as the database super user on the PuppetDB database to correct\n"
-        "this, then restart PuppetDB.\n")))))
+        (trs "Missing PostgreSQL extension `pg_trgm`")
+        "\n\n"
+        (trs "We are unable to create the recommended pg_trgm indexes due to\nthe extension not being installed correctly.")
+        " "
+        (trs " Run the command:\n\n    CREATE EXTENSION pg_trgm;\n\nas the database super user on the PuppetDB database to correct\nthis, then restart PuppetDB.\n"))))))

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -44,7 +44,8 @@
             [metrics.timers :refer [timer time!]]
             [puppetlabs.puppetdb.jdbc :refer [query-to-vec]]
             [puppetlabs.puppetdb.time :refer [to-timestamp]]
-            [honeysql.core :as hcore])
+            [honeysql.core :as hcore]
+            [puppetlabs.i18n.core :refer [trs]])
   (:import [org.postgresql.util PGobject]
            [org.joda.time Period]))
 
@@ -760,7 +761,7 @@
               (cond
                 (some-> latest-producer-timestamp
                         (.after (to-timestamp producer_timestamp)))
-                (log/warnf "Not replacing catalog for certname %s because local data is newer." certname)
+                (log/warn (trs "Not replacing catalog for certname {0} because local data is newer." certname))
 
                 (= stored-hash hash)
                 (update-existing-catalog catalog-id hash catalog received-timestamp)
@@ -1313,8 +1314,8 @@
    (deactivate-node! certname (now)))
   ([certname :- String timestamp :- pls/Timestamp]
    (if (have-newer-record-for-certname? certname timestamp)
-     (log/warnf "Not deactivating node %s because local data is newer than %s."
-                certname timestamp)
+     (log/warn (trs "Not deactivating node {0} because local data is newer than {1}."
+                    certname timestamp))
      (let [sql-timestamp (to-timestamp timestamp)]
        (jdbc/do-prepared "UPDATE certnames SET deactivated = ?
                             WHERE certname=?
@@ -1357,7 +1358,7 @@
          (if-let [local-factset-producer-ts (timestamp-of-newest-record :factsets certname)]
            (if-not (.after local-factset-producer-ts (to-timestamp producer_timestamp))
              (update-facts! fact-data)
-             (log/warnf "Not updating facts for certname %s because local data is newer." certname))
+             (log/warn (trs "Not updating facts for certname {0} because local data is newer." certname)))
            (add-facts! fact-data))))
 
 (s/defn add-report!

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -10,7 +10,8 @@
             [puppetlabs.puppetdb.schema :as pls]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.kitchensink.core :as kitchensink]
-            [schema.core :as s])
+            [schema.core :as s]
+            [puppetlabs.i18n.core :refer [trs]])
   (:import [org.postgresql.util PGobject]))
 
 ;; SCHEMA
@@ -298,7 +299,7 @@
 
 (defn analyze-small-tables
   [small-tables]
-  (log/info "Analyzing small tables")
+  (log/info (trs "Analyzing small tables"))
   (apply jdbc/do-commands-outside-txn
          (map #(str "analyze " %) small-tables)))
 

--- a/src/puppetlabs/puppetdb/status.clj
+++ b/src/puppetlabs/puppetdb/status.clj
@@ -5,7 +5,8 @@
             [puppetlabs.puppetdb.schema :as pls]
             [schema.core :as s]
             [puppetlabs.trapperkeeper.services.status.status-core :as status-core]
-            [trptcolin.versioneer.core :as versioneer]))
+            [trptcolin.versioneer.core :as versioneer]
+            [puppetlabs.i18n.core :refer [trs]]))
 
 (def status-details-schema {:maintenance_mode? s/Bool
                             :queue_depth (s/maybe s/Int)
@@ -20,9 +21,10 @@
   (let [version (versioneer/get-version group-id artifact-id)]
     (when (empty? version)
       (throw (IllegalStateException.
-               (format "Unable to find version number for '%s/%s'"
-                 group-id
-                 artifact-id))))
+              (trs
+               "Unable to find version number for ''{0}/{1}''"
+               group-id
+               artifact-id))))
     version))
 
 (pls/defn-validated status-details :- status-details-schema

--- a/src/puppetlabs/puppetdb/threadpool.clj
+++ b/src/puppetlabs/puppetdb/threadpool.clj
@@ -6,7 +6,7 @@
            [org.apache.commons.lang3.concurrent BasicThreadFactory BasicThreadFactory$Builder])
   (:require [clojure.core.async :as async]
             [clojure.tools.logging :as log]
-            [puppetlabs.i18n.core :as i18n]
+            [puppetlabs.i18n.core :refer [trs tru]]
             [slingshot.slingshot :refer [throw+]]))
 
 (def logging-exception-handler
@@ -15,7 +15,7 @@
   (reify Thread$UncaughtExceptionHandler
     (uncaughtException [_ thread throwable]
       (log/error throwable
-                 (i18n/trs "Error processing command on thread {0}" (.getName thread))))))
+                 (trs "Error processing command on thread {0}" (.getName thread))))))
 
 (defn thread-factory
   "Creates a command thread factory, wrapping the
@@ -48,13 +48,13 @@
   (when-not (.awaitTermination threadpool shutdown-timeout java.util.concurrent.TimeUnit/MILLISECONDS)
 
     (log/warn
-     (i18n/trs "Threadpool not stopped after {0} milliseconds, forcibly shutting it down" shutdown-timeout))
+     (trs "Threadpool not stopped after {0} milliseconds, forcibly shutting it down" shutdown-timeout))
 
     ;; This will force the shutdown of the threadpool and will
     ;; not allow current threads to finish
     (.shutdownNow threadpool)
     (log/warn
-     (i18n/trs "Threadpool forcibly shutdown"))))
+     (trs "Threadpool forcibly shutdown"))))
 
 (defrecord GatedThreadpool [^Semaphore semaphore ^ExecutorService threadpool shutdown-timeout]
   java.io.Closeable
@@ -94,7 +94,7 @@
                            (try
                              (f)
                              (catch InterruptedException e
-                               (log/debug e (i18n/trs "Thread interrupted while processing on threadpool")))
+                               (log/debug e (trs "Thread interrupted while processing on threadpool")))
                              (finally
                                (.release semaphore)))))
     ;; RejectedExecutionExceptions only occur when attempting ot
@@ -119,5 +119,5 @@
           (throw+ {:kind ::rejected
                    :message cmd}
                   e
-                  (i18n/trs "Threadpool shutting down, message rejected"))))
+                  (tru "Threadpool shutting down, message rejected"))))
       (recur (async/<!! in-chan)))))

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.puppetdb.utils
   (:require [puppetlabs.kitchensink.core :as kitchensink]
-            [puppetlabs.i18n.core :as i18n]
+            [puppetlabs.i18n.core :refer [trs tru]]
             [clojure.tools.logging :as log]
             [clojure.string :as string]
             [schema.core :as s]
@@ -36,7 +36,7 @@
   "Returns error message instructing the user to switch to JDK 1.7"
   []
   (attention-msg
-   (i18n/trs "JDK 1.6 is no longer supported. PuppetDB requires JDK 1.7+, currently running: {0}" kitchensink/java-version)))
+   (trs "JDK 1.6 is no longer supported. PuppetDB requires JDK 1.7+, currently running: {0}" kitchensink/java-version)))
 
 (defn println-err
   "Redirects output to standard error before invoking println"
@@ -295,7 +295,8 @@
 (defn regex-quote
   [s]
   (when (and (string? s) (re-find #"\\E" s))
-    (throw (IllegalArgumentException. "cannot regex-quote strings containing '\\E'")))
+    (throw (IllegalArgumentException.
+            (tru "cannot regex-quote strings containing '\\E'"))))
   (format "\\Q%s\\E" (str s)))
 
 (defn match-any-of


### PR DESCRIPTION
This PR adds a new logging utilities namespace that makes this conversion process easier. Then the next commit switches everything over to that new namespace.

Marking this as "Don't Merge Yet" as it should go in after our releases.
