### PR TITLE
(PDB-3151) admin-clean-competition: inc deref wait

### DIFF
--- a/test/puppetlabs/puppetdb/admin_clean_test.clj
+++ b/test/puppetlabs/puppetdb/admin_clean_test.clj
@@ -81,7 +81,7 @@
           (finally
             (.await test-finished)
             (is (not= ::timed-out
-                      (deref cleanup-result 10000 ::timed-out)))))))))
+                      (deref cleanup-result 120000 ::timed-out)))))))))
 
 (defn- clean-status []
   (gauges/value (:cleaning cli-svc/admin-metrics)))


### PR DESCRIPTION
Wait for 120s instead of 10s to hopefully accommodate surprising CI
behavior.
