### PR TITLE
(maint) Start using clj-parent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: lein2
+lein: 2.7.1
 
 # Always explicitly set sudo.  Otherwise travis' defaults may vary
 # based on when the repository testing was enabled.

--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -519,7 +519,7 @@ module PuppetDBExtensions
     begin
       Timeout.timeout(timeout) do
         until queue_size == 0
-          result = on host, %Q(curl http://localhost:8080/metrics/v1/mbeans/#{CGI.escape(metric)} 2> /dev/null | grep Count | awk -F ":" '{print $2}')
+          result = on host, %Q(curl http://localhost:8080/metrics/v1/mbeans/#{CGI.escape(metric)} 2> /dev/null | python -c "import sys, json; print json.load(sys.stdin)['Count']")
           queue_size = Integer(result.stdout.chomp)
         end
       end

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Puppet Labs <docs@puppetlabs.com>
+# Copyright (C) YEAR Puppet <docs@puppet.com>
 # This file is distributed under the same license as the puppetlabs.puppetdb package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: puppetlabs.puppetdb \n"
-"Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
@@ -17,263 +17,876 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/puppetlabs/puppetdb/admin.clj:40
+#: src/puppetlabs/puppetdb/admin.clj
 msgid "Invalid command {0}: {1}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/admin.clj:50
+#: src/puppetlabs/puppetdb/admin.clj
 msgid "Another cleanup is already in progress"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/command.clj:425
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "receiver queue connection error"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj src/puppetlabs/puppetdb/mq.clj
+msgid "Only read {0}/{1} bytes from incoming message"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "[{0}] [{1}] [{2}] Unable to process message"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "Unable to process message: {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "Transferring {0} commands to new queue"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "No ActiveMQ delivery for 5s; waiting 120s"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "Completed transfer from {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "Abandoning transfer from {0} after IllegalStateException"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "Processing messages from the scheduler"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "Received IllegalStateException, shutting down"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj src/puppetlabs/puppetdb/mq.clj
+msgid "Setting ActiveMQ {0} limit to {1} MB"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "EOF Exception caught during broker start."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "This might be due to KahaDB corruption."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "Consult the PuppetDB troubleshooting guide."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj src/puppetlabs/puppetdb/mq.clj
+msgid "Caught EOFException on broker startup, trying again."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj src/puppetlabs/puppetdb/mq.clj
+msgid ""
+"This is probably due to KahaDB corruption (see \"KahaDB Corruption\" in the "
+"PuppetDB manual)."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj src/puppetlabs/puppetdb/mq.clj
+msgid "Unable to start broker in {0}."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj src/puppetlabs/puppetdb/mq.clj
+msgid ""
+"This is probably due to KahaDB corruption or version incompatibility after a "
+"PuppetDB downgrade (see \"KahaDB Corruption\" in the PuppetDB manual)."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "Unable to migrate all ActiveMQ messages (will retry on restart)"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "Starting broker"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/amq_migration.clj
+msgid "You may safely delete {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/archive.clj
+msgid ""
+"Unable to convert type ''{0}'' to an OutputStream; expected String, File, or "
+"OutputStream"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/archive.clj
+msgid ""
+"Unable to convert type ''{0}'' to an InputStream; expected String, File, or "
+"InputStream"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/catalogs.clj
+msgid "Resource ''{0}'' has an invalid tag ''{1}''."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/catalogs.clj
+msgid "Tags must match the pattern /{0}/."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/catalogs.clj
+msgid ""
+"Edge ''{0}'' refers to resource ''{1}'', which doesn't exist in the catalog."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/catalogs.clj
+msgid "Edge ''{0}'' has invalid relationship type ''{1}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/catalogs.clj
+msgid "Catalog has unexpected keys: {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/catalogs.clj
+msgid "Catalog is missing keys: {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/catalogs.clj
+msgid "Catalog version ''{0}'' is not a legal version number"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/catalogs.clj
+msgid "Catalog must be specified as a string or a map, not ''{0}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/catalogs.clj
+msgid "Unknown catalog version ''{0}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/benchmark.clj
+msgid "Error parsing {0}; skipping"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/benchmark.clj
+msgid "Supplied directory {0} contains no usable data!"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/benchmark.clj
+msgid "Sending {0} messages for {1} hosts, will exit upon completion"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/benchmark.clj
+msgid "No catalogs specified; skipping catalog submission"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/benchmark.clj
+msgid "No reports specified; skipping report submission"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/benchmark.clj
+msgid "No facts specified; skipping fact submission"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/services.clj
+msgid "Auto-expired node {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/services.clj
+msgid "Error while deactivating stale nodes"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/services.clj
+msgid "Error while purging deactivated and expired nodes"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/services.clj
+msgid "Error while sweeping reports"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/services.clj
+msgid "Error during garbage collection"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/services.clj
+msgid "cleanup lock is not already held"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/services.clj
+msgid "Skipping update check on Puppet Enterprise"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/services.clj
+msgid "Shutdown request received; puppetdb exiting."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/services.clj
+msgid "Error while attempting to create connection pool"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/cli/services.clj
+msgid "PuppetDB version {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/command.clj
+msgid "[{0}-{1}] ''{2}'' command enqueued for {3}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/command.clj
+msgid "[{0}-{1}] ''{2}'' command processed for {3}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/command.clj
+msgid "[{0}-{1}] ''{2}'' puppet v{3} command processed for {4}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/command.clj
+msgid "command ''{0}'' version {1} is deprecated, use the latest version"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/command.clj
 msgid "Exception throw in L1 retry attempt {0}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/config.clj:369
+#: src/puppetlabs/puppetdb/command.clj
+msgid "[{0}] [{1}] Fatal error on attempt {2} for {3}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/command.clj
+msgid "[{0}] [{1}] Retrying after attempt {2} for {3}, due to: {4}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/command.clj
+msgid "[{0}] [{1}] Exceeded max attempts ({2}) for {3}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/command.clj
+msgid "Fatal error parsing command: {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/command/dlo.clj
+msgid "DLO path {0} is not a directory"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/config.clj
+msgid ""
+"The configuration item `{0}` does not exist and should be removed from the "
+"config."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/config.clj
 msgid ""
 "Configuring the route for `{0}` is not allowed. The default route is `{1}` "
 "and server is `{2}`."
 msgstr ""
 
-#: src/puppetlabs/puppetdb/http.clj:143
+#: src/puppetlabs/puppetdb/dashboard.clj
+msgid "Redirecting / to the PuppetDB dashboard"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/export.clj
+msgid "Export triggered for PuppetDB"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/export.clj
+msgid "Finished exporting PuppetDB"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/http.clj
 msgid "Caught HTTP processing exception"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/http.clj:153
+#: src/puppetlabs/puppetdb/http.clj
 msgid "Permission denied: {0}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/http.clj:164
-#: src/puppetlabs/puppetdb/middleware.clj:114
+#: src/puppetlabs/puppetdb/http.clj src/puppetlabs/puppetdb/middleware.clj
 msgid "must accept {0}"
 msgstr ""
 
 #. IOException includes things like broken pipes due to
 #. client disconnect, so no need to spam the log normally.
-#: src/puppetlabs/puppetdb/http.clj:226 src/puppetlabs/puppetdb/http.clj:228
+#: src/puppetlabs/puppetdb/http.clj
 msgid "Error streaming response"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/http.clj:286
-#: src/puppetlabs/puppetdb/middleware.clj:294
+#: src/puppetlabs/puppetdb/http.clj src/puppetlabs/puppetdb/middleware.clj
 msgid "No information is known about {0} {1}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/middleware.clj:37
+#: src/puppetlabs/puppetdb/http/command.clj
+msgid "Unable to stream command posted without parameters (loading into RAM)"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/http/command.clj
+msgid "Empty application/json POST body"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/http/command.clj
+msgid "Unexpected body type: {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/http/command.clj
+msgid "Command size exceeds max-command-size"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/http/handlers.clj
+msgid "The root endpoint is experimental"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/http/query.clj
+#: src/puppetlabs/puppetdb/middleware.clj
+msgid "Missing required query parameter ''{0}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/http/query.clj
+#: src/puppetlabs/puppetdb/middleware.clj
+msgid "Unsupported query parameter ''{0}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/http/query.clj
+msgid "PuppetDB queries must be made via GET/POST"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/http/query.clj
+msgid ""
+"query parameters ''distinct_start_time'' and ''distinct_end_time'' must be "
+"valid datetime strings: {0} {1}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/http/query.clj
+msgid ""
+"''distinct_resources'' query parameter must accompany parameters "
+"''distinct_start_time'' and ''distinct_end_time''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/http/query.clj
+msgid ""
+"''distinct_resources'' query parameter requires accompanying parameters "
+"''distinct_start_time'' and ''distinct_end_time''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/http/server.clj
+msgid "The {0} API has been retired; please use v4"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/import.clj
+msgid "Importing catalog from archive entry ''{0}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/import.clj
+msgid "Importing report from archive entry ''{0}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/import.clj
+msgid "Importing facts from archive entry ''{0}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/import.clj
+msgid "Unable to find export metadata file ''{0}'' in archive"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/jdbc.clj
+msgid "Caught exception. Last attempt, throwing exception."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/jdbc.clj
+msgid "Caught {0}: ''{1}''. SQL Error code: ''{2}''. Attempt: {3} of {4}."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/jdbc/internal.clj
+msgid "Query returns more than the maximum number of results (max: {0})"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/meta.clj
+msgid "Could not find version"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/meta.clj
+msgid "Could not retrieve update information ({0})"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/meta.clj
+msgid "Error when checking for latest version"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/meta.clj
+msgid "Error when checking for latest version: {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/middleware.clj
 msgid "Processing HTTP request to URI: ''{0}''"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/middleware.clj:52
+#: src/puppetlabs/puppetdb/middleware.clj
 msgid "{0} rejected by certificate whitelist {1}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/middleware.clj:53
+#: src/puppetlabs/puppetdb/middleware.clj
 msgid ""
 "The client certificate name {0} doesn't appear in the certificate whitelist. "
 "Is your master''s (or other PuppetDB client''s) certname listed in "
 "PuppetDB''s certificate-whitelist file?"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/middleware.clj:128
+#: src/puppetlabs/puppetdb/middleware.clj
 msgid "content type {0} not supported"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/middleware.clj:144
-msgid "Missing required query parameter ''{0}''"
-msgstr ""
-
-#: src/puppetlabs/puppetdb/middleware.clj:150
-msgid "Unsupported query parameter ''{0}''"
-msgstr ""
-
-#: src/puppetlabs/puppetdb/middleware.clj:253
+#: src/puppetlabs/puppetdb/middleware.clj
 msgid "Processing command with a content-length of {0} bytes"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/middleware.clj:254
-msgid ""
-"No content length found for POST. POST bodies that are too large could cause "
-"memory-related failures."
+#: src/puppetlabs/puppetdb/middleware.clj
+msgid "No content length found for POST."
 msgstr ""
 
-#: src/puppetlabs/puppetdb/middleware.clj:260
+#: src/puppetlabs/puppetdb/middleware.clj
+msgid "POST bodies that are too large could cause memory-related failures."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/middleware.clj
 msgid ""
 "content-length of command is {0} bytes and is larger than the maximum "
 "allowed command size of {1} bytes"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/middleware.clj:265
+#: src/puppetlabs/puppetdb/middleware.clj
 msgid "Command rejected due to size exceeding max-command-size"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/mq_listener.clj:250
-msgid "[{0}] [{1}] Exceeded max {2} attempts for {3}"
+#: src/puppetlabs/puppetdb/mq.clj
+msgid "Expected TextMessage or BytesMessage; found {0}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/mq_listener.clj:255
-msgid "Fatal error parsing command: {0}"
+#: src/puppetlabs/puppetdb/pdb_routing.clj
+msgid "HTTP request received while in maintenance mode"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/mq_listener.clj:265
-msgid "[{0}] [{1}] Fatal error on attempt {2} for {3}"
+#: src/puppetlabs/puppetdb/pdb_routing.clj
+msgid "PuppetDB is currently down. Try again later."
 msgstr ""
 
-#: src/puppetlabs/puppetdb/mq_listener.clj:283
-msgid "[{0}] [{1}] Retrying after attempt {2} for {3}, due to: {4}"
+#: src/puppetlabs/puppetdb/pdb_routing.clj
+msgid "Not Found"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/pql.clj:24
+#: src/puppetlabs/puppetdb/pdb_routing.clj
+msgid "Starting PuppetDB, entering maintenance mode"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/pdb_routing.clj
+msgid "PuppetDB finished starting, disabling maintenance mode"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/pql.clj
 msgid "The syntax for PQL is still experimental, and may change in the future."
 msgstr ""
 
-#: src/puppetlabs/puppetdb/pql.clj:68
+#: src/puppetlabs/puppetdb/pql.clj
+msgid "NOT {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/pql.clj
+msgid "PQL parse error at line {0}, column {1}:nn{2}n{3}nn"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/pql.clj
+msgid "Expected:n"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/pql.clj
+msgid "Expected one of:nn"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/pql.clj
+msgid "{0} (followed by end-of-string)"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/pql.clj
 msgid "Malformed JSON for query: {0}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:161
+#: src/puppetlabs/puppetdb/query.clj
 msgid "{0} is not well-formed: queries must contain at least one operator"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:168
+#: src/puppetlabs/puppetdb/query.clj
 msgid "{0} is not well-formed: query operator ''{1}'' is unknown"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:181
+#: src/puppetlabs/puppetdb/query.clj
 msgid "{0} requires at least one term"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:213
+#: src/puppetlabs/puppetdb/query.clj
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
 msgid "''not'' takes exactly one argument, but {0} were supplied"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:376
+#: src/puppetlabs/puppetdb/query.clj
 msgid "The argument to extract must be a select operator, not ''{0}''"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:380
+#: src/puppetlabs/puppetdb/query.clj
 msgid "Can't extract unknown {0} field ''{1}''. Acceptable fields are: {2}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:396
+#: src/puppetlabs/puppetdb/query.clj
 msgid ""
 "Can''t match on unknown {0} field ''{1}'' for ''in''. Acceptable fields are: "
 "{2}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:400
+#: src/puppetlabs/puppetdb/query.clj
 msgid "The subquery argument of ''in'' must be an ''extract'', not ''{0}''"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:466 src/puppetlabs/puppetdb/query.clj:656
-#: src/puppetlabs/puppetdb/query.clj:747
+#: src/puppetlabs/puppetdb/query.clj
 msgid "= requires exactly two arguments, but {0} were supplied"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:500
+#: src/puppetlabs/puppetdb/query.clj
 msgid "''{0}'' is not a queryable object for resources in the version {1} API"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:532
+#: src/puppetlabs/puppetdb/query.clj
 msgid ""
 "''{0}'' cannot be the target of a regexp match for version {1} of the "
 "resources API"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:564
+#: src/puppetlabs/puppetdb/query.clj
 msgid "{0} is not a queryable object for version {1} of the facts query api"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:595
+#: src/puppetlabs/puppetdb/query.clj
 msgid "{0} is not a valid version {1} operand for regexp comparison"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:615
+#: src/puppetlabs/puppetdb/query.clj
 msgid "{0} is not a queryable object for facts"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:617
+#: src/puppetlabs/puppetdb/query.clj
 msgid "Value {0} must be a number for {1} comparison."
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:628 src/puppetlabs/puppetdb/query.clj:765
+#: src/puppetlabs/puppetdb/query.clj
 msgid "{0} requires exactly two arguments, but {1} were supplied"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:641
+#: src/puppetlabs/puppetdb/query.clj
 msgid "''{0}'' is not a valid timestamp value"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:644
+#: src/puppetlabs/puppetdb/query.clj
 msgid "{0} operator does not support object ''{1}'' for resource events"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:699 src/puppetlabs/puppetdb/query.clj:736
+#: src/puppetlabs/puppetdb/query.clj
 msgid ""
 "''{0}'' is not a queryable object for version {1} of the resource events API"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:711
+#: src/puppetlabs/puppetdb/query.clj
 msgid "~ requires exactly two arguments, but {0} were supplied"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:755
+#: src/puppetlabs/puppetdb/query.clj
 msgid "{0} is not a queryable object for event counts"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query.clj:773
+#: src/puppetlabs/puppetdb/query.clj
 msgid "{0} operator does not support object ''{1}'' for event counts"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query_eng.clj:70
+#: src/puppetlabs/puppetdb/query/event_counts.clj
+msgid "Unsupported value for ''summarize_by'': ''{0}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query/event_counts.clj
+msgid "Unsupported value for ''count_by'': ''{0}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query/paging.clj
+msgid "Illegal value ''{0}'' for :order_by; expected a JSON array of maps."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query/paging.clj
+msgid "Illegal value ''{0}'' for :order_by; expected an array of maps."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query/paging.clj
+msgid "Illegal value ''{0}'' in :order_by; missing required key 'field'."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query/paging.clj
+msgid ""
+"Illegal value ''{0}'' in :order_by; ''order'' must be either ''asc'' or "
+"''desc''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query/paging.clj
+msgid "Illegal value ''{0}'' in :order_by; unknown key ''{1}''."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query/paging.clj
+msgid "Illegal value ''{0}'' for :limit; expected a positive non-zero integer."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query/paging.clj
+msgid "Illegal value ''{0}'' for :offset; expected a non-negative integer."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query/paging.clj
+msgid ""
+"Unrecognized column ''{0}'' specified in :order_by; Supported columns are "
+"''{1}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng.clj
 msgid "Invalid entity ''{0}'' in query"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query_eng.clj:197
-#: src/puppetlabs/puppetdb/query_eng.clj:203
+#: src/puppetlabs/puppetdb/query_eng.clj
 msgid ""
 "Error executing query ''{0}'' with query options ''{1}''. Returning a 400 "
 "error code."
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query_eng.clj:208
+#: src/puppetlabs/puppetdb/query_eng.clj
 msgid "Caught PSQL processing exception"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query_eng/engine.clj:1306
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
 msgid "Value {0} of type {1} unsupported."
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query_eng/engine.clj:1310
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
 msgid "Operator ''{0}'' not allowed on value ''{1}''"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/query_eng/engine.clj:1419
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "All values in 'array' must be the same type."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "Column definition for entity relationship ''{0}'' not valid"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "The `subquery` operator is experimental and may change in the future."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "No implicit relationship for entity ''{0}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
 msgid "Field 'latest_report?' not supported on endpoint ''{0}''"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/threadpool.clj:18
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "Argument \"{0}\" is incompatible with numeric field \"{1}\"."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "Query operators >,>=,<,<= are not allowed on field {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "Query operator ~> is not allowed on field {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "[] is not well-formed: queries must contain at least one operator"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "{0} requires exactly two arguments"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "Multiple ''{0}'' clauses are not permitted"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "Received ''{0}'' clause without an argument"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "Operator 'array' requires a vector argument"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "Operator 'in'...'array' is not supported on array types"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "Argument \"{0}\" and operator \"{1}\" have incompatible types."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "Unsupported subquery `{0}` - did you mean `{1}`?"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "Unsupported subquery `{0}`"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid ""
+"The {0} entity is experimental and may be altered or removed in the future."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "Your `from` query accepts an optional query only as a second argument."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid "Check your query and try again."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/query_eng/engine.clj
+msgid ""
+"Your initial query must be of the form: [\"from\",<entity>,(<optional-"
+"query>)]."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/queue.clj
+msgid "unknown command ''{0}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/queue.clj
+msgid "Cleaned up orphaned command temp file: {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/queue.clj
+msgid "Unable to clean up orphaned command temp file: {0}"
+msgstr ""
+
+#. stockpile/store failed with the exception described by
+#. the :cause, and then, on the way out, the attempt to remove the temporary
+#. file described by path failed with the given exception.
+#. Don't try to delete the path again, just log the path with the
+#. removal exception, and then rethrow the exception for logging
+#. at the "top level".
+#: src/puppetlabs/puppetdb/queue.clj
+msgid "Unable to remove temp file while trying to store incoming command: {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/queue.clj
+msgid "Cannot enqueue item of type {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/migrate.clj
+msgid "Caught SQLException during migration"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/migrate.clj
+msgid "Unravelled exception"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/migrate.clj
+msgid "Found an old and unuspported database migration (migration number {0})."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/migrate.clj
+msgid ""
+"PuppetDB only supports upgrading from the previous major version to the "
+"current major version."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/migrate.clj
+msgid ""
+"As an example, users wanting to upgrade from 2.x to 4.x should first upgrade "
+"to 3.x."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/migrate.clj
+msgid ""
+"Your PuppetDB database contains a schema migration numbered {0}, but this "
+"version of PuppetDB does not recognize that version."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/migrate.clj
+msgid "Applying database migration version {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/migrate.clj
+msgid "There are no pending migrations"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/migrate.clj
+msgid "Creating additional index `fact_paths_path_trgm`"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/migrate.clj
+msgid "Creating additional index `fact_values_string_trgm`"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/migrate.clj
+msgid "Missing PostgreSQL extension `pg_trgm`"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/migrate.clj
+msgid ""
+"We are unable to create the recommended pg_trgm indexes due tonthe extension "
+"not being installed correctly."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/migrate.clj
+msgid ""
+" Run the command:nn    CREATE EXTENSION pg_trgm;nnas the database super user "
+"on the PuppetDB database to correctnthis, then restart PuppetDB.n"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/storage.clj
+msgid "Not replacing catalog for certname {0} because local data is newer."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/storage.clj
+msgid "Not deactivating node {0} because local data is newer than {1}."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/storage.clj
+msgid "Not updating facts for certname {0} because local data is newer."
+msgstr ""
+
+#: src/puppetlabs/puppetdb/scf/storage_utils.clj
+msgid "Analyzing small tables"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/status.clj
+msgid "Unable to find version number for ''{0}/{1}''"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/threadpool.clj
 msgid "Error processing command on thread {0}"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/threadpool.clj:51
+#: src/puppetlabs/puppetdb/threadpool.clj
 msgid ""
 "Threadpool not stopped after {0} milliseconds, forcibly shutting it down"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/threadpool.clj:57
+#: src/puppetlabs/puppetdb/threadpool.clj
 msgid "Threadpool forcibly shutdown"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/threadpool.clj:97
+#: src/puppetlabs/puppetdb/threadpool.clj
 msgid "Thread interrupted while processing on threadpool"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/threadpool.clj:122
+#: src/puppetlabs/puppetdb/threadpool.clj
 msgid "Threadpool shutting down, message rejected"
 msgstr ""
 
-#: src/puppetlabs/puppetdb/utils.clj:37
+#: src/puppetlabs/puppetdb/utils.clj
 msgid ""
 "JDK 1.6 is no longer supported. PuppetDB requires JDK 1.7+, currently "
 "running: {0}"
+msgstr ""
+
+#: src/puppetlabs/puppetdb/utils.clj
+msgid "cannot regex-quote strings containing ''\\E''"
 msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -134,7 +134,7 @@
   :classifiers  [["test" :testutils]]
 
   :profiles {:dev {:resource-paths ["test-resources"],
-                   :dependencies [[ring-mock]
+                   :dependencies [[ring-mock nil]
                                   [puppetlabs/trapperkeeper nil :classifier "test"]
                                   [puppetlabs/kitchensink nil :classifier "test"]
                                   [puppetlabs/trapperkeeper-webserver-jetty9 nil :classifier "test"]
@@ -147,7 +147,7 @@
                                   (require 'schema.core)
                                   (schema.core/set-fn-validation! true))]}
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
-                                               [org.clojure/tools.nrepl "0.2.3"]]
+                                               [org.clojure/tools.nrepl nil]]
                       :name "puppetdb"
                       :plugins [[puppetlabs/lein-ezbake "1.1.3"
                                  :exclusions [org.clojure/clojure]]]}

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.1.7"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.2.5"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -43,7 +43,7 @@
                  [org.clojure/tools.macro]
                  [org.clojure/math.combinatorics "0.1.1"]
                  [org.clojure/math.numeric-tower "0.0.4"]
-                 [org.clojure/tools.logging "0.3.1"]
+                 [org.clojure/tools.logging]
 
                  ;; Puppet specific
                  [puppetlabs/comidi]
@@ -55,12 +55,12 @@
                  [puppetlabs/tools.namespace "0.2.4.1"]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-webserver-jetty9]
-                 [puppetlabs/trapperkeeper-metrics "0.2.0" :exclusions [ring/ring-defaults org.slf4j/slf4j-api]]
+                 [puppetlabs/trapperkeeper-metrics :exclusions [ring/ring-defaults org.slf4j/slf4j-api]]
                  [puppetlabs/trapperkeeper-status]
 
                  ;; Various
                  [cheshire]
-                 [clj-stacktrace "0.2.8"]
+                 [clj-stacktrace]
                  [clj-time]
                  [com.rpl/specter "0.5.7"]
                  [com.taoensso/nippy "2.10.0" :exclusions [org.clojure/tools.reader]]
@@ -72,10 +72,10 @@
                  [prismatic/schema "1.1.2"]
                  [robert/hooke "1.3.0"]
                  [slingshot]
-                 [trptcolin/versioneer "0.2.0"]
+                 [trptcolin/versioneer]
 
                  ;; Filesystem utilities
-                 [org.apache.commons/commons-lang3 "3.3.1"]
+                 [org.apache.commons/commons-lang3 "3.4"]
                  ;; Version information
                  ;; Job scheduling
                  [overtone/at-at "1.2.0"]
@@ -134,23 +134,40 @@
   :classifiers  [["test" :testutils]]
 
   :profiles {:dev {:resource-paths ["test-resources"],
-                   :dependencies [[ring-mock nil]
-                                  [puppetlabs/trapperkeeper nil :classifier "test"]
-                                  [puppetlabs/kitchensink nil :classifier "test"]
-                                  [puppetlabs/trapperkeeper-webserver-jetty9 nil :classifier "test"]
+                   :dependencies [[ring-mock]
+                                  [puppetlabs/trapperkeeper :classifier "test"]
+                                  [puppetlabs/kitchensink :classifier "test"]
+                                  [puppetlabs/trapperkeeper-webserver-jetty9 :classifier "test"]
                                   [org.flatland/ordered "1.5.3"]
                                   [org.clojure/test.check "0.5.9"]
                                   [environ "1.0.2"]
-                                  [org.clojure/tools.cli "0.3.3"] ; prevents dependency clash caused by lein-cloverage
                                   [riddley "0.1.12"]]
                    :injections [(do
                                   (require 'schema.core)
                                   (schema.core/set-fn-validation! true))]}
-             :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
+             :ezbake {:dependencies ^:replace [;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+                                               ;; NOTE: we need to explicitly pass in `nil` values
+                                               ;; for the version numbers here in order to correctly
+                                               ;; inherit the versions from our parent project.
+                                               ;; This is because of a bug in lein 2.7.1 that
+                                               ;; prevents the deps from being processed properly
+                                               ;; with `:managed-dependencies` when you specify
+                                               ;; dependencies in a profile.  See:
+                                               ;; https://github.com/technomancy/leiningen/issues/2216
+                                               ;; Hopefully we can remove those `nil`s (if we care)
+                                               ;; and this comment when lein 2.7.2 is available.
+                                               ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+                                               ;; we need to explicitly pull in our parent project's
+                                               ;; clojure version here, because without it, lein
+                                               ;; brings in its own version, and older versions of
+                                               ;; lein depend on clojure 1.6.
+                                               [org.clojure/clojure nil]
+                                               [puppetlabs/puppetdb ~pdb-version]
+                                               [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "1.1.3"
-                                 :exclusions [org.clojure/clojure]]]}
+                      :plugins [[puppetlabs/lein-ezbake "1.1.5"]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}
 

--- a/project.clj
+++ b/project.clj
@@ -9,10 +9,6 @@
    :password :env/nexus_jenkins_password
    :sign-releases false})
 
-(def tk-version "1.5.1")
-(def tk-jetty9-version "1.5.9")
-(def ks-version "1.3.1")
-(def tk-status-version "0.5.0")
 (def i18n-version "0.4.3")
 
 (def pdb-jvm-opts
@@ -28,73 +24,82 @@
 
   :url "https://docs.puppetlabs.com/puppetdb/"
 
+  :min-lein-version "2.7.1"
+
+  :parent-project {:coords [puppetlabs/clj-parent "0.1.7"]
+                   :inherit [:managed-dependencies]}
+
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [puppetlabs/i18n ~i18n-version]
-                 [cheshire "5.6.1"]
-                 [digest "1.4.3"]
+  :dependencies [;; Clojure org
+                 [org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.async]
                  [org.clojure/core.match "0.3.0-alpha4" :exclusions [org.clojure/tools.analyzer.jvm]]
+                 [org.clojure/core.memoize "0.5.9"]
+                 [org.clojure/java.jdbc "0.6.1"]
+                 [org.clojure/tools.macro]
                  [org.clojure/math.combinatorics "0.1.1"]
                  [org.clojure/math.numeric-tower "0.0.4"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [org.clojure/core.memoize "0.5.8"]
+
+                 ;; Puppet specific
+                 [puppetlabs/comidi]
+                 [puppetlabs/dujour-version-check]
+                 [puppetlabs/http-client]
+                 [puppetlabs/i18n]
+                 [puppetlabs/kitchensink]
+                 [puppetlabs/stockpile "0.0.4"]
                  [puppetlabs/tools.namespace "0.2.4.1"]
+                 [puppetlabs/trapperkeeper]
+                 [puppetlabs/trapperkeeper-webserver-jetty9]
+                 [puppetlabs/trapperkeeper-metrics "0.2.0" :exclusions [ring/ring-defaults org.slf4j/slf4j-api]]
+                 [puppetlabs/trapperkeeper-status]
+
+                 ;; Various
+                 [cheshire]
                  [clj-stacktrace "0.2.8"]
+                 [clj-time]
+                 [com.rpl/specter "0.5.7"]
+                 [com.taoensso/nippy "2.10.0" :exclusions [org.clojure/tools.reader]]
+                 [digest "1.4.3"]
+                 [fast-zip-visit "1.0.2"]
+                 [instaparse "1.4.1"]
+                 [me.raynes/fs]
                  [metrics-clojure "2.6.1" :exclusions [org.clojure/clojure org.slf4j/slf4j-api]]
-                 [clj-time "0.11.0"]
+                 [prismatic/schema "1.1.2"]
+                 [robert/hooke "1.3.0"]
+                 [slingshot]
+                 [trptcolin/versioneer "0.2.0"]
+
                  ;; Filesystem utilities
-                 [me.raynes/fs "1.4.6"]
                  [org.apache.commons/commons-lang3 "3.3.1"]
                  ;; Version information
-                 [puppetlabs/dujour-version-check "0.1.3"]
                  ;; Job scheduling
                  [overtone/at-at "1.2.0"]
-                 ;; Nicer exception handling with try+/throw+
-                 [slingshot "0.12.2"]
 
                  ;; Database connectivity
                  [com.zaxxer/HikariCP "2.4.3" :exclusions [org.slf4j/slf4j-api]]
-                 [org.clojure/java.jdbc "0.6.1"]
+                 [honeysql "0.6.3"]
                  [org.postgresql/postgresql "9.4.1208.jre7"]
 
                  ;; MQ connectivity
                  [org.apache.activemq/activemq-broker "5.13.2" :exclusions [org.slf4j/slf4j-api]]
                  [org.apache.activemq/activemq-kahadb-store "5.13.2" :exclusions [org.slf4j/slf4j-api]]
                  [org.apache.activemq/activemq-pool "5.13.2" :exclusions [org.slf4j/slf4j-api]]
-
-                 ;; Parsing library required by PQL
-                 [instaparse "1.4.1"]
-
                  ;; bridge to allow some spring/activemq stuff to log over slf4j
                  [org.slf4j/jcl-over-slf4j "1.7.14" :exclusions [org.slf4j/slf4j-api]]
+
                  ;; WebAPI support libraries.
-                 [compojure "1.5.0"]
-                 [clj-http "2.0.1"  :exclusions [org.apache.httpcomponents/httpcore org.apache.httpcomponents/httpclient]]
-                 [ring/ring-core "1.4.0" :exclusions [javax.servlet/servlet-api org.clojure/tools.reader]]
-                 [org.apache.commons/commons-compress "1.10"]
-                 [puppetlabs/kitchensink ~ks-version]
-                 [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]
-                 [puppetlabs/trapperkeeper-metrics "0.2.0" :exclusions [ring/ring-defaults org.slf4j/slf4j-api]]
-                 [prismatic/schema "1.1.2"]
-                 [trptcolin/versioneer "0.2.0"]
-                 [puppetlabs/trapperkeeper-status ~tk-status-version :exclusions [org.slf4j/slf4j-api]]
-                 [org.clojure/tools.macro "0.1.5"]
-                 [com.novemberain/pantomime "2.1.0"]
-                 [fast-zip-visit "1.0.2"]
-                 [robert/hooke "1.3.0"]
-                 [honeysql "0.6.3"]
-                 [com.rpl/specter "0.5.7"]
-                 [org.clojure/core.async "0.2.374"]
-                 [puppetlabs/http-client "0.5.0" :exclusions [org.slf4j/slf4j-api]]
-                 [com.taoensso/nippy "2.10.0" :exclusions [org.clojure/tools.reader]]
                  [bidi "1.25.1" :exclusions [org.clojure/clojurescript]]
-                 [puppetlabs/comidi "0.3.1"]
-                 [puppetlabs/stockpile "0.0.4"]]
+                 [clj-http "2.0.1" :exclusions [org.apache.httpcomponents/httpcore org.apache.httpcomponents/httpclient]]
+                 [com.novemberain/pantomime "2.1.0"]
+                 [compojure]
+                 [org.apache.commons/commons-compress "1.10"]
+                 [ring/ring-core :exclusions [javax.servlet/servlet-api org.clojure/tools.reader]]
+                 ]
 
   :jvm-opts ~pdb-jvm-opts
 
@@ -103,6 +108,7 @@
 
   :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]
             [lein-cloverage "1.0.6" :exclusions [org.clojure/clojure]]
+            [lein-parent "0.3.1"]
             [puppetlabs/i18n ~i18n-version]]
 
   :lein-release {:scm        :git
@@ -128,10 +134,10 @@
   :classifiers  [["test" :testutils]]
 
   :profiles {:dev {:resource-paths ["test-resources"],
-                   :dependencies [[ring-mock "0.1.5"]
-                                  [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
-                                  [puppetlabs/kitchensink ~ks-version :classifier "test"]
-                                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version :classifier "test"]
+                   :dependencies [[ring-mock]
+                                  [puppetlabs/trapperkeeper nil :classifier "test"]
+                                  [puppetlabs/kitchensink nil :classifier "test"]
+                                  [puppetlabs/trapperkeeper-webserver-jetty9 nil :classifier "test"]
                                   [org.flatland/ordered "1.5.3"]
                                   [org.clojure/test.check "0.5.9"]
                                   [environ "1.0.2"]

--- a/resources/puppetlabs/puppetdb/bootstrap.cfg
+++ b/resources/puppetlabs/puppetdb/bootstrap.cfg
@@ -12,6 +12,7 @@ puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-servi
 # TK status
 puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice
 puppetlabs.trapperkeeper.services.status.status-service/status-service
+puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
 
 # PuppetDB Services
 puppetlabs.puppetdb.cli.services/puppetdb-service

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -202,8 +202,8 @@
   [{db-config :database :or {db-config {}} :as config}]
   (when (str/blank? (:subname db-config))
     (throw+
-     {:type ::cli-error
-      :message
+     {:kind ::cli-error
+      :msg
       (str "PuppetDB requires PostgreSQL."
            "  The [database] section must contain an appropriate"
            " \"//host:port/database\" subname setting.")}))
@@ -414,7 +414,7 @@
 (defn hook-tk-parse-config-data
   "This is a robert.hooke compatible hook that is designed to intercept
    trapperkeeper configuration before it is used, so that we may munge &
-   customize it.  It may throw {:type ::cli-error :message m}."
+   customize it.  It may throw {:kind ::cli-error :msg m}."
   [f args]
   (adjust-and-validate-tk-config (f args)))
 

--- a/src/puppetlabs/puppetdb/meta/version.clj
+++ b/src/puppetlabs/puppetdb/meta/version.clj
@@ -44,5 +44,5 @@
 (defn check-for-updates!
   [update-server db]
   (try
-    (version-check/check-for-updates! (pdb-version-check-values db) update-server)
+    @(version-check/check-for-updates! (pdb-version-check-values db) update-server)
     (catch Exception e)))

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -215,8 +215,8 @@
 
 (defn throw+-cli-error!
   [msg]
-  (throw+ {:type ::cli-error
-           :message msg}))
+  (throw+ {:kind ::cli-error
+           :msg msg}))
 
 (defn validate-cli-base-url!
   "A utility function which will validate the base-url
@@ -231,8 +231,8 @@
   (try+
    (body)
    (catch map? m
-     (println (:message m))
-     (case (kitchensink/without-ns (:type m))
+     (println (:msg m))
+     (case (kitchensink/without-ns (:kind m))
        :cli-error (flush-and-exit 1)
        :cli-help (flush-and-exit 0)
        (throw+ m)))))
@@ -310,7 +310,7 @@
   [s]
   (when (and (string? s) (re-find #"\\E" s))
     (throw (IllegalArgumentException.
-            (tru "cannot regex-quote strings containing '\\E'"))))
+            (tru "cannot regex-quote strings containing ''\\E''"))))
   (format "\\Q%s\\E" (str s)))
 
 (defn match-any-of

--- a/test/puppetlabs/puppetdb/cli/benchmark_test.clj
+++ b/test/puppetlabs/puppetdb/cli/benchmark_test.clj
@@ -41,20 +41,20 @@
 
 (deftest config-is-required
   (is (thrown+-with-msg?
-       [:type ::ks/cli-error]
+       [:kind ::ks/cli-error]
        #"Missing required argument '--config'"
        (run-benchmark {}))))
 
 (deftest config-is-required
   (is (thrown+-with-msg?
-       [:type ::ks/cli-error]
+       [:kind ::ks/cli-error]
        #"Missing required argument '--numhosts'"
        (run-benchmark {}
                       "--config" "anything.ini"))))
 
 (deftest nummsgs-or-runinterval-is-required
   (is (thrown+-with-msg?
-       [:type ::utils/cli-error]
+       [:kind ::utils/cli-error]
        #"Either -N/--nummsgs or -i/--runinterval is required."
        (run-benchmark {}
                       "--config" "anything.ini"

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -76,7 +76,7 @@
         ;; Valid config
         (is (= cfg (validate-db-settings cfg)))
         ;; Empty config
-        (is (thrown+-with-msg? [:type ::conf/cli-error] req-re
+        (is (thrown+-with-msg? [:kind ::conf/cli-error] req-re
                                (validate-db-settings {})))))
 
     (testing "the read-db defaulted to the specified write-db"

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -14,6 +14,7 @@
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :refer [webrouting-service]]
             [puppetlabs.trapperkeeper.services.status.status-service :refer [status-service]]
+            [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :refer [scheduler-service]]
             [puppetlabs.trapperkeeper.services.metrics.metrics-service :refer [metrics-webservice]]
             [puppetlabs.puppetdb.client :as pdb-client]
             [puppetlabs.puppetdb.cli.services :as svcs]
@@ -67,6 +68,7 @@
    #'svcs/puppetdb-service
    #'command-service
    #'status-service
+   #'scheduler-service
    #'metrics-webservice
    #'dashboard-redirect-service
    #'pdb-routing-service


### PR DESCRIPTION
This switches us over to use clj-parent for managed dependencies.

Edit (AJ): And updates all the dependencies we're using in the process.

Signed-off-by: Ken Barber <ken@bob.sh>