### PR TITLE
Nov2016 link fixes

### DIFF
--- a/documentation/api/admin/v1/archive.markdown
+++ b/documentation/api/admin/v1/archive.markdown
@@ -4,7 +4,7 @@ layout: default
 canonical: "/puppetdb/latest/api/admin/v1/archive.html"
 ---
 
-[curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
+[curl]: ../../query/curl.html#using-curl-from-localhost-non-sslhttp
 
 The `/archive` endpoint can be used for importing and exporting PuppetDB
 archives.

--- a/documentation/api/admin/v1/cmd.markdown
+++ b/documentation/api/admin/v1/cmd.markdown
@@ -4,7 +4,7 @@ layout: default
 canonical: "/puppetdb/latest/api/admin/v1/cmd.html"
 ---
 
-[curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
+[curl]: ../../query/curl.html#using-curl-from-localhost-non-sslhttp
 
 The `/cmd` endpoint can be used to trigger PuppetDB maintenance
 operations.  Only one maintenance operation can be running at a time.

--- a/documentation/api/ext/v1/resource-graphs.markdown
+++ b/documentation/api/ext/v1/resource-graphs.markdown
@@ -10,7 +10,7 @@ canonical: "/puppetdb/latest/api/ext/v1/resource-graphs.html"
 [ast]: ../../query/v4/ast.html
 [environments]: ../../query/v4/environments.html
 [nodes]: ../../query/v4/nodes.html
-[statuses]: /puppet/latest/reference/format_report.html#puppettransactionreport
+[statuses]: {{puppet}}/format_report.html#puppettransactionreport
 
 You can query resource-graphs by making an HTTP request to the
 `/pdb/ext/v1/resource-graphs` endpoint.

--- a/documentation/api/meta/v1/server-time.markdown
+++ b/documentation/api/meta/v1/server-time.markdown
@@ -4,7 +4,7 @@ layout: default
 canonical: "/puppetdb/latest/api/meta/v1/server-time.html"
 ---
 
-[curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
+[curl]: ../../query/curl.html#using-curl-from-localhost-non-sslhttp
 
 The `/server-time` endpoint can be used to retrieve the server time from the PuppetDB server.
 

--- a/documentation/api/meta/v1/version.markdown
+++ b/documentation/api/meta/v1/version.markdown
@@ -4,7 +4,7 @@ layout: default
 canonical: "/puppetdb/latest/api/meta/v1/version.html"
 ---
 
-[curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
+[curl]: ../../query/curl.html#using-curl-from-localhost-non-sslhttp
 
 The `/version` endpoint can be used to retrieve version information from the PuppetDB server.
 

--- a/documentation/api/query/curl.markdown
+++ b/documentation/api/query/curl.markdown
@@ -45,8 +45,8 @@ make sure to authorize the certificate you are using:
       --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem \
       --cert /etc/puppetlabs/puppet/ssl/certs/<node>.pem \
       --key /etc/puppetlabs/puppet/ssl/private_keys/<node>.pem
-      
-      
+
+
 ### Using an RBAC token (PE only)
 
 To make secured requests from other hosts, you will need to supply the following
@@ -58,7 +58,7 @@ via the command line:
 Any node managed by Puppet agent will already have the CA certificate, and you
 can reuse the CA certificate for contacting PuppetDB. You can read more about
 generating RBAC tokens and how they work in the
-[PE documention](https://docs.puppet.com/pe/latest/rbac_token_auth.html).
+[PE documention]({{pe}}/rbac_token_auth.html).
 
 **Note:** The token the user is for must have the correct permissions for
 viewing or editting node data depending on the operation.
@@ -67,7 +67,7 @@ viewing or editting node data depending on the operation.
       -H "X-Authentication: <token contents>"
       --tlsv1 \
       --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem \
-      
+
 **Note:** PE 2016.2 users will need to set `client-auth = want` under the
 `[jetty]` header of their jetty.ini configuration. Later versions of PE have
 this setting managed by the `puppetlabs-puppet_enterprise` module by default.

--- a/documentation/api/query/v4/fact-paths.markdown
+++ b/documentation/api/query/v4/fact-paths.markdown
@@ -7,7 +7,7 @@ canonical: "/puppetdb/latest/api/query/v4/fact-paths.html"
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
 [paging]: ./paging.html
 [query]: ./query.html
-[fact-names]: ./query/v4/fact-names.html
+[fact-names]: ./fact-names.html
 [subqueries]: ./ast.html#subquery-operators
 [ast]: ./ast.html
 [facts]: ./facts.html

--- a/documentation/api/query/v4/nodes.markdown
+++ b/documentation/api/query/v4/nodes.markdown
@@ -6,7 +6,7 @@ canonical: "/puppetdb/latest/api/query/v4/nodes.html"
 
 [resource]: ./resources.html
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
-[statuses]: /puppet/latest/reference/format_report.html#puppettransactionreport
+[statuses]: {{puppet}}/format_report.html#puppettransactionreport
 [paging]: ./paging.html
 [query]: ./query.html
 [8601]: http://en.wikipedia.org/wiki/ISO_8601

--- a/documentation/api/query/v4/pql.markdown
+++ b/documentation/api/query/v4/pql.markdown
@@ -79,7 +79,7 @@ In this case, this would return only the certname field of nodes starting with
 The entity or context of a query (or subquery) defines what results you will get
 returned when performing a query, and provides the main context for any
 projections or filters in the query. There are many entities; for a full list
-see the [entities] documentation.
+see the [entities][] documentation.
 
 For PQL queries, the entity context is the minimal amount of information one
 must provide, as it defines the results returned. For example, if you wanted to
@@ -89,8 +89,10 @@ see all node information, you could provide a query as follows:
 
 And it would be enough to return all node data, without filtering or pagination.
 
-The entity context can also be used within a subquery, see the [subquery]
-section for more details.
+The entity context can also be used within a subquery; for more details, see:
+
+* [The `in` operator][in], which can take a subquery.
+* [Implicit subqueries][].
 
 ## Projection
 
@@ -240,6 +242,8 @@ operator and a valid regular expression:
 
 #### Array Match: `in`
 
+[in]: #array-match-in
+
 The `in` operator matches a field or set of fields against either an array or a
 subquery.
 
@@ -376,6 +380,8 @@ Currently lists are only supported with the `in` operator.
 
 ### Implicit Subqueries
 
+[Implicit subqueries]: #implicit-subqueries
+
 Implicit subqueries work the same way as the `in` operator,
 however the relationship between some entities is clear. When an implicit
 relationship exists between two entity types, you can avoid the overhead of
@@ -395,7 +401,7 @@ only Debian nodes).
 
 This often allows you to avoid having to know which fields are
 required, unlike the `in` operator, but be aware that only some relationships are well
-defined. See the [entities] documentation for each entity to learn which
+defined. See the [entities][] documentation for each entity to learn which
 implicit subqueries are provided automatically.
 
 Also, implicit subqueries are like any other conditional operator, and therefore
@@ -408,7 +414,7 @@ subquery as before, included with a `certname` match on the node itself:
     }
 
 They can even be combined with other implict subqueries, to provide more complex
-matching capabilities. This query combines everything we've discussed so far, 
+matching capabilities. This query combines everything we've discussed so far,
 and adds a `resource` subquery for `Package[tomcat]`:
 
     nodes {

--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -8,7 +8,7 @@ canonical: "/puppetdb/latest/api/query/v4/reports.html"
 [ast]: ./ast.html
 [events]: ./events.html
 [paging]: ./paging.html
-[statuses]: /puppet/latest/reference/format_report.html#puppettransactionreport
+[statuses]: {{puppet}}/format_report.html#puppettransactionreport
 [query]: ./query.html
 [8601]: http://en.wikipedia.org/wiki/ISO_8601
 [subqueries]: ./ast.html#subquery-operators

--- a/documentation/api/query/v4/upgrading-from-v3.markdown
+++ b/documentation/api/query/v4/upgrading-from-v3.markdown
@@ -12,7 +12,7 @@ marked 'experimental' since 2.0.0 but is the only API available in 3.0.
 Note that this document focuses on API changes only, and only includes changes
 leading up to the release of 3.0. For a more complete description
 of the changes listed and changes in versions subsequent to 3.0, see the
-[release notes](https://docs.puppetlabs.com/puppetdb/latest/release_notes.html).
+[release notes]({{puppetdb}}/release_notes.html).
 
 Each change below is marked with the corresponding release version.
 
@@ -23,7 +23,7 @@ Each change below is marked with the corresponding release version.
 * (3.0) The query API has been moved from `/` to `/pdb/query`, so
   http://localhost:8080/v4/facts has become
   http://localhost:8080/pdb/query/v4/facts.
-  
+
 * (3.0) The `/commands` endpoint has been moved to its own API at `/pdb/cmd`, so
   http://localhost:8080/v3/commands has become
   http://localhost:8080/pdb/cmd/v1.
@@ -60,7 +60,7 @@ Each change below is marked with the corresponding release version.
   compose the v4 response body, along with the new fields
   `producer_timestamp`, `hash`, and `environment`. For more
   information, see the
-  [/pdb/query/v4/catalogs documentation](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/catalogs.html).
+  [/pdb/query/v4/catalogs documentation]({{puppetdb}}/api/query/v4/catalogs.html).
 
 #### /pdb/query/v4/facts
 
@@ -73,13 +73,13 @@ Each change below is marked with the corresponding release version.
 
 * (2.2) The v4 factsets endpoint was added to facilitate the grouping
   of facts per node. For more information, see the
-  [/pdb/query/v4/factsets documentation](./api/query/v4/factsets.html).
+  [/pdb/query/v4/factsets documentation]({{puppetdb}}/api/query/v4/factsets.html).
 
 * (3.0) We added a `hash` field to the endpoint fields to support a unique identifer for factsets.
 
 * (3.0) The `facts` field is now expanded as per our new expansion
   convention, so the data format has changed. For more information, see
-  the [/pdb/query/v4/factsets documentation](./api/query/v4/factsets.html).
+  the [/pdb/query/v4/factsets documentation]({{puppetdb}}/api/query/v4/factsets.html).
 
 * (3.0) The `/pdb/query/v4/factsets/<node>/facts` endpoints will now
   return results even for deactivated or expired nodes.
@@ -92,14 +92,14 @@ Each change below is marked with the corresponding release version.
   parameters and returns an array of maps instead of a map. An additional
   `summarize_by` field has also been added to describe the parameter used. For
   more information, see the [aggregate-event-counts
-  documentation](./api/query/v4/aggregate_event_counts).
+  documentation]({{puppetdb}}/api/query/v4/aggregate_event_counts).
 
 #### /metrics/v1 (formerly /v3/metrics)
 
 * (3.0) The former metrics endpoint has been split off into a separate service, and
   reversioned at v1. If you are currently accessing mbeans at
   http://localhost:8080/v3/metrics/mbeans, you will now access them at
-  http://localhost:8080/metrics/v1/mbeans and so on, according to the [metrics api documentation](https://docs.puppetlabs.com/puppetdb/master/api/metrics/v1/index.html).
+  http://localhost:8080/metrics/v1/mbeans and so on, according to the [metrics api documentation]({{puppetdb}}/api/metrics/v1/mbeans.html).
 
 * (3.0) PuppetDB's mbeans (listed at /metrics/v1/mbeans) are no longer prefixed with
   "com."
@@ -109,9 +109,9 @@ Each change below is marked with the corresponding release version.
   * (3.0) For users posting commands directly to the
     /pdb/cmd/v1 endpoint, the only valid command submission
     versions will be
-    [replace catalogs v6](https://docs.puppetlabs.com/puppetdb/master/api/wire_format/catalog_format_v6.html),
-    [store report v5](https://docs.puppetlabs.com/puppetdb/master/api/wire_format/report_format_v5.html),
-    and [replace facts v4](https://docs.puppetlabs.com/puppetdb/master/api/wire_format/facts_format_v4.html).
+    [replace catalogs v6]({{puppetdb}}/api/wire_format/catalog_format_v6.html),
+    [store report v5]({{puppetdb}}/api/wire_format/report_format_v5.html),
+    and [replace facts v4]({{puppetdb}}/api/wire_format/facts_format_v4.html).
 
 #### /pdb/meta/v1/version (formerly /v3/version)
 * (3.0) The version endpoint has been split from the query service and mounted
@@ -127,16 +127,16 @@ Each change below is marked with the corresponding release version.
 
 * (2.2.0) `/pdb/query/v4/factsets` This endpoint returns a key-value
   hash for each certname. For more information, see the
-  [/pdb/query/v4/factsets documentation](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/factsets.html#response-format).
+  [/pdb/query/v4/factsets documentation]({{puppetdb}}/api/query/v4/factsets.html#response-format).
 
 * (2.2.0) `/pdb/query/v4/fact-paths` This endpoint is similar to the
   existing fact-names endpoint in that one expected use is GUI
   autocompletion. For more information, see the
-  [/pdb/query/v4/fact-paths documentation](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/fact-paths.html).
+  [/pdb/query/v4/fact-paths documentation]({{puppetdb}}/api/query/v4/fact-paths.html).
 
 * (2.2.0) `/pdb/query/v4/fact-contents` This endpoint allows
   fine-grained querying of structured facts. For more information, see
-  the [/pdb/query/v4/fact-contents documentation](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/fact-contents.html).
+  the [/pdb/query/v4/fact-contents documentation]({{puppetdb}}/api/query/v4/fact-contents.html).
 
 * (3.0) `/pdb/query/v4/edges` This endpoint allows querying edges
   inside a catalog. For more information, see the
@@ -157,12 +157,12 @@ Each change below is marked with the corresponding release version.
 * (3.0) `/pdb/query/v4/catalogs/<node>/[resources|edges]` Both of
   these endpoints provide convenience for drilling into resources and
   edges data specific to a particular catalog. See
-  [/pdb/query/v4/catalogs documentation](./catalogs)
+  [/pdb/query/v4/catalogs documentation](./catalogs.html)
 
 #### Features affecting all endpoints
 
 * (3.0) Extract is available as a top-level query operator, useful for selecting only
-  certain fields from a response. See the [documentation on the extract operator](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/ast.html#extract) for more information.
+  certain fields from a response. See the [documentation on the extract operator]({{puppetdb}}/api/query/v4/ast.html#extract) for more information.
 
 * (2.2.0) The `in` and `extract` operators have been changed to accept multiple fields,
   allowing more concise subquerying as explained [here](https://github.com/puppetlabs/puppetdb/pull/1053).
@@ -171,18 +171,18 @@ Each change below is marked with the corresponding release version.
 
 * (3.0) The v4 events endpoint does not require a query parameter, so
   `/pdb/query/v4/events` is now a valid query. See the
-  [events endpoint documentation](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/events.html#get-v4events)
+  [events endpoint documentation]({{puppetdb}}/api/query/v4/events.html#pdbqueryv4events)
   for more information.
 
 #### /pdb/query/v4/reports
 
 * (3.0) The response of the reports endpoint includes the new fields `noop`,
-  `environment`, `status`, `resource_events`, `logs`, and `metrics`. For more information, see the [documentation on the reports endpoint](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/reports.html). For comparison, see [an example of the new format](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/reports.html#examples), and [an example of the old format](https://docs.puppetlabs.com/puppetdb/latest/api/query/v3/reports.html#response-format).
+  `environment`, `status`, `resource_events`, `logs`, and `metrics`. For more information, see the [documentation on the reports endpoint]({{puppetdb}}/api/query/v4/reports.html). For comparison, see [an example of the new format]({{puppetdb}}/api/query/v4/reports.html#examples), and [an example of the old format](/puppetdb/2.3/api/query/v3/reports.html#response-format) (PuppetDB 2.3 docs).
 
 * (3.0) The reports endpoint takes a `latest_report?` query to return only reports
   associated with the most recent puppet run for their nodes. Similar to the
   corresponding events query, there is no corresponding field in the response.
-  For more information, see the [documentation on the report query fields](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/reports.html#query-fields).
+  For more information, see the [documentation on the report query fields]({{puppetdb}}/api/query/v4/reports.html#query-fields).
 
 #### /pdb/query/v4/catalogs
 
@@ -191,17 +191,17 @@ Each change below is marked with the corresponding release version.
   single host. The old query format (`/pdb/query/v4/catalogs/myhost`)
   still works as before, but `/pdb/query/v4/catalogs` returns results
   too. For more information, see the
-  [catalog query examples](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/catalogs.html#examples).
+  [catalog query examples]({{puppetdb}}/api/query/v4/catalogs.html#examples).
 
 #### Operators
 
 * (2.2.0) The new `select_fact_contents` subquery operator allows for filtering the
   results of other endpoints based on detailed queries about structured fact
-  values. This is exhibited on the bottom of the [subquery examples documentation](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/ast.html#subquery-examples).
+  values. This is exhibited on the bottom of the [subquery examples documentation]({{puppetdb}}/api/query/v4/ast.html#explicit-subquery-examples).
 
 * (2.2.0) We have added the regexp array match operator `~>` for querying fact paths on
-  the `fact-contents` or `fact-paths endpoints`. This is documented with the other [operators](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/ast.html#regexp-array-match).
-  An example of usage is given at the bottom of the [subquery examples page](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/ast.html#subquery-examples).
+  the `fact-contents` or `fact-paths endpoints`. This is documented with the other [operators]({{puppetdb}}/api/query/v4/ast.html#regexp-array-match).
+  An example of usage is given at the bottom of the [subquery examples page]({{puppetdb}}/api/query/v4/ast.html#explicit-subquery-examples).
 
 * (3.0) We have added the `group_by` and `function` operators, as well as
-  support for the `count` function. For more information, see the [operators documentation](https://docs.puppetlabs.com/puppetdb/master/api/query/v4/ast.html#function).
+  support for the `count` function. For more information, see the [operators documentation]({{puppetdb}}/api/query/v4/ast.html#function).

--- a/documentation/api/status/v1/status.markdown
+++ b/documentation/api/status/v1/status.markdown
@@ -5,7 +5,7 @@ canonical: "/puppetdb/latest/api/status/v1/status.html"
 ---
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
-[status-api]: https://docs.puppetlabs.com/pe/latest/status_api.html
+[status-api]: {{pe}}/status_api.html
 
 The `/status` endpoint implements the Puppet Labs Status API for coordinated
 monitoring of Puppet Labs services. See the [central documentation][status-api]

--- a/documentation/api/wire_format/catalog_format_v6.markdown
+++ b/documentation/api/wire_format/catalog_format_v6.markdown
@@ -4,19 +4,19 @@ layout: default
 canonical: "/puppetdb/latest/api/wire_format/catalog_format_v6.html"
 ---
 
-[containment]: /puppet/latest/reference/lang_containment.html
-[relationship]: /puppet/latest/reference/lang_relationships.html
-[chain]: /puppet/latest/reference/lang_relationships.html#chaining-arrows
-[metaparameters]: /puppet/latest/reference/lang_relationships.html#relationship-metaparameters
-[require]: /puppet/latest/reference/lang_relationships.html#the-require-function
-[resource_ref]: /puppet/latest/reference/lang_datatypes.html#resource-references
-[numbers]: /puppet/latest/reference/lang_datatypes.html#numbers
-[undef]: /puppet/latest/reference/lang_datatypes.html#undef
-[namevar]: /puppet/latest/reference/lang_resources.html#namenamevar
-[resource]: /puppet/latest/reference/lang_resources.html
-[title]: /puppet/latest/reference/lang_resources.html#title
-[type]: /puppet/latest/reference/lang_resources.html#type
-[attributes]: /puppet/latest/reference/lang_resources.html#attributes
+[containment]: {{puppet}}/lang_containment.html
+[relationship]: {{puppet}}/lang_relationships.html
+[chain]: {{puppet}}/lang_relationships.html#syntax-chaining-arrows
+[metaparameters]: {{puppet}}/lang_relationships.html#syntax-relationship-metaparameters
+[require]: {{puppet}}/lang_relationships.html#syntax-the-require-function
+[resource_ref]: {{puppet}}/lang_data_resource_reference.html
+[numbers]: {{puppet}}/lang_data_number.html
+[undef]: {{puppet}}/lang_data_undef.html
+[namevar]: {{puppet}}/lang_resources.html#namenamevar
+[resource]: {{puppet}}/lang_resources.html
+[title]: {{puppet}}/lang_resources.html#title
+[type]: {{puppet}}/lang_resources.html#type
+[attributes]: {{puppet}}/lang_resources.html#attributes
 
 PuppetDB receives catalogs from Puppet masters in the following wire format. This format is subtly different from the internal format used by Puppet, so catalogs are converted by the [PuppetDB catalog terminus](../../connect_puppet_master.html) before they are sent.
 
@@ -51,7 +51,7 @@ String. The name of the node for which the catalog was compiled.
 
 #### `version`
 
-String. An arbitrary string that uniquely identifies this specific catalog across time for a single node. This is controlled by Puppet's [`config_version` setting](/references/latest/configuration.html#configversion) and is usually the seconds elapsed since the epoch.
+String. An arbitrary string that uniquely identifies this specific catalog across time for a single node. This is controlled by Puppet's [`config_version` setting]({{puppet}}/configuration.html#configversion) and is usually the seconds elapsed since the epoch.
 
 #### `environment`
 

--- a/documentation/api/wire_format/catalog_format_v7.markdown
+++ b/documentation/api/wire_format/catalog_format_v7.markdown
@@ -4,19 +4,19 @@ layout: default
 canonical: "/puppetdb/latest/api/wire_format/catalog_format_v7.html"
 ---
 
-[containment]: /puppet/latest/reference/lang_containment.html
-[relationship]: /puppet/latest/reference/lang_relationships.html
-[chain]: /puppet/latest/reference/lang_relationships.html#chaining-arrows
-[metaparameters]: /puppet/latest/reference/lang_relationships.html#relationship-metaparameters
-[require]: /puppet/latest/reference/lang_relationships.html#the-require-function
-[resource_ref]: /puppet/latest/reference/lang_datatypes.html#resource-references
-[numbers]: /puppet/latest/reference/lang_datatypes.html#numbers
-[undef]: /puppet/latest/reference/lang_datatypes.html#undef
-[namevar]: /puppet/latest/reference/lang_resources.html#namenamevar
-[resource]: /puppet/latest/reference/lang_resources.html
-[title]: /puppet/latest/reference/lang_resources.html#title
-[type]: /puppet/latest/reference/lang_resources.html#type
-[attributes]: /puppet/latest/reference/lang_resources.html#attributes
+[containment]: {{puppet}}/lang_containment.html
+[relationship]: {{puppet}}/lang_relationships.html
+[chain]: {{puppet}}/lang_relationships.html#syntax-chaining-arrows
+[metaparameters]: {{puppet}}/lang_relationships.html#syntax-relationship-metaparameters
+[require]: {{puppet}}/lang_relationships.html#syntax-the-require-function
+[resource_ref]: {{puppet}}/lang_data_resource_reference.html
+[numbers]: {{puppet}}/lang_data_number.html
+[undef]: {{puppet}}/lang_data_undef.html
+[namevar]: {{puppet}}/lang_resources.html#namenamevar
+[resource]: {{puppet}}/lang_resources.html
+[title]: {{puppet}}/lang_resources.html#title
+[type]: {{puppet}}/lang_resources.html#type
+[attributes]: {{puppet}}/lang_resources.html#attributes
 
 PuppetDB receives catalogs from Puppet masters in the following wire format. This format is subtly different from the internal format used by Puppet, so catalogs are converted by the [PuppetDB catalog terminus](../../connect_puppet_master.html) before they are sent.
 
@@ -52,7 +52,7 @@ String. The name of the node for which the catalog was compiled.
 
 #### `version`
 
-String. An arbitrary string that uniquely identifies this specific catalog across time for a single node. This is controlled by Puppet's [`config_version` setting](/references/latest/configuration.html#configversion) and is usually the seconds elapsed since the epoch.
+String. An arbitrary string that uniquely identifies this specific catalog across time for a single node. This is controlled by Puppet's [`config_version` setting]({{puppet}}/configuration.html#configversion) and is usually the seconds elapsed since the epoch.
 
 #### `environment`
 

--- a/documentation/api/wire_format/catalog_format_v8.markdown
+++ b/documentation/api/wire_format/catalog_format_v8.markdown
@@ -4,19 +4,19 @@ layout: default
 canonical: "/puppetdb/latest/api/wire_format/catalog_format_v8.html"
 ---
 
-[containment]: /puppet/latest/reference/lang_containment.html
-[relationship]: /puppet/latest/reference/lang_relationships.html
-[chain]: /puppet/latest/reference/lang_relationships.html#chaining-arrows
-[metaparameters]: /puppet/latest/reference/lang_relationships.html#relationship-metaparameters
-[require]: /puppet/latest/reference/lang_relationships.html#the-require-function
-[resource_ref]: /puppet/latest/reference/lang_datatypes.html#resource-references
-[numbers]: /puppet/latest/reference/lang_datatypes.html#numbers
-[undef]: /puppet/latest/reference/lang_datatypes.html#undef
-[namevar]: /puppet/latest/reference/lang_resources.html#namenamevar
-[resource]: /puppet/latest/reference/lang_resources.html
-[title]: /puppet/latest/reference/lang_resources.html#title
-[type]: /puppet/latest/reference/lang_resources.html#type
-[attributes]: /puppet/latest/reference/lang_resources.html#attributes
+[containment]: {{puppet}}/lang_containment.html
+[relationship]: {{puppet}}/lang_relationships.html
+[chain]: {{puppet}}/lang_relationships.html#syntax-chaining-arrows
+[metaparameters]: {{puppet}}/lang_relationships.html#syntax-relationship-metaparameters
+[require]: {{puppet}}/lang_relationships.html#syntax-the-require-function
+[resource_ref]: {{puppet}}/lang_data_resource_reference.html
+[numbers]: {{puppet}}/lang_data_number.html
+[undef]: {{puppet}}/lang_data_undef.html
+[namevar]: {{puppet}}/lang_resources.html#namenamevar
+[resource]: {{puppet}}/lang_resources.html
+[title]: {{puppet}}/lang_resources.html#title
+[type]: {{puppet}}/lang_resources.html#type
+[attributes]: {{puppet}}/lang_resources.html#attributes
 
 PuppetDB receives catalogs from Puppet masters in the following wire format.
 This format is subtly different from the internal format used by Puppet, so
@@ -60,7 +60,7 @@ String. The name of the node for which the catalog was compiled.
 
 String. An arbitrary string that uniquely identifies this specific catalog
 across time for a single node. This is controlled by Puppet's
-[`config_version` setting](/references/latest/configuration.html#configversion)
+[`config_version` setting]({{puppet}}/configuration.html#configversion)
 and is usually the seconds elapsed since the epoch.
 
 #### `environment`

--- a/documentation/api/wire_format/catalog_format_v9.markdown
+++ b/documentation/api/wire_format/catalog_format_v9.markdown
@@ -4,19 +4,19 @@ layout: default
 canonical: "/puppetdb/latest/api/wire_format/catalog_format_v9.html"
 ---
 
-[containment]: /puppet/latest/reference/lang_containment.html
-[relationship]: /puppet/latest/reference/lang_relationships.html
-[chain]: /puppet/latest/reference/lang_relationships.html#chaining-arrows
-[metaparameters]: /puppet/latest/reference/lang_relationships.html#relationship-metaparameters
-[require]: /puppet/latest/reference/lang_relationships.html#the-require-function
-[resource_ref]: /puppet/latest/reference/lang_datatypes.html#resource-references
-[numbers]: /puppet/latest/reference/lang_datatypes.html#numbers
-[undef]: /puppet/latest/reference/lang_datatypes.html#undef
-[namevar]: /puppet/latest/reference/lang_resources.html#namenamevar
-[resource]: /puppet/latest/reference/lang_resources.html
-[title]: /puppet/latest/reference/lang_resources.html#title
-[type]: /puppet/latest/reference/lang_resources.html#type
-[attributes]: /puppet/latest/reference/lang_resources.html#attributes
+[containment]: {{puppet}}/lang_containment.html
+[relationship]: {{puppet}}/lang_relationships.html
+[chain]: {{puppet}}/lang_relationships.html#syntax-chaining-arrows
+[metaparameters]: {{puppet}}/lang_relationships.html#syntax-relationship-metaparameters
+[require]: {{puppet}}/lang_relationships.html#syntax-the-require-function
+[resource_ref]: {{puppet}}/lang_data_resource_reference.html
+[numbers]: {{puppet}}/lang_data_number.html
+[undef]: {{puppet}}/lang_data_undef.html
+[namevar]: {{puppet}}/lang_resources.html#namenamevar
+[resource]: {{puppet}}/lang_resources.html
+[title]: {{puppet}}/lang_resources.html#title
+[type]: {{puppet}}/lang_resources.html#type
+[attributes]: {{puppet}}/lang_resources.html#attributes
 
 PuppetDB receives catalogs from Puppet masters in the following wire format.
 This format is subtly different from the internal format used by Puppet, so
@@ -61,7 +61,7 @@ String. The name of the node for which the catalog was compiled.
 
 String. An arbitrary string that uniquely identifies this specific catalog
 across time for a single node. This is controlled by Puppet's
-[`config_version` setting](/references/latest/configuration.html#configversion)
+[`config_version` setting]({{puppet}}/configuration.html#configversion)
 and is usually the seconds elapsed since the epoch.
 
 #### `environment`

--- a/documentation/api/wire_format/report_format_v5.markdown
+++ b/documentation/api/wire_format/report_format_v5.markdown
@@ -4,7 +4,7 @@ layout: default
 canonical: "/puppetdb/latest/api/wire_format/report_format_v5.html"
 ---
 
-[puppetreportformat]: http://docs.puppetlabs.com/puppet/latest/reference/format_report.html
+[puppetreportformat]: {{puppet}}/format_report.html
 [reportsv4]: ../query/v4/reports.markdown
 
 ## Report interchange format

--- a/documentation/community_add_ons.markdown
+++ b/documentation/community_add_ons.markdown
@@ -11,7 +11,7 @@ canonical: "/puppetdb/latest/community_add_ons.html"
 [dashboard]: ./maintain_and_tune.html#monitor-the-performance-dashboard
 [query]: https://github.com/dalen/puppet-puppetdbquery
 [exports]: http://forge.puppetlabs.com/zack/exports
-[exported]: /puppet/latest/reference/lang_exported.html
+[exported]: {{puppet}}/lang_exported.html
 [cms-puppetdb-tools]: https://github.com/tskirvin/cms-puppetdb-tools
 
 [Jason Hancock --- nagios-puppetdb][nagios]

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -713,7 +713,7 @@ logging for the `puppetlabs.puppetdb.middleware` appender in the
 
 The `[jetty]` section configures HTTP for PuppetDB.
 
-> **Note:** If you are using Puppet Enterprise and want to enable the PuppetDB dashboard from the PE console, refer to [our guide to changing PuppetDB's parameters](/pe/latest/maintain_console-db.html#changing-puppetdbs-parameters) for more information. PE users should not edit `jetty.ini`.
+> **Note:** If you are using Puppet Enterprise and want to enable the PuppetDB dashboard from the PE console, refer to [our guide to changing PuppetDB's parameters]({{pe}}/maintain_console-db.html#changing-puppetdbs-parameters) for more information. PE users should not edit `jetty.ini`.
 
 ### `host`
 

--- a/documentation/connect_puppet_apply.markdown
+++ b/documentation/connect_puppet_apply.markdown
@@ -4,19 +4,19 @@ layout: default
 canonical: "/puppetdb/latest/connect_puppet_apply.html"
 ---
 
-[exported]: /puppet/latest/reference/lang_exported.html
-[package]: /references/latest/type.html#package
-[file]: /references/latest/type.html#file
-[yumrepo]: /references/latest/type.html#yumrepo
+[exported]: {{puppet}}/lang_exported.html
+[package]: {{puppet}}/type.html#package
+[file]: {{puppet}}/type.html#file
+[yumrepo]: {{puppet}}/type.html#yumrepo
 [apt]: http://forge.puppetlabs.com/puppetlabs/apt
 [puppetdb_download]: http://downloads.puppetlabs.com/puppetdb
-[puppetdb_conf]: /puppet/latest/reference/config_file_puppetdb.html
-[routes_yaml]: /puppet/latest/reference/config_file_routes.html
-[exported]: /puppet/latest/reference/lang_exported.html
+[puppetdb_conf]: {{puppet}}/config_file_puppetdb.html
+[routes_yaml]: {{puppet}}/config_file_routes.html
+[exported]: {{puppet}}/lang_exported.html
 [jetty]: ./configure.html#jetty-http-settings
-[settings_namespace]: /puppet/latest/reference/lang_facts_and_builtin_vars.html#variables-set-by-the-puppet-master
-[ssl_script]: ./install_from_source.html#step-3-option-a-run-the-ssl-configuration-script
-[package_repos]: /puppet/latest/reference/puppet_collections.html
+[ssl_script]: ./maintain_and_tune.html#redo-ssl-setup-after-changing-certificates
+[settings_namespace]: {{puppet}}/lang_facts_and_builtin_vars.html#puppet-master-variables
+[package_repos]: {{puppet}}/puppet_collections.html
 
 > Note: To use PuppetDB, the nodes at your site must be running Puppet version 3.8.1 or later.
 
@@ -43,7 +43,7 @@ PuppetDB requires client authentication (CA) for its SSL connections, and the Pu
 
 When talking to PuppetDB, `puppet apply` can use the certificates issued by a Puppet master's certificate authority. You can issue certificates to every node by setting up a Puppet master server with dummy manifests, running `puppet agent --test` once on every node, signing every certificate request on the Puppet master, and running `puppet agent --test` again on every node.
 
-Do the same on your PuppetDB node, then [re-run the SSL setup script][ssl_script]. PuppetDB will now trust connections from your Puppet nodes.
+Do the same on your PuppetDB node, then [re-run the SSL setup script][ssl_script] (which usually runs automatically during installation). PuppetDB will now trust connections from your Puppet nodes.
 
 You will have to sign a certificate for every new node you add to your site.
 

--- a/documentation/connect_puppet_master.markdown
+++ b/documentation/connect_puppet_master.markdown
@@ -6,15 +6,15 @@ canonical: "/puppetdb/latest/connect_puppet_master.html"
 
 [puppetdb_download]: http://downloads.puppetlabs.com/puppetdb
 [puppetdb_conf]: ./puppetdb_connection.html
-[routes_yaml]: /puppet/latest/reference/config_file_routes.html
-[exported]: /puppet/latest/reference/lang_exported.html
+[routes_yaml]: {{puppet}}/config_file_routes.html
+[exported]: {{puppet}}/lang_exported.html
 [install_via_module]: ./install_via_module.html
-[report_processors]: /guides/reporting.html
+[report_processors]: {{puppet}}/reporting_about.html
 [event]: ./api/query/v4/events.html
 [report]: ./api/query/v4/reports.html
-[store_report]: ./api/command/v1/commands.html#store-report-version-1
+[store_report]: ./api/command/v1/commands.html#store-report-version-7
 [report_format]: ./api/wire_format/report_format_v5.html
-[puppetdb_server_urls]: ./puppetdb_connection.html#server_urls
+[puppetdb_server_urls]: ./puppetdb_connection.html#serverurls
 
 > Note: To use PuppetDB, your site's Puppet master(s) must be running Puppet version 4.0.0 or later.
 
@@ -33,7 +33,7 @@ Currently, Puppet masters need additional Ruby plug-ins in order to use PuppetDB
 
 ### On platforms with packages
 
-[Enable the Puppet Collection repo](/puppet/latest/reference/puppet_collections.html) and then install the `puppetdb-termini` package:
+[Enable the Puppet Collection repo]({{puppet}}/puppet_collections.html) and then install the `puppetdb-termini` package:
 
     $ sudo puppet resource package puppetdb-termini ensure=latest
 

--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -3,15 +3,15 @@ title: "PuppetDB 4.3 overview"
 layout: default
 ---
 
-[exported]: /puppet/latest/reference/lang_exported.html
+[exported]: {{puppet}}/lang_exported.html
 [connect]: ./connect_puppet_master.html
 [apply]: ./connect_puppet_apply.html
 [install_via_module]: ./install_via_module.html
 [install_from_packages]: ./install_from_packages.html
 [install_advanced]: ./install_from_source.html
 [scaling]: ./scaling_recommendations.html
-[facts]: /puppet/latest/reference/lang_facts_and_builtin_vars.html
-[catalog]: /puppet/latest/reference/lang_summary.html#compilation-and-catalogs
+[facts]: {{puppet}}/lang_facts_and_builtin_vars.html
+[catalog]: {{puppet}}/lang_summary.html#compilation-and-catalogs
 [releasenotes]: ./release_notes.html
 [github]: https://github.com/puppetlabs/puppetdb
 [tracker]: https://tickets.puppetlabs.com/browse/PDB

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -51,7 +51,7 @@ If Puppet isn't fully installed and configured on your PuppetDB server,
 [install it][installpuppet] and request/sign/retrieve a certificate for the
 node.
 
-[installpuppet]: /puppet/latest/reference/install_pre.html
+[installpuppet]: {{puppet}}/install_pre.html
 
 Your PuppetDB server should be running Puppet agent and have a signed
 certificate from your Puppet master server. If you run `puppet agent --test`, it
@@ -68,7 +68,7 @@ Step 2: Enable the Puppet Collection package repository
 -----
 
 If you didn't already use it to install Puppet, you will need to
-[enable the Puppet Collection package repository](/puppet/latest/reference/puppet_collections.html)
+[enable the Puppet Collection package repository]({{puppet}}/puppet_collections.html)
 
 Step 3: Install PuppetDB
 -----

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -5,11 +5,11 @@ layout: default
 
 [connect_master]: ./connect_puppet_master.html
 [connect_apply]: ./connect_puppet_apply.html
-[ssl_script]: ./install_from_source.html#step-3-option-a-run-the-ssl-configuration-script
+[ssl_script]: ./maintain_and_tune.html#redo-ssl-setup-after-changing-certificates
 [configure_postgres]: ./configure.html#using-postgresql
 [configure_heap]: ./configure.html#configuring-the-java-heap-size
 [configure_jetty]: ./configure.html#jetty-http-settings
-[requirements]: ./index.html#standard-install-rhel-centos-debian-ubuntu-or-fedora
+[requirements]: ./index.html#standard-install-rhel-centos-debian-and-ubuntu
 [module]: ./install_via_module.html
 
 > **Note:** If you are running Puppet Enterprise version 3.0 or later, you do

--- a/documentation/install_via_module.markdown
+++ b/documentation/install_via_module.markdown
@@ -26,7 +26,7 @@ Step 1: Enable the Puppet Collection package repository
 
 If you haven't done so already, you will need to do **one** of the following:
 
-* [Enable the Puppet Collection package repository](/puppet/latest/reference/puppet_collections.html)
+* [Enable the Puppet Collection package repository]({{puppet}}/puppet_collections.html)
   on your PuppetDB server and Puppet master server.
 * Grab the PuppetDB and PuppetDB-termini packages, and import them into your
   site's local package repos.

--- a/documentation/maintain_and_tune.markdown
+++ b/documentation/maintain_and_tune.markdown
@@ -11,7 +11,7 @@ canonical: "/puppetdb/latest/maintain_and_tune.html"
 [puppetdb_report_processor]: ./connect_puppet_master.html#enabling-report-storage
 [node_ttl]: ./configure.html#node-ttl
 [report_ttl]: ./configure.html#report-ttl
-[resources_type]: /references/latest/type.html#resources
+[resources_type]: {{puppet}}/type.html#resources
 [logback]: ./configure.html#the-logback-logging-config-file
 [dashboard]: #monitor-the-performance-dashboard
 
@@ -19,7 +19,7 @@ PuppetDB requires a relatively small amount of maintenance and tuning. However, 
 
 ## Monitor the performance dashboard
 
-Once PuppetDB is running, visit `http://localhost:8080/pdb/dashboard/index.html`, substituting the name and port of your PuppetDB server. 
+Once PuppetDB is running, visit `http://localhost:8080/pdb/dashboard/index.html`, substituting the name and port of your PuppetDB server.
 
 > **Note:** You may need to [edit PuppetDB's HTTP configuration][configure_jetty] first, changing the `host` setting to the server's externally-accessible hostname. If you installed with the PuppetDB module, [set the `listen_address` parameter](./install_via_module.html#step-2-assign-classes-to-nodes). When you do this, you should also configure your firewall to control access to PuppetDB's cleartext HTTP port.
 

--- a/documentation/pdb_client_tools.markdown
+++ b/documentation/pdb_client_tools.markdown
@@ -3,10 +3,10 @@ title: "PuppetDB 4.3: PuppetDB CLI"
 layout: default
 ---
 
-[installpuppet]: /puppet/latest/reference/install_pre.html
-[repos]: /puppet/latest/reference/puppet_collections.html
+[installpuppet]: {{puppet}}/install_pre.html
+[repos]: {{puppet}}/puppet_collections.html
 [export]: ./anonymization.html
-[installpeclienttools]: /pe/latest/install_pe_client_tools.html
+[installpeclienttools]: {{pe}}/install_pe_client_tools.html
 
 # PuppetDB CLI
 
@@ -73,9 +73,9 @@ take the following settings:
 
 - `cacert` The path for the CA cert.
 
-  *nix sytems - /etc/puppetlabs/puppet/ssl/certs/ca.pem  
+  *nix sytems - /etc/puppetlabs/puppet/ssl/certs/ca.pem
   Windows - C:\ProgramData\PuppetLabs\puppet\etc\ssl\certs\ca.pem
-  
+
 - `cert` An SSL certificate signed by your site's Puppet CA. Note that the PE
  version of the CLI supports token auth via `puppet-access` and this option
  should not be necessary.
@@ -93,7 +93,7 @@ necessary configuration items are `server_urls` and `cacert`.
 below for an example configuration) but setting `cert` and `key` in the PuppetDB
 CLI configuration will prevent you from using token authentication (i.e.
 certicate authentication takes precendence over token authentication).
- 
+
 ```json
 {
   "puppetdb": {
@@ -102,7 +102,7 @@ certicate authentication takes precendence over token authentication).
   }
 }
 ```
- 
+
 #### Example configuration file (puppet-client-tools)
 
 The open source version of the PuppetDB CLI requires certificate authentication

--- a/documentation/pdb_support_guide.markdown
+++ b/documentation/pdb_support_guide.markdown
@@ -4,12 +4,12 @@ layout: default
 ---
 
 [commands]: ./api/command/v1/commands.html#list-of-commands
-[threads]: https://docs.puppetlabs.com/puppetdb/latest/configure.html#threads
+[threads]: ./configure.html#threads
 [erd]: ./images/pdb_erd.png
 [pgstattuple]: http://www.postgresql.org/docs/9.4/static/pgstattuple.html
 [pgtune]: https://github.com/gregs1104/pgtune
 [postgres-config]: http://www.postgresql.org/docs/current/static/runtime-config-resource.html
-[fact-precedence]: https://docs.puppetlabs.com/facter/3.1/custom_facts.html#fact-precedence
+[fact-precedence]: {{facter}}/custom_facts.html#fact-precedence
 [stockpile]: https://github.com/puppetlabs/stockpile
 
 ## Support and Troubleshooting for PuppetDB

--- a/documentation/puppetdb-faq.markdown
+++ b/documentation/puppetdb-faq.markdown
@@ -10,7 +10,7 @@ subtitle: "Frequently asked questions"
 [puppetdb3]: /puppetdb/3.2/migrate.html
 [threads]: ./configure.html#threads
 [concurrent-writes]: ./configure.html#concurrent-writes
-[mq metrics]: ./api/metrics/v1/mbeans.html#mq-metrics
+[mq metrics]: ./api/metrics/v1/mbeans.html#message-queue-metrics
 [java heap]: ./configure.html#configuring-the-java-heap-size
 
 ## Can I migrate my data from ActiveRecord storeconfigs?

--- a/documentation/puppetdb_connection.markdown
+++ b/documentation/puppetdb_connection.markdown
@@ -50,7 +50,7 @@ You can use a comma-separated list of URLs if there are multiple PuppetDB instan
 
 The default value is `https://puppetdb:8081`.
 
-The PuppetDB terminus will always attempt to connect to the first PuppetDB instance specified (listed above as `puppetdb1`). If a server-side exception occurs, or the request takes too long (see [`server_url_timeout`](#server_url_timeout)), the PuppetDB terminus will attempt the same operation on the next instance in the list.
+The PuppetDB terminus will always attempt to connect to the first PuppetDB instance specified (listed above as `puppetdb1`). If a server-side exception occurs, or the request takes too long (see [`server_url_timeout`](#serverurltimeout)), the PuppetDB terminus will attempt the same operation on the next instance in the list.
 
 ### `submit_only_server_urls`
 
@@ -91,7 +91,7 @@ The default value in PE is true.
 
 **Note: For use with Puppet Enterprise only.**
 
-When using multiple `server_urls`, this flag can be set to `true` to cause queries to be made to the last PuppetDB instance that was successfully contacted. 
+When using multiple `server_urls`, this flag can be set to `true` to cause queries to be made to the last PuppetDB instance that was successfully contacted.
 
 The default value is false.
 

--- a/documentation/puppetdb_connection.markdown
+++ b/documentation/puppetdb_connection.markdown
@@ -6,7 +6,7 @@ canonical: "/puppetdb/latest/puppetdb_connection.html"
 
 [puppetdb_root]: ./index.html
 [connect_to_puppetdb]: ./connect_puppet_master.html
-[confdir]: /puppet/latest/reference/dirs_confdir.html
+[confdir]: {{puppet}}/dirs_confdir.html
 [puppetdb_conf]: ./connect_puppet_master.html#edit-puppetdb\.conf
 
 The `puppetdb.conf` file contains the hostname and port of the [PuppetDB][puppetdb_root] server. It is only used if you are using PuppetDB and have [connected your Puppet master to it][connect_to_puppetdb].

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -5,7 +5,7 @@ canonical: "/puppetdb/latest/release_notes.html"
 ---
 
 [configure_postgres]: ./configure.html#using-postgresql
-[kahadb_corruption]: ./trouble_kahadb_corruption.html
+[kahadb_corruption]: /puppetdb/4.2/trouble_kahadb_corruption.html
 [pg_trgm]: http://www.postgresql.org/docs/current/static/pgtrgm.html
 [upgrading]: ./api/query/v4/upgrading-from-v3.html
 [puppetdb-module]: https://forge.puppetlabs.com/puppetlabs/puppetdb
@@ -2019,10 +2019,10 @@ Ryan Senior, and Wyatt Alt
   documentation.
 
 * A missing `-L` option has been added to a curl invocation
-  [here](http://docs.puppetlabs.com/puppetdb/2.3/install_from_souce.html).
+  [here](http://docs.puppetlabs.com/puppetdb/2.3/install_from_source.html).
 
 * An incorrect reference to "Java" has been changed to "JVM" in the
-  [configuration](http://docs.puppetlabs.com/puppetdb/2.32.3/configure.html) documentation.
+  [configuration](http://docs.puppetlabs.com/puppetdb/2.3/configure.html) documentation.
 
 * The relationship between "MQ depth" and "Command Queue depth" has
   been clarified in the [tuning and maintenance](http://docs.puppetlabs.com/puppetdb/2.3/maintain_and_tune.html)
@@ -2391,13 +2391,13 @@ Brian Cain, Eric Timmerman, Justin Holguin, Ken Barber, Nick Fagerlund, Ryan Sen
 
 #### Changes to endpoints
 
-* [/v4/facts](http://docs.puppetlabs.com/puppetdb/2.2/api/query/v4/facts)
+* [/v4/facts](http://docs.puppetlabs.com/puppetdb/2.2/api/query/v4/facts.html)
 
     This endpoint is now capable of returning structured facts. Facts that contain hashes, arrays, floats, integers,
     booleans, strings (and combinations thereof) will be preserved when stored and able to now be returned via this
     endpoint.
 
-* [/v3/facts](http://docs.puppetlabs.com/puppetdb/2.2/api/query/v3/facts)
+* [/v3/facts](http://docs.puppetlabs.com/puppetdb/2.2/api/query/v3/facts.html)
 
     This endpoint will return JSON stringified structured facts to preserve backwards compatibility.
 
@@ -2425,7 +2425,7 @@ Brian Cain, Eric Timmerman, Justin Holguin, Ken Barber, Nick Fagerlund, Ryan Sen
 
     This new operator was designed for the `path` field type to allow for matching a path
     against an array of regular expressions. The only endpoints that contains such fields today
-    are [/v4/fact-contents](http://docs.puppetlabs.com/puppetdb/2.2/api/query/v4/fact-contents.html) and [/v4/fact-paths](http://docs.puppetlabs.com/puppetdb/2.2/api/query/v4/fact-paths).
+    are [/v4/fact-contents](http://docs.puppetlabs.com/puppetdb/2.2/api/query/v4/fact-contents.html) and [/v4/fact-paths](http://docs.puppetlabs.com/puppetdb/2.2/api/query/v4/fact-paths.html).
 
 #### Commands
 

--- a/documentation/repl.markdown
+++ b/documentation/repl.markdown
@@ -11,7 +11,7 @@ This interface is mostly of use to developers who know Clojure and are familiar 
 Enabling the REPL
 -----
 
-To enable the REPL, you must edit PuppetDB's config file to [enable it, configure the listening IP address, and choose a port](./configure.html#repl-settings):
+To enable the REPL, you must edit PuppetDB's config file to [enable it, configure the listening IP address, and choose a port](./configure.html#nrepl-settings):
 
     # /etc/puppetdb/conf.d/repl.ini
     [nrepl]

--- a/documentation/scaling_recommendations.markdown
+++ b/documentation/scaling_recommendations.markdown
@@ -12,7 +12,7 @@ canonical: "/puppetdb/latest/scaling_recommendations.html"
 [pg_ha]: http://www.postgresql.org/docs/current/interactive/high-availability.html
 [pg_replication]: http://wiki.postgresql.org/wiki/Replication,_Clustering,_and_Connection_Pooling
 [ram]: #bottleneck-java-heap-size
-[runinterval]: /references/latest/configuration.html#runinterval
+[runinterval]: {{puppet}}/configuration.html#runinterval
 
 PuppetDB will be a critical component of your Puppet deployment, as agent nodes will be unable to request catalogs if it goes down. Therefore, you should make sure it can handle your site's load and is resilient against failures.
 

--- a/documentation/scaling_recommendations.markdown
+++ b/documentation/scaling_recommendations.markdown
@@ -44,7 +44,7 @@ following links may be helpful:
 Bottleneck: Java heap size
 -----
 
-PuppetDB is limited by the amount of memory available to it, which is [set in the init script's config file][configure_heap]. If PuppetDB runs out of memory, it will start logging `OutOfMemoryError` exceptions and delaying command processing. Unlike many of the bottlenecks listed here, this one is fairly binary: PuppetDB either has enough memory to function under its load, or it doesn't. The exact amount needed will depend on the [database backend](#database-backend), the number of nodes, the similarity of the nodes, the complexity of each node's catalog, and how often the nodes check in.
+PuppetDB is limited by the amount of memory available to it, which is [set in the init script's config file][configure_heap]. If PuppetDB runs out of memory, it will start logging `OutOfMemoryError` exceptions and delaying command processing. Unlike many of the bottlenecks listed here, this one is fairly binary: PuppetDB either has enough memory to function under its load, or it doesn't. The exact amount needed will depend on the number of nodes, the similarity of the nodes, the complexity of each node's catalog, and how often the nodes check in.
 
 ### Initial memory recommendations
 

--- a/documentation/upgrade.markdown
+++ b/documentation/upgrade.markdown
@@ -8,7 +8,7 @@ layout: default
 [connect_master]: ./connect_puppet_master.html
 [connect_apply]: ./connect_puppet_apply.html
 [tracker]: https://tickets.puppetlabs.com/browse/PDB
-[start_source]: ./install_from_source.html#step-6-start-the-puppetdb-service
+[start_source]: ./install_from_source.html#step-4-start-the-puppetdb-service
 [plugin_source]: ./connect_puppet_master.html#on-platforms-without-packages
 [module]: ./install_via_module.html
 [puppetdb3]: /puppetdb/3.2/migrate.html

--- a/documentation/using.markdown
+++ b/documentation/using.markdown
@@ -4,7 +4,7 @@ layout: default
 canonical: "/puppetdb/latest/using.html"
 ---
 
-[exported]: /puppet/latest/reference/lang_exported.html
+[exported]: {{puppet}}/lang_exported.html
 
 
 Currently, PuppetDB's primary use is enabling advanced Puppet features. As use becomes more widespread, we expect additional applications to be built on PuppetDB.


### PR DESCRIPTION
I went through our most recent broken link report and fixed a bunch of stuff from the PuppetDB docs. I also switched to "magic URLs" for a few cross-project links. (So once a version of PE includes this PuppetDB version, links from here will go to THAT specific PE version, not just /latest/.)