### PR TITLE
(maint) update support guide and faq

### DIFF
--- a/documentation/pdb_support_guide.markdown
+++ b/documentation/pdb_support_guide.markdown
@@ -244,6 +244,22 @@ for information on these settings.
 
 There are a few things to watch for in the PDB dashboard:
 
+* Low catalog duplication rate: PuppetDB includes some optimizations built on
+  the assumption that the catalog for a given node changes relatively
+  infrequently. Namely, when PuppetDB receives a catalog for a node that hashes
+  to the same value as the node's previous catalog, PuppetDB will
+  simply update the timestamp associated with the last catalog, rather than
+  insert the data again. This works fine most of the time, but is failure prone
+  in cases where aspects of the catalog are guaranteed to change on every run.
+  For example, if the catalog contains a resource that embeds the current
+  timestamp, the hashes will never match and additional work must be done to
+  assess which resources need to be replaced. The catalog duplication rate
+  metric in the dashboard shows the ratio of hash matches to catalogs received.
+  Typically the duplication rate will be above 70%, and often above 90%. If
+  your duplication rate is substantially lower than this, it may be worth
+  investigating whether anything can be done to reduce the rate of change
+  between runs.
+
 * Deep command queue: Under sustainable conditions, the command queue depth
   should be in the neighborhood of 0-100 most of the time, with occasional
   spikes allowed. If the command queue is deeper than 10,000 for any extended

--- a/documentation/puppetdb-faq.markdown
+++ b/documentation/puppetdb-faq.markdown
@@ -6,7 +6,7 @@ subtitle: "Frequently asked questions"
 
 [maintaining_tuning]: ./maintain_and_tune.html
 [connect_puppet_apply]: ./connect_puppet_apply.html
-[low_catalog_dupe]: ./trouble_low_catalog_duplication.html
+[support_guide]: ./pdb_support_guide.markdown
 [puppetdb3]: /puppetdb/3.2/migrate.html
 [threads]: ./configure.html#threads
 [concurrent-writes]: ./configure.html#concurrent-writes
@@ -111,24 +111,14 @@ PuppetDB will error with this message if the IP address associated with the
 ssl-host parameter in the jetty.ini isn't linked to a known interface or
 resolvable.
 
-## Why is the load so high on the database server?
+## Why is PuppetDB using so much CPU?
 
-There are many possible reasons for a high load on the database server,
-including the total number of nodes managed by Puppet, the frequency of the
-agent runs, and the number of changes to the nodes on each run. One possible
-cause of execessive load on the database server is a low catalog duplication
-rate. See the [PuppetDB dashboard][maintaining_tuning] to find this rate for
-your PuppetDB instance. If this rate is significantly lower than 90%, see
-[Why is my catalog duplication rate so low?](#why-is-my-catalog-duplication-rate-so-low).
-
-## Why is my catalog duplication rate so low?
-
-The catalog duplication rate can be found on the
-[dashboard][maintaining_tuning]. Typically, the duplication rate should be 90%
-or above. If the duplication rate is lower, it might cause a much heavier I/O
-load on the database. Refer to the
-[low catalog duplication troubleshooting guide][low_catalog_dupe] for help
-diagnosing the problem.
+There are numerous possible contributing factors to high CPU usage by PuppetDB,
+both on the application server and (if different) the database. Examples
+include the total number of nodes managed by Puppet, the frequency of the agent
+runs, and the number of changes to the nodes on each run. For more information
+on possible causes and ways to mitigate them, refer to the [support and
+troubleshooting guide][support_guide].
 
 ## My Puppet master is running slower since I enabled PuppetDB. How can I profile it?
 


### PR DESCRIPTION
Update the FAQ to remove dead links to the old catalog duplication page.
Fold some of the information from that duplication page into the support
guide, and link to that instead.