### PR TITLE
(PDB-3175) Fix transient AMQ upgrade failures

### DIFF
--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -27,7 +27,7 @@
             [puppetlabs.puppetdb.config :as conf]
             [puppetlabs.puppetdb.reports :as reports]
             [puppetlabs.puppetdb.testutils
-             :refer [args-supplied call-counter dotestseq times-called mock-fn]]
+             :refer [args-supplied call-counter dotestseq times-called mock-fn default-timeout-ms]]
             [puppetlabs.puppetdb.test-protocols :refer [called?]]
             [puppetlabs.puppetdb.jdbc :refer [query-to-vec] :as jdbc]
             [puppetlabs.puppetdb.jdbc-test :refer [full-sql-exception-msg]]
@@ -115,9 +115,6 @@
 
 (defn store-command' [q old-command]
   (apply tqueue/store-command q (unroll-old-command old-command)))
-
-(def default-timeout-ms
-  (* 1000 60 5))
 
 (defn take-with-timeout!!
   "Takes from `port` via <!!, but will throw an exception if

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -456,3 +456,6 @@
              (Semaphore. 100))
     false
     nil)))
+
+(def default-timeout-ms
+  (* 1000 60 5))


### PR DESCRIPTION
The issue is startup will proceed if all messages from AMQ have been
enqueued, but doesn't ensure that the messages have finished processing
before startup can proceed. CI server slowness exposed issues in our
tests that assumed if the service has started, the messages have been
processed.