### PR TITLE
(MAINT) Remove classname/subprotocol from tests

### DIFF
--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -82,6 +82,9 @@
               x))
     metrics))
 
+(defn strip-retired-config [config]
+  (update config :database dissoc :classname :subprotocol))
+
 (defn call-with-puppetdb-instance
   "Stands up a puppetdb instance with the specified config, calls f,
   and then tears the instance down, binding *server* to the instance
@@ -103,6 +106,7 @@
    (when (zero? bind-attempts)
      (throw (RuntimeException. "Repeated attempts to bind port failed, giving up")))
    (let [config (-> config
+                    strip-retired-config
                     conf/adjust-and-validate-tk-config
                     assoc-open-port)
          port (or (get-in config [:jetty :port])


### PR DESCRIPTION
This specifically removes the fields from our "call-with-pdb-instance"
tests which leads test output like:

  The [database] classname setting has been retired and will be ignored.
  The [database] subprotocol setting has been retired and will be ignored.