### PR TITLE
(PDB-2909) Update clojure.java.jdbc usage

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,7 @@
 
                  ;; Database connectivity
                  [com.zaxxer/HikariCP "2.4.3" :exclusions [org.slf4j/slf4j-api]]
-                 [org.clojure/java.jdbc "0.4.2"]
+                 [org.clojure/java.jdbc "0.5.8"]
                  [org.postgresql/postgresql "9.4.1208.jre7"]
 
                  ;; MQ connectivity

--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,7 @@
 
                  ;; Database connectivity
                  [com.zaxxer/HikariCP "2.4.3" :exclusions [org.slf4j/slf4j-api]]
-                 [org.clojure/java.jdbc "0.5.8"]
+                 [org.clojure/java.jdbc "0.6.1"]
                  [org.postgresql/postgresql "9.4.1208.jre7"]
 
                  ;; MQ connectivity

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -56,29 +56,38 @@
       (finally (.setAutoCommit conn orig)))))
 
 (defn insert!
-  "Calls clojure.jdbc/insert! after adding (jdbc/db) as the first argument."
-  {:arglists '([table row-map :transaction? true :entities identity]
-               [table row-map & row-maps :transaction? true :entities identity]
-               [table col-name-vec col-val-vec
-                & col-val-vecs :transaction? true :entities identity])}
-  [table & options]
-  (apply sql/insert! *db* table options))
+  "Inserts a single row in either map form or lists of columns & values form. The
+  database to use is given by (jdbc/db). Returns a one-element sequence with the
+  inserted row as returned by the database."
+  ([table row]
+   (sql/insert! *db* table row {}))
+  ([table columns values]
+   (sql/insert! *db* table columns values {})))
+
+(defn insert-multi!
+  "Inserts multiple rows in either map form or lists of columns & values form. The
+  database to use is given by (jdbc/db). Returns a sequence with every inserted
+  row as returned by the database."
+  ;; since clojure.java.jdbc will open a connection even when given an empty
+  ;; rows or values sequence, bypass it here if either of those are empty
+  ([table rows]
+   (if (seq rows)
+     (sql/insert-multi! *db* table rows {})
+     ()))
+  ([table columns values]
+   (if (seq values)
+     (sql/insert-multi! *db* table columns values {})
+     ())))
 
 (defn update!
   "Calls clojure.jdbc/update! after adding (jdbc/db) as the first argument."
-  {:arglists '([[table set-map where-clause
-                 & {:keys [entities transaction?]
-                    :or {entities identity transaction? true}}]])}
-  [table set-map where-clause & options]
-  (apply sql/update! *db* table set-map where-clause options))
+  [table set-map where-clause]
+  (sql/update! *db* table set-map where-clause {}))
 
 (defn delete!
   "Calls clojure.jdbc/delete! after adding (jdbc/db) as the first argument."
-  {:arglists '([table where-clause
-                & {:keys [entities transaction?]
-                   :or {entities identity transaction? true}}])}
-  [table where-clause & options]
-  (apply sql/delete! *db* table where-clause options))
+  [table where-clause]
+  (sql/delete! *db* table where-clause {}))
 
 (defn query
   "Calls clojure.jdbc/query after adding (jdbc/db) as the first argument."

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -465,12 +465,12 @@
 
       (sql/create-table-ddl
        :factsets_transform
-       ["id" "bigint NOT NULL DEFAULT nextval('factsets_id_seq')"]
-       ["certname" "text NOT NULL"]
-       ["timestamp" "timestamp with time zone NOT NULL"]
-       ["environment_id" "bigint"]
-       ["hash" hash-type]
-       ["producer_timestamp" "timestamp with time zone NOT NULL"])
+       [["id" "bigint NOT NULL DEFAULT nextval('factsets_id_seq')"]
+        ["certname" "text NOT NULL"]
+        ["timestamp" "timestamp with time zone NOT NULL"]
+        ["environment_id" "bigint"]
+        ["hash" hash-type]
+        ["producer_timestamp" "timestamp with time zone NOT NULL"]])
 
       "INSERT INTO factsets_transform
          (id, certname, timestamp, environment_id, producer_timestamp)
@@ -479,14 +479,14 @@
 
       (sql/create-table-ddl
        :fact_values_transform
-       ["id" "bigint NOT NULL DEFAULT nextval('fact_values_id_seq')"]
-       ["value_hash" hash-type "NOT NULL"]
-       ["value_type_id" "bigint NOT NULL"]
-       ["value_integer" "bigint"]
-       ["value_float" "double precision"]
-       ["value_string" "text"]
-       ["value_boolean" "boolean"]
-       ["value_json" "text"])
+       [["id" "bigint NOT NULL DEFAULT nextval('fact_values_id_seq')"]
+        ["value_hash" hash-type "NOT NULL"]
+        ["value_type_id" "bigint NOT NULL"]
+        ["value_integer" "bigint"]
+        ["value_float" "double precision"]
+        ["value_string" "text"]
+        ["value_boolean" "boolean"]
+        ["value_json" "text"]])
 
       (str "INSERT INTO fact_values_transform
               (id, value_hash, value_type_id, value_integer, value_float,
@@ -497,8 +497,8 @@
                 FROM fact_values")
 
       (sql/create-table-ddl :resource_params_cache_transform
-                            ["resource" hash-type "NOT NULL"]
-                            ["parameters" "TEXT"])
+                            [["resource" hash-type "NOT NULL"]
+                             ["parameters" "TEXT"]])
 
       (str "INSERT INTO resource_params_cache_transform
               (resource, parameters)
@@ -507,14 +507,14 @@
 
       (sql/create-table-ddl
        :catalog_resources_transform
-       ["catalog_id" "bigint NOT NULL"]
-       ["resource" hash-type "NOT NULL"]
-       ["tags" (sutils/sql-array-type-string "TEXT") "NOT NULL"]
-       ["type" "TEXT" "NOT NULL"]
-       ["title" "TEXT" "NOT NULL"]
-       ["exported" "BOOLEAN" "NOT NULL"]
-       ["file" "TEXT"]
-       ["line" "INT"])
+       [["catalog_id" "bigint NOT NULL"]
+        ["resource" hash-type "NOT NULL"]
+        ["tags" (sutils/sql-array-type-string "TEXT") "NOT NULL"]
+        ["type" "TEXT" "NOT NULL"]
+        ["title" "TEXT" "NOT NULL"]
+        ["exported" "BOOLEAN" "NOT NULL"]
+        ["file" "TEXT"]
+        ["line" "INT"]])
 
       (str "INSERT INTO catalog_resources_transform
               (resource, catalog_id, tags, type, title, exported, file, line)
@@ -523,9 +523,9 @@
                 FROM catalog_resources")
 
       (sql/create-table-ddl :resource_params_transform
-                            ["resource" hash-type "NOT NULL"]
-                            ["name"  "TEXT" "NOT NULL"]
-                            ["value" "TEXT" "NOT NULL"])
+                            [["resource" hash-type "NOT NULL"]
+                             ["name"  "TEXT" "NOT NULL"]
+                             ["value" "TEXT" "NOT NULL"]])
 
       (str "INSERT INTO resource_params_transform
               (resource, name, value)
@@ -533,10 +533,10 @@
                 FROM resource_params")
 
       (sql/create-table-ddl :edges_transform
-                            ["certname" "TEXT" "NOT NULL"]
-                            ["source" hash-type "NOT NULL"]
-                            ["target" hash-type "NOT NULL"]
-                            ["type" "TEXT" "NOT NULL"])
+                            [["certname" "TEXT" "NOT NULL"]
+                             ["source" hash-type "NOT NULL"]
+                             ["target" hash-type "NOT NULL"]
+                             ["type" "TEXT" "NOT NULL"]])
 
       (str "INSERT INTO edges_transform (certname, source, target, type)
               SELECT certname, " (munge-hash "source") ",
@@ -547,15 +547,15 @@
 
       (sql/create-table-ddl
        :catalogs_transform
-       ["id" "bigint NOT NULL DEFAULT nextval('catalogs_id_seq')"]
-       ["hash" hash-type "NOT NULL"]
-       ["transaction_uuid" uuid-type]
-       ["certname" "text NOT NULL"]
-       ["producer_timestamp" "timestamp with time zone NOT NULL"]
-       ["api_version" "INTEGER NOT NULL"]
-       ["timestamp" "TIMESTAMP WITH TIME ZONE"]
-       ["catalog_version" "TEXT NOT NULL"]
-       ["environment_id" "bigint"])
+       [["id" "bigint NOT NULL DEFAULT nextval('catalogs_id_seq')"]
+        ["hash" hash-type "NOT NULL"]
+        ["transaction_uuid" uuid-type]
+        ["certname" "text NOT NULL"]
+        ["producer_timestamp" "timestamp with time zone NOT NULL"]
+        ["api_version" "INTEGER NOT NULL"]
+        ["timestamp" "TIMESTAMP WITH TIME ZONE"]
+        ["catalog_version" "TEXT NOT NULL"]
+        ["environment_id" "bigint"]])
 
       (str "INSERT INTO catalogs_transform
               (id, hash, transaction_uuid, certname, producer_timestamp,
@@ -571,24 +571,24 @@
 
       (sql/create-table-ddl
        :reports_transform
-       ["id" "bigint NOT NULL DEFAULT nextval('reports_id_seq')"]
-       ["hash" hash-type "NOT NULL"]
-       ["transaction_uuid" uuid-type]
-       ["certname" "text NOT NULL"]
-       ["puppet_version" "varchar(255) NOT NULL"]
-       ["report_format" "smallint NOT NULL"]
-       ["configuration_version" "varchar(255) NOT NULL"]
-       ["start_time" "timestamp with time zone NOT NULL"]
-       ["end_time" "timestamp with time zone NOT NULL"]
-       ["receive_time" "timestamp with time zone NOT NULL"]
-       ;; Insert a column in reports to be populated by boolean noop flag
-       ["noop" "boolean"]
-       ["environment_id" "bigint"]
-       ["status_id" "bigint"]
-       ;; Insert columns in reports to be populated by metrics and logs.
-       ;; Text for hsql, JSON for postgres.
-       ["metrics" json-type]
-       ["logs" json-type])
+       [["id" "bigint NOT NULL DEFAULT nextval('reports_id_seq')"]
+        ["hash" hash-type "NOT NULL"]
+        ["transaction_uuid" uuid-type]
+        ["certname" "text NOT NULL"]
+        ["puppet_version" "varchar(255) NOT NULL"]
+        ["report_format" "smallint NOT NULL"]
+        ["configuration_version" "varchar(255) NOT NULL"]
+        ["start_time" "timestamp with time zone NOT NULL"]
+        ["end_time" "timestamp with time zone NOT NULL"]
+        ["receive_time" "timestamp with time zone NOT NULL"]
+        ;; Insert a column in reports to be populated by boolean noop flag
+        ["noop" "boolean"]
+        ["environment_id" "bigint"]
+        ["status_id" "bigint"]
+        ;; Insert columns in reports to be populated by metrics and logs.
+        ;; Text for hsql, JSON for postgres.
+        ["metrics" json-type]
+        ["logs" json-type]])
 
       (str "INSERT INTO reports_transform (
             hash, certname, puppet_version, report_format, configuration_version,
@@ -601,19 +601,19 @@
 
       (sql/create-table-ddl
        :resource_events_transform
-       ["report_id" "bigint NOT NULL"]
-       ["status" "varchar(40) NOT NULL"]
-       ["timestamp" "timestamp with time zone NOT NULL"]
-       ["resource_type" "text NOT NULL"]
-       ["resource_title" "text NOT NULL"]
-       ["property" "varchar (40)"]
-       ["new_value" "text"]
-       ["old_value" "text"]
-       ["message" "text"]
-       ["file" "varchar(1024) DEFAULT NULL"]
-       ["line" "integer"]
-       ["containment_path" (sutils/sql-array-type-string "TEXT")]
-       ["containing_class" "varchar(255)"])
+       [["report_id" "bigint NOT NULL"]
+        ["status" "varchar(40) NOT NULL"]
+        ["timestamp" "timestamp with time zone NOT NULL"]
+        ["resource_type" "text NOT NULL"]
+        ["resource_title" "text NOT NULL"]
+        ["property" "varchar (40)"]
+        ["new_value" "text"]
+        ["old_value" "text"]
+        ["message" "text"]
+        ["file" "varchar(1024) DEFAULT NULL"]
+        ["line" "integer"]
+        ["containment_path" (sutils/sql-array-type-string "TEXT")]
+        ["containing_class" "varchar(255)"]])
 
       (str "INSERT INTO resource_events_transform (
             report_id, status, timestamp, resource_type, resource_title, property,
@@ -628,9 +628,9 @@
       (sql/create-table-ddl
        :certnames_transform
        ;; Rename the 'name' column of certnames to 'certname'.
-       ["certname" "text NOT NULL"]
-       ["latest_report_id" "bigint"]
-       ["deactivated" "timestamp with time zone"])
+       [["certname" "text NOT NULL"]
+        ["latest_report_id" "bigint"]
+        ["deactivated" "timestamp with time zone"]])
 
       (str "INSERT INTO certnames_transform(certname,latest_report_id,deactivated)
             SELECT c.name, rt.id as latest_report_id, c.deactivated FROM
@@ -939,11 +939,11 @@
    (sql/create-table-ddl
     :certnames_transform
     ;; Rename the 'name' column of certnames to 'certname'.
-    ["id" "bigint NOT NULL PRIMARY KEY default nextval('certname_id_seq')"]
-    ["certname" "text NOT NULL UNIQUE"]
-    ["latest_report_id" "bigint"]
-    ["deactivated" "timestamp with time zone"]
-    ["expired" "timestamp with time zone"])
+    [["id" "bigint NOT NULL PRIMARY KEY default nextval('certname_id_seq')"]
+     ["certname" "text NOT NULL UNIQUE"]
+     ["latest_report_id" "bigint"]
+     ["deactivated" "timestamp with time zone"]
+     ["expired" "timestamp with time zone"]])
 
    "INSERT INTO certnames_transform
      (certname, latest_report_id, deactivated, expired)
@@ -971,20 +971,20 @@
   (jdbc/do-commands
    (sql/create-table-ddl
     :resource_events_transform
-    ["report_id" "bigint NOT NULL"]
-    ["certname_id" "bigint NOT NULL"]
-    ["status" "varchar(40) NOT NULL"]
-    ["timestamp" "timestamp with time zone NOT NULL"]
-    ["resource_type" "text NOT NULL"]
-    ["resource_title" "text NOT NULL"]
-    ["property" "varchar (40)"]
-    ["new_value" "text"]
-    ["old_value" "text"]
-    ["message" "text"]
-    ["file" "varchar(1024) DEFAULT NULL"]
-    ["line" "integer"]
-    ["containment_path" (sutils/sql-array-type-string "TEXT")]
-    ["containing_class" "varchar(255)"])
+    [["report_id" "bigint NOT NULL"]
+     ["certname_id" "bigint NOT NULL"]
+     ["status" "varchar(40) NOT NULL"]
+     ["timestamp" "timestamp with time zone NOT NULL"]
+     ["resource_type" "text NOT NULL"]
+     ["resource_title" "text NOT NULL"]
+     ["property" "varchar (40)"]
+     ["new_value" "text"]
+     ["old_value" "text"]
+     ["message" "text"]
+     ["file" "varchar(1024) DEFAULT NULL"]
+     ["line" "integer"]
+     ["containment_path" (sutils/sql-array-type-string "TEXT")]
+     ["containing_class" "varchar(255)"]])
 
    "INSERT INTO resource_events_transform (
        report_id, certname_id, status, timestamp, resource_type, resource_title,
@@ -1035,8 +1035,8 @@
   (jdbc/do-commands
     (sql/create-table-ddl
       :producers
-      ["id" "bigint PRIMARY KEY"]
-      ["name" "text NOT NULL UNIQUE"])
+      [["id" "bigint PRIMARY KEY"]
+       ["name" "text NOT NULL UNIQUE"]])
     "CREATE SEQUENCE producers_id_seq CYCLE"
     "ALTER TABLE producers ALTER COLUMN id SET DEFAULT nextval('producers_id_seq')"
     "ALTER TABLE reports ADD COLUMN producer_id bigint"
@@ -1090,8 +1090,8 @@
   []
   (jdbc/do-commands
     (sql/create-table-ddl :resource_params_cache_transform
-                          ["resource" "bytea NOT NULL"]
-                          ["parameters" "jsonb"]))
+                          [["resource" "bytea NOT NULL"]
+                           ["parameters" "jsonb"]]))
 
   (migrate-through-app
     :resource_params_cache
@@ -1120,14 +1120,14 @@
   []
   (jdbc/do-commands
     (sql/create-table-ddl :fact_values_transform
-                          ["id" "bigint NOT NULL PRIMARY KEY DEFAULT nextval('fact_values_id_seq')"]
-                          ["value_hash" "bytea NOT NULL UNIQUE"]
-                          ["value_type_id" "bigint NOT NULL"]
-                          ["value_integer" "bigint"]
-                          ["value_float" "double precision"]
-                          ["value_string" "text"]
-                          ["value_boolean" "boolean"]
-                          ["value" "jsonb"]))
+                          [["id" "bigint NOT NULL PRIMARY KEY DEFAULT nextval('fact_values_id_seq')"]
+                           ["value_hash" "bytea NOT NULL UNIQUE"]
+                           ["value_type_id" "bigint NOT NULL"]
+                           ["value_integer" "bigint"]
+                           ["value_float" "double precision"]
+                           ["value_string" "text"]
+                           ["value_boolean" "boolean"]
+                           ["value" "jsonb"]]))
 
   (migrate-through-app
     :fact_values

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -60,14 +60,6 @@
             [puppetlabs.puppetdb.config :as conf]
             [puppetlabs.i18n.core :refer [trs]]))
 
-;; taken from storage.clj; preserved here in case of change
-(defn insert-records*
-  "Nil/empty safe insert-records, see java.jdbc's insert-records for more "
-  [table
-   record-coll]
-  (when (seq record-coll)
-    (apply jdbc/insert! table record-coll)))
-
 (defn init-through-2-3-8
   []
 
@@ -1092,8 +1084,7 @@
       [(format "select %s from %s" columns (name table1))]
       #(->> %
             (map munge-fn)
-            (map (partial jdbc/insert! (name table2)))
-            dorun))))
+            (jdbc/insert-multi! (name table2))))))
 
 (defn resource-params-cache-parameters-to-jsonb
   []

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -240,7 +240,7 @@
 (defn vacuum-analyze
   [db]
   (sql/with-db-connection [conn db]
-    (sql/execute! db ["vacuum analyze"] :transaction? false)))
+    (sql/execute! db ["vacuum analyze"] {:transaction? false})))
 
 (defn parse-db-hash
   [db-hash]

--- a/test/puppetlabs/puppetdb/jdbc_test.clj
+++ b/test/puppetlabs/puppetdb/jdbc_test.clj
@@ -4,7 +4,7 @@
             [puppetlabs.puppetdb.testutils.db
              :refer [*db* antonym-data
                      create-temp-db
-                     insert-map
+                     insert-entries
                      defaulted-read-db-config
                      defaulted-write-db-config
                      call-with-antonym-test-database
@@ -35,7 +35,7 @@
                             subject/pooled-datasource)]
          (with-open [_ (:datasource write-pool)]
            (subject/with-transacted-connection write-pool
-             (insert-map {"foo" 1})
+             (insert-entries {"foo" 1})
              (is (= [{:value "1"}]
                     (subject/query-to-vec
                      "SELECT value FROM test WHERE key='foo'"))))))
@@ -45,7 +45,7 @@
          (with-open [_ (:datasource read-pool)]
            (subject/with-transacted-connection read-pool
              (let [msg (try
-                         (insert-map {"bar" 1})
+                         (insert-entries {"bar" 1})
                          ""
                          (catch java.sql.SQLException ex
                            (full-sql-exception-msg ex)))]

--- a/test/puppetlabs/puppetdb/query/population_test.clj
+++ b/test/puppetlabs/puppetdb/query/population_test.clj
@@ -19,33 +19,34 @@
         (is (= 0 (pop/num-resources))))
 
       (testing "should only count current resources"
-        (jdbc/insert! :certnames
-                      {:certname "h1" :id 1}
-                      {:certname "h2" :id 2})
+        (jdbc/insert-multi! :certnames
+                            [{:certname "h1" :id 1}
+                             {:certname "h2" :id 2}])
 
         (deactivate-node! "h2")
 
-        (jdbc/insert! :catalogs
-                      {:id 1 :hash (sutils/munge-hash-for-storage "c1")
-                       :api_version 1 :catalog_version "1"
-                       :certname "h1" :producer_timestamp (to-timestamp (now))}
-                      {:id 2 :hash (sutils/munge-hash-for-storage "c2")
-                       :api_version 1 :catalog_version "1"
-                       :certname "h2" :producer_timestamp (to-timestamp (now))})
+        (jdbc/insert-multi!
+          :catalogs
+          [{:id 1 :hash (sutils/munge-hash-for-storage "c1")
+            :api_version 1 :catalog_version "1"
+            :certname "h1" :producer_timestamp (to-timestamp (now))}
+           {:id 2 :hash (sutils/munge-hash-for-storage "c2")
+            :api_version 1 :catalog_version "1"
+            :certname "h2" :producer_timestamp (to-timestamp (now))}])
 
-        (jdbc/insert!
-         :resource_params_cache
-         {:resource (sutils/munge-hash-for-storage "01") :parameters nil}
-         {:resource (sutils/munge-hash-for-storage "02") :parameters nil}
-         {:resource (sutils/munge-hash-for-storage "03") :parameters nil})
+        (jdbc/insert-multi!
+          :resource_params_cache
+          [{:resource (sutils/munge-hash-for-storage "01") :parameters nil}
+           {:resource (sutils/munge-hash-for-storage "02") :parameters nil}
+           {:resource (sutils/munge-hash-for-storage "03") :parameters nil}])
 
-        (jdbc/insert!
+        (jdbc/insert-multi!
          :catalog_resources
-         {:certname_id 1 :resource (sutils/munge-hash-for-storage "01") :type "Foo" :title "Bar" :exported true :tags (to-jdbc-varchar-array [])}
-         ;; c2's resource shouldn'sutils/munge-hash-for-storage t be counted, as they don't correspond to an active node
-         {:certname_id 2 :resource (sutils/munge-hash-for-storage "01") :type "Foo" :title "Baz" :exported true :tags (to-jdbc-varchar-array [])}
-         {:certname_id 1 :resource (sutils/munge-hash-for-storage "02") :type "Foo" :title "Boo" :exported true :tags (to-jdbc-varchar-array [])}
-         {:certname_id 1 :resource (sutils/munge-hash-for-storage "03") :type "Foo" :title "Goo" :exported true :tags (to-jdbc-varchar-array [])})
+          [{:certname_id 1 :resource (sutils/munge-hash-for-storage "01") :type "Foo" :title "Bar" :exported true :tags (to-jdbc-varchar-array [])}
+           ;; c2's resource shouldn'sutils/munge-hash-for-storage t be counted, as they don't correspond to an active node
+           {:certname_id 2 :resource (sutils/munge-hash-for-storage "01") :type "Foo" :title "Baz" :exported true :tags (to-jdbc-varchar-array [])}
+           {:certname_id 1 :resource (sutils/munge-hash-for-storage "02") :type "Foo" :title "Boo" :exported true :tags (to-jdbc-varchar-array [])}
+           {:certname_id 1 :resource (sutils/munge-hash-for-storage "03") :type "Foo" :title "Goo" :exported true :tags (to-jdbc-varchar-array [])}])
 
         (sutils/vacuum-analyze *db*)
         (is (= 4 (pop/num-resources)))))))
@@ -57,9 +58,9 @@
         (is (= 0 (pop/num-active-nodes))))
 
       (testing "should only count active nodes"
-        (jdbc/insert! :certnames
-                      {:certname "h1"}
-                      {:certname "h2"})
+        (jdbc/insert-multi! :certnames
+                            [{:certname "h1"}
+                             {:certname "h2"}])
 
         (is (= 2 (pop/num-active-nodes)))
 
@@ -75,31 +76,31 @@
         (is (= 0 (pop/pct-resource-duplication))))
 
       (testing "should equal (total-unique) / total"
-        (jdbc/insert! :certnames
-                      {:certname "h1"}
-                      {:certname "h2"})
+        (jdbc/insert-multi! :certnames
+                            [{:certname "h1"}
+                             {:certname "h2"}])
 
-        (jdbc/insert!
+        (jdbc/insert-multi!
          :catalogs
-         {:id 1 :hash (sutils/munge-hash-for-storage "c1") :api_version 1
-          :transaction_uuid (sutils/munge-uuid-for-storage "68b08e2a-eeb1-4322-b241-bfdf151d294b")
-          :catalog_version "1" :certname "h1" :producer_timestamp (to-timestamp (now))}
-         {:id 2 :hash (sutils/munge-hash-for-storage "c2") :api_version 1
-          :transaction_uuid (sutils/munge-uuid-for-storage "68b08e2a-eeb1-4322-b241-bfdf151d294b")
-          :catalog_version "1" :certname "h2" :producer_timestamp (to-timestamp (now))})
+          [{:id 1 :hash (sutils/munge-hash-for-storage "c1") :api_version 1
+            :transaction_uuid (sutils/munge-uuid-for-storage "68b08e2a-eeb1-4322-b241-bfdf151d294b")
+            :catalog_version "1" :certname "h1" :producer_timestamp (to-timestamp (now))}
+           {:id 2 :hash (sutils/munge-hash-for-storage "c2") :api_version 1
+            :transaction_uuid (sutils/munge-uuid-for-storage "68b08e2a-eeb1-4322-b241-bfdf151d294b")
+            :catalog_version "1" :certname "h2" :producer_timestamp (to-timestamp (now))}])
 
-        (jdbc/insert!
+        (jdbc/insert-multi!
          :resource_params_cache
-         {:resource (sutils/munge-hash-for-storage "01") :parameters nil}
-         {:resource (sutils/munge-hash-for-storage "02") :parameters nil}
-         {:resource (sutils/munge-hash-for-storage "03") :parameters nil})
+          [{:resource (sutils/munge-hash-for-storage "01") :parameters nil}
+           {:resource (sutils/munge-hash-for-storage "02") :parameters nil}
+           {:resource (sutils/munge-hash-for-storage "03") :parameters nil}])
 
-        (jdbc/insert!
+        (jdbc/insert-multi!
          :catalog_resources
-         {:certname_id 1 :resource  (sutils/munge-hash-for-storage "01") :type "Foo" :title "Bar" :exported true :tags (to-jdbc-varchar-array [])}
-         {:certname_id 2 :resource  (sutils/munge-hash-for-storage "01") :type "Foo" :title "Baz" :exported true :tags (to-jdbc-varchar-array [])}
-         {:certname_id 1 :resource  (sutils/munge-hash-for-storage "02") :type "Foo" :title "Boo" :exported true :tags (to-jdbc-varchar-array [])}
-         {:certname_id 1 :resource  (sutils/munge-hash-for-storage "03") :type "Foo" :title "Goo" :exported true :tags (to-jdbc-varchar-array [])})
+          [{:certname_id 1 :resource  (sutils/munge-hash-for-storage "01") :type "Foo" :title "Bar" :exported true :tags (to-jdbc-varchar-array [])}
+           {:certname_id 2 :resource  (sutils/munge-hash-for-storage "01") :type "Foo" :title "Baz" :exported true :tags (to-jdbc-varchar-array [])}
+           {:certname_id 1 :resource  (sutils/munge-hash-for-storage "02") :type "Foo" :title "Boo" :exported true :tags (to-jdbc-varchar-array [])}
+           {:certname_id 1 :resource  (sutils/munge-hash-for-storage "03") :type "Foo" :title "Goo" :exported true :tags (to-jdbc-varchar-array [])}])
 
         (let [total  4
               unique 3

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -101,36 +101,37 @@
                       {:status "testing1" :id 1})
         (jdbc/insert! :environments
                       {:id 1 :name "testing1"})
-        (jdbc/insert! :certnames
-                      {:name "testing1" :deactivated nil}
-                      {:name "testing2" :deactivated nil})
-        (jdbc/insert! :reports
-                      {:hash "01"
-                       :configuration_version  "thisisacoolconfigversion"
-                       :transaction_uuid "bbbbbbbb-2222-bbbb-bbbb-222222222222"
-                       :certname "testing1"
-                       :puppet_version "0.0.0"
-                       :report_format 1
-                       :start_time current-time
-                       :end_time current-time
-                       :receive_time current-time
-                       :environment_id 1
-                       :status_id 1}
-                      {:hash "0000"
-                       :transaction_uuid "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"
-                       :configuration_version "blahblahblah"
-                       :certname "testing2"
-                       :puppet_version "911"
-                       :report_format 1
-                       :start_time current-time
-                       :end_time current-time
-                       :receive_time current-time
-                       :environment_id 1
-                       :status_id 1})
+        (jdbc/insert-multi! :certnames
+                            [{:name "testing1" :deactivated nil}
+                             {:name "testing2" :deactivated nil}])
+        (jdbc/insert-multi!
+          :reports
+          [{:hash "01"
+            :configuration_version  "thisisacoolconfigversion"
+            :transaction_uuid "bbbbbbbb-2222-bbbb-bbbb-222222222222"
+            :certname "testing1"
+            :puppet_version "0.0.0"
+            :report_format 1
+            :start_time current-time
+            :end_time current-time
+            :receive_time current-time
+            :environment_id 1
+            :status_id 1}
+           {:hash "0000"
+            :transaction_uuid "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"
+            :configuration_version "blahblahblah"
+            :certname "testing2"
+            :puppet_version "911"
+            :report_format 1
+            :start_time current-time
+            :end_time current-time
+            :receive_time current-time
+            :environment_id 1
+            :status_id 1}])
 
-        (jdbc/insert! :latest_reports
-                      {:report "01" :certname "testing1"}
-                      {:report "0000" :certname "testing2"})
+        (jdbc/insert-multi! :latest_reports
+                            [{:report "01" :certname "testing1"}
+                             {:report "0000" :certname "testing2"}])
 
         (apply-migration-for-testing! 29)
 
@@ -167,40 +168,41 @@
                       {:status "testing1" :id 1})
         (jdbc/insert! :environments
                       {:id 1 :environment "testing1"})
-        (jdbc/insert! :certnames
-                      {:certname "testing1" :deactivated nil}
-                      {:certname "testing2" :deactivated nil})
-        (jdbc/insert! :reports
-                      {:hash (sutils/munge-hash-for-storage "01")
-                       :transaction_uuid (sutils/munge-uuid-for-storage
-                                          "bbbbbbbb-2222-bbbb-bbbb-222222222222")
-                       :configuration_version "thisisacoolconfigversion"
-                       :certname "testing1"
-                       :puppet_version "0.0.0"
-                       :report_format 1
-                       :start_time current-time
-                       :end_time current-time
-                       :receive_time current-time
-                       :producer_timestamp current-time
-                       :environment_id 1
-                       :status_id 1
-                       :metrics (sutils/munge-json-for-storage [{:foo "bar"}])
-                       :logs (sutils/munge-json-for-storage [{:bar "baz"}])}
-                      {:hash (sutils/munge-hash-for-storage "0000")
-                       :transaction_uuid (sutils/munge-uuid-for-storage
-                                          "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa")
-                       :configuration_version "blahblahblah"
-                       :certname "testing2"
-                       :puppet_version "911"
-                       :report_format 1
-                       :start_time current-time
-                       :end_time current-time
-                       :receive_time current-time
-                       :producer_timestamp current-time
-                       :environment_id 1
-                       :status_id 1
-                       :metrics (sutils/munge-json-for-storage [{:foo "bar"}])
-                       :logs (sutils/munge-json-for-storage [{:bar "baz"}])})
+        (jdbc/insert-multi! :certnames
+                            [{:certname "testing1" :deactivated nil}
+                             {:certname "testing2" :deactivated nil}])
+        (jdbc/insert-multi!
+          :reports
+          [{:hash (sutils/munge-hash-for-storage "01")
+            :transaction_uuid (sutils/munge-uuid-for-storage
+                                "bbbbbbbb-2222-bbbb-bbbb-222222222222")
+            :configuration_version "thisisacoolconfigversion"
+            :certname "testing1"
+            :puppet_version "0.0.0"
+            :report_format 1
+            :start_time current-time
+            :end_time current-time
+            :receive_time current-time
+            :producer_timestamp current-time
+            :environment_id 1
+            :status_id 1
+            :metrics (sutils/munge-json-for-storage [{:foo "bar"}])
+            :logs (sutils/munge-json-for-storage [{:bar "baz"}])}
+           {:hash (sutils/munge-hash-for-storage "0000")
+            :transaction_uuid (sutils/munge-uuid-for-storage
+                                "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa")
+            :configuration_version "blahblahblah"
+            :certname "testing2"
+            :puppet_version "911"
+            :report_format 1
+            :start_time current-time
+            :end_time current-time
+            :receive_time current-time
+            :producer_timestamp current-time
+            :environment_id 1
+            :status_id 1
+            :metrics (sutils/munge-json-for-storage [{:foo "bar"}])
+            :logs (sutils/munge-json-for-storage [{:bar "baz"}])}])
 
         (jdbc/update! :certnames
                       {:latest_report_id 1}
@@ -313,10 +315,10 @@
                               {:certname "baz.com"
                                :hash (sutils/munge-hash-for-storage "abc123")}])]
 
-      (apply jdbc/insert! :certnames (map (fn [{:keys [certname]}]
+      (jdbc/insert-multi! :certnames (map (fn [{:keys [certname]}]
                                             {:certname certname :deactivated nil})
                                           factset-data))
-      (apply jdbc/insert! :factsets factset-data)
+      (jdbc/insert-multi! :factsets factset-data)
 
       (is (= 2 (:c (first (query-to-vec "SELECT count(*) as c FROM factsets where hash is null")))))
 

--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -269,8 +269,8 @@
                    "blandness"  "zest"
                    "lethargy"   "zest"})
 
-(defn insert-map [data]
-  (apply (partial jdbc/insert! :test [:key :value]) data))
+(defn insert-entries [m]
+  (jdbc/insert-multi! :test [:key :value] (seq m)))
 
 (defn call-with-antonym-test-database
   [function]
@@ -280,7 +280,7 @@
        (sql/create-table-ddl :test
                              [:key "VARCHAR(256)" "PRIMARY KEY"]
                              [:value "VARCHAR(256)" "NOT NULL"]))
-      (insert-map antonym-data))
+      (insert-entries antonym-data))
     (function)))
 
 (def indexes-sql

--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -278,8 +278,8 @@
     (jdbc/with-db-transaction []
       (jdbc/do-commands
        (sql/create-table-ddl :test
-                             [:key "VARCHAR(256)" "PRIMARY KEY"]
-                             [:value "VARCHAR(256)" "NOT NULL"]))
+                             [[:key "VARCHAR(256)" "PRIMARY KEY"]
+                              [:value "VARCHAR(256)" "NOT NULL"]]))
       (insert-entries antonym-data))
     (function)))
 

--- a/test/puppetlabs/puppetdb/testutils/resources.clj
+++ b/test/puppetlabs/puppetdb/testutils/resources.clj
@@ -13,46 +13,47 @@
   ([] (store-example-resources true))
   ([environment?]
    (jdbc/with-transacted-connection *db*
-     (jdbc/insert!
+     (jdbc/insert-multi!
        :resource_params_cache
-       {:resource (sutils/munge-hash-for-storage "01")
-        :parameters (sutils/munge-jsonb-for-storage
-                      {"ensure" "file"
-                       "owner"  "root"
-                       "group"  "root"
-                       "acl"    ["john:rwx" "fred:rwx"]})}
-       {:resource (sutils/munge-hash-for-storage "02")
-        :parameters nil})
-     (jdbc/insert!
+       [{:resource (sutils/munge-hash-for-storage "01")
+         :parameters (sutils/munge-jsonb-for-storage
+                       {"ensure" "file"
+                        "owner"  "root"
+                        "group"  "root"
+                        "acl"    ["john:rwx" "fred:rwx"]})}
+        {:resource (sutils/munge-hash-for-storage "02")
+         :parameters nil}])
+     (jdbc/insert-multi!
        :resource_params
-       {:resource (sutils/munge-hash-for-storage "01") :name "ensure"
-        :value (sutils/db-serialize "file")}
-       {:resource (sutils/munge-hash-for-storage "01") :name "owner"
-        :value (sutils/db-serialize "root")}
-       {:resource (sutils/munge-hash-for-storage "01") :name "group"
-        :value (sutils/db-serialize "root")}
-       {:resource (sutils/munge-hash-for-storage "01") :name "acl"
-        :value (sutils/db-serialize ["john:rwx" "fred:rwx"])})
-       (jdbc/insert!
+       [{:resource (sutils/munge-hash-for-storage "01") :name "ensure"
+         :value (sutils/db-serialize "file")}
+        {:resource (sutils/munge-hash-for-storage "01") :name "owner"
+         :value (sutils/db-serialize "root")}
+        {:resource (sutils/munge-hash-for-storage "01") :name "group"
+         :value (sutils/db-serialize "root")}
+        {:resource (sutils/munge-hash-for-storage "01") :name "acl"
+         :value (sutils/db-serialize ["john:rwx" "fred:rwx"])}])
+       (jdbc/insert-multi!
         :certnames
-        {:id 1 :certname "one.local"}
-        {:id 2 :certname "two.local"})
-       (jdbc/insert!
+         [{:id 1 :certname "one.local"}
+          {:id 2 :certname "two.local"}])
+       (jdbc/insert-multi!
         :catalogs
-        {:id 1
-         :hash (sutils/munge-hash-for-storage "f0")
-         :api_version 1
-         :catalog_version "12"
-         :certname "one.local"
-         :producer_timestamp (to-timestamp (now))
-         :environment_id (when environment? (ensure-environment "DEV"))}
-        {:id 2
-         :hash (sutils/munge-hash-for-storage "ba")
-         :api_version 1
-         :catalog_version "14"
-         :certname "two.local"
-         :producer_timestamp (to-timestamp (now))
-         :environment_id (when environment? (ensure-environment "PROD"))})
+         [{:id 1
+           :hash (sutils/munge-hash-for-storage "f0")
+           :api_version 1
+           :catalog_version "12"
+           :certname "one.local"
+           :producer_timestamp (to-timestamp (now))
+           :environment_id (when environment? (ensure-environment "DEV"))}
+          {:id 2
+           :hash (sutils/munge-hash-for-storage "ba")
+           :api_version 1
+           :catalog_version "14"
+           :certname "two.local"
+           :producer_timestamp (to-timestamp (now))
+           :environment_id (when environment? (ensure-environment "PROD"))}])
+
        (add-facts! {:certname "one.local"
                     :values {"operatingsystem" "Debian"
                              "kernel" "Linux"
@@ -71,20 +72,20 @@
                     :producer_timestamp (to-timestamp (now))
                     :producer "foo.com"})
 
-       (jdbc/insert!
+       (jdbc/insert-multi!
         :catalog_resources
-        {:certname_id 1 :resource (sutils/munge-hash-for-storage "01")
-         :type "File" :title "/etc/passwd" :exported false
-         :tags (to-jdbc-varchar-array ["one" "two"])}
-        {:certname_id 1 :resource (sutils/munge-hash-for-storage "02")
-         :type "Notify" :title "hello" :exported false
-         :tags (to-jdbc-varchar-array [])}
-        {:certname_id 2 :resource (sutils/munge-hash-for-storage "01")
-         :type "File" :title "/etc/passwd" :exported false
-         :tags (to-jdbc-varchar-array ["one" "two"])}
-        {:certname_id 2 :resource (sutils/munge-hash-for-storage "02")
-         :type "Notify" :title "hello" :exported true :file "/foo/bar" :line 22
-         :tags (to-jdbc-varchar-array [])}))
+         [{:certname_id 1 :resource (sutils/munge-hash-for-storage "01")
+           :type "File" :title "/etc/passwd" :exported false
+           :tags (to-jdbc-varchar-array ["one" "two"])}
+          {:certname_id 1 :resource (sutils/munge-hash-for-storage "02")
+           :type "Notify" :title "hello" :exported false
+           :tags (to-jdbc-varchar-array [])}
+          {:certname_id 2 :resource (sutils/munge-hash-for-storage "01")
+           :type "File" :title "/etc/passwd" :exported false
+           :tags (to-jdbc-varchar-array ["one" "two"])}
+          {:certname_id 2 :resource (sutils/munge-hash-for-storage "02")
+           :type "Notify" :title "hello" :exported true :file "/foo/bar" :line 22
+           :tags (to-jdbc-varchar-array [])}]))
 
      {:foo1 {:certname   "one.local"
              :resource   "01"


### PR DESCRIPTION
Update PuppetDB's usage of clojure.java.jdbc to the most recent non-alpha release, changing the shadow JDBC API implementation in `puppetdb.jdbc` accordingly. The `puppetdb.jdbc` API didn't change in any significant way, though some unused functionality (namely transaction booleans) was removed. See the individual commit messages for more details.