### PR TITLE
(PDB-3188) Clarify the RBAC permissions required for PuppetDB data

### DIFF
--- a/documentation/api/query/curl.markdown
+++ b/documentation/api/query/curl.markdown
@@ -61,12 +61,13 @@ generating RBAC tokens and how they work in the
 [PE documention](https://docs.puppet.com/pe/latest/rbac_token_auth.html).
 
 **Note:** The token the user is for must have the correct permissions for
-viewing or editting node data depending on the operation.
+viewing (`nodes:view_data:*`) or editing (`nodes:edit_data:*`) node data
+depending on the operation.
 
     curl 'https://<your.puppetdb.server>:8081/pdb/query/v4/nodes' \
       -H "X-Authentication: <token contents>"
       --tlsv1 \
-      --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem \
+      --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem
       
 **Note:** PE 2016.2 users will need to set `client-auth = want` under the
 `[jetty]` header of their jetty.ini configuration. Later versions of PE have


### PR DESCRIPTION
This commit clarifies the permissions required for accessing PuppetDB
data with a token.