### PR TITLE
(PDB-3191) Attempt to flush output before exit

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -272,7 +272,7 @@
   This function will return true iff any migrations were run."
   [db-conn-pool config]
   (jdbc/with-db-connection db-conn-pool
-    (scf-store/validate-database-version #(System/exit 1))
+    (scf-store/validate-database-version #(utils/flush-and-exit 1))
     @sutils/db-metadata
     (let [migrated? (migrate! db-conn-pool)]
       (indexes! config)

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -353,9 +353,7 @@
                             " please remove this item from your config."
                             " PuppetDB has a non-configurable context route of `/pdb`."
                             " Consult the documentation for more details."))
-    (flush)
-    (binding [*out* *err*] (flush))
-    (System/exit 1)) ; cf. PDB-2053
+    (utils/flush-and-exit 1)) ; cf. PDB-2053
   config-data)
 
 (def default-web-router-config

--- a/src/puppetlabs/puppetdb/core.clj
+++ b/src/puppetlabs/puppetdb/core.clj
@@ -88,4 +88,4 @@
 
 (defn -main
   [& args]
-  (run-command #(System/exit 0) #(System/exit 1) args))
+  (run-command #(utils/flush-and-exit 0) #(utils/flush-and-exit 1) args))

--- a/src/puppetlabs/puppetdb/main.clj
+++ b/src/puppetlabs/puppetdb/main.clj
@@ -3,8 +3,12 @@
 
    Used by our main startup scripts, to avoid having to variabilize the
    sub-command within ezbake."
-  (:require [puppetlabs.puppetdb.core :as core]))
+  (:require
+   [puppetlabs.puppetdb.core :as core]
+   [puppetlabs.puppetdb.utils :refer [flush-and-exit]]))
 
 (defn -main
   [& args]
-  (core/run-command #(System/exit 0) #(System/exit 1) (cons "services" args)))
+  (core/run-command #(flush-and-exit 0)
+                    #(flush-and-exit 1)
+                    (cons "services" args)))

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -51,6 +51,7 @@
             [clojure.tools.logging :as log]
             [clojure.string :as string]
             [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.utils :refer [flush-and-exit]]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [clojure.set :refer :all]
@@ -1237,11 +1238,11 @@
 
 (defn- sql-or-die
   "Calls (f) and returns its result.  If f throws an SQLException,
-  logs the exception and its parent and then calls (System/exit 1)"
+  logs the exception and its parent and then calls (flush-and-exit 1)"
   [f]
   ;; Here we've preserved existing behavior, but this may warrant
   ;; further consideration later.  If possible, we might want to
-  ;; avoid System/exit in favor of careful exception
+  ;; avoid flush-and-exit in favor of careful exception
   ;; handling (cf. PDB-1118).
   (try
     (f)
@@ -1250,7 +1251,7 @@
       (when-let [next (.getNextException e)]
         (log/error next (trs "Unravelled exception")))
       (binding [*out* *err*] (flush)) (flush)
-      (System/exit 1))))
+      (flush-and-exit 1))))
 
 (defn previous-migrations
   "Returns the list of migration numbers that existed before the

--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -8,7 +8,8 @@
             [puppetlabs.puppetdb.scf.migrate :refer [migrate!]]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.schema :refer [transform-data]]
-            [puppetlabs.puppetdb.testutils :refer [pprint-str]]))
+            [puppetlabs.puppetdb.testutils :refer [pprint-str]]
+            [puppetlabs.puppetdb.utils :refer [flush-and-exit]]))
 
 (defn valid-sql-id? [id]
   (re-matches #"[a-zA-Z][a-zA-Z0-9_]*" id))
@@ -22,7 +23,7 @@
         (binding [*out* *err*]
           (println (format "Invalid test %s name %s" who (pr-str name)))
           (flush))
-        (System/exit 1)))
+        (flush-and-exit 1)))
     {:host (env :pdb-test-db-host "127.0.0.1")
      :port (env :pdb-test-db-port 5432)
      :user {:name user


### PR DESCRIPTION
While we may still want to pursue a more coherent exit strategy
eventually (PDB-2053), this hopes to make it less likely that we'll lose
output (diagnostic or otherwise) when we quit via System/exit.

The underlying issue is that the JVM does not necessarily flush stdout
or stderr during a System/exit.