### PR TITLE
(maint) add test-unit gem to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,10 @@ gem 'facter'
 gem 'rake'
 
 group :test do
+
+  # Add test-unit for ruby 2.2+ support (has been removed from stdlib)
+  gem 'test-unit'
+
   # Pinning for Ruby 1.9.3 support
   gem 'json_pure', '~> 1.8'
   # Pinning for Ruby < 2.2.0 support


### PR DESCRIPTION
Add test-unit gem to gemfile. This was apparently removed from ruby
stdlib in 2.2.0, and has become necessary since we've bumped our CI
tests to use ruby 2.3.0.