### PR TITLE
(PDB-3207) Backport ezbake reload and logback file-sized based rotation

### DIFF
--- a/documentation/maintain_and_tune.markdown
+++ b/documentation/maintain_and_tune.markdown
@@ -62,7 +62,11 @@ PuppetDB will react to certain types of processing failures by storing a complet
 
 PuppetDB's log file lives at `/var/log/puppetlabs/puppetdb/puppetdb.log`. Check the log when you need to confirm that PuppetDB is working correctly or to troubleshoot visible malfunctions. If you have changed the logging settings, examine the [logback.xml file][logback] to find the log.
 
-The PuppetDB packages install a logrotate job in `/etc/logrotate.d/puppetdb`, which will keep the log from becoming too large.
+The PuppetDB packages configure log file rotation via Logback in order to keep
+log files from becoming too large.  The "logback.xml" file contains the rotation
+parameters.  By default, the active log file is compressed into a .gz file if
+it exceeds 200 MB in size.  At most 90 days and at most 1 GB of the most recent
+.gz archives are preserved on disk.
 
 ## Tune the max heap size
 

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
    :password :env/nexus_jenkins_password
    :sign-releases false})
 
-(def tk-version "1.4.1")
+(def tk-version "1.5.1")
 (def tk-jetty9-version "1.5.9")
 (def ks-version "1.3.1")
 (def tk-status-version "0.4.0")
@@ -81,7 +81,7 @@
                  [puppetlabs/trapperkeeper-metrics "0.2.0" :exclusions [ring/ring-defaults org.slf4j/slf4j-api]]
                  [prismatic/schema "1.1.2"]
                  [trptcolin/versioneer "0.2.0"]
-                 [puppetlabs/trapperkeeper-status ~tk-status-version]
+                 [puppetlabs/trapperkeeper-status ~tk-status-version :exclusions [org.slf4j/slf4j-api]]
                  [org.clojure/tools.macro "0.1.5"]
                  [com.novemberain/pantomime "2.1.0"]
                  [fast-zip-visit "1.0.2"]
@@ -140,7 +140,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "0.5.1"
+                      :plugins [[puppetlabs/lein-ezbake "1.1.3"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}

--- a/project.clj
+++ b/project.clj
@@ -111,7 +111,8 @@
                        :group "puppetdb"
                        :build-type "foss"
                        :main-namespace "puppetlabs.puppetdb.main"
-                       :repo-target "PC1"}
+                       :repo-target "PC1"
+                       :logrotate-enabled false}
                 :config-dir "ext/config/foss"
                 }
 

--- a/resources/ext/cli/config-migration
+++ b/resources/ext/cli/config-migration
@@ -99,6 +99,7 @@ function replaceline {
   tmp="$3.tmp.$(date +%s)"
   sed "s/$1/$(echo "$2" | sed -e 's/[\/&]/\\&/g')/g" "$3" > "$tmp"
   mv "$tmp" "$3"
+  chmod 644 "$3"
 }
 
 # This funtion gives a generic error message if a given path or file isn't found

--- a/resources/ext/cli/ssl-setup.erb
+++ b/resources/ext/cli/ssl-setup.erb
@@ -101,6 +101,7 @@ function replaceline {
   tmp=$3.tmp.`date +%s`
   sed "s/$1/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g" $3 > $tmp
   mv $tmp $3
+  chmod 644 $3
 }
 
 # This function comments out a line in a file, based on a regexp

--- a/resources/ext/config/logback.xml
+++ b/resources/ext/config/logback.xml
@@ -10,8 +10,8 @@
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
-            <maxFileSize>10MB</maxFileSize>
+            <!-- each file should be at most 200MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>200MB</maxFileSize>
             <maxHistory>90</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
@@ -36,8 +36,8 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- rollover daily -->
             <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-status-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
-            <maxFileSize>10MB</maxFileSize>
+            <!-- each file should be at most 200MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>200MB</maxFileSize>
             <maxHistory>90</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>

--- a/resources/ext/config/logback.xml
+++ b/resources/ext/config/logback.xml
@@ -30,6 +30,28 @@
     <logger name="org.apache.activemq.store.kahadb.MessageDatabase"
         level="info"/>
 
+    <appender name="STATUS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/var/log/puppetlabs/puppetdb/puppetdb-status.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- rollover daily -->
+            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-status-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <!-- note that this will only log the JSON message (%m) and a newline (%n)-->
+            <pattern>%m%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- without additivity="false", the status log messages will be sent to every other appender as well-->
+    <logger name="puppetlabs.trapperkeeper.services.status.status-debug-logging" additivity="false">
+        <appender-ref ref="STATUS"/>
+    </logger>
+
     <root level="info">
         <appender-ref ref="${logappender:-DUMMY}" />
         <appender-ref ref="F1" />

--- a/resources/ext/config/logback.xml
+++ b/resources/ext/config/logback.xml
@@ -7,10 +7,13 @@
 
     <appender name="F1" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/var/log/puppetlabs/puppetdb/puppetdb.log</file>
-
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>10MB</maxFileSize>
             <maxHistory>90</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
             <pattern>%d %-5p [%c{2}] %m%n</pattern>

--- a/resources/ext/config/request-logging.xml
+++ b/resources/ext/config/request-logging.xml
@@ -1,6 +1,14 @@
 <configuration debug="false">
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/var/log/puppetlabs/puppetdb/puppetdb-access.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-access-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
         <encoder>
             <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D</pattern>
         </encoder>

--- a/resources/ext/config/request-logging.xml
+++ b/resources/ext/config/request-logging.xml
@@ -4,8 +4,8 @@
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-access-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
-            <maxFileSize>10MB</maxFileSize>
+            <!-- each file should be at most 200MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>200MB</maxFileSize>
             <maxHistory>90</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>


### PR DESCRIPTION
This PR backports changes done originally for the PuppetDB 4.2.4 release for:

1) Adding a 'reload' action (via ezbake) that the service framework can use to
    HUP the puppetdb service.

2) Add file-size based log rotation to the logback configuration.

This PR includes cherry-picks of commits from the following PRs that were
previously merged for the 4.2.4 release: #2087, #2091, #2097, #2098, and
#2102.