### PR TITLE
Change where clause on fact nodes to operate on smaller table

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -469,7 +469,7 @@
                                   [:= :fv.value_type_id :vt.id]]
                            :left-join [[:environments :env]
                                        [:= :fs.environment_id :env.id]]
-                           :where [:!= :fv.value_type_id 5]}
+                           :where [:!= :vt.id 5]}
 
                :relationships {;; Parents - direct
                                "facts" {:columns ["certname" "name"]}


### PR DESCRIPTION
Prior to this commit, the where clause operated on the fact_values
table which is a giant table compared to the value_types table.

After this comit, the where clause operates on the value_types
table.  The <> 5 filter forces a seq_scan of the table so doing
that on a table with 6 rows is better than doing it on a table with
100K rows.  Also, filtering on the smaller table first improves the
row estimates in the rest of the query as well.