### PR TITLE
(docs) Convert nav sidebar to Markdown

### DIFF
--- a/documentation/_puppetdb_nav.html
+++ b/documentation/_puppetdb_nav.html
@@ -1,4 +1,4 @@
-<h2 id="puppetdb">PuppetDB {{ page.doc.version }}</h2>
+<h2 id="puppetdb">PuppetDB {{ page.doc.my_versions.puppetdb }}</h2>
 
 <ul>
   <li><strong>General information</strong>

--- a/documentation/_puppetdb_nav.html
+++ b/documentation/_puppetdb_nav.html
@@ -1,133 +1,90 @@
 <h2 id="puppetdb">PuppetDB {{ page.doc.my_versions.puppetdb }}</h2>
 
-<ul>
-  <li><strong>General information</strong>
-    <ul>
-      <li><a href="{{puppetdb}}/index.html">Overview and requirements</a></li>
-      <li><a href="{{puppetdb}}/CONTRIBUTING.html">Contributing to PuppetDB</a></li>
-      <li><a href="{{puppetdb}}/puppetdb-faq.html">Frequently asked questions</a></li>
-      <li><a href="{{puppetdb}}/release_notes.html">Release notes</a></li>
-      <li><a href="{{puppetdb}}/versioning_policy.html">Versioning policy</a></li>
-      <li><a href="{{puppetdb}}/known_issues.html">Known issues</a></li>
-      <li><a href="{{puppetdb}}/community_add_ons.html">Community add-ons</a></li>
-    </ul>
-  </li>
-  <li><strong>Installation</strong>
-    <ul>
-      <li><a href="{{puppetdb}}/install_via_module.html">Installing via Puppet module</a></li>
-      <li><a href="{{puppetdb}}/install_from_packages.html">Installing from packages</a></li>
-      <li><a href="{{puppetdb}}/install_from_source.html">Installing from source</a></li>
-      <li><a href="{{puppetdb}}/upgrade.html">Upgrading PuppetDB</a></li>
-      <li><a href="{{puppetdb}}/connect_puppet_master.html">Connecting Puppet masters</a></li>
-      <li><a href="{{puppetdb}}/connect_puppet_apply.html">Connecting standalone Puppet nodes</a></li>
-    </ul>
-  </li>
-  <li><strong>Configuration</strong>
-    <ul>
-      <li><a href="{{puppetdb}}/configure.html">Configuring PuppetDB</a></li>
-      <li><a href="{{puppetdb}}/puppetdb_connection.html">puppetdb.conf: Configuring a Puppet/PuppetDB connection</a></li>
-      <li><a href="{{puppetdb}}/postgres_ssl.html">Setting up SSL for PostgreSQL</a></li>
-    </ul>
-  <li><strong>Usage/admin</strong>
-    <ul>
-      <li><a href="{{puppetdb}}/using.html">Using PuppetDB</a></li>
-      <li><a href="{{puppetdb}}/maintain_and_tune.html">Maintaining and tuning</a></li>
-      <li><a href="{{puppetdb}}/pdb_client_tools.html">PuppetDB CLI</a></li>
-      <li><a href="{{puppetdb}}/anonymization.html">Exporting and anonymizing data</a></li>
-      <li><a href="{{puppetdb}}/scaling_recommendations.html">Scaling recommendations</a></li>
-      <li><a href="{{puppetdb}}/repl.html">Debugging with remote REPL</a></li>
-      <li><a href="{{puppetdb}}/load_testing_tool.html">Load testing</a></li>
-    </ul>
-  </li>
-  <li><strong>Troubleshooting</strong>
-    <ul>
-      <li><a href="{{puppetdb}}/pdb_support_guide.html">General Support Guide</a></li>
-      <li><a href="{{puppetdb}}/trouble_low_catalog_duplication.html">Low catalog duplication</a></li>
-      <li><a href="{{puppetdb}}/trouble_session_logging.html">Session logging</a></li>
-    </ul>
-  </li>
-  <li><strong>PQL - Puppet Query Language (experimental)</strong></li>
-    <ul>
-      <li><a href="{{puppetdb}}/api/query/tutorial-pql.html">Tutorial</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/pql.html">Reference guide</a></li>
-      <li><a href="{{puppetdb}}/api/query/examples-pql.html">Examples</a></li>
-    </ul>
-  </li>
-  <li><strong>API</strong>
-    <ul>
-      <li><a href="{{puppetdb}}/api/index.html">Overview</a></li>
-      <li><a href="{{puppetdb}}/api/query/tutorial.html">Query tutorial</a></li>
-      <li><a href="{{puppetdb}}/api/query/curl.html">Curl tips</a></li>
-    </ul>
-  </li>
-  <li><strong>Query API version 4</strong>
-    <ul>
-      <li><a href="{{puppetdb}}/api/query/v4/upgrading-from-v3.html">Upgrading from version 3</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/query.html">Query structure</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/entities.html">Entities</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/ast.html">AST query language</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/paging.html">Query paging</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/index.html">Root endpoint (experimental)</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/nodes.html">Nodes endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/environments.html">Environments endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/producers.html">Producers endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/factsets.html">Factsets endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/facts.html">Facts endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/fact-names.html">Fact-names endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/fact-paths.html">Fact-paths endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/fact-contents.html">Fact-contents endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/inventory.html">Inventory endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/catalogs.html">Catalogs endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/resources.html">Resources endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/edges.html">Edges endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/reports.html">Reports endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/events.html">Events endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/event-counts.html">Event counts endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/query/v4/aggregate-event-counts.html">Aggregate event counts endpoint</a></li>
-    </ul>
-  </li>
+{% md %}
 
-  <li><strong>Extensions API version 1 (PE-only) </strong>
-      <ul>
-      <li><a href="{{puppetdb}}/api/ext/v1/state-overview.html">State overview endpoint</a></li>
-      </ul>
-  </li>
+* **General information**
+    * [Overview and requirements]({{puppetdb}}/index.html)
+    * [Contributing to PuppetDB]({{puppetdb}}/CONTRIBUTING.html)
+    * [Frequently asked questions]({{puppetdb}}/puppetdb-faq.html)
+    * [Release notes]({{puppetdb}}/release_notes.html)
+    * [Versioning policy]({{puppetdb}}/versioning_policy.html)
+    * [Known issues]({{puppetdb}}/known_issues.html)
+    * [Community add-ons]({{puppetdb}}/community_add_ons.html)
+* **Installation**
+    * [Installing via Puppet module]({{puppetdb}}/install_via_module.html)
+    * [Installing from packages]({{puppetdb}}/install_from_packages.html)
+    * [Installing from source]({{puppetdb}}/install_from_source.html)
+    * [Upgrading PuppetDB]({{puppetdb}}/upgrade.html)
+    * [Connecting Puppet masters]({{puppetdb}}/connect_puppet_master.html)
+    * [Connecting standalone Puppet nodes]({{puppetdb}}/connect_puppet_apply.html)
+* **Configuration**
+    * [Configuring PuppetDB]({{puppetdb}}/configure.html)
+    * [puppetdb.conf: Configuring a Puppet/PuppetDB connection]({{puppetdb}}/puppetdb_connection.html)
+    * [Setting up SSL for PostgreSQL]({{puppetdb}}/postgres_ssl.html)
+* **Usage/admin**
+    * [Using PuppetDB]({{puppetdb}}/using.html)
+    * [Maintaining and tuning]({{puppetdb}}/maintain_and_tune.html)
+    * [PuppetDB CLI]({{puppetdb}}/pdb_client_tools.html)
+    * [Exporting and anonymizing data]({{puppetdb}}/anonymization.html)
+    * [Scaling recommendations]({{puppetdb}}/scaling_recommendations.html)
+    * [Debugging with remote REPL]({{puppetdb}}/repl.html)
+    * [Load testing]({{puppetdb}}/load_testing_tool.html)
+* **Troubleshooting**
+    * [General Support Guide]({{puppetdb}}/pdb_support_guide.html)
+    * [Low catalog duplication]({{puppetdb}}/trouble_low_catalog_duplication.html)
+    * [Session logging]({{puppetdb}}/trouble_session_logging.html)
+* **PQL - Puppet Query Language (experimental)**
+    * [Tutorial]({{puppetdb}}/api/query/tutorial-pql.html)
+    * [Reference guide]({{puppetdb}}/api/query/v4/pql.html)
+    * [Examples]({{puppetdb}}/api/query/examples-pql.html)
 
-  <li><strong>Admin API version 1</strong>
-    <ul>
-      <li><a href="{{puppetdb}}/api/admin/v1/archive.html">Archive endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/admin/v1/cmd.html">Command (cmd) endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/admin/v1/summary-stats.html">Summary stats endpoint</a></li>
-    </ul>
-  </li>
-  <li><strong>Command API version 1</strong>
-    <ul>
-      <li><a href="{{puppetdb}}/api/command/v1/commands.html">Commands endpoint</a></li>
-    </ul>
-  </li>
-  <li><strong>Status API version 1</strong>
-      <ul>
-          <li><a href="{{puppetdb}}/api/status/v1/status.html">Status endpoint</a></li>
-      </ul>
-  </li>
-  <li><strong>Metadata API version 1</strong>
-    <ul>
-      <li><a href="{{puppetdb}}/api/meta/v1/version.html">Version endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/meta/v1/server-time.html">Server time endpoint</a></li>
-    </ul>
-  </li>
-  <li><strong>Metrics API version 1</strong>
-    <ul>
-      <li><a href="{{puppetdb}}/api/metrics/v1/mbeans.html">Metrics endpoint</a></li>
-      <li><a href="{{puppetdb}}/api/metrics/v1/changes-from-puppetdb-v3.html">Changes from PuppetDB version 3</a></li>
-    </ul>
-  </li>
-  <li><strong>Wire formats</strong>
-    <ul>
-      <li><a href="{{puppetdb}}/api/wire_format/catalog_format_v9.html">Catalog wire format - v9</a></li>
-      <li><a href="{{puppetdb}}/api/wire_format/facts_format_v5.html">Facts wire format - v5</a></li>
-      <li><a href="{{puppetdb}}/api/wire_format/report_format_v8.html">Report wire format - v8</a></li>
-      <li><a href="{{puppetdb}}/api/wire_format/deactivate_node_format_v3.html">Deactivate node wire format - v3</a></li>
-    </ul>
-  </li>
-</ul>
+* **API**
+    * [Overview]({{puppetdb}}/api/index.html)
+    * [Query tutorial]({{puppetdb}}/api/query/tutorial.html)
+    * [Curl tips]({{puppetdb}}/api/query/curl.html)
+* **Query API version 4**
+    * [Upgrading from version 3]({{puppetdb}}/api/query/v4/upgrading-from-v3.html)
+    * [Query structure]({{puppetdb}}/api/query/v4/query.html)
+    * [Entities]({{puppetdb}}/api/query/v4/entities.html)
+    * [AST query language]({{puppetdb}}/api/query/v4/ast.html)
+    * [Query paging]({{puppetdb}}/api/query/v4/paging.html)
+    * [Root endpoint (experimental)]({{puppetdb}}/api/query/v4/index.html)
+    * [Nodes endpoint]({{puppetdb}}/api/query/v4/nodes.html)
+    * [Environments endpoint]({{puppetdb}}/api/query/v4/environments.html)
+    * [Producers endpoint]({{puppetdb}}/api/query/v4/producers.html)
+    * [Factsets endpoint]({{puppetdb}}/api/query/v4/factsets.html)
+    * [Facts endpoint]({{puppetdb}}/api/query/v4/facts.html)
+    * [Fact-names endpoint]({{puppetdb}}/api/query/v4/fact-names.html)
+    * [Fact-paths endpoint]({{puppetdb}}/api/query/v4/fact-paths.html)
+    * [Fact-contents endpoint]({{puppetdb}}/api/query/v4/fact-contents.html)
+    * [Inventory endpoint]({{puppetdb}}/api/query/v4/inventory.html)
+    * [Catalogs endpoint]({{puppetdb}}/api/query/v4/catalogs.html)
+    * [Resources endpoint]({{puppetdb}}/api/query/v4/resources.html)
+    * [Edges endpoint]({{puppetdb}}/api/query/v4/edges.html)
+    * [Reports endpoint]({{puppetdb}}/api/query/v4/reports.html)
+    * [Events endpoint]({{puppetdb}}/api/query/v4/events.html)
+    * [Event counts endpoint]({{puppetdb}}/api/query/v4/event-counts.html)
+    * [Aggregate event counts endpoint]({{puppetdb}}/api/query/v4/aggregate-event-counts.html)
+* **Extensions API version 1 (PE-only)**
+    * [State overview endpoint]({{puppetdb}}/api/ext/v1/state-overview.html)
+* **Admin API version 1**
+    * [Archive endpoint]({{puppetdb}}/api/admin/v1/archive.html)
+    * [Command (cmd) endpoint]({{puppetdb}}/api/admin/v1/cmd.html)
+    * [Summary stats endpoint]({{puppetdb}}/api/admin/v1/summary-stats.html)
+* **Command API version 1**
+    * [Commands endpoint]({{puppetdb}}/api/command/v1/commands.html)
+* **Status API version 1**
+    * [Status endpoint]({{puppetdb}}/api/status/v1/status.html)
+* **Metadata API version 1**
+    * [Version endpoint]({{puppetdb}}/api/meta/v1/version.html)
+    * [Server time endpoint]({{puppetdb}}/api/meta/v1/server-time.html)
+* **Metrics API version 1**
+    * [Metrics endpoint]({{puppetdb}}/api/metrics/v1/mbeans.html)
+    * [Changes from PuppetDB version 3]({{puppetdb}}/api/metrics/v1/changes-from-puppetdb-v3.html)
+* **Wire formats**
+    * [Catalog wire format - v9]({{puppetdb}}/api/wire_format/catalog_format_v9.html)
+    * [Facts wire format - v5]({{puppetdb}}/api/wire_format/facts_format_v5.html)
+    * [Report wire format - v8]({{puppetdb}}/api/wire_format/report_format_v8.html)
+    * [Deactivate node wire format - v3]({{puppetdb}}/api/wire_format/deactivate_node_format_v3.html)
+
+{% endmd %}


### PR DESCRIPTION
We just did this for the newest versions of our other docs, because nested list elements in HTML are the illegible worst. This way you can easily see the tree structure without having to go crosseyed looking for that last missing `</ul>`.