### PR TITLE
(PDB-3228) Allow configuration of the ActiveMQ Broker's MemoryLimit

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -474,6 +474,18 @@ This setting sets the maximum amount of space in megabytes that PuppetDB's Activ
 
 This setting sets the maximum amount of space in megabytes that PuppetDB's ActiveMQ can use for temporary message storage.
 
+### `memory-usage`
+
+This setting sets the maximum amount of memory in megabytes available for
+PuppetDB's ActiveMQ Broker.
+
+**Warning** Setting this value too high (such that memory-usage exceeds the size
+of the heap) can cause out of memory (OOM) errors. ActiveMQ does not treat this
+as a hard limit. In testing, we've seen it use up to `125%` of the specified
+value, and overall memory usage will also be affected by the `max-command-size`
+and `threads` parameters.
+
+
 ### `max-frame-size`
 
 This setting sets the maximum frame size for persisted activemq messages

--- a/src/com/puppetlabs/mq.clj
+++ b/src/com/puppetlabs/mq.clj
@@ -4,6 +4,7 @@
   (:import [org.apache.activemq.broker BrokerService]
            [org.apache.activemq ScheduledMessage]
            [org.apache.activemq.usage SystemUsage]
+           [org.apache.activemq.usage SystemUsage MemoryUsage]
            [javax.jms Message TextMessage BytesMessage ExceptionListener MessageListener]
            [org.apache.activemq ActiveMQConnectionFactory]
            [org.springframework.jms.connection CachingConnectionFactory]
@@ -53,6 +54,15 @@
   [broker megabytes]
   (set-usage!* broker megabytes #(.getStoreUsage %) "StoreUsage"))
 
+(defn- set-memory-usage!
+  "Configures the `MemoryUsage` setting for an instance of `BrokerService`.
+  `broker`     - the `BrokerService` to configure
+  `megabytes ` - the maximum amount of memory usage to allow for the
+  BrokerService, or `nil` to use the default value of 1GB.
+  Returns the (potentially modified) `broker` object."
+  [broker megabytes]
+(set-usage!* broker megabytes #(.getMemoryUsage %) "MemoryUsage"))
+
 (defn- set-temp-usage!
   "Configures the `TempUsage` setting for an instance of `BrokerService`.
 
@@ -100,6 +110,7 @@
                (.setDataDirectory dir)
                (.setSchedulerSupport true)
                (.setPersistent true)
+	       (set-memory-usage! (:memory-usage config))
                (set-store-usage! (:store-usage config))
                (set-temp-usage!  (:temp-usage config)))
           mc (doto (.getManagementContext mq)

--- a/src/com/puppetlabs/puppetdb/config.clj
+++ b/src/com/puppetlabs/puppetdb/config.clj
@@ -104,7 +104,8 @@
    (s/optional-key :threads) (pls/defaulted-maybe s/Int half-the-cores)
    (s/optional-key :store-usage) s/Int
    (s/optional-key :max-frame-size) (pls/defaulted-maybe String "209715200")
-   (s/optional-key :temp-usage) s/Int})
+   (s/optional-key :temp-usage) s/Int
+   (s/optional-key :memory-usage) s/Int })
 
 (def command-processing-out
   "Schema for parsed/processed command processing config - currently incomplete"
@@ -112,7 +113,8 @@
    :threads s/Int
    :max-frame-size s/Str
    (s/optional-key :store-usage) s/Int
-   (s/optional-key :temp-usage) s/Int})
+   (s/optional-key :temp-usage) s/Int
+   (s/optional-key :memory-usage) s/Int})
 
 (def puppetdb-config-in
   "Schema for validating the [puppetdb] block"

--- a/test/com/puppetlabs/puppetdb/test/config.clj
+++ b/test/com/puppetlabs/puppetdb/test/config.clj
@@ -27,6 +27,10 @@
     (let [config (configure-command-params {:command-processing {:temp-usage 10000}})]
       (is (= (get-in config [:command-processing :temp-usage]) 10000))))
 
+    (testing "should use the memory-usage specified"
+      (let [config (configure-command-params {:command-processing {:memory-usage 10000}})]
+        (is (= (get-in config [:command-processing :memory-usage]) 10000))))
+
   (let [with-ncores (fn [cores]
                       (with-redefs [kitchensink/num-cpus (constantly cores)]
                         (half-the-cores*)))]

--- a/test/com/puppetlabs/test/mq.clj
+++ b/test/com/puppetlabs/test/mq.clj
@@ -98,12 +98,14 @@
 
           broker (build-embedded-broker "localhost" "somedir"
                       {:store-usage size-megs
-                       :temp-usage  size-megs})]
+                       :temp-usage  size-megs
+                       :memory-usage  size-megs})]
       (is (instance? BrokerService broker))
       (is (.. broker (getPersistenceAdapter) (isIgnoreMissingJournalfiles)))
       (is (.. broker (getPersistenceAdapter) (isArchiveCorruptedIndex)))
       (is (.. broker (getPersistenceAdapter) (isCheckForCorruptJournalFiles)))
       (is (.. broker (getPersistenceAdapter) (isChecksumJournalFiles)))
+      (is (= size-bytes (.. broker (getSystemUsage) (getMemoryUsage) (getLimit))))
       (is (= size-bytes (.. broker (getSystemUsage) (getStoreUsage) (getLimit))))
       (is (= size-bytes (.. broker (getSystemUsage) (getTempUsage) (getLimit)))))))
 


### PR DESCRIPTION
Same changes as https://github.com/puppetlabs/puppetdb/pull/1949/files (v 3.2) but to 2.3

https://tickets.puppetlabs.com/browse/PDB-3228?filter=-2

This commit adds the ability to configure the ActiveMQ Broker's
MemoryLimit in PuppetDB. Before this commit the MemoryLimit was always
the default 64MB.