### PR TITLE
(PDB-3056) pre_suite: fix gem install i18n

### DIFF
--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -88,7 +88,16 @@ unless (test_config[:skip_presuite_provisioning])
           on master, "gem install activerecord -v 3.2.17 --no-ri --no-rdoc -V --backtrace"
           on master, "gem install sqlite3 -v 1.3.9 --no-ri --no-rdoc -V --backtrace"
         else
-          on master, "apt-get install -y rubygems ruby-dev libsqlite3-dev build-essential"
+          if (master['platform'] =~ /^debian-8/)
+            # Required to address failure during i18n install:
+            # /usr/lib/x86_64-linux-gnu/ruby/2.1.0/openssl.so: symbol
+            # SSLv2_method, version OPENSSL_1.0.0 not defined in file
+            # libssl.so.1.0.0 with link time reference -
+            # /usr/lib/x86_64-linux-gnu/ruby/2.1.0/openssl.so
+            on master, "apt-get install -y openssl"
+          end
+
+          on master, "apt-get install -y ruby ruby-dev libsqlite3-dev build-essential"
           # this is to get around the activesupport dependency on Ruby 1.9.3 for
           # Ubuntu 12.04. We can remove it when we drop support for 1.8.7.
           on master, "gem install i18n -v 0.6.11"


### PR DESCRIPTION
On the Debian 8 hosts, "gem install i18n" is failing like this:

  # gem install i18n -v 0.6.11
  ERROR:  Loading command: install (LoadError)
          /usr/lib/x86_64-linux-gnu/ruby/2.1.0/openssl.so: symbol SSLv2_method, version OPENSSL_1.0.0 not defined in file libssl.so.1.0.0 with link time reference - /usr/lib/x86_64-linux-gnu/ruby/2.1.0/openssl.so
  ERROR:  While executing gem ... (NoMethodError)
      undefined method `invoke_with_build_args' for nil:NilClass

Fix it by upgrading to the latest available openssl.