### PR TITLE
(PDB-3209) Bump clj-parent to 0.3.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.2.5"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.3.0"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in


### PR DESCRIPTION
This includes a new version of trapperkeeper-metrics that fixes a bug
affecting PuppetDB. Specifically when requesting many metrics via
POST, a stream closed exception would occur. Bumping to 0.3.0 of
clj-parent will fix that.