### PR TITLE
(docs) Fix quoting error in frontmatter for ha.markdown and logging.m…

### DIFF
--- a/documentation/ha.markdown
+++ b/documentation/ha.markdown
@@ -1,7 +1,6 @@
 ---
 title: "PuppetDB 4.2: PuppetDB HA"
 layout: default
-canonical: "/puppetdb/latest/ha.html
 ---
 
 [configure]: ./configure.html

--- a/documentation/logging.markdown
+++ b/documentation/logging.markdown
@@ -1,7 +1,6 @@
 ---
 title: "PuppetDB 4.2 » Logging Configuration"
 layout: default
-canonical: "/puppetdb/latest/logging.html
 ---
 
 Structured logging
@@ -75,7 +74,7 @@ You can also log directly to logstash with an appender configured like this:
 You will also need to add a reference to the appender from the `<root>` element:
 
     <root>
-      ... 
+      ...
       <appender-ref ref="stash" />
     </root>
 


### PR DESCRIPTION
…arkdown

The unclosed quote in these pages was causing display errors on the site.

Since the `canonical` key is no longer necessary (we automatically set the
latest version as canonical now), I deleted it instead of closing the quote.