### PR TITLE
(PDB-3240) Convert log event to map for logging predicates

### DIFF
--- a/test/puppetlabs/puppetdb/testutils/log.clj
+++ b/test/puppetlabs/puppetdb/testutils/log.clj
@@ -10,7 +10,8 @@
    [ch.qos.logback.core.spi LifeCycle]
    [ch.qos.logback.classic Level Logger]
    [ch.qos.logback.classic.encoder PatternLayoutEncoder]
-   [org.slf4j LoggerFactory]))
+   [org.slf4j LoggerFactory]
+   [ch.qos.logback.classic.spi ILoggingEvent]))
 
 (defmacro with-started
   "Ensures that if a given name's init form executes without throwing
@@ -196,10 +197,15 @@
 ;;The below functions are useful with
 ;;puppetlabs.trapperkeeper.testutils.logging/with-log-suppressed-unless-notable
 
-(def critical-errors (comp #{:fatal :error} :level))
+(defn critical-errors
+  [^ILoggingEvent event]
+  (= Level/ERROR
+     (.getLevel event)))
 
 (defn starting-with
   "Filters log events that have a message starting with `string`"
   [string]
-  (fn [event]
-    (.startsWith (:message event) string)))
+  (fn [^ILoggingEvent event]
+    (-> event
+        .getMessage
+        (.startsWith string))))


### PR DESCRIPTION
The 'with-log-suppressed-unless-notable' macro passes it's predicates
log event objects, NOT the Clojure map versions created by the
event->map function. The predicates were written to expect the map
version. This resulted in ALL log messages being filtered out. This
commit makes that conversion in the predicates to ensure we don't
lose related log messages in tests.