### PR TITLE
(PDB-3234) Explicitly install python 2 on debs

### DIFF
--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -12,6 +12,22 @@ unless (test_config[:skip_presuite_provisioning])
     end
   end
 
+  step "Ensure python 2 is available" do
+    master_os = test_config[:os_families][master.name]
+    case master_os
+    when :debian
+      on master, "apt-get -y install python"
+    end
+
+    databases.each do |database|
+      os = test_config[:os_families][database.name]
+      case os
+      when :debian
+        on database, "apt-get -y install python"
+      end
+    end
+  end
+
   step "Install other dependencies on database" do
     databases.each do |database|
       os = test_config[:os_families][database.name]


### PR DESCRIPTION
It looks like Ubuntu 16.10 may no longer have "python" available by
default, so make sure it's explicitly installed on Debian derivatives in
the pre-suite.