### PR TITLE
(PDB-3247) Bump timeout in testutils sync-command-post to 20sec

### DIFF
--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -308,10 +308,10 @@
   "Syncronously post a command to PDB by blocking until the message is consumed
    off the queue."
   [base-url cmd version payload]
-  (let [timeout-seconds 10]
+  (let [timeout-seconds 20]
     (let [response (pdb-client/submit-command-via-http! base-url cmd version payload timeout-seconds)]
       (if (>= (:status response) 400)
-        (throw (ex-info "Command processing failed" {:response response}))
+        (throw (RuntimeException. (format "Command processing failed: %s" response)))
         response))))
 
 (defn wait-for-server-processing


### PR DESCRIPTION
This commit bumps the testutils sync-command-post to 20sec aligning it
with the 4.x branches of PuppetDB, which should avoid some errors caused
by Jenkins testing performance.

This commit also changes the sync-command-post to not use ex-info and
throw a formated string error instead so that lein test will format the
actual error response instead of hiding it.