### PR TITLE
(PDB-3108) Add producer-timestamp to the command header, enable "bash in place"

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -22,8 +22,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   def extract_extra_request_data(request)
     {
       :transaction_uuid => request.options[:transaction_uuid],
-      :environment => request.environment.to_s,
-      :producer_timestamp => request.options[:producer_timestamp] || Time.now.iso8601(5),
+      :environment => request.environment.to_s
     }
   end
 
@@ -100,7 +99,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   # @return [Hash] returns original hash augmented with producer_timestamp
   # @api private
   def add_producer_timestamp(hash, producer_timestamp)
-    hash['producer_timestamp'] = producer_timestamp
+    hash['producer_timestamp'] = Puppet::Util::Puppetdb.to_wire_time(Time.now)
 
     hash
   end

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -18,6 +18,9 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
 
   def save(request)
     profile("facts#save", [:puppetdb, :facts, :save, request.key]) do
+
+      current_time = Time.now
+
       payload = profile("Encode facts command submission payload",
                         [:puppetdb, :facts, :encode]) do
         facts = request.instance.dup
@@ -30,12 +33,12 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
           # when we attempt to use ActiveSupport 2.3.16 on RHEL 5 with
           # legacy storeconfigs.
           "environment" => request.options[:environment] || request.environment.to_s,
-          "producer_timestamp" => Puppet::Util::Puppetdb.to_wire_time(Time.now),
+          "producer_timestamp" => Puppet::Util::Puppetdb.to_wire_time(current_time),
           "producer" => Puppet[:node_name_value]
         }
       end
 
-      submit_command(request.key, payload, CommandReplaceFacts, 5)
+      submit_command(request.key, payload, CommandReplaceFacts, 5, current_time.clone.utc)
     end
   end
 

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -30,7 +30,7 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
           # when we attempt to use ActiveSupport 2.3.16 on RHEL 5 with
           # legacy storeconfigs.
           "environment" => request.options[:environment] || request.environment.to_s,
-          "producer_timestamp" => request.options[:producer_timestamp] || Time.now.iso8601(5),
+          "producer_timestamp" => Puppet::Util::Puppetdb.to_wire_time(Time.now),
           "producer" => Puppet[:node_name_value]
         }
       end

--- a/puppet/lib/puppet/indirector/node/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/node/puppetdb.rb
@@ -13,7 +13,7 @@ class Puppet::Node::Puppetdb < Puppet::Indirector::REST
 
   def destroy(request)
     payload = { :certname => request.key,
-                :producer_timestamp => request.options[:producer_timestamp] || Time.now.iso8601(5) }
+                :producer_timestamp => Puppet::Util::Puppetdb.to_wire_time(Time.now) }
     submit_command(request.key, payload, CommandDeactivateNode, 3)
   end
 end

--- a/puppet/lib/puppet/indirector/node/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/node/puppetdb.rb
@@ -12,8 +12,10 @@ class Puppet::Node::Puppetdb < Puppet::Indirector::REST
   end
 
   def destroy(request)
+    current_time = Time.now
     payload = { :certname => request.key,
-                :producer_timestamp => Puppet::Util::Puppetdb.to_wire_time(Time.now) }
-    submit_command(request.key, payload, CommandDeactivateNode, 3)
+                :producer_timestamp => Puppet::Util::Puppetdb.to_wire_time(current_time) }
+
+    submit_command(request.key, payload, CommandDeactivateNode, 3, current_time.clone.utc)
   end
 end

--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -19,7 +19,9 @@ Puppet::Reports.register_report(:puppetdb) do
   # @return [void]
   def process
     profile("report#process", [:puppetdb, :report, :process]) do
-      submit_command(self.host, report_to_hash, CommandStoreReport, 8)
+      current_time = Time.now
+      report_hash = report_to_hash(current_time)
+      submit_command(self.host, report_hash, CommandStoreReport, 8, current_time.utc)
     end
 
     nil
@@ -30,7 +32,7 @@ Puppet::Reports.register_report(:puppetdb) do
   #
   # @return Hash[<String, Object>]
   # @api private
-  def report_to_hash
+  def report_to_hash(producer_timestamp)
     profile("Convert report to wire format hash",
             [:puppetdb, :report, :convert_to_wire_format_hash]) do
       if environment.nil?
@@ -53,7 +55,7 @@ Puppet::Reports.register_report(:puppetdb) do
         "puppet_version" => puppet_version,
         "report_format" => report_format,
         "configuration_version" => configuration_version.to_s,
-        "producer_timestamp" => Puppet::Util::Puppetdb.to_wire_time(Time.now),
+        "producer_timestamp" => Puppet::Util::Puppetdb.to_wire_time(producer_timestamp),
         "start_time" => Puppet::Util::Puppetdb.to_wire_time(time),
         "end_time" => Puppet::Util::Puppetdb.to_wire_time(time + run_duration),
         "environment" => environment,

--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -30,12 +30,10 @@ module Puppet::Util::Puppetdb
   end
 
   # Given an instance of ruby's Time class, this method converts it to a String
-  # that conforms to PuppetDB's wire format for representing a date/time.
+  # that conforms to PuppetDB's wire format for representing a date/time. All PuppetDB
+  # timestamps are stored at millisecond accurace (i.e. 10^-3)
   def self.to_wire_time(time)
-    # The current implementation simply calls iso8601, but having this method
-    # allows us to change that in the future if needed w/o being forced to
-    # update all of the date objects elsewhere in the code.
-    time.iso8601(9)
+    time.iso8601(3)
   end
 
   # Convert a value (usually a string) to a boolean

--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -55,10 +55,10 @@ module Puppet::Util::Puppetdb
   # @param command_name [String] name of command
   # @param version [Number] version number of command
   # @return [Hash <String, String>]
-  def submit_command(certname, payload, command_name, version)
+  def submit_command(certname, payload, command_name, version, producer_timestamp_utc)
     profile("Submitted command '#{command_name}' version '#{version}'",
             [:puppetdb, :command, :submit, command_name, version]) do
-      command = Puppet::Util::Puppetdb::Command.new(command_name, version, certname, payload)
+      command = Puppet::Util::Puppetdb::Command.new(command_name, version, certname, producer_timestamp_utc, payload)
       command.submit
     end
   end

--- a/puppet/spec/spec_helper.rb
+++ b/puppet/spec/spec_helper.rb
@@ -20,6 +20,10 @@ def create_environmentdir(environment)
   end
 end
 
+def extract_producer_timestamp(command)
+  DateTime.parse(command["producer_timestamp"]).to_time.to_i
+end
+
 RSpec.configure do |config|
 
   config.before :each do

--- a/puppet/spec/spec_helper.rb
+++ b/puppet/spec/spec_helper.rb
@@ -24,6 +24,14 @@ def extract_producer_timestamp(command)
   DateTime.parse(command["producer_timestamp"]).to_time.to_i
 end
 
+def assert_command_req(expected_payload, actual_payload)
+  req = JSON.parse(actual_payload)
+  actual_producer_timestamp = extract_producer_timestamp(req)
+  req.delete("producer_timestamp")
+  req == expected_payload &&
+    actual_producer_timestamp <= Time.now.to_i
+end
+
 RSpec.configure do |config|
 
   config.before :each do

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -52,13 +52,7 @@ describe Puppet::Node::Facts::Puppetdb do
       }
 
       http.expects(:post).with do |uri, body, headers|
-
-        req = JSON.parse(body)
-        actual_producer_timestamp = extract_producer_timestamp(req)
-        req.delete("producer_timestamp")
-        req == payload &&
-          actual_producer_timestamp <= Time.now.to_i
-
+        assert_command_req(payload, body)
       end.returns response
 
       save

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -6,7 +6,8 @@ require 'puppet/indirector/facts/puppetdb'
 require 'puppet/util/puppetdb'
 require 'puppet/util/puppetdb/command_names'
 require 'json'
-
+require 'date'
+require 'time'
 
 describe Puppet::Node::Facts::Puppetdb do
 
@@ -26,7 +27,6 @@ describe Puppet::Node::Facts::Puppetdb do
     let(:facts)    { Puppet::Node::Facts.new('foo') }
 
     let(:options) {{
-      :producer_timestamp => 'a test',
       :environment => "my_environment",
     }}
 
@@ -48,12 +48,17 @@ describe Puppet::Node::Facts::Puppetdb do
         "certname" => facts.name,
         "values" => facts.values.merge({"trusted" => trusted_data}),
         "environment" => "my_environment",
-        "producer_timestamp" => "a test",
         "producer" => "mom"
-      }.to_pson
+      }
 
       http.expects(:post).with do |uri, body, headers|
-        expect(body).to eq(payload)
+
+        req = JSON.parse(body)
+        actual_producer_timestamp = extract_producer_timestamp(req)
+        req.delete("producer_timestamp")
+        req == payload &&
+          actual_producer_timestamp <= Time.now.to_i
+
       end.returns response
 
       save

--- a/puppet/spec/unit/util/puppetdb/command_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/command_spec.rb
@@ -9,7 +9,7 @@ describe Puppet::Util::Puppetdb::Command do
   let(:payload) { {'resistance' =>  'futile', 'opinion' => 'irrelevant'} }
 
   let(:subject) { described_class.new("OPEN SESAME", 1,
-                                      'foo.localdomain', producer-time-ms, payload) }
+                                      'foo.localdomain', payload) }
 
 
   describe "#submit" do

--- a/puppet/spec/unit/util/puppetdb/command_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/command_spec.rb
@@ -9,7 +9,8 @@ describe Puppet::Util::Puppetdb::Command do
   let(:payload) { {'resistance' =>  'futile', 'opinion' => 'irrelevant'} }
 
   let(:subject) { described_class.new("OPEN SESAME", 1,
-                                      'foo.localdomain', payload) }
+                                      'foo.localdomain',
+                                      Time.now.utc, payload) }
 
 
   describe "#submit" do
@@ -66,7 +67,7 @@ describe Puppet::Util::Puppetdb::Command do
 
   it "should not warn when the the string contains valid UTF-8 characters" do
     Puppet.expects(:warning).never
-    cmd = described_class.new("command-1", 1, "foo.localdomain", {"foo" => "\u2192"})
+    cmd = described_class.new("command-1", 1, "foo.localdomain", Time.now.utc, {"foo" => "\u2192"})
     cmd.payload.include?("\u2192").should be_truthy
   end
 
@@ -74,7 +75,7 @@ describe Puppet::Util::Puppetdb::Command do
 
     it "should warn when a command payload includes non-ascii UTF-8 characters" do
       Puppet.expects(:warning).with {|msg| msg =~ /Error encoding a 'command-1' command for host 'foo.localdomain' ignoring invalid UTF-8 byte sequences/}
-      cmd = described_class.new("command-1", 1, "foo.localdomain", {"foo" => [192].pack('c*')})
+      cmd = described_class.new("command-1", 1, "foo.localdomain", Time.now.utc, {"foo" => [192].pack('c*')})
       cmd.payload.include?("\ufffd").should be_truthy
     end
 
@@ -98,7 +99,7 @@ describe Puppet::Util::Puppetdb::Command do
             msg =~ Regexp.new(Regexp.quote('"command":"command-1","version":1,"certname":"foo.localdomain","payload":{"foo"')) &&
             msg =~ /1 invalid\/undefined/
         end
-        cmd = described_class.new("command-1", 1, "foo.localdomain", {"foo" => [192].pack('c*')})
+        cmd = described_class.new("command-1", 1, "foo.localdomain", Time.now.utc, {"foo" => [192].pack('c*')})
         cmd.payload.include?("\ufffd").should be_truthy
       end
     end

--- a/puppet/spec/unit/util/puppetdb/command_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/command_spec.rb
@@ -2,12 +2,14 @@ require 'spec_helper'
 require 'digest/sha1'
 require 'puppet/network/http_pool'
 require 'puppet/util/puppetdb'
-
+require 'uri'
+require 'cgi'
 
 describe Puppet::Util::Puppetdb::Command do
   let(:payload) { {'resistance' =>  'futile', 'opinion' => 'irrelevant'} }
+
   let(:subject) { described_class.new("OPEN SESAME", 1,
-                                      'foo.localdomain', payload) }
+                                      'foo.localdomain', producer-time-ms, payload) }
 
 
   describe "#submit" do
@@ -21,7 +23,13 @@ describe Puppet::Util::Puppetdb::Command do
 
       it "should issue the HTTP POST and log success" do
         httpok.stubs(:body).returns '{"uuid": "a UUID"}'
-        http.expects(:post).returns httpok
+        http.expects(:post).with() do | path, payload, headers |
+          param_map = CGI::parse(URI(path).query)
+          param_map['certname'].first.should == 'foo.localdomain' &&
+            param_map['version'].first.should == '1' &&
+            param_map['command'].first.should == 'OPEN_SESAME'
+
+        end.returns(httpok)
 
         subject.submit
         test_logs.find_all { |m|

--- a/puppet/spec/unit/util/puppetdb_spec.rb
+++ b/puppet/spec/unit/util/puppetdb_spec.rb
@@ -21,7 +21,7 @@ describe Puppet::Util::Puppetdb do
 
   describe "#submit_command" do
     let(:payload) { {'resistance' =>  'futile', 'opinion' => 'irrelevant'} }
-    let(:command1) { Puppet::Util::Puppetdb::Command.new("OPEN SESAME", 1, 'foo.localdomain',
+    let(:command1) { Puppet::Util::Puppetdb::Command.new("OPEN SESAME", 1, 'foo.localdomain', Time.now.utc,
                                                          payload.merge(:uniqueprop => "command1")) }
 
     it "should submit the command" do
@@ -32,6 +32,7 @@ describe Puppet::Util::Puppetdb do
       subject.submit_command(command1.certname,
                              command1.payload,
                              command1.command,
+                             command1.producer_timestamp_utc,
                              command1.version)
     end
 

--- a/src/puppetlabs/puppetdb/amq_migration.clj
+++ b/src/puppetlabs/puppetdb/amq_migration.clj
@@ -124,7 +124,14 @@
         (try
           (let [{:keys [command version certname payload] :as msg} (coerce-to-new-command headers message-bytes)]
             (try
-              (enqueue-fn command version certname payload)
+              ;; The nil below is for producer_timestamp. Older
+              ;; commands won't have that in the headers of the AMQ
+              ;; message, so the only way to get that is parsing the
+              ;; body. Rather than do that, nil is being passed. This
+              ;; is still correct, the only downside is comands won't
+              ;; be overwritten in the queue by newer commands.
+              (enqueue-fn command version certname nil payload)
+
               (catch Exception ex
                 (log/error ex
                            (trs

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -331,7 +331,10 @@
 
     ;; Error handling here?
     (let [stockdir (conf/stockpile-dir config)
-          command-chan (async/chan max-enqueued)
+          command-chan (async/chan
+                         (queue/sorted-command-buffer
+                          max-enqueued
+                          #(cmd/update-counter! :invalidated %1 %2 inc!)))
           [q load-messages] (queue/create-or-open-stockpile (conf/stockpile-dir config))
           globals {:scf-read-db read-db
                    :scf-write-db write-db

--- a/src/puppetlabs/puppetdb/client.clj
+++ b/src/puppetlabs/puppetdb/client.clj
@@ -31,8 +31,8 @@
     timeout]
    (let [body (json/generate-string payload)
          url (str (utils/base-url->str base-url)
-                  (format "?command=%s&version=%s&certname=%s"
-                          (str/replace command #" " "_") version certname)
+                  (format "?command=%s&version=%s&certname=%s&producer-timestamp=%s"
+                          (str/replace command #" " "_") version certname (System/currentTimeMillis))
                   (when timeout (format "&secondsToWaitForCompletion=%s" timeout)))]
      (http-client/post url {:body body
                             :throw-exceptions false

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -135,9 +135,8 @@
 ;; * `:queue-time`: how long the message spent in the queue before processing
 ;; * `:retry-counts`: histogram containing the number of times
 ;;                    messages have been retried prior to suceeding
-;; * `:invalidated`: *CURRENTLY DISABLED* - see PDB-3108 commands marked as delete?,
-;;                   caused by a newer command was enqueued that will overwrite an
-;;                   existing one in the queue
+;; * `:invalidated`: commands marked as delete?, caused by a newer command
+;;                   was enqueued that will overwrite an existing one in the queue
 ;; * `:depth`: number of commands currently enqueued
 ;;
 
@@ -151,11 +150,7 @@
      :queue-time (histogram mq-metrics-registry (to-metric-name-fn :queue-time))
      :retry-counts (histogram mq-metrics-registry (to-metric-name-fn :retry-counts))
      :depth (counter mq-metrics-registry (to-metric-name-fn :depth))
-
-     ;; There's currently no way for a command to be invalidated due to a replication/HA issue that
-     ;; is to be addressed in PDB-3108.
-     ;; :invalidated (counter mq-metrics-registry (to-metric-name-fn :invalidated))
-
+     :invalidated (counter mq-metrics-registry (to-metric-name-fn :invalidated))
      :seen (meter mq-metrics-registry (to-metric-name-fn :seen))
      :size (histogram mq-metrics-registry (to-metric-name-fn :size))
      :processed (meter mq-metrics-registry (to-metric-name-fn :processed))
@@ -485,11 +480,7 @@
   (mark-both-metrics! (:command cmdref) (:version cmdref) :discarded))
 
 (defn process-delete-cmdref
-  "Note that currently this function is unreachable, because commands
-  cannot currently be invalidated due to a replication/HA issue that
-  is to be addressed in PDB-3108.
-
-  Processes a command ref marked for deletion. This is similar to
+  "Processes a command ref marked for deletion. This is similar to
   processing a non-delete cmdref except different metrics need to be
   updated to indicate the difference in command"
   [{:keys [command version] :as cmdref} q scf-write-db response-chan stats]

--- a/src/puppetlabs/puppetdb/command/dlo.clj
+++ b/src/puppetlabs/puppetdb/command/dlo.clj
@@ -168,7 +168,7 @@
   (let [{:keys [path registry metrics]} dlo
         {:keys [id received command version certname attempts]} cmdref
         entry (stock/entry id (serialize-metadata
-                                received command version certname))
+                                received nil command version certname))
         cmd-dest (.resolve path (entry-cmd-data-filename entry))]
     ;; We're going to assume that our moves will be atomic, and if
     ;; they're not, that we don't care about the possibility of
@@ -201,7 +201,7 @@
   ;; indicator that the unknown message may be complete.
   (let [{:keys [path registry metrics]} dlo
         digest (digest/sha1 [bytes])
-        metadata (serialize-metadata received "unknown" 0 digest)
+        metadata (serialize-metadata received nil "unknown" 0 digest)
         cmd-dest (.resolve path (str id \- metadata))]
     (Files/write cmd-dest bytes (oopts []))
     (let [info-dest (store-failed-command-info id metadata "unknown"

--- a/src/puppetlabs/puppetdb/command/dlo.clj
+++ b/src/puppetlabs/puppetdb/command/dlo.clj
@@ -166,9 +166,8 @@
   stockpile/discard.  Returns {:info Path :command Path}."
   [cmdref stockpile dlo]
   (let [{:keys [path registry metrics]} dlo
-        {:keys [id received command version certname attempts]} cmdref
-        entry (stock/entry id (serialize-metadata
-                                received nil command version certname))
+        {:keys [id received command attempts]} cmdref
+        entry (stock/entry id (serialize-metadata received cmdref))
         cmd-dest (.resolve path (entry-cmd-data-filename entry))]
     ;; We're going to assume that our moves will be atomic, and if
     ;; they're not, that we don't care about the possibility of
@@ -201,7 +200,11 @@
   ;; indicator that the unknown message may be complete.
   (let [{:keys [path registry metrics]} dlo
         digest (digest/sha1 [bytes])
-        metadata (serialize-metadata received nil "unknown" 0 digest)
+        metadata (serialize-metadata received
+                                     {:producer-ts nil
+                                      :command "unknown"
+                                      :version 0
+                                      :certname digest})
         cmd-dest (.resolve path (str id \- metadata))]
     (Files/write cmd-dest bytes (oopts []))
     (let [info-dest (store-failed-command-info id metadata "unknown"

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -16,7 +16,8 @@
             [ring.util.request :as request]
             [schema.core :as s]
             [slingshot.slingshot :refer [try+ throw+]]
-            [puppetlabs.i18n.core :refer [trs tru]])
+            [puppetlabs.i18n.core :refer [trs tru]]
+            [puppetlabs.puppetdb.time :as pdbtime])
   (:import [org.apache.commons.io IOUtils]
            [org.apache.commons.fileupload.util LimitedInputStream]))
 
@@ -219,6 +220,7 @@
                         (get submit-params "command")
                         (Integer/parseInt (get submit-params "version"))
                         (get submit-params "certname")
+                        (pdbtime/from-string (get submit-params "producer-ts"))
                         (stream-with-max-check body max-command-size)
                         command-callback))]
 

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -117,7 +117,8 @@
             (s/required-key "certname") s/Str
             (s/required-key "received") s/Str
             (s/optional-key "secondsToWaitForCompletion") s/Str
-            (s/optional-key "checksum") s/Str}
+            (s/optional-key "checksum") s/Str
+            (s/optional-key "producer-timestamp") s/Str}
    :body java.io.InputStream
    s/Any s/Any})
 
@@ -261,7 +262,7 @@
       add-received-param ;; must be (temporally) after validate-query-params
       ;; The checksum here is vestigial.  It is no longer checked
       (mid/validate-query-params {:optional ["checksum" "secondsToWaitForCompletion"
-                                             "certname" "command" "version"]})
+                                             "certname" "command" "version" "producer-timestamp"]})
       mid/verify-accepts-json
       (mid/verify-content-type ["application/json"])
       (mid/fail-when-payload-too-large reject-large-commands? max-command-size)

--- a/src/puppetlabs/puppetdb/import.clj
+++ b/src/puppetlabs/puppetdb/import.clj
@@ -57,6 +57,7 @@
                       (command-fn command-kwd
                                   command-version
                                   certname
+                                  nil ;-> No producer timestamp on imports
                                   (-> tar-reader
                                       utils/read-json-content
                                       json/generate-string

--- a/src/puppetlabs/puppetdb/time.clj
+++ b/src/puppetlabs/puppetdb/time.clj
@@ -224,8 +224,9 @@
 (s/defn ^:always-validate from-string :- (s/maybe DateTime)
   "Similar to the clj-time.coerce/from-string, but prioritizes the
   more likely formatters first"
-  [s :- String]
-  (some #(attempt-date-time-parse % s) ordered-formatters))
+  [s :- (s/maybe String)]
+  (when s
+    (some #(attempt-date-time-parse % s) ordered-formatters)))
 
 (s/defn ^:always-validate to-timestamp :- (s/maybe java.sql.Timestamp)
   "Delegates to clj-time.core/to-timestamp, except when `ts` is a

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -71,6 +71,7 @@
                        "replace facts"
                        4
                        "foo.local"
+                       nil
                        (tqueue/coerce-to-stream
                         {:certname "foo.local"
                          :environment "DEV"
@@ -107,6 +108,7 @@
                        "replace facts"
                        4
                        "foo.local"
+                       nil
                        (tqueue/coerce-to-stream
                         {:certname "foo.local"
                          :environment "DEV"

--- a/test/puppetlabs/puppetdb/command/dlo_test.clj
+++ b/test/puppetlabs/puppetdb/command/dlo_test.clj
@@ -11,9 +11,10 @@
    [puppetlabs.puppetdb.examples :refer [wire-catalogs]]
    [puppetlabs.puppetdb.metrics.core :refer [new-metrics]]
    [puppetlabs.puppetdb.nio :refer [get-path]]
-   [puppetlabs.puppetdb.queue :refer [cmdref->entry cons-attempt store-command]]
+   [puppetlabs.puppetdb.queue :refer [cmdref->entry cons-attempt store-command create-command-req]]
    [puppetlabs.puppetdb.testutils :refer [ordered-matches?]]
    [puppetlabs.puppetdb.testutils.nio :refer [call-with-temp-dir-path]]
+   [puppetlabs.puppetdb.testutils.queue :refer [catalog->command-req]]
    [puppetlabs.stockpile.queue :as stock])
   (import
    [java.nio.file Files]))
@@ -32,10 +33,9 @@
     (slurp stream)))
 
 (defn store-catalog [q dlo]
-  (let [cmd (get-in wire-catalogs [9 :basic])
-        cmd-bytes (-> cmd json/generate-string (.getBytes "UTF-8"))]
-    (store-command q "replace catalog" 9 (:certname cmd) nil
-                   (java.io.ByteArrayInputStream. cmd-bytes))))
+  (->> (get-in wire-catalogs [9 :basic])
+       (catalog->command-req 9)
+       (store-command q)))
 
 (defn err-attempt-line? [n s]
   (-> (str "Attempt " n " @ \\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\dZ")

--- a/test/puppetlabs/puppetdb/command/dlo_test.clj
+++ b/test/puppetlabs/puppetdb/command/dlo_test.clj
@@ -34,7 +34,7 @@
 (defn store-catalog [q dlo]
   (let [cmd (get-in wire-catalogs [9 :basic])
         cmd-bytes (-> cmd json/generate-string (.getBytes "UTF-8"))]
-    (store-command q "replace catalog" 9 (:certname cmd)
+    (store-command q "replace catalog" 9 (:certname cmd) nil
                    (java.io.ByteArrayInputStream. cmd-bytes))))
 
 (defn err-attempt-line? [n s]
@@ -48,19 +48,19 @@
 
     (are [cmd-info metadata-str] (= cmd-info (#'dlo/parse-cmd-filename metadata-str))
 
-      {:received r0 :version 0 :command "replace catalog" :certname "foo"}
+      {:received r0 :version 0 :command "replace catalog" :certname "foo" :producer-ts nil}
       "0-0_catalog_0_foo.json"
 
-      {:received r0 :version 0 :command "replace catalog" :certname "foo.json"}
+      {:received r0 :version 0 :command "replace catalog" :certname "foo.json" :producer-ts nil}
       "0-0_catalog_0_foo.json.json"
 
-      {:received r10 :version 10 :command "replace catalog" :certname "foo"}
+      {:received r10 :version 10 :command "replace catalog" :certname "foo" :producer-ts nil}
       "10-10_catalog_10_foo.json"
 
-      {:received r10 :version 42 :command "replace catalog" :certname "foo"}
+      {:received r10 :version 42 :command "replace catalog" :certname "foo" :producer-ts nil}
       "10-10_catalog_42_foo.json"
 
-      {:received r10 :version 10 :command "unknown" :certname "foo"}
+      {:received r10 :version 10 :command "unknown" :certname "foo" :producer-ts nil}
       "10-10_unknown_10_foo.json")
 
     (is (not (#'dlo/parse-cmd-filename "0-0_foo_0_foo.json")))))

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -50,7 +50,8 @@
             [clojure.string :as str]
             [puppetlabs.stockpile.queue :as stock]
             [puppetlabs.puppetdb.testutils.nio :as nio]
-            [puppetlabs.puppetdb.testutils.queue :as tqueue]
+            [puppetlabs.puppetdb.testutils.queue :as tqueue
+             :refer [catalog->command-req facts->command-req report->command-req deactivate->command-req]]
             [puppetlabs.puppetdb.queue :as queue]
             [puppetlabs.trapperkeeper.services
              :refer [service-context]]
@@ -58,14 +59,6 @@
             [puppetlabs.puppetdb.testutils :as tu])
   (:import [java.util.concurrent TimeUnit]
            [org.joda.time DateTime DateTimeZone]))
-
-(defn unroll-old-command [{:keys [command version payload]}]
-  [command
-   version
-   (or (:certname payload)
-       (:name payload))
-   nil
-   payload])
 
 (defrecord CommandHandlerContext [message-handler command-chan dlo delay-pool response-chan q]
   java.io.Closeable
@@ -116,9 +109,6 @@
       .getQueue
       count))
 
-(defn store-command' [q old-command]
-  (apply tqueue/store-command q (unroll-old-command old-command)))
-
 (defn take-with-timeout!!
   "Takes from `port` via <!!, but will throw an exception if
   `timeout-in-ms` expires"
@@ -135,16 +125,19 @@
       meters/rates
       :total))
 
+(defn failed-catalog-req [version certname payload]
+  (queue/create-command-req "replace catalog" version certname nil identity
+                            (tqueue/coerce-to-stream payload)))
+
 (deftest command-processor-integration
-  (let [command {:command "replace catalog" :version 5
-                 :payload (get-in wire-catalogs [5 :empty])}]
+  (let [v5-catalog (get-in wire-catalogs [5 :empty])]
     (testing "correctly formed messages"
 
       (testing "which are not yet expired"
 
         (testing "when successful should not raise errors or retry"
           (with-message-handler {:keys [handle-message dlo delay-pool q]}
-            (handle-message (store-command' q command))
+            (handle-message (queue/store-command q (catalog->command-req 5 v5-catalog)))
             (is (= 0 (count (scheduled-jobs delay-pool))))
             (is (empty? (fs/list-dir (:path dlo))))))
 
@@ -152,7 +145,7 @@
           (with-redefs [process-command-and-respond! (fn [& _] (throw+ (fatality (Exception. "fatal error"))))]
             (with-message-handler {:keys [handle-message dlo delay-pool q]}
               (let [discards (discard-count)]
-                (handle-message (store-command' q command))
+                (handle-message (queue/store-command q (catalog->command-req 5 v5-catalog)))
                 (is (= (inc discards) (discard-count))))
               (is (= 0 (count (scheduled-jobs delay-pool))))
               (is (= 2 (count (fs/list-dir (:path dlo))))))))
@@ -164,7 +157,7 @@
                           command-delay-ms 1
                           quick-retry-count 0]
               (with-message-handler {:keys [handle-message command-chan dlo delay-pool q]}
-                (let [cmdref (store-command' q command)]
+                (let [cmdref (queue/store-command q (catalog->command-req 5 v5-catalog))]
 
                   (is (= 0 (task-count delay-pool)))
                   (handle-message cmdref)
@@ -179,23 +172,24 @@
                       actual-exception expected-exception))))))))
 
       (testing "should be discarded if expired"
-        (let [command (assoc command :version 9)]
-          (with-redefs [process-command-and-respond! (fn [& _] (throw (RuntimeException. "Expected failure")))]
-            (with-message-handler {:keys [handle-message dlo delay-pool q]}
-              (let [cmdref (store-command' q (assoc command :version 9))]
-                (let [discards (discard-count)]
-                  (handle-message (add-fake-attempts cmdref maximum-allowable-retries))
-                  (is (= (inc discards) (discard-count))))
-                (is (= 0 (task-count delay-pool)))
-                (is (= 2 (count (fs/list-dir (:path dlo)))))))))))
+        (with-redefs [process-command-and-respond! (fn [& _] (throw (RuntimeException. "Expected failure")))]
+          (with-message-handler {:keys [handle-message dlo delay-pool q]}
+            (let [cmdref (->> (get-in wire-catalogs [9 :empty])
+                              (catalog->command-req 9)
+                              (queue/store-command q))]
+              (let [discards (discard-count)]
+                (handle-message (add-fake-attempts cmdref maximum-allowable-retries))
+                (is (= (inc discards) (discard-count))))
+              (is (= 0 (task-count delay-pool)))
+              (is (= 2 (count (fs/list-dir (:path dlo))))))))))
 
     (testing "should be discarded if incorrectly formed"
-      (let [command (assoc command :payload "{\"malformed\": \"with no closing brace\"")
+      (let [catalog-req (failed-catalog-req 5 (:name v5-catalog) "{\"malformed\": \"with no closing brace\"")
             process-counter (call-counter)]
         (with-redefs [process-command-and-respond! process-counter]
           (with-message-handler {:keys [handle-message dlo delay-pool q]}
             (let [discards (discard-count)]
-              (handle-message (store-command' q command))
+              (handle-message (queue/store-command q catalog-req))
               (is (= (inc discards) (discard-count))))
             (is (= 0 (task-count delay-pool)))
             (is (= 2 (count (fs/list-dir (:path dlo)))))
@@ -210,8 +204,8 @@
           (binding [*logger-factory* (atom-logger log-output)]
             (with-message-handler {:keys [handle-message dlo delay-pool q]}
               (is (= 0 (task-count delay-pool)))
-              (handle-message (-> (tqueue/store-command q "replace catalog" 10
-                                                        "cats" {:certname "cats"})
+              (handle-message (-> q
+                                  (queue/store-command (failed-catalog-req 10 "cats" {:certname "cats"}))
                                   (add-fake-attempts i)))
               (is (= 1 (task-count delay-pool)))
               (is (= 0 (count (fs/list-dir (:path dlo)))))
@@ -225,8 +219,8 @@
         (let [log-output (atom [])]
           (binding [*logger-factory* (atom-logger log-output)]
             (with-message-handler {:keys [handle-message dlo delay-pool q]}
-              (handle-message (-> (tqueue/store-command q "replace catalog" 10
-                                                        "cats" {:certname "cats"})
+              (handle-message (-> q
+                                  (queue/store-command (failed-catalog-req 10 "cats" {:certname "cats"}))
                                   (add-fake-attempts maximum-allowable-retries)))
               (is (= 0 (task-count delay-pool)))
               (is (= 2 (count (fs/list-dir (:path dlo)))))
@@ -240,9 +234,9 @@
   (testing "happy path, message acknowledgement when no failures occured"
     (tqueue/with-stockpile q
       (with-message-handler {:keys [handle-message dlo delay-pool q]}
-        (let [command {:command "replace catalog" :version 5
-                       :payload (get-in wire-catalogs [5 :empty])}
-              cmdref (store-command' q command)]
+        (let [cmdref (->> (get-in wire-catalogs [5 :empty])
+                          (catalog->command-req 5)
+                          (queue/store-command q))]
           (is (:payload (queue/cmdref->cmd q cmdref)))
           (handle-message cmdref)
           (is (thrown+-with-msg? [:kind :puppetlabs.stockpile.queue/no-such-entry]
@@ -255,7 +249,7 @@
     (tqueue/with-stockpile q
       (with-redefs [process-command-and-respond! (fn [& _] (throw+ (RuntimeException. "retry me")))]
         (with-message-handler {:keys [handle-message dlo delay-pool q]}
-          (let [entry (tqueue/store-command q "replace catalog" 10 "cats" {:certname "cats"})]
+          (let [entry (queue/store-command q (failed-catalog-req 10 "cats" {:certname "cats"}))]
             (is (:payload (queue/cmdref->cmd q entry)))
             (handle-message entry)
             (is (= 1 (task-count delay-pool)))
@@ -346,21 +340,21 @@
 
 (deftest replace-catalog-test
   (dotestseq [version catalog-versions
-              :let [raw-command {:command (command-names :replace-catalog)
-                                 :version (version-kwd->num version)
-                                 :payload (-> (get-in wire-catalogs [(version-kwd->num version) :empty])
-                                              (assoc :producer_timestamp (now)))}]]
+              :let [version-num (version-kwd->num version)
+                    {:keys [certname] :as catalog} (-> wire-catalogs
+                                                       (get-in [version-num :empty])
+                                                       (assoc :producer_timestamp (now)))
+                    make-cmd-req #(catalog->command-req version-num catalog)]]
     (testing (str (command-names :replace-catalog) " " version)
-      (let [certname (get-in raw-command [:payload :certname])
-            catalog-hash (shash/catalog-similarity-hash
-                          (catalog/parse-catalog (:payload raw-command) (version-kwd->num version) (now)))
+      (let [catalog-hash (shash/catalog-similarity-hash
+                          (catalog/parse-catalog catalog version-num (now)))
             one-day      (* 24 60 60 1000)
             yesterday    (to-timestamp (- (System/currentTimeMillis) one-day))
             tomorrow     (to-timestamp (+ (System/currentTimeMillis) one-day))]
 
         (testing "with no catalog should store the catalog"
           (with-message-handler {:keys [handle-message dlo delay-pool q]}
-            (handle-message (store-command' q raw-command))
+            (handle-message (queue/store-command q (make-cmd-req)))
             (is (= [(with-env {:certname certname})]
                    (query-to-vec "SELECT certname, environment_id FROM catalogs")))
             (is (= 0 (task-count delay-pool)))
@@ -369,7 +363,7 @@
         (testing "with code-id should store the catalog"
           (with-message-handler {:keys [handle-message dlo delay-pool q]}
             (handle-message
-             (store-command' q (assoc-in raw-command [:payload :code_id] "my_git_sha1")))
+             (queue/store-command q (catalog->command-req version-num (assoc catalog :code_id "my_git_sha1"))))
             (is (= [(with-env {:certname certname :code_id "my_git_sha1"})]
                    (query-to-vec "SELECT certname, code_id, environment_id FROM catalogs")))
             (is (= 0 (task-count delay-pool)))
@@ -385,20 +379,25 @@
                                      :catalog_version "foo"
                                      :certname certname
                                      :producer_timestamp (to-timestamp (-> 1 days ago))})
-            (handle-message (store-command' q raw-command))
+            (handle-message (queue/store-command q (make-cmd-req)))
             (is (= [(with-env {:certname certname :catalog catalog-hash})]
                    (query-to-vec (format "SELECT certname, %s as catalog, environment_id FROM catalogs"
                                          (sutils/sql-hash-as-str "hash")))))
             (is (= 0 (task-count delay-pool)))
             (is (empty? (fs/list-dir (:path dlo))))))
 
-        (let [command (assoc raw-command :payload "bad stuff")]
-          (testing "with a bad payload should discard the message"
-            (with-message-handler {:keys [handle-message dlo delay-pool q]}
-              (handle-message (store-command' q command))
-              (is (empty? (query-to-vec "SELECT * FROM catalogs")))
-              (is (= 0 (task-count delay-pool)))
-              (is (seq (fs/list-dir (:path dlo)))))))
+        (testing "with a bad payload should discard the message"
+          (with-message-handler {:keys [handle-message dlo delay-pool q]}
+            (handle-message (queue/store-command q
+                                                 (queue/create-command-req "replace catalog"
+                                                                           version-num
+                                                                           certname
+                                                                           (ks/timestamp (now))
+                                                                           identity
+                                                                           (tqueue/coerce-to-stream "bad stuff"))))
+            (is (empty? (query-to-vec "SELECT * FROM catalogs")))
+            (is (= 0 (task-count delay-pool)))
+            (is (seq (fs/list-dir (:path dlo))))))
 
         (testing "with a newer catalog should ignore the message"
           (with-message-handler {:keys [handle-message dlo delay-pool q]}
@@ -408,8 +407,8 @@
                                      :catalog_version "foo"
                                      :certname certname
                                      :timestamp tomorrow
-                                     :producer_timestamp (to-timestamp (now))})
-            (handle-message (store-command' q raw-command))
+                                     :producer_timestamp (to-timestamp (t/plus (now) (days 1)))})
+            (handle-message (queue/store-command q (make-cmd-req)))
             (is (= [{:certname certname :catalog "ab"}]
                    (query-to-vec (format "SELECT certname, %s as catalog FROM catalogs"
                                          (sutils/sql-hash-as-str "hash")))))
@@ -420,7 +419,7 @@
           (with-message-handler {:keys [handle-message dlo delay-pool q]}
             (jdbc/insert! :certnames {:certname certname :deactivated yesterday})
 
-            (handle-message (store-command' q raw-command))
+            (handle-message (queue/store-command q (make-cmd-req)))
 
             (is (= [{:certname certname :deactivated nil}]
                    (query-to-vec "SELECT certname,deactivated FROM certnames")))
@@ -436,7 +435,7 @@
               (scf-store/delete-certname! certname)
               (jdbc/insert! :certnames {:certname certname :deactivated tomorrow})
 
-              (handle-message (store-command' q raw-command))
+              (handle-message (queue/store-command q (make-cmd-req)))
 
               (is (= [{:certname certname :deactivated tomorrow}]
                      (query-to-vec "SELECT certname,deactivated FROM certnames")))
@@ -460,7 +459,7 @@
 
       (with-message-handler {:keys [handle-message dlo delay-pool q]}
 
-        (handle-message (store-command' q command))
+        (handle-message (queue/store-command q (catalog->command-req 6 (get-in wire-catalogs [6 :empty]))))
 
         ;;names in v5 are hyphenated, this check ensures we're sending a v5 catalog
         (is (contains? (:payload command) :producer_timestamp))
@@ -477,17 +476,15 @@
 
 (deftest replace-catalog-with-v5
   (testing "catalog wireformat v5"
-    (let [command {:command (command-names :replace-catalog)
-                   :version 5
-                   :payload (get-in wire-catalogs [5 :empty])}
-          certname (get-in command [:payload :name])
-          cmd-producer-timestamp (get-in command [:payload :producer-timestamp])]
+    (let [{certname :name
+           producer-timestamp :producer-timestamp
+           :as v5-catalog} (get-in wire-catalogs [5 :empty])]
       (with-message-handler {:keys [handle-message dlo delay-pool q]}
 
-        (handle-message (store-command' q command))
+        (handle-message (queue/store-command q (catalog->command-req 5 v5-catalog)))
 
         ;;names in v5 are hyphenated, this check ensures we're sending a v5 catalog
-        (is (contains? (:payload command) :producer-timestamp))
+        (is (contains? v5-catalog :producer-timestamp))
         (is (= [(with-env {:certname certname})]
                (query-to-vec "SELECT certname, environment_id FROM catalogs")))
         (is (= 0 (task-count delay-pool)))
@@ -497,20 +494,17 @@
         (is (= (-> (query-to-vec "SELECT producer_timestamp FROM catalogs")
                    first
                    :producer_timestamp)
-               (to-timestamp cmd-producer-timestamp)))))))
+               (to-timestamp producer-timestamp)))))))
 
 (deftest replace-catalog-with-v4
-  (let [command {:command (command-names :replace-catalog)
-                 :version 4
-                 :payload (get-in wire-catalogs [4 :empty])}
-        certname (get-in command [:payload :name])
-        cmd-producer-timestamp (get-in command [:payload :producer-timestamp])
+  (let [{certname :name
+         producer-timestmap :producer-timestamp :as v4-catalog} (get-in wire-catalogs [4 :empty])
         recent-time (-> 1 seconds ago)]
     (with-message-handler {:keys [handle-message dlo delay-pool q]}
 
-      (handle-message (store-command' q command))
+      (handle-message (queue/store-command q (catalog->command-req 4 v4-catalog)))
 
-      (is (false? (contains? (:payload command) :producer-timestamp)))
+      (is (false? (contains? v4-catalog :producer-timestamp)))
       (is (= [(with-env {:certname certname})]
              (query-to-vec "SELECT certname, environment_id FROM catalogs")))
       (is (= 0 (task-count delay-pool)))
@@ -527,131 +521,114 @@
   "Updated the resource in `catalog` with the given `type` and `title`.
    `update-fn` is a function that accecpts the resource map as an argument
    and returns a (possibly mutated) resource map."
-  [version catalog type title update-fn]
-  (let [path [:payload :resources]]
-    (update-in catalog path
-               (fn [resources]
-                 (mapv (fn [res]
-                         (if (and (= (:title res) title)
-                                  (= (:type res) type))
-                           (update-fn res)
-                           res))
-                       resources)))))
+  [catalog type title update-fn]
+  (update catalog :resources
+          (fn [resources]
+            (mapv (fn [res]
+                    (if (and (= (:title res) title)
+                             (= (:type res) type))
+                      (update-fn res)
+                      res))
+                  resources))))
 
 (def basic-wire-catalog
   (get-in wire-catalogs [9 :basic]))
 
 (deftest catalog-with-updated-resource-line
-  (dotestseq [version catalog-versions
-              :let [command-1 {:command (command-names :replace-catalog)
-                               :version latest-catalog-version
-                               :payload basic-wire-catalog}
-                    command-2 (update-resource version command-1 "File" "/etc/foobar"
-                                               #(assoc % :line 20))]]
-    (with-message-handler {:keys [handle-message dlo delay-pool q]}
-      (handle-message (store-command' q command-1))
+  (with-message-handler {:keys [handle-message dlo delay-pool q]}
+    (handle-message (queue/store-command q (catalog->command-req 9 basic-wire-catalog)))
 
-      (let [orig-resources (scf-store/catalog-resources (:certname_id
-                                                         (scf-store/latest-catalog-metadata
-                                                          "basic.wire-catalogs.com")))]
-        (is (= 10
-               (get-in orig-resources [{:type "File" :title "/etc/foobar"} :line])))
-        (is (= 0 (task-count delay-pool)))
-        (is (empty? (fs/list-dir (:path dlo))))
+    (let [orig-resources (scf-store/catalog-resources (:certname_id
+                                                       (scf-store/latest-catalog-metadata
+                                                        "basic.wire-catalogs.com")))]
+      (is (= 10
+             (get-in orig-resources [{:type "File" :title "/etc/foobar"} :line])))
+      (is (= 0 (task-count delay-pool)))
+      (is (empty? (fs/list-dir (:path dlo))))
 
-        (handle-message (store-command' q command-2))
+      (handle-message (queue/store-command q (catalog->command-req 9
+                                                                   (update-resource basic-wire-catalog "File" "/etc/foobar"
+                                                                                    #(assoc % :line 20)))))
 
-        (is (= (assoc-in orig-resources [{:type "File" :title "/etc/foobar"} :line] 20)
-               (scf-store/catalog-resources (:certname_id
-                                             (scf-store/latest-catalog-metadata
-                                              "basic.wire-catalogs.com")))))
-        (is (= 0 (task-count delay-pool)))
-        (is (empty? (fs/list-dir (:path dlo))))))))
+      (is (= (assoc-in orig-resources [{:type "File" :title "/etc/foobar"} :line] 20)
+             (scf-store/catalog-resources (:certname_id
+                                           (scf-store/latest-catalog-metadata
+                                            "basic.wire-catalogs.com")))))
+      (is (= 0 (task-count delay-pool)))
+      (is (empty? (fs/list-dir (:path dlo)))))))
 
 (deftest catalog-with-updated-resource-file
-  (dotestseq [version catalog-versions
-              :let [command-1 {:command (command-names :replace-catalog)
-                               :version latest-catalog-version
-                               :payload basic-wire-catalog}
-                    command-2 (update-resource version command-1 "File" "/etc/foobar"
-                                               #(assoc % :file "/tmp/not-foo"))]]
-    (with-message-handler {:keys [handle-message dlo delay-pool q]}
-      (handle-message (store-command' q command-1))
+  (with-message-handler {:keys [handle-message dlo delay-pool q]}
+    (handle-message (queue/store-command q (catalog->command-req 9 basic-wire-catalog)))
 
 
-      (let [orig-resources (scf-store/catalog-resources (:certname_id
-                                                         (scf-store/latest-catalog-metadata
-                                                          "basic.wire-catalogs.com")))]
-        (is (= "/tmp/foo"
-               (get-in orig-resources [{:type "File" :title "/etc/foobar"} :file])))
-        (is (= 0 (task-count delay-pool)))
-        (is (empty? (fs/list-dir (:path dlo))))
+    (let [orig-resources (scf-store/catalog-resources (:certname_id
+                                                       (scf-store/latest-catalog-metadata
+                                                        "basic.wire-catalogs.com")))]
+      (is (= "/tmp/foo"
+             (get-in orig-resources [{:type "File" :title "/etc/foobar"} :file])))
+      (is (= 0 (task-count delay-pool)))
+      (is (empty? (fs/list-dir (:path dlo))))
 
-        (handle-message (store-command' q command-2))
+      (handle-message (queue/store-command q (catalog->command-req 9
+                                                                   (update-resource basic-wire-catalog "File" "/etc/foobar"
+                                                                                    #(assoc % :file "/tmp/not-foo")))))
 
-        (is (= (assoc-in orig-resources [{:type "File" :title "/etc/foobar"} :file] "/tmp/not-foo")
-               (scf-store/catalog-resources (:certname_id
-                                             (scf-store/latest-catalog-metadata
-                                              "basic.wire-catalogs.com")))))
-        (is (= 0 (task-count delay-pool)))
-        (is (empty? (fs/list-dir (:path dlo))))))))
+      (is (= (assoc-in orig-resources [{:type "File" :title "/etc/foobar"} :file] "/tmp/not-foo")
+             (scf-store/catalog-resources (:certname_id
+                                           (scf-store/latest-catalog-metadata
+                                            "basic.wire-catalogs.com")))))
+      (is (= 0 (task-count delay-pool)))
+      (is (empty? (fs/list-dir (:path dlo)))))))
 
 (deftest catalog-with-updated-resource-exported
-  (dotestseq [version catalog-versions
-              :let [command-1 {:command (command-names :replace-catalog)
-                               :version latest-catalog-version
-                               :payload basic-wire-catalog}
-                    command-2 (update-resource version command-1 "File" "/etc/foobar"
-                                               #(assoc % :exported true))]]
-    (with-message-handler {:keys [handle-message dlo delay-pool q]}
+  (with-message-handler {:keys [handle-message dlo delay-pool q]}
 
-      (handle-message (store-command' q command-1))
+    (handle-message (queue/store-command q (catalog->command-req 9 basic-wire-catalog)))
 
-      (let [orig-resources (scf-store/catalog-resources (:certname_id
-                                                         (scf-store/latest-catalog-metadata
-                                                          "basic.wire-catalogs.com")))]
-        (is (= false
-               (get-in orig-resources [{:type "File" :title "/etc/foobar"} :exported])))
-        (is (= 0 (task-count delay-pool)))
-        (is (empty? (fs/list-dir (:path dlo))))
+    (let [orig-resources (scf-store/catalog-resources (:certname_id
+                                                       (scf-store/latest-catalog-metadata
+                                                        "basic.wire-catalogs.com")))]
+      (is (= false
+             (get-in orig-resources [{:type "File" :title "/etc/foobar"} :exported])))
+      (is (= 0 (task-count delay-pool)))
+      (is (empty? (fs/list-dir (:path dlo))))
 
-        (handle-message (store-command' q command-2))
-        (is (= (assoc-in orig-resources [{:type "File" :title "/etc/foobar"} :exported] true)
-               (scf-store/catalog-resources (:certname_id
-                                             (scf-store/latest-catalog-metadata
-                                              "basic.wire-catalogs.com")))))))))
+      (handle-message (queue/store-command q (catalog->command-req 9
+                                                                   (update-resource basic-wire-catalog "File" "/etc/foobar"
+                                                                                    #(assoc % :exported true)))))
+      (is (= (assoc-in orig-resources [{:type "File" :title "/etc/foobar"} :exported] true)
+             (scf-store/catalog-resources (:certname_id
+                                           (scf-store/latest-catalog-metadata
+                                            "basic.wire-catalogs.com"))))))))
 
 (deftest catalog-with-updated-resource-tags
-  (dotestseq [version catalog-versions
-              :let [command-1 {:command (command-names :replace-catalog)
-                               :version latest-catalog-version
-                               :payload basic-wire-catalog}
-                    command-2 (update-resource version command-1 "File" "/etc/foobar"
-                                               #(assoc %
-                                                       :tags #{"file" "class" "foobar" "foo"}
-                                                       :line 20))]]
-    (with-message-handler {:keys [handle-message dlo delay-pool q]}
-      (handle-message (store-command' q command-1))
+  (with-message-handler {:keys [handle-message dlo delay-pool q]}
+    (handle-message (queue/store-command q (catalog->command-req 9 basic-wire-catalog)))
 
-      (let [orig-resources (scf-store/catalog-resources (:certname_id
-                                                         (scf-store/latest-catalog-metadata
-                                                          "basic.wire-catalogs.com")))]
-        (is (= #{"file" "class" "foobar"}
-               (get-in orig-resources [{:type "File" :title "/etc/foobar"} :tags])))
-        (is (= 10
-               (get-in orig-resources [{:type "File" :title "/etc/foobar"} :line])))
-        (is (= 0 (task-count delay-pool)))
-        (is (empty? (fs/list-dir (:path dlo))))
+    (let [orig-resources (scf-store/catalog-resources (:certname_id
+                                                       (scf-store/latest-catalog-metadata
+                                                        "basic.wire-catalogs.com")))]
+      (is (= #{"file" "class" "foobar"}
+             (get-in orig-resources [{:type "File" :title "/etc/foobar"} :tags])))
+      (is (= 10
+             (get-in orig-resources [{:type "File" :title "/etc/foobar"} :line])))
+      (is (= 0 (task-count delay-pool)))
+      (is (empty? (fs/list-dir (:path dlo))))
 
-        (handle-message (store-command' q command-2))
+      (handle-message (queue/store-command q (catalog->command-req 9
+                                                                   (update-resource basic-wire-catalog "File" "/etc/foobar"
+                                                                                    #(assoc %
+                                                                                            :tags #{"file" "class" "foobar" "foo"}
+                                                                                            :line 20)))))
 
-        (is (= (-> orig-resources
-                   (assoc-in [{:type "File" :title "/etc/foobar"} :tags]
-                             #{"file" "class" "foobar" "foo"})
-                   (assoc-in [{:type "File" :title "/etc/foobar"} :line] 20))
-               (scf-store/catalog-resources (:certname_id
-                                             (scf-store/latest-catalog-metadata
-                                              "basic.wire-catalogs.com")))))))))
+      (is (= (-> orig-resources
+                 (assoc-in [{:type "File" :title "/etc/foobar"} :tags]
+                           #{"file" "class" "foobar" "foo"})
+                 (assoc-in [{:type "File" :title "/etc/foobar"} :line] 20))
+             (scf-store/catalog-resources (:certname_id
+                                           (scf-store/latest-catalog-metadata
+                                            "basic.wire-catalogs.com"))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -679,10 +656,10 @@
 
   (deftest replace-facts-no-facts
     (dotestseq [version fact-versions
-                :let [command v4-command]]
+                :let [command facts]]
       (testing "should store the facts"
         (with-message-handler {:keys [handle-message dlo delay-pool q]}
-          (handle-message (store-command' q command))
+          (handle-message (queue/store-command q (facts->command-req (version-kwd->num version) command)))
           (is (= (query-to-vec
                   "SELECT fp.path as name,
                           COALESCE(fv.value_string,
@@ -707,7 +684,7 @@
 
   (deftest replace-facts-existing-facts
     (dotestseq [version fact-versions
-                :let [command v4-command]]
+                :let [command facts]]
       (with-test-db
         (jdbc/with-db-transaction []
           (scf-store/ensure-environment "DEV")
@@ -721,7 +698,7 @@
 
         (testing "should replace the facts"
           (with-message-handler {:keys [handle-message dlo delay-pool q]}
-            (handle-message (store-command' q command))
+            (handle-message (queue/store-command q (facts->command-req (version-kwd->num version) command)))
             (let [[result & _] (query-to-vec "SELECT certname,timestamp, environment_id FROM factsets")]
               (is (= (:certname result)
                      certname))
@@ -751,7 +728,7 @@
 
   (deftest replace-facts-newer-facts
     (dotestseq [version fact-versions
-                :let [command v4-command]]
+                :let [command facts]]
       (testing "should ignore the message"
         (with-message-handler {:keys [handle-message dlo delay-pool q]}
           (jdbc/with-db-transaction []
@@ -763,7 +740,7 @@
                                    :producer_timestamp (to-timestamp (now))
                                    :producer "bar.com"
                                    :environment "DEV"}))
-          (handle-message (store-command' q command))
+          (handle-message (queue/store-command q (facts->command-req (version-kwd->num version) command)))
 
           (is (= (query-to-vec "SELECT certname,timestamp,environment_id FROM factsets")
                  [(with-env {:certname certname :timestamp tomorrow})]))
@@ -789,13 +766,13 @@
 
   (deftest replace-facts-deactivated-node-facts
     (dotestseq [version fact-versions
-                :let [command v4-command]]
+                :let [command facts]]
       (testing "should reactivate the node if it was deactivated before the message"
         (with-message-handler {:keys [handle-message dlo delay-pool q]}
 
           (jdbc/insert! :certnames {:certname certname :deactivated yesterday})
 
-          (handle-message (store-command' q command))
+          (handle-message (queue/store-command q (facts->command-req (version-kwd->num version) command)))
           (is (= (query-to-vec "SELECT certname,deactivated FROM certnames")
                  [{:certname certname :deactivated nil}]))
           (is (= (query-to-vec
@@ -824,7 +801,7 @@
           (scf-store/delete-certname! certname)
           (jdbc/insert! :certnames {:certname certname :deactivated tomorrow})
 
-          (handle-message (store-command' q command))
+          (handle-message (queue/store-command q (facts->command-req (version-kwd->num version) command)))
 
           (is (= (query-to-vec "SELECT certname,deactivated FROM certnames")
                  [{:certname certname :deactivated tomorrow}]))
@@ -857,16 +834,14 @@
                           json/generate-string
                           json/parse-string
                           pt/to-timestamp)
-        facts-cmd {:command (command-names :replace-facts)
-                   :version 3
-                   :payload {:name certname
-                             :environment "DEV"
-                             :producer-timestamp producer-time
-                             :values {"a" "1"
-                                      "b" "2"
-                                      "c" "3"}}}]
+        facts-cmd {:name certname
+                   :environment "DEV"
+                   :producer-timestamp producer-time
+                   :values {"a" "1"
+                            "b" "2"
+                            "c" "3"}}]
     (with-message-handler {:keys [handle-message dlo delay-pool q]}
-      (handle-message (store-command' q facts-cmd))
+      (handle-message (queue/store-command q (facts->command-req 3 facts-cmd)))
 
       (is (= (query-to-vec
               "SELECT fp.path as name,
@@ -896,16 +871,14 @@
 (deftest replace-facts-with-v2-wire-format
   (let [certname  "foo.example.com"
         before-test-starts-time (-> 1 seconds ago)
-        facts-cmd {:command (command-names :replace-facts)
-                   :version 2
-                   :payload {:name certname
-                             :environment "DEV"
-                             :values {"a" "1"
-                                      "b" "2"
-                                      "c" "3"}}}]
+        facts-cmd {:name certname
+                   :environment "DEV"
+                   :values {"a" "1"
+                            "b" "2"
+                            "c" "3"}}]
     (with-message-handler {:keys [handle-message dlo delay-pool q]}
 
-      (handle-message (store-command' q facts-cmd))
+      (handle-message (queue/store-command q (facts->command-req 2 facts-cmd)))
 
       (is (= (query-to-vec
               "SELECT fp.path as name,
@@ -939,30 +912,33 @@
         (is (= result [(with-env {:certname certname})]))))))
 
 (deftest replace-facts-bad-payload
-  (let [bad-command {:command (command-names :replace-facts)
-                     :version latest-facts-version
-                     :payload "bad stuff"}]
+  (let [bad-command "bad stuff"]
     (dotestseq [version fact-versions
                 :let [command bad-command]]
       (testing "should discard the message"
         (with-message-handler {:keys [handle-message dlo delay-pool q]}
-          (handle-message (apply tqueue/store-command q (unroll-old-command command)))
+          (handle-message (queue/store-command q (queue/create-command-req "replace facts"
+                                                                           latest-facts-version
+                                                                           "foo.example.com"
+                                                                           (ks/timestamp (now))
+                                                                           identity
+                                                                           (tqueue/coerce-to-stream "bad stuff"))))
           (is (empty? (query-to-vec "SELECT * FROM facts")))
           (is (= 0 (task-count delay-pool)))
           (is (seq (fs/list-dir (:path dlo)))))))))
 
 (deftest replace-facts-bad-payload-v2
-  (let [bad-command {:command (command-names :replace-facts)
-                     :version 2
-                     :payload "bad stuff"}]
-    (dotestseq [version fact-versions
-                :let [command bad-command]]
-      (testing "should discard the message"
-        (with-message-handler {:keys [handle-message dlo delay-pool q]}
-          (handle-message (store-command' q command))
-          (is (empty? (query-to-vec "SELECT * FROM facts")))
-          (is (= 0 (task-count delay-pool)))
-          (is (seq (fs/list-dir (:path dlo)))))))))
+  (testing "should discard the message"
+    (with-message-handler {:keys [handle-message dlo delay-pool q]}
+      (handle-message (queue/store-command q (queue/create-command-req "replace facts"
+                                                                       2
+                                                                       "foo.example.com"
+                                                                       (ks/timestamp (now))
+                                                                       identity
+                                                                       (tqueue/coerce-to-stream "bad stuff"))))
+      (is (empty? (query-to-vec "SELECT * FROM facts")))
+      (is (= 0 (task-count delay-pool)))
+      (is (seq (fs/list-dir (:path dlo)))))))
 
 (defn extract-error
   "Pulls the error from the publish var of a test-msg-handler"
@@ -1023,7 +999,7 @@
           (let [first-message? (atom false)
                 second-message? (atom false)
                 fut (future
-                      (handle-message (store-command' q command))
+                      (handle-message (queue/store-command q (facts->command-req 4 facts)))
                       (reset! first-message? true))
 
                 new-facts (update-in facts [:values]
@@ -1035,7 +1011,7 @@
                                :version 4
                                :payload new-facts}]
 
-            (handle-message (store-command' q new-facts-cmd))
+            (handle-message (queue/store-command q (facts->command-req 4 new-facts)))
             (reset! second-message? true)
 
             @fut
@@ -1114,18 +1090,6 @@
                            "operatingsystem" "Debian"}
                   :producer_timestamp (now)
                   :producer producer-2}
-        command-1b   {:command (command-names :replace-facts)
-                      :version 4
-                      :payload facts-1b}
-        command-2b   {:command (command-names :replace-facts)
-                      :version 4
-                      :payload facts-2b}
-        command-1c   {:command (command-names :replace-facts)
-                      :version 4
-                      :payload facts-1c}
-        command-2c   {:command (command-names :replace-facts)
-                      :version 4
-                      :payload facts-2c}
 
         ;; Wait for two threads to countdown before proceeding
         latch (java.util.concurrent.CountDownLatch. 2)
@@ -1172,10 +1136,10 @@
         (let [first-message? (atom false)
               second-message? (atom false)
               fut-1 (future
-                      (handle-message (store-command' q command-1b))
+                      (handle-message (queue/store-command q (facts->command-req 4 facts-1b)))
                       (reset! first-message? true))
               fut-2 (future
-                      (handle-message (store-command' q command-2b))
+                      (handle-message (queue/store-command q (facts->command-req 4 facts-2b)))
                       (reset! second-message? true))]
           ;; The two commands are being submitted in future, ensure they
           ;; have both completed before proceeding
@@ -1188,7 +1152,7 @@
           (is (true? @second-message?))
           ;; Submit another factset that does NOT include mytimestamp,
           ;; this disassociates certname-1's fact_value (which is 1b)
-          (handle-message (store-command' q command-1c))
+          (handle-message (queue/store-command q (facts->command-req 4 facts-1c)))
           (reset! first-message? true)
 
           ;; Do the same thing with certname-2. Since the reference to 1b
@@ -1197,7 +1161,7 @@
           ;; of 1 is still in the table. It's now attempting to delete
           ;; that fact path, when the mytimestamp 1 value is still in
           ;; there.
-          (handle-message (store-command' q command-2c))
+          (handle-message (queue/store-command q (facts->command-req 4 facts-2c)))
           (is (= 0 (task-count delay-pool)))
 
           ;; Can we see the orphaned value '1', and does the global gc remove it.
@@ -1216,10 +1180,6 @@
       (let [test-catalog (get-in catalogs [:empty])
             {certname :certname :as wire-catalog} (get-in wire-catalogs [6 :empty])
             nonwire-catalog (catalog/parse-catalog wire-catalog 6 (now))
-            command {:command (command-names :replace-catalog)
-                     :version 6
-                     :payload wire-catalog}
-
             latch (java.util.concurrent.CountDownLatch. 2)
             orig-replace-catalog! scf-store/replace-catalog!]
 
@@ -1237,18 +1197,15 @@
           (let [first-message? (atom false)
                 second-message? (atom false)
                 fut (future
-                      (handle-message (store-command' q command))
+                      (handle-message (queue/store-command q (catalog->command-req 4 wire-catalog)))
                       (reset! first-message? true))
 
                 new-wire-catalog (assoc-in wire-catalog [:edges]
                                            #{{:relationship "contains"
                                               :target       {:title "Settings" :type "Class"}
-                                              :source       {:title "main" :type "Stage"}}})
-                new-catalog-cmd {:command (command-names :replace-catalog)
-                                 :version 6
-                                 :payload new-wire-catalog}]
+                                              :source       {:title "main" :type "Stage"}}})]
 
-            (handle-message (store-command' q new-catalog-cmd))
+            (handle-message (queue/store-command q (catalog->command-req 6 new-wire-catalog)))
             (reset! second-message? true)
             (is (empty? (fs/list-dir (:path dlo))))
 
@@ -1268,10 +1225,6 @@
       (let [test-catalog (get-in catalogs [:empty])
             {certname :certname :as wire-catalog} (get-in wire-catalogs [6 :empty])
             nonwire-catalog (catalog/parse-catalog wire-catalog 6 (now))
-            command {:command (command-names :replace-catalog)
-                     :version 6
-                     :payload wire-catalog}
-
             latch (java.util.concurrent.CountDownLatch. 2)
             orig-replace-catalog! scf-store/replace-catalog!]
 
@@ -1287,7 +1240,7 @@
                         (.await latch)
                         (apply orig-replace-catalog! args))]
           (let [fut (future
-                      (handle-message (store-command' q command))
+                      (handle-message (queue/store-command q (catalog->command-req 6 wire-catalog)))
                       ::handled-first-message)
 
                 new-wire-catalog (update wire-catalog :resources
@@ -1300,12 +1253,9 @@
                                           :tags       #{"file" "class" "foobar2"}
                                           :parameters {:ensure "directory"
                                                        :group  "root"
-                                                       :user   "root"}})
-                new-catalog-cmd {:command (command-names :replace-catalog)
-                                 :version 6
-                                 :payload new-wire-catalog}]
+                                                       :user   "root"}})]
 
-            (handle-message (store-command' q new-catalog-cmd))
+            (handle-message (queue/store-command q (catalog->command-req 6 new-wire-catalog)))
 
             (is (= ::handled-first-message (deref fut tu/default-timeout-ms nil)))
             (is (empty? (fs/list-dir (:path dlo))))
@@ -1314,32 +1264,21 @@
               (is (-> failed-cmdref :attempts first :exception
                       pg-serialization-failure-ex?)))))))))
 
-(let [cases [{:certname "foo.example.com"
-              :command {:command (command-names :deactivate-node)
-                        :version 3
-                        :payload {:certname "foo.example.com"}}}
-             {:certname "bar.example.com"
-              :command {:command (command-names :deactivate-node)
-                        :version 3
-                        :payload {:certname "bar.example.com"
-                                  :producer_timestamp (now)}}}
-             {:certname "bar.example.com"
-              :command {:command (command-names :deactivate-node)
-                        :version 2
-                        :payload (json/generate-string "bar.example.com")}}
-             {:certname "bar.example.com"
-              :command {:command (command-names :deactivate-node)
-                        :version 1
-                        :payload (-> "bar.example.com"
-                                     json/generate-string
-                                     json/generate-string)}}]]
+(let [cases [[3 {:certname "foo.example.com"}]
+             [3 {:certname "bar.example.com"
+                 :producer_timestamp (now)}]
+             [2 (json/generate-string "bar.example.com")]
+             [1 (-> "bar.example.com"
+                    json/generate-string
+                    json/generate-string)]]]
 
   (deftest deactivate-node-node-active
     (testing "should deactivate the node"
-      (doseq [{:keys [certname command]} cases]
+      (doseq [[version command] cases
+              :let [{:keys [certname] :as command-req} (deactivate->command-req version command)]]
         (with-message-handler {:keys [handle-message dlo delay-pool q]}
           (jdbc/insert! :certnames {:certname certname})
-          (handle-message (store-command' q command))
+          (handle-message (queue/store-command q command-req))
           (let [results (query-to-vec "SELECT certname,deactivated FROM certnames")
                 result  (first results)]
             (is (= (:certname result) certname))
@@ -1349,28 +1288,28 @@
             (jdbc/do-prepared "delete from certnames"))))))
 
   (deftest deactivate-node-node-inactive
-    (doseq [{:keys [certname command]} cases]
+    (doseq [[version orig-command] cases]
       (testing "should leave the node alone"
         (let [one-day   (* 24 60 60 1000)
               yesterday (to-timestamp (- (System/currentTimeMillis) one-day))
-              command (if (#{1 2} (:version command))
+              command (if (#{1 2} version)
                         ;; Can't set the :producer_timestamp for the older
                         ;; versions (so that we can control the deactivation
                         ;; timestamp).
-                        command
-                        (assoc-in command
-                                  [:payload :producer_timestamp] yesterday))]
+                        orig-command
+                        (assoc orig-command :producer_timestamp yesterday))
+              {:keys [certname] :as command-req} (deactivate->command-req version command)]
 
           (with-message-handler {:keys [handle-message dlo delay-pool q]}
             (jdbc/insert! :certnames
                           {:certname certname :deactivated yesterday})
-            (handle-message (store-command' q command))
+            (handle-message (queue/store-command q command-req))
 
             (let [[row & rest] (query-to-vec
                                 "SELECT certname,deactivated FROM certnames")]
               (is (empty? rest))
               (is (instance? java.sql.Timestamp (:deactivated row)))
-              (if (#{1 2} (:version command))
+              (if (#{1 2} version)
                 (do
                   ;; Since we can't control the producer_timestamp.
                   (is (= certname (:certname row)))
@@ -1383,9 +1322,10 @@
 
   (deftest deactivate-node-node-missing
     (testing "should add the node and deactivate it"
-      (doseq [{:keys [certname command]} cases]
+      (doseq [[version command] cases
+              :let [{:keys [certname] :as command-req} (deactivate->command-req version command)]]
         (with-message-handler {:keys [handle-message dlo delay-pool q]}
-          (handle-message (store-command' q command))
+          (handle-message (queue/store-command q command-req))
           (let [result (-> "SELECT certname, deactivated FROM certnames"
                            query-to-vec first)]
             (is (= (:certname result) certname))
@@ -1403,66 +1343,51 @@
 (def store-report-name (command-names :store-report))
 
 (deftest store-v8-report-test
-  (let [command {:command store-report-name
-                 :version 8
-                 :payload v8-report}]
-    (with-message-handler {:keys [handle-message dlo delay-pool q]}
-      (handle-message (store-command' q command))
-      (is (= [(with-producer (select-keys v8-report [:certname]))]
-             (-> (str "select certname, producer_id"
-                      "  from reports")
-                 query-to-vec)))
-      (is (= 0 (task-count delay-pool)))
-      (is (empty? (fs/list-dir (:path dlo)))))))
+  (with-message-handler {:keys [handle-message dlo delay-pool q]}
+    (handle-message (queue/store-command q (report->command-req 8 v8-report)))
+    (is (= [(with-producer (select-keys v8-report [:certname]))]
+           (-> (str "select certname, producer_id"
+                    "  from reports")
+               query-to-vec)))
+    (is (= 0 (task-count delay-pool)))
+    (is (empty? (fs/list-dir (:path dlo))))))
 
 (deftest store-v7-report-test
-  (let [command {:command store-report-name
-                 :version 7
-                 :payload v7-report}]
-    (with-message-handler {:keys [handle-message dlo delay-pool q]}
-      (handle-message (store-command' q command))
-      (is (= [(select-keys v7-report [:certname :catalog_uuid :cached_catalog_status :code_id])]
-             (->> (str "select certname, catalog_uuid, cached_catalog_status, code_id"
-                       "  from reports")
-                  query-to-vec
-                  (map (fn [row] (update row :catalog_uuid sutils/parse-db-uuid))))))
-      (is (= 0 (task-count delay-pool)))
-      (is (empty? (fs/list-dir (:path dlo)))))))
+  (with-message-handler {:keys [handle-message dlo delay-pool q]}
+    (handle-message (queue/store-command q (report->command-req 7 v7-report)))
+    (is (= [(select-keys v7-report [:certname :catalog_uuid :cached_catalog_status :code_id])]
+           (->> (str "select certname, catalog_uuid, cached_catalog_status, code_id"
+                     "  from reports")
+                query-to-vec
+                (map (fn [row] (update row :catalog_uuid sutils/parse-db-uuid))))))
+    (is (= 0 (task-count delay-pool)))
+    (is (empty? (fs/list-dir (:path dlo))))))
 
 (deftest store-v6-report-test
-  (let [command {:command store-report-name
-                 :version 6
-                 :payload v6-report}]
-    (with-message-handler {:keys [handle-message dlo delay-pool q]}
-      (handle-message (store-command' q command))
-      (is (= [(with-env (select-keys v6-report [:certname :configuration_version]))]
-             (-> (str "select certname, configuration_version, environment_id"
-                      "  from reports")
-                 query-to-vec)))
-      (is (= 0 (task-count delay-pool)))
-      (is (empty? (fs/list-dir (:path dlo)))))))
+  (with-message-handler {:keys [handle-message dlo delay-pool q]}
+    (handle-message (queue/store-command q (report->command-req 6 v6-report)))
+    (is (= [(with-env (select-keys v6-report [:certname :configuration_version]))]
+           (-> (str "select certname, configuration_version, environment_id"
+                    "  from reports")
+               query-to-vec)))
+    (is (= 0 (task-count delay-pool)))
+    (is (empty? (fs/list-dir (:path dlo))))))
 
 (deftest store-v5-report-test
-  (let [command {:command store-report-name
-                 :version 5
-                 :payload v5-report}]
-    (with-message-handler {:keys [handle-message dlo delay-pool q]}
-      (handle-message (store-command' q command))
-      (is (= [(with-env (select-keys v5-report [:certname
-                                                :configuration_version]))]
-             (-> (str "select certname, configuration_version, environment_id"
-                      "  from reports")
-                 query-to-vec)))
-      (is (= 0 (task-count delay-pool)))
-      (is (empty? (fs/list-dir (:path dlo)))))))
+  (with-message-handler {:keys [handle-message dlo delay-pool q]}
+    (handle-message (queue/store-command q (report->command-req 5 v5-report)))
+    (is (= [(with-env (select-keys v5-report [:certname
+                                              :configuration_version]))]
+           (-> (str "select certname, configuration_version, environment_id"
+                    "  from reports")
+               query-to-vec)))
+    (is (= 0 (task-count delay-pool)))
+    (is (empty? (fs/list-dir (:path dlo))))))
 
 (deftest store-v4-report-test
-  (let [command {:command store-report-name
-                 :version 4
-                 :payload v4-report}
-        recent-time (-> 1 seconds ago)]
+  (let [recent-time (-> 1 seconds ago)]
     (with-message-handler {:keys [handle-message dlo delay-pool q]}
-      (handle-message (store-command' q command))
+      (handle-message (queue/store-command q (report->command-req 4 v4-report)))
       (is (= [(with-env (utils/dash->underscore-keys
                          (select-keys v4-report
                                       [:certname :configuration-version])))]
@@ -1486,12 +1411,9 @@
 
 (deftest store-v3-report-test
   (let [v3-report (dissoc v4-report :status)
-        recent-time (-> 1 seconds ago)
-        command {:command store-report-name
-                 :version 3
-                 :payload v3-report}]
+        recent-time (-> 1 seconds ago)]
     (with-message-handler {:keys [handle-message dlo delay-pool q]}
-      (handle-message (store-command' q command))
+      (handle-message (queue/store-command q (report->command-req 3 v3-report)))
       (is (= [(with-env (utils/dash->underscore-keys
                          (select-keys v3-report
                                       [:certname :configuration-version])))]

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -64,6 +64,7 @@
    version
    (or (:certname payload)
        (:name payload))
+   nil
    payload])
 
 (defrecord CommandHandlerContext [message-handler command-chan dlo delay-pool response-chan q]
@@ -1535,6 +1536,7 @@
           (enqueue-command (command-names :replace-facts)
                            4
                            "foo.local"
+                           nil
                            (tqueue/coerce-to-stream
                             {:environment "DEV" :certname "foo.local"
                              :values {:foo "foo"}
@@ -1560,6 +1562,7 @@
       (enqueue-command (command-names :deactivate-node)
                        3
                        "foo.local"
+                       nil
                        (tqueue/coerce-to-stream
                         {:certname "foo.local" :producer_timestamp input-stamp}))
       (is (svc-utils/wait-for-server-processing svc-utils/*server* default-timeout-ms)
@@ -1599,6 +1602,7 @@
       (enqueue-command (command-names :deactivate-node)
                        3
                        "foo.local"
+                       nil
                        (tqueue/coerce-to-stream
                         {:certname "foo.local" :producer_timestamp producer-ts}))
 
@@ -1649,6 +1653,7 @@
            (enqueue-command (command-names :replace-catalog)
                             9
                             "foo.com"
+                            nil
                             (->  base-cmd
                                  (assoc :producer_timestamp old-producer-ts
                                         :certname "foo.com")
@@ -1658,6 +1663,7 @@
            (enqueue-command (command-names :replace-catalog)
                             9
                             (:certname base-cmd)
+                            nil
                             (-> base-cmd
                                 (assoc :producer_timestamp old-producer-ts)
                                 tqueue/coerce-to-stream)
@@ -1666,6 +1672,7 @@
            (enqueue-command (command-names :replace-catalog)
                             9
                             (:certname base-cmd)
+                            nil
                             (-> base-cmd
                                 (assoc :producer_timestamp new-producer-ts)
                                 tqueue/coerce-to-stream)

--- a/test/puppetlabs/puppetdb/http/command_test.clj
+++ b/test/puppetlabs/puppetdb/http/command_test.clj
@@ -253,10 +253,12 @@
 
 (defn handler-with-max [q command-chan max-command-size]
   (#'tgt/enqueue-command-handler
-   (partial cmd/do-enqueue-command
-            q
-            command-chan
-            (Semaphore. 100))
+   (fn [command version certname producer-ts stream callback]
+     (cmd/do-enqueue-command
+              q
+              command-chan
+              (Semaphore. 100)
+              (queue/create-command-req command version certname producer-ts callback stream)))
    max-command-size))
 
 (deftest enqueue-max-command-size

--- a/test/puppetlabs/puppetdb/testutils/queue.clj
+++ b/test/puppetlabs/puppetdb/testutils/queue.clj
@@ -43,5 +43,8 @@
 (defn coerce-to-stream [x]
   (-coerce-to-stream x))
 
-(defn store-command [q command-type version certname payload]
-  (q/store-command q command-type version certname (coerce-to-stream payload)))
+(defn store-command
+  ([q command-type version certname payload]
+   (store-command q command-type version certname nil payload))
+  ([q command-type version certname producer-ts payload]
+   (q/store-command q command-type version certname producer-ts (coerce-to-stream payload))))

--- a/test/puppetlabs/puppetdb/testutils/queue.clj
+++ b/test/puppetlabs/puppetdb/testutils/queue.clj
@@ -6,7 +6,9 @@
             [puppetlabs.puppetdb.nio :refer [get-path]]
             [puppetlabs.puppetdb.testutils.nio :refer [create-temp-dir]]
             [puppetlabs.puppetdb.queue :as q]
-            [puppetlabs.puppetdb.cheshire :as json]))
+            [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.kitchensink.core :as ks]
+            [clj-time.core :refer [now]]))
 
 (defmacro with-stockpile [queue-sym & body]
   `(let [ns-str#  (str (ns-name ~*ns*))
@@ -43,8 +45,37 @@
 (defn coerce-to-stream [x]
   (-coerce-to-stream x))
 
-(defn store-command
-  ([q command-type version certname payload]
-   (store-command q command-type version certname nil payload))
-  ([q command-type version certname producer-ts payload]
-   (q/store-command q command-type version certname producer-ts (coerce-to-stream payload))))
+(defn catalog->command-req [version {:keys [certname name] :as catalog}]
+  (q/create-command-req "replace catalog"
+                        version
+                        (or certname name)
+                        (ks/timestamp (now))
+                        identity
+                        (coerce-to-stream catalog)))
+
+(defn facts->command-req [version {:keys [certname name] :as facts}]
+  (q/create-command-req "replace facts"
+                        version
+                        (or certname name)
+                        (ks/timestamp (now))
+                        identity
+                        (coerce-to-stream facts)))
+
+(defn deactivate->command-req [version {:keys [certname] :as command}]
+  (q/create-command-req "deactivate node"
+                        version
+                        (case version
+                          3 certname
+                          2 (json/parse-string command)
+                          1 (json/parse-string (json/parse-string command)))
+                        (ks/timestamp (now))
+                        identity
+                        (coerce-to-stream command)))
+
+(defn report->command-req [version {:keys [certname name] :as command}]
+  (q/create-command-req "store report"
+                        version
+                        (or certname name)
+                        (ks/timestamp (now))
+                        identity
+                        (coerce-to-stream command)))


### PR DESCRIPTION
This PR adds producer-timestamp to the command POST headers and threads it through the stack. The parameter is used in the "bash in place" code to determine which command is older. This also required modifying the terminus to include that parameter in the POST.

While working on this patch, I found it difficult to thread the new producer-timestamp value through the stack for enqueuing. There's also a commit in this set that refactors the enqueuing functions to pass a "command request" through the stack. That map gets created (and validated) by the service, which is then passed through the stack.

Note to reviewers, it will probably be easier to look at the commits individually.

~~This PR depends on https://github.com/puppetlabs/puppetdb/pull/2152, which needs to go in first.~~