### PR TITLE
(MAINT) Upgrade to clj-parent 0.3.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.3.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.3.2"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in


### PR DESCRIPTION
This commit upgrades the clj-parent dependency from 0.3.0 to 0.3.2 in
order to pick up a fix from trapperkeeper-status 0.7.1 where gc/cpu
metric collection could corrupt the status endpoint.