### PR TITLE
(PDB-2524) Data-driven dashboard

### DIFF
--- a/resources/public/dashboard/index.html
+++ b/resources/public/dashboard/index.html
@@ -159,6 +159,7 @@ body {
     for(var i=0; i<meters.length; i++) {
       m = meters[i];
       meterUpdateFunctions[m.id] = counterAndSparkline(m, options);
+      meterUpdateFunctions[m.id](m.value);
     }
   });
 

--- a/resources/public/dashboard/index.html
+++ b/resources/public/dashboard/index.html
@@ -101,13 +101,6 @@ body {
 </table>
 
 <script>(function() {
-  // Formatting middleware that collapses small values to 0
-  function clampToZero(f, window) {
-    return function(n) {
-      return f(Math.abs(n) < window ? 0 : n);
-    };
-  };
-
   // Parse URL arguments
   function getParameter(paramName) {
     var searchString = window.location.search.substring(1),
@@ -135,7 +128,6 @@ body {
 
   function checkForUpdates() {
     d3.json("/pdb/meta/v1/version/latest", function (res) {
-      console.log(res);
       if (res != null && res.newer) {
         d3.select('#latest-version').html('v' + res.version);
         d3.select('#update-link').classed('hidden', false);
@@ -158,125 +150,29 @@ body {
                  width: width,
                  height: height,
                  container: "#metrics"};
+  var data_url = "/pdb/dashboard/data";
 
-  function getValueSnag(res) {
-      return res["Value"];
-  }
+  var meterUpdateFunctions = {};
 
-  function getCountSnag(res) {
-      return res["Count"];
-  }
+  // Initial fetch of the meters to create the UI
+  d3.json(data_url, function cb(meters) {
+    for(var i=0; i<meters.length; i++) {
+      m = meters[i];
+      meterUpdateFunctions[m.id] = counterAndSparkline(m, options);
+    }
+  });
 
-  function getPercentileSnag(res) {
-      return res["50thPercentile"] / 1000;
-  }
+  function tick() {
+    // Get the meters in bulk, then update each widget
+    d3.json(data_url, function cb(meters) {
+      for(var i=0; i<meters.length; i++) {
+        m = meters[i];
+        meterUpdateFunctions[m.id](m.value);
+      }
+    });
+  };
 
-  var metrics = [
-      {description: "JVM Heap",
-       addendum: "bytes",
-       url: "/metrics/v1/mbeans/java.lang:type=Memory",
-       format: d3.format(",.3s"),
-       snag: function(res) { return res["HeapMemoryUsage"]["used"]; }},
-      {description: "Active Nodes",
-       addendum: "in the population",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.population:name=num-active-nodes",
-       format: d3.format(","),
-       snag: getValueSnag},
-      {description: "Inactive Nodes",
-       addendum: "in the population",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.population:name=num-inactive-nodes",
-       format: d3.format(","),
-       snag: getValueSnag},
-      {description: "Resources",
-       addendum: "in the population",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.population:name=num-resources",
-       format: d3.format(","),
-       snag: getValueSnag},
-      {description: "Resource duplication",
-       addendum: "% of resources stored",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.population:name=pct-resource-dupes",
-       format: d3.format(",.1%"),
-       snag: getValueSnag},
-      {description: "Catalog duplication",
-       addendum: "% of catalogs encountered",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.storage:name=duplicate-pct",
-       format: d3.format(",.1%"),
-       snag: getValueSnag},
-      {description: "Command Queue",
-       addendum: "depth",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.mq%3Aname%3Dglobal.depth",
-       format: d3.format(",s"),
-       snag: function(res) { return res["Count"]; }},
-      {description: "Command Processing",
-       addendum: "sec/command",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.mq:name=global.processing-time",
-       format: d3.format(",.3s"),
-       snag: getPercentileSnag},
-      {description: "Command Processing",
-       addendum: "command/sec",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.mq:name=global.processed",
-       format: clampToZero(d3.format(",.3s"), 0.001),
-       snag: function(res) { return res["FiveMinuteRate"]; }},
-      {description: "Processed",
-       addendum: "since startup",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.mq:name=global.processed",
-       format: d3.format(","),
-       snag: getCountSnag},
-      {description: "Retried",
-       addendum: "since startup",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.mq:name=global.retried",
-       format: d3.format(","),
-       snag: getCountSnag},
-      {description: "Discarded",
-       addendum: "since startup",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.mq:name=global.discarded",
-       format: d3.format(","),
-       snag: getCountSnag},
-      {description: "Rejected",
-       addendum: "since startup",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.mq:name=global.fatal",
-       format: d3.format(","),
-       snag: getCountSnag},
-      {description: "Enqueueing",
-       addendum: "service time, seconds",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.http:name=/pdb/cmd/v1.service-time",
-       format: d3.format(",.3s"),
-       snag: getPercentileSnag},
-      {description: "Command Persistence",
-       addendum: "Message persistence time, milliseconds",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.mq%3Aname%3Dglobal.message-persistence-time",
-       format: d3.format(",.2s"),
-       snag: function(res) { return res["FiveMinuteRate"]; }},
-      {description: "Collection Queries",
-       addendum: "service time, seconds",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.http:name=/pdb/query/v4/resources.service-time",
-       format: d3.format(",.3s"),
-       snag: getPercentileSnag},
-      {description: "DB Compaction",
-       addendum: "round trip time, seconds",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.storage:name=gc-time",
-       format: d3.format(",.3s"),
-       snag: getPercentileSnag},
-      {description: "DLO Size on Disk",
-       addendum: "bytes",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.dlo:name=global.filesize",
-       format: d3.format(",.3s"),
-       snag: getValueSnag},
-      {description: "Discarded Messages",
-       addendum: "to be reviewed",
-       url: "/metrics/v1/mbeans/puppetlabs.puppetdb.dlo:name=global.messages",
-       format: d3.format(","),
-       snag: getValueSnag}]
-
-  for (i = 0; i < metrics.length; i++) {
-      var metric = metrics[i];
-      counterAndSparkline(metric.description,
-                          metric.addendum,
-                          metric.url,
-                          metric.format,
-                          metric.snag,
-                          options);
-  }
+  setInterval(tick, 5 * 1000);
 
   // Check the current version and for updates now, and then check for updates every 5 minutes
   setVersion();

--- a/src/puppetlabs/puppetdb/dashboard.clj
+++ b/src/puppetlabs/puppetdb/dashboard.clj
@@ -4,7 +4,173 @@
             [puppetlabs.trapperkeeper.core :refer [defservice]]
             [ring.util.response :as rr]
             [puppetlabs.comidi :as cmdi]
-            [puppetlabs.i18n.core :refer [trs]]))
+            [puppetlabs.i18n.core :refer [trs]]
+            [puppetlabs.trapperkeeper.services.metrics.metrics-utils :refer [get-mbean]]
+            [puppetlabs.puppetdb.http :as http]
+            [puppetlabs.puppetdb.middleware :as middleware]
+            [puppetlabs.i18n.core :refer [tru]]
+            [schema.core :as s]
+            [puppetlabs.puppetdb.schema :as pls]))
+
+;;; Dashboard data endpoint
+
+(def meter-def-schema
+  {:description s/Str
+   :addendum s/Str
+   :mbean s/Str
+   :format s/Str
+   (s/optional-key :clampToZero) s/Num
+   :value-path [s/Keyword]
+   (s/optional-key :value-scale) s/Num})
+
+(def meter-schema
+  (-> meter-def-schema
+      (dissoc :value-path :value-scale)
+      (merge {:id s/Str
+              :value (s/maybe s/Num)})))
+
+(defn default-meter-defs []
+  [{:description (tru "JVM Heap")
+    :addendum (tru "bytes")
+    :mbean "java.lang:type=Memory"
+    :format ".3s"
+    :value-path [:HeapMemoryUsage :used]}
+
+   {:description (tru "Active Nodes")
+    :addendum (tru "in the population")
+    :mbean "puppetlabs.puppetdb.population:name=num-active-nodes"
+    :format ""
+    :value-path [:Value]}
+
+   {:description (tru "Inactive Nodes")
+    :addendum (tru "in the population")
+    :mbean "puppetlabs.puppetdb.population:name=num-inactive-nodes"
+    :format ""
+    :value-path [:Value]}
+
+   {:description (tru "Resources")
+    :addendum (tru "in the population")
+    :mbean "puppetlabs.puppetdb.population:name=num-resources"
+    :format ""
+    :value-path [:Value]}
+
+   {:description (tru "Resource duplication")
+    :addendum (tru "% of resources stored")
+    :mbean "puppetlabs.puppetdb.population:name=pct-resource-dupes"
+    :format ".1%"
+    :value-path [:Value]}
+
+   {:description (tru "Catalog duplication")
+    :addendum (tru "% of catalogs encountered")
+    :mbean "puppetlabs.puppetdb.storage:name=duplicate-pct"
+    :format ".1%"
+    :value-path [:Value]}
+
+   {:description (tru "Command Queue")
+    :addendum (tru "depth")
+    :mbean "puppetlabs.puppetdb.mq:name=global.depth"
+    :format "s"
+    :value-path [:Count]}
+
+   {:description (tru "Command Processing")
+    :addendum (tru "sec/command")
+    :mbean "puppetlabs.puppetdb.mq:name=global.processing-time"
+    :format ".3s"
+    :value-path [:50thPercentile]
+    :value-scale 1/1000
+    :clampToZero 0.001}
+
+   {:description (tru "Command Processing")
+    :addendum (tru "command/sec")
+    :mbean "puppetlabs.puppetdb.mq:name=global.processed"
+    :format ".3s" ;; TODO: clampToZero((".3s") 0.001)
+    :value-path [:FiveMinuteRate]}
+
+   {:description (tru "Processed")
+    :addendum (tru "since startup")
+    :mbean "puppetlabs.puppetdb.mq:name=global.processed"
+    :format ""
+    :value-path [:Count]}
+
+   {:description (tru "Retried")
+    :addendum (tru "since startup")
+    :mbean "puppetlabs.puppetdb.mq:name=global.retried"
+    :format ""
+    :value-path [:Count]}
+
+   {:description (tru "Discarded")
+    :addendum (tru "since startup")
+    :mbean "puppetlabs.puppetdb.mq:name=global.discarded"
+    :format ""
+    :value-path [:Count]}
+
+   {:description (tru "Rejected")
+    :addendum (tru "since startup")
+    :mbean "puppetlabs.puppetdb.mq:name=global.fatal"
+    :format ""
+    :value-path [:Count]}
+
+   {:description (tru "Enqueueing")
+    :addendum (tru "service time seconds")
+    :mbean "puppetlabs.puppetdb.http:name=/pdb/cmd/v1.service-time"
+    :format ".3s"
+    :value-path [:50thPercentile]
+    :value-scale 1/1000}
+
+   {:description (tru "Command Persistence")
+    :addendum (tru "Message persistence time milliseconds")
+    :mbean "puppetlabs.puppetdb.mq:name=global.message-persistence-time"
+    :format ".2s"
+    :value-path [:FiveMinuteRate]}
+
+   {:description (tru "Collection Queries")
+    :addendum (tru "service time seconds")
+    :mbean "puppetlabs.puppetdb.http:name=/pdb/query/v4/resources.service-time"
+    :format ".3s"
+    :value-path [:50thPercentile]
+    :value-scale 1/1000}
+
+   {:description (tru "DB Compaction")
+    :addendum (tru "round trip time seconds")
+    :mbean "puppetlabs.puppetdb.storage:name=gc-time"
+    :format ".3s"
+    :value-path [:50thPercentile]
+    :value-scale 1/1000}
+
+   {:description (tru "DLO Size on Disk")
+    :addendum (tru "bytes")
+    :mbean "puppetlabs.puppetdb.dlo:name=global.filesize"
+    :format ".3s"
+    :value-path [:Value]}
+
+   {:description (tru "Discarded Messages")
+    :addendum (tru "to be reviewed")
+    :mbean "puppetlabs.puppetdb.dlo:name=global.messages"
+    :format ""
+    :value-path [:Value]}])
+
+(defn meter-id [meter-def]
+  (format "%x"
+          (hash (select-keys meter-def [:description :addendum :mbean :format :value-path]))))
+
+(pls/defn-validated get-dashboard-data :- [meter-schema]
+  [meter-defs]
+  (for [{:keys [mbean value-path value-scale] :or {value-scale 1} :as m} meter-defs]
+    (-> m
+        (dissoc :value-path :value-scale)
+        (assoc :value (some-> (get-in (get-mbean mbean) value-path)
+                              (* value-scale))
+               :id (meter-id m)))))
+
+(defn build-app [meter-defs-fn]
+  (middleware/make-pdb-handler
+   (cmdi/routes
+    (cmdi/context "/data"
+                  (cmdi/GET "" []
+                            (http/json-response
+                             (get-dashboard-data (meter-defs-fn))))))))
+
+;;; Dashboard redirect
 
 (def dashboard-routes
   (cmdi/context "/"

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -18,7 +18,8 @@
             [puppetlabs.puppetdb.middleware :as mid]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.puppetdb.status :as pdb-status]
-            [puppetlabs.i18n.core :refer [trs tru]]))
+            [puppetlabs.i18n.core :refer [trs tru]]
+            [puppetlabs.puppetdb.dashboard :as dashboard]))
 
 
 (defn resource-request-handler [req]
@@ -46,6 +47,7 @@
                       rreq/request-url
                       (format "%s/dashboard/index.html")
                       rr/redirect))
+           "/dashboard" (dashboard/build-app dashboard/default-meter-defs)
            "/meta" (meta/build-app db-cfg defaulted-config)
            "/cmd" (cmd/command-app get-shared-globals
                                    enqueue-command-fn

--- a/test/puppetlabs/puppetdb/dashboard_test.clj
+++ b/test/puppetlabs/puppetdb/dashboard_test.clj
@@ -9,14 +9,23 @@
             [puppetlabs.puppetdb.utils :refer [base-url->str-with-prefix]]
             [puppetlabs.puppetdb.testutils :as tu]
             [puppetlabs.puppetdb.testutils.dashboard :as dtu]
-            [puppetlabs.puppetdb.middleware :as mid]))
+            [puppetlabs.puppetdb.middleware :as mid]
+            [puppetlabs.puppetdb.cheshire :as json]))
 
 (deftest dashboard-resource-requests
   (testing "dashboard redirect works"
     (let [handler (mid/make-pdb-handler dashboard-routes)
           {:keys [status headers]} (handler (request :get "/"))]
       (is (= status 302))
-      (is (= "/pdb/dashboard/index.html" (get headers "Location"))))))
+      (is (= "/pdb/dashboard/index.html" (get headers "Location")))))
+  (testing "dashboard data request works"
+    (let [handler (build-app default-meter-defs)
+          {:keys [status headers body]} (handler (request :get "/data"))
+          body (json/parse-string body true)]
+      (is (= status 200))
+      (is (seq? body))
+      (is (= (count body)
+             (->> body (map :id) distinct count))))))
 
 (deftest root-dashboard-routing
   (svc-utils/call-with-single-quiet-pdb-instance


### PR DESCRIPTION
Rework the dashboard to get the list of meters to display in a request to the
server, rather than hardcoding them in javascript. This has several benefits:

- All metrics can be returned in a single response, instead of having to poll
  each metric individually

- The meter descriptions can be localized

- The data can be overriden in PE, to allow new meters to be added there for
  PE-only functionality.