### PR TITLE
(PDB-3169) Increase timeout in command test

### DIFF
--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -1672,9 +1672,9 @@
 
            (.release semaphore)
 
-           (is (not= ::timed-out (deref cmd-1 5000 ::timed-out)))
-           (is (not= ::timed-out (deref cmd-2 5000 ::timed-out)))
-           (is (not= ::timed-out (deref cmd-3 5000 ::timed-out)))
+           (is (not= ::timed-out (deref cmd-1 15000 ::timed-out)))
+           (is (not= ::timed-out (deref cmd-2 15000 ::timed-out)))
+           (is (not= ::timed-out (deref cmd-3 15000 ::timed-out)))
 
            ;; There's currently a lot of layering in the messaging
            ;; stack. The callback mechanism that delivers the promise


### PR DESCRIPTION
This sometimes times out when running on shared test infrastructure; attempt to
work around this by increasing the timeout.