### PR TITLE
(PDB-3169) Increase timeout in command test

### DIFF
--- a/test/puppetlabs/puppetdb/amq_migration_test.clj
+++ b/test/puppetlabs/puppetdb/amq_migration_test.clj
@@ -11,7 +11,7 @@
             [puppetlabs.puppetdb.cli.services :refer [shared-globals]]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.testutils.db :refer [*db* with-test-db]]
-            [puppetlabs.puppetdb.testutils :as tutils]
+            [puppetlabs.puppetdb.testutils :as tu]
             [puppetlabs.trapperkeeper.app :refer [get-service]]
             [puppetlabs.trapperkeeper.services :refer [service-context]]
             [puppetlabs.kitchensink.core :as ks]
@@ -119,7 +119,7 @@
             (svc-utils/call-with-puppetdb-instance
              (assoc config :database *db*)
              (fn []
-               (await-processed 2 before-start-state tutils/default-timeout-ms)
+               (await-processed 2 before-start-state tu/default-timeout-ms)
                (is (not (needs-upgrade? config)))
                (let [results (cli-utils/get-catalogs "basic.wire-catalogs.com")]
                  (is (= 1 (count results)))
@@ -158,7 +158,7 @@
             (svc-utils/call-with-puppetdb-instance
              (assoc config :database *db*)
              (fn []
-               (await-processed 1 before-start-state tutils/default-timeout-ms)
+               (await-processed 1 before-start-state tu/default-timeout-ms)
                (is (= 2
                       (-> svc-utils/*server*
                           dlo-paths
@@ -173,7 +173,7 @@
       (with-test-db
         (let [config (svc-utils/create-temp-config)
               defaulted-config (conf/process-config! (assoc config :database *db*))
-              mock-upgrade-fn (tutils/mock-fn)]
+              mock-upgrade-fn (tu/mock-fn)]
 
           (is (not (needs-upgrade? config)))
 

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -54,7 +54,7 @@
             [puppetlabs.trapperkeeper.services
              :refer [service-context]]
             [overtone.at-at :refer [mk-pool scheduled-jobs]]
-            [puppetlabs.puppetdb.testutils :as tutils])
+            [puppetlabs.puppetdb.testutils :as tu])
   (:import [java.util.concurrent TimeUnit]
            [org.joda.time DateTime DateTimeZone]))
 
@@ -1305,7 +1305,7 @@
 
             (handle-message (store-command' q new-catalog-cmd))
 
-            (is (= ::handled-first-message (deref fut tutils/default-timeout-ms nil)))
+            (is (= ::handled-first-message (deref fut tu/default-timeout-ms nil)))
             (is (empty? (fs/list-dir (:path dlo))))
             (let [failed-cmdref (take-with-timeout!! command-chan default-timeout-ms)]
               (is (= 1 (count (:attempts failed-cmdref))))
@@ -1672,9 +1672,9 @@
 
            (.release semaphore)
 
-           (is (not= ::timed-out (deref cmd-1 tutils/default-timeout-ms ::timed-out)))
-           (is (not= ::timed-out (deref cmd-2 tutils/default-timeout-ms ::timed-out)))
-           (is (not= ::timed-out (deref cmd-3 tutils/default-timeout-ms ::timed-out)))
+           (is (not= ::timed-out (deref cmd-1 tu/default-timeout-ms ::timed-out)))
+           (is (not= ::timed-out (deref cmd-2 tu/default-timeout-ms ::timed-out)))
+           (is (not= ::timed-out (deref cmd-3 tu/default-timeout-ms ::timed-out)))
 
            ;; There's currently a lot of layering in the messaging
            ;; stack. The callback mechanism that delivers the promise

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -53,7 +53,8 @@
             [puppetlabs.puppetdb.queue :as queue]
             [puppetlabs.trapperkeeper.services
              :refer [service-context]]
-            [overtone.at-at :refer [mk-pool scheduled-jobs]])
+            [overtone.at-at :refer [mk-pool scheduled-jobs]]
+            [puppetlabs.puppetdb.testutils :as tutils])
   (:import [java.util.concurrent TimeUnit]
            [org.joda.time DateTime DateTimeZone]))
 
@@ -1304,7 +1305,7 @@
 
             (handle-message (store-command' q new-catalog-cmd))
 
-            (is (= ::handled-first-message (deref fut (* 1000 60) nil)))
+            (is (= ::handled-first-message (deref fut tutils/default-timeout-ms nil)))
             (is (empty? (fs/list-dir (:path dlo))))
             (let [failed-cmdref (take-with-timeout!! command-chan default-timeout-ms)]
               (is (= 1 (count (:attempts failed-cmdref))))
@@ -1671,9 +1672,9 @@
 
            (.release semaphore)
 
-           (is (not= ::timed-out (deref cmd-1 5000 ::timed-out)))
-           (is (not= ::timed-out (deref cmd-2 5000 ::timed-out)))
-           (is (not= ::timed-out (deref cmd-3 5000 ::timed-out)))
+           (is (not= ::timed-out (deref cmd-1 tutils/default-timeout-ms ::timed-out)))
+           (is (not= ::timed-out (deref cmd-2 tutils/default-timeout-ms ::timed-out)))
+           (is (not= ::timed-out (deref cmd-3 tutils/default-timeout-ms ::timed-out)))
 
            ;; There's currently a lot of layering in the messaging
            ;; stack. The callback mechanism that delivers the promise


### PR DESCRIPTION
This sometimes times out when running on shared test infrastructure; attempt to
work around this by increasing the timeout.