### PR TITLE
(MAINT) Close datasource in max connection jdbc pool tests

### DIFF
--- a/test/puppetlabs/puppetdb/jdbc_test.clj
+++ b/test/puppetlabs/puppetdb/jdbc_test.clj
@@ -54,19 +54,21 @@
   (testing "max connections setting defaults to 25"
     (call-with-antonym-test-database
       (fn []
-        (let [pool (-> *db*
-                       defaulted-read-db-config
-                       subject/pooled-datasource)]
-          (is (= 25 (.getMaximumPoolSize (:datasource pool))))))))
+        (with-open [data-source (-> *db*
+                                    defaulted-read-db-config
+                                    subject/pooled-datasource
+                                    :datasource)]
+          (is (= 25 (.getMaximumPoolSize data-source)))))))
 
   (testing "max connections setting takes effect"
     (call-with-antonym-test-database
       (fn []
-        (let [pool (-> *db*
-                       defaulted-read-db-config
-                       (assoc :maximum-pool-size 5)
-                       subject/pooled-datasource)]
-          (is (= 5 (.getMaximumPoolSize (:datasource pool)))))))))
+        (with-open [data-source (-> *db*
+                                    defaulted-read-db-config
+                                    (assoc :maximum-pool-size 5)
+                                    subject/pooled-datasource
+                                    :datasource)]
+          (is (= 5 (.getMaximumPoolSize data-source))))))))
 
 (deftest-antonyms query-to-vec
   (testing "query string only"


### PR DESCRIPTION
Previously, the max connections jdbc pool-construction tests did not
close the connection pool data source before falling out of scope.
Depending upon timing, this could cause the tests to fail on
attempting to drop temp databases which are still busy being used
by the connection pool.

This commit wraps usage of the data source in each of the max
connections tests with `with-open` calls, allowing the connection pool
to be closed off before any calls to drop the temporary databases occur
(and, therefore, for the tests to complete successfully).