### PR TITLE
(PDB-3053) Create unique index on certnames.latest_report_id

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1031,6 +1031,12 @@
   (jdbc/do-commands
     "CREATE INDEX idx_certnames_latest_report_id on certnames(latest_report_id)"))
 
+(defn index-certnames-unique-latest-report-id
+  []
+  (jdbc/do-commands
+    "DROP INDEX IF EXISTS idx_certnames_latest_report_id"
+    "CREATE UNIQUE INDEX idx_certnames_latest_report_id on certnames(latest_report_id)"))
+
 (defn add-producer-to-reports-catalogs-and-factsets
   []
   (jdbc/do-commands
@@ -1197,8 +1203,8 @@
    51 fact-values-value-to-jsonb
    52 resource-params-cache-parameters-to-jsonb
    53 add-corrective-change-index
-   54 drop-resource-events-resource-type-idx})
-
+   54 drop-resource-events-resource-type-idx
+   55 index-certnames-unique-latest-report-id})
 
 (def desired-schema-version (apply max (keys migrations)))
 


### PR DESCRIPTION
Prior to this commit, there was no index on latest_report_id.
In PDB-2789, it was thought that this index caused performance
issues but this was potentially a red-herring.

After this commit, we create a unique index on latest_report_id. 
The index is absolutely necessary for deleting reports as the
reports table has a constraint on latest_report_id and without this
index it scans the whole certnames table once for every row it
deletes from reports.  For a 100,000 rows this index causes
deleting from reports to go from 3-4 mins to 3-4 seconds.