### PR TITLE
(PDB-2640) Add support for gzip-compressing commands via terminus

### DIFF
--- a/puppet/lib/puppet/util/puppetdb/command.rb
+++ b/puppet/lib/puppet/util/puppetdb/command.rb
@@ -62,7 +62,7 @@ class Puppet::Util::Puppetdb::Command
     begin
       response = profile("Submit command HTTP post", [:puppetdb, :command, :submit]) do
         Http.action("#{CommandsUrl}?#{params}", :command) do |http_instance, path|
-          http_instance.post(path, payload, headers)
+          http_instance.post(path, payload, headers, {:compress => :gzip})
         end
       end
 

--- a/puppet/spec/unit/util/puppetdb/command_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/command_spec.rb
@@ -24,12 +24,12 @@ describe Puppet::Util::Puppetdb::Command do
 
       it "should issue the HTTP POST and log success" do
         httpok.stubs(:body).returns '{"uuid": "a UUID"}'
-        http.expects(:post).with() do | path, payload, headers |
+        http.expects(:post).with() do | path, payload, headers, options |
           param_map = CGI::parse(URI(path).query)
           param_map['certname'].first.should == 'foo.localdomain' &&
             param_map['version'].first.should == '1' &&
             param_map['command'].first.should == 'OPEN_SESAME'
-
+          options[:compress].should == :gzip
         end.returns(httpok)
 
         subject.submit

--- a/src/puppetlabs/puppetdb/amq_migration.clj
+++ b/src/puppetlabs/puppetdb/amq_migration.clj
@@ -130,7 +130,7 @@
               ;; body. Rather than do that, nil is being passed. This
               ;; is still correct, the only downside is comands won't
               ;; be overwritten in the queue by newer commands.
-              (enqueue-fn command version certname nil payload)
+              (enqueue-fn command version certname nil payload "")
 
               (catch Exception ex
                 (log/error ex

--- a/src/puppetlabs/puppetdb/command/dlo.clj
+++ b/src/puppetlabs/puppetdb/command/dlo.clj
@@ -204,7 +204,8 @@
                                      {:producer-ts nil
                                       :command "unknown"
                                       :version 0
-                                      :certname digest})
+                                      :certname digest
+                                      :compression ""})
         cmd-dest (.resolve path (str id \- metadata))]
     (Files/write cmd-dest bytes (oopts []))
     (let [info-dest (store-failed-command-info id metadata "unknown"

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.puppetdb.http.command
   (:require [clojure.set :as set]
             [puppetlabs.puppetdb.command.constants :refer [command-names]]
+            [puppetlabs.puppetdb.utils :refer [content-encoding->file-extension]]
             [puppetlabs.trapperkeeper.core :refer [defservice]]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -26,10 +27,6 @@
    "replace facts" 4
    "store report" 5
    "deactivate node" 3})
-
-(defn content-encoding->file-extension
-  [encoding]
-  (get {"gzip" "gz"} encoding ""))
 
 (def valid-commands-str (str/join ", " (sort (vals command-names))))
 

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -27,6 +27,10 @@
    "store report" 5
    "deactivate node" 3})
 
+(defn content-encoding->file-extension
+  [encoding]
+  (get {"gzip" "gz"} encoding ""))
+
 (def valid-commands-str (str/join ", " (sort (vals command-names))))
 
 (defn- validate-command-version
@@ -203,7 +207,7 @@
 (defn- enqueue-command-handler
   "Enqueues the command in request and returns a UUID"
   [enqueue-fn max-command-size]
-  (fn [{:keys [body params] :as request}]
+  (fn [{:keys [body params headers]}]
     ;; For now body will be in-memory, but eventually may be a stream.
     (try+
      (let [uuid (kitchensink/uuid)
@@ -215,6 +219,8 @@
            submit-params (if-let [v (submit-params "version")]
                            (update submit-params "version" str)
                            submit-params)
+           compression (content-encoding->file-extension
+                        (get headers "content-encoding"))
            ;; Replace read-body when our queue supports streaming
            do-submit (fn [command-callback]
                        (enqueue-fn
@@ -223,6 +229,7 @@
                         (get submit-params "certname")
                         (pdbtime/from-string (get submit-params "producer-ts"))
                         (stream-with-max-check body max-command-size)
+                        compression
                         command-callback))]
 
        (if (some-> completion-timeout-ms pos?)
@@ -265,6 +272,7 @@
                                              "certname" "command" "version" "producer-timestamp"]})
       mid/verify-accepts-json
       (mid/verify-content-type ["application/json"])
+      (mid/verify-content-encoding ["gzip" "identity"])
       (mid/fail-when-payload-too-large reject-large-commands? max-command-size)
       (mid/wrap-with-metrics (atom {}) http/leading-uris)
       (mid/wrap-with-globals get-shared-globals)))

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -1,7 +1,8 @@
 (ns puppetlabs.puppetdb.http.command
   (:require [clojure.set :as set]
             [puppetlabs.puppetdb.command.constants :refer [command-names]]
-            [puppetlabs.puppetdb.utils :refer [content-encoding->file-extension]]
+            [puppetlabs.puppetdb.utils :refer [content-encoding->file-extension
+                                               supported-content-encodings]]
             [puppetlabs.trapperkeeper.core :refer [defservice]]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -18,7 +19,8 @@
             [schema.core :as s]
             [slingshot.slingshot :refer [try+ throw+]]
             [puppetlabs.i18n.core :refer [trs tru]]
-            [puppetlabs.puppetdb.time :as pdbtime])
+            [puppetlabs.puppetdb.time :as pdbtime]
+            [puppetlabs.puppetdb.utils :as utils])
   (:import [org.apache.commons.io IOUtils]
            [org.apache.commons.fileupload.util LimitedInputStream]))
 
@@ -269,7 +271,7 @@
                                              "certname" "command" "version" "producer-timestamp"]})
       mid/verify-accepts-json
       (mid/verify-content-type ["application/json"])
-      (mid/verify-content-encoding ["gzip" "identity"])
+      (mid/verify-content-encoding utils/supported-content-encodings)
       (mid/fail-when-payload-too-large reject-large-commands? max-command-size)
       (mid/wrap-with-metrics (atom {}) http/leading-uris)
       (mid/wrap-with-globals get-shared-globals)))

--- a/src/puppetlabs/puppetdb/import.clj
+++ b/src/puppetlabs/puppetdb/import.clj
@@ -53,6 +53,7 @@
    command-versions]
   (let [path (.getName tar-entry)
         [command-type certname] (command-matcher path)
+        compression ""
         command-fn' (fn [command-kwd command-version]
                       (command-fn command-kwd
                                   command-version
@@ -62,7 +63,8 @@
                                       utils/read-json-content
                                       json/generate-string
                                       (.getBytes "UTF-8")
-                                      java.io.ByteArrayInputStream.)))]
+                                      java.io.ByteArrayInputStream.)
+                                  compression))]
     (case command-type
       "catalogs"
       (do

--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -115,6 +115,21 @@
       (http/error-response (tru "must accept {0}" content-type)
                            http/status-not-acceptable))))
 
+(defn verify-content-encoding
+  "Verification for the specified list of content-encodings."
+  [app content-encodings]
+  {:pre [(coll? content-encodings)
+         (every? string? content-encodings)]}
+  (fn [{:keys [headers request-method] :as req}]
+    (let [content-encoding (headers "content-encoding")]
+      (if (or (not= request-method :post)
+              (empty? content-encoding)
+              (some #{content-encoding} content-encodings))
+        (app req)
+        (http/error-response (tru "content encoding {0} not supported"
+                                  content-encoding)
+                             http/status-unsupported-type)))))
+
 (defn verify-content-type
   "Verification for the specified list of content-types."
   [app content-types]

--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -117,14 +117,14 @@
 
 (defn verify-content-encoding
   "Verification for the specified list of content-encodings."
-  [app content-encodings]
-  {:pre [(coll? content-encodings)
-         (every? string? content-encodings)]}
+  [app allowed-encodings]
+  {:pre [(coll? allowed-encodings)
+         (every? string? allowed-encodings)]}
   (fn [{:keys [headers request-method] :as req}]
     (let [content-encoding (headers "content-encoding")]
       (if (or (not= request-method :post)
               (empty? content-encoding)
-              (some #{content-encoding} content-encodings))
+              (some #{content-encoding} allowed-encodings))
         (app req)
         (http/error-response (tru "content encoding {0} not supported"
                                   content-encoding)

--- a/src/puppetlabs/puppetdb/queue.clj
+++ b/src/puppetlabs/puppetdb/queue.clj
@@ -3,7 +3,8 @@
            [java.io InputStreamReader BufferedReader InputStream]
            [java.util TreeMap HashMap]
            [java.nio.file Files LinkOption]
-           [java.nio.file.attribute FileAttribute])
+           [java.nio.file.attribute FileAttribute]
+           (org.apache.commons.compress.compressors.gzip GzipCompressorInputStream))
   (:require [clojure.string :as str :refer [re-quote-replacement]]
             [puppetlabs.stockpile.queue :as stock]
             [clj-time.coerce :as tcoerce]
@@ -132,18 +133,22 @@
   certname if the certname is long or contains filesystem special characters."
   ([] (metadata-serializer puppetdb-command->metadata-command))
   ([puppetdb-command->metadata-command]
-   (fn [received {:keys [producer-ts command version certname]}]
+   (fn [received {:keys [producer-ts command version certname compression]}]
      (when-not (puppetdb-command->metadata-command command)
        (throw (IllegalArgumentException. (trs "unknown command ''{0}''" command))))
      (let [certname (or certname "unknown-host")
            received+producer-time (encode-command-time received producer-ts)
            short-command (puppetdb-command->metadata-command command)
-           safe-certname (embeddable-certname received short-command version certname)]
-       (if (= safe-certname certname)
-         (format "%s_%s_%d_%s.json" received+producer-time short-command version safe-certname)
-         (let [name-hash (kitchensink/utf8-string->sha1 certname)]
-           (format "%s_%s_%d_%s_%s.json"
-                   received+producer-time short-command version safe-certname name-hash)))))))
+           safe-certname (embeddable-certname received short-command version certname)
+           name (if (= safe-certname certname)
+                  safe-certname
+                  (format "%s_%s"
+                          safe-certname
+                          (kitchensink/utf8-string->sha1 certname)))
+           extension (str "json" (if (not-empty compression)
+                                   (str "." compression)))]
+       (format "%s_%s_%d_%s.%s"
+               received+producer-time short-command version name extension)))))
 
 (def serialize-metadata (metadata-serializer))
 
@@ -151,7 +156,7 @@
   (re-pattern (str
                "([0-9]+)([+|-][0-9]+)?_"
                (match-any-of valid-commands)
-               "_([0-9]+)_(.*)\\.json")))
+               "_([0-9]+)_(.*)\\.json(\\..*)?")))
 
 (defn metadata-parser
   "Given an (optional) map between the command names that appear in metadata
@@ -167,7 +172,7 @@
    (let [rx (metadata-rx (keys metadata-command->puppetdb-command))
          md-cmd->pdb-cmd metadata-command->puppetdb-command]
      (fn [s]
-       (when-let [[_ received-stamp producer-offset md-command version certname] (re-matches rx s)]
+       (when-let [[_ received-stamp producer-offset md-command version certname compression] (re-matches rx s)]
          (let [received-time-long (Long/parseLong received-stamp)
                producer-offset (and producer-offset (Long/parseLong producer-offset))]
            (and certname
@@ -179,7 +184,10 @@
                                       tcoerce/from-long)
                  :version (Long/parseLong version)
                  :command (get md-cmd->pdb-cmd md-command "unknown")
-                 :certname certname})))))))
+                 :certname certname
+                 :compression (if (nil? compression)
+                                ""
+                                (subs compression 1))})))))))
 
 (def parse-metadata (metadata-parser))
 
@@ -190,7 +198,8 @@
    :certname s/Str
    :producer-ts (s/maybe pls/Timestamp)
    :callback (s/=> s/Any s/Any)
-   :command-stream java.io.InputStream})
+   :command-stream java.io.InputStream
+   :compression s/Str})
 
 (s/defn create-command-req :- command-req-schema
   "Validating constructor function for command requests"
@@ -198,6 +207,7 @@
    version :- s/Int
    certname :- s/Str
    producer-ts :- (s/maybe s/Str)
+   compression :- s/Str
    callback :- (s/=> s/Any s/Any)
    command-stream :- java.io.InputStream]
   {:command command
@@ -205,32 +215,48 @@
    :certname certname
    :producer-ts (when producer-ts
                   (pdbtime/from-string producer-ts))
+   :compression compression
    :callback callback
    :command-stream command-stream})
 
-(defrecord CommandRef [id command version certname received producer-ts callback delete?])
+(defrecord CommandRef [id command version certname received producer-ts callback delete? compression])
 
 (defn cmdref->entry [{:keys [id received] :as cmdref}]
   (stock/entry id (serialize-metadata received cmdref)))
 
 (defn entry->cmdref [entry]
-  (let [{:keys [received command version certname producer-ts]} (-> entry
-                                                                    stock/entry-meta
-                                                                    parse-metadata)]
+  (let [{:keys [received command version
+                certname producer-ts compression]} (-> entry
+                                                       stock/entry-meta
+                                                       parse-metadata)]
     (map->CommandRef {:id (stock/entry-id entry)
                       :command command
                       :version version
                       :certname certname
                       :received received
                       :producer-ts producer-ts
-                      :callback identity})))
+                      :callback identity
+                      :compression compression})))
+
+(defn wrap-decompression-stream
+  [compression command-stream]
+  (condp = compression
+    nil command-stream
+    "" command-stream
+    "gz" (GzipCompressorInputStream. command-stream)
+    (throw+ {:kind ::parse-error} nil
+            (trs "Unsupported compression format for command: {0}"
+                 compression))))
 
 (defn cmdref->cmd [q cmdref]
-  (let [entry (cmdref->entry cmdref)]
+  (let [compression (:compression cmdref)
+        entry (cmdref->entry cmdref)]
     (with-open [command-stream (stock/stream q entry)]
       (assoc cmdref
-             :payload (stream->json command-stream)
-             :entry entry))))
+        :payload (stream->json (wrap-decompression-stream
+                                compression
+                                command-stream))
+        :entry entry))))
 
 (defn cons-attempt [cmdref exception]
   (update cmdref :attempts conj {:exception exception
@@ -278,7 +304,7 @@
                                   current-time
                                   command-req)]
     (-> command-req
-        (select-keys [:command :version :certname :producer-ts :callback])
+        (select-keys [:command :version :certname :producer-ts :callback :compression])
         (assoc :id (stock/entry-id entry)
                :received (kitchensink/timestamp current-time))
         map->CommandRef)))

--- a/src/puppetlabs/puppetdb/queue.clj
+++ b/src/puppetlabs/puppetdb/queue.clj
@@ -254,6 +254,13 @@
         entry (cmdref->entry cmdref)]
     (with-open [command-stream (stock/stream q entry)]
       (assoc cmdref
+        ;; For performance reasons, it's best to wrap any decompression stream
+        ;; around the original command stream before calling into stream->json.
+        ;; stream->json wraps it's own BufferedReader around the stream before
+        ;; parsing bytes from it as json.  From testing, we've seen that if we
+        ;; wrap an extra buffered input stream between the original command
+        ;; stream and the decompressing stream, Gzip in particular, that
+        ;; throughput would be much worse - could be up to 400x times slower.
         :payload (stream->json (wrap-decompression-stream
                                 compression
                                 command-stream))

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -421,3 +421,16 @@
          (binding [*out* *err*]
            (println ex#))
          (throw ex#)))))
+
+(def content-encodings->file-extensions
+  {"gzip" "gz"})
+
+(defn content-encoding->file-extension
+  [encoding]
+  (get content-encodings->file-extensions encoding ""))
+
+(def compression-file-extension-schema
+  (->> content-encodings->file-extensions
+       vals
+       (cons "")
+       (apply s/enum)))

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -423,7 +423,8 @@
          (throw ex#)))))
 
 (def content-encodings->file-extensions
-  {"gzip" "gz"})
+  {"gzip" "gz"
+   "identity" ""})
 
 (defn content-encoding->file-extension
   [encoding]
@@ -434,3 +435,6 @@
        vals
        (cons "")
        (apply s/enum)))
+
+(def supported-content-encodings
+  (vec (keys content-encodings->file-extensions)))

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -78,7 +78,8 @@
                          :values {:foo "the foo"
                                   :bar "the bar"
                                   :baz "the baz"}
-                         :producer_timestamp (to-string (now))}))
+                         :producer_timestamp (to-string (now))})
+                       "")
 
       @(block-until-results 200 (first (get-factsets "foo.local")))
 
@@ -113,7 +114,8 @@
                         {:certname "foo.local"
                          :environment "DEV"
                          :values {:a "a" :b "b" :c "c"}
-                         :producer_timestamp (to-string (now))}))
+                         :producer_timestamp (to-string (now))})
+                       "")
 
       @(block-until-results 200 (first (get-factsets "foo.local")))
       (let [exp ["a" "b" "c"]

--- a/test/puppetlabs/puppetdb/command/dlo_test.clj
+++ b/test/puppetlabs/puppetdb/command/dlo_test.clj
@@ -48,19 +48,19 @@
 
     (are [cmd-info metadata-str] (= cmd-info (#'dlo/parse-cmd-filename metadata-str))
 
-      {:received r0 :version 0 :command "replace catalog" :certname "foo" :producer-ts nil}
+      {:received r0 :version 0 :command "replace catalog" :certname "foo" :producer-ts nil :compression ""}
       "0-0_catalog_0_foo.json"
 
-      {:received r0 :version 0 :command "replace catalog" :certname "foo.json" :producer-ts nil}
+      {:received r0 :version 0 :command "replace catalog" :certname "foo.json" :producer-ts nil :compression ""}
       "0-0_catalog_0_foo.json.json"
 
-      {:received r10 :version 10 :command "replace catalog" :certname "foo" :producer-ts nil}
+      {:received r10 :version 10 :command "replace catalog" :certname "foo" :producer-ts nil :compression ""}
       "10-10_catalog_10_foo.json"
 
-      {:received r10 :version 42 :command "replace catalog" :certname "foo" :producer-ts nil}
+      {:received r10 :version 42 :command "replace catalog" :certname "foo" :producer-ts nil :compression ""}
       "10-10_catalog_42_foo.json"
 
-      {:received r10 :version 10 :command "unknown" :certname "foo" :producer-ts nil}
+      {:received r10 :version 10 :command "unknown" :certname "foo" :producer-ts nil :compression ""}
       "10-10_unknown_10_foo.json")
 
     (is (not (#'dlo/parse-cmd-filename "0-0_foo_0_foo.json")))))

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -126,7 +126,7 @@
       :total))
 
 (defn failed-catalog-req [version certname payload]
-  (queue/create-command-req "replace catalog" version certname nil identity
+  (queue/create-command-req "replace catalog" version certname nil "" identity
                             (tqueue/coerce-to-stream payload)))
 
 (deftest command-processor-integration
@@ -393,6 +393,7 @@
                                                                            version-num
                                                                            certname
                                                                            (ks/timestamp (now))
+                                                                           ""
                                                                            identity
                                                                            (tqueue/coerce-to-stream "bad stuff"))))
             (is (empty? (query-to-vec "SELECT * FROM catalogs")))
@@ -921,6 +922,7 @@
                                                                            latest-facts-version
                                                                            "foo.example.com"
                                                                            (ks/timestamp (now))
+                                                                           ""
                                                                            identity
                                                                            (tqueue/coerce-to-stream "bad stuff"))))
           (is (empty? (query-to-vec "SELECT * FROM facts")))
@@ -933,6 +935,7 @@
       (handle-message (queue/store-command q (queue/create-command-req "replace facts"
                                                                        2
                                                                        "foo.example.com"
+                                                                       ""
                                                                        (ks/timestamp (now))
                                                                        identity
                                                                        (tqueue/coerce-to-stream "bad stuff"))))
@@ -1462,7 +1465,8 @@
                            (tqueue/coerce-to-stream
                             {:environment "DEV" :certname "foo.local"
                              :values {:foo "foo"}
-                             :producer_timestamp (to-string (now))}))
+                             :producer_timestamp (to-string (now))})
+                           "")
           @received-cmd?
           (is (= {:received-commands 1 :executed-commands 0} (stats)))
           (deliver go-ahead-and-execute true)
@@ -1486,7 +1490,8 @@
                        "foo.local"
                        nil
                        (tqueue/coerce-to-stream
-                        {:certname "foo.local" :producer_timestamp input-stamp}))
+                        {:certname "foo.local" :producer_timestamp input-stamp})
+                       "")
       (is (svc-utils/wait-for-server-processing svc-utils/*server* default-timeout-ms)
           (format "Server didn't process received commands after %dms" default-timeout-ms))
 
@@ -1526,7 +1531,8 @@
                        "foo.local"
                        nil
                        (tqueue/coerce-to-stream
-                        {:certname "foo.local" :producer_timestamp producer-ts}))
+                        {:certname "foo.local" :producer_timestamp producer-ts})
+                       "")
 
       (let [received-uuid (async/alt!! response-chan ([msg] (:producer-timestamp msg))
                                        (async/timeout 10000) ::timeout)]
@@ -1580,6 +1586,7 @@
                                  (assoc :producer_timestamp old-producer-ts
                                         :certname "foo.com")
                                  tqueue/coerce-to-stream)
+                            ""
                             #(deliver cmd-1 %))
 
            (enqueue-command (command-names :replace-catalog)
@@ -1589,6 +1596,7 @@
                             (-> base-cmd
                                 (assoc :producer_timestamp old-producer-ts)
                                 tqueue/coerce-to-stream)
+                            ""
                             #(deliver cmd-2 %))
 
            (enqueue-command (command-names :replace-catalog)
@@ -1598,6 +1606,7 @@
                             (-> base-cmd
                                 (assoc :producer_timestamp new-producer-ts)
                                 tqueue/coerce-to-stream)
+                            ""
                             #(deliver cmd-3 %))
 
            (.release semaphore)

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -935,8 +935,8 @@
       (handle-message (queue/store-command q (queue/create-command-req "replace facts"
                                                                        2
                                                                        "foo.example.com"
-                                                                       ""
                                                                        (ks/timestamp (now))
+                                                                       ""
                                                                        identity
                                                                        (tqueue/coerce-to-stream "bad stuff"))))
       (is (empty? (query-to-vec "SELECT * FROM facts")))

--- a/test/puppetlabs/puppetdb/middleware_test.clj
+++ b/test/puppetlabs/puppetdb/middleware_test.clj
@@ -143,6 +143,23 @@
         (let [wrapped-fn   (verify-content-type identity ["application/json"])]
           (is (= (wrapped-fn test-req) test-req)))))))
 
+(deftest verify-content-encoding-test
+  (testing "with content-encoding of gzip"
+    (let [test-req {:request-method :post
+                    :content-type "application/json"
+                    :headers {"content-encoding" "gzip"}}]
+
+      (testing "should succeed with matching content encoding"
+        (let [wrapped-fn (verify-content-encoding identity ["gzip"])]
+          (is (= (wrapped-fn test-req) test-req))))
+
+      (testing "should fail with no matching content encoding"
+        (let [wrapped-fn (verify-content-encoding identity ["compress" "deflate"])]
+          (is (= (wrapped-fn test-req)
+                 {:status 415
+                  :headers {"Content-Type" http/error-response-content-type}
+                  :body "content encoding gzip not supported"})))))))
+
 (deftest whitelist-middleware
   (testing "should log on reject"
     (let [wl (temp-file "whitelist-log-reject")]

--- a/test/puppetlabs/puppetdb/middleware_test.clj
+++ b/test/puppetlabs/puppetdb/middleware_test.clj
@@ -158,7 +158,13 @@
           (is (= (wrapped-fn test-req)
                  {:status 415
                   :headers {"Content-Type" http/error-response-content-type}
-                  :body "content encoding gzip not supported"})))))))
+                  :body "content encoding gzip not supported"}))))))
+  (testing "should succeed with no content-encoding"
+    (let [test-req {:request-method :post
+                    :content-type "application/json"
+                    :headers {}}
+          wrapped-fn (verify-content-encoding identity ["whatever"])]
+      (is (= (wrapped-fn test-req) test-req)))))
 
 (deftest whitelist-middleware
   (testing "should log on reject"

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -450,12 +450,12 @@
   (wrap-with-puppetdb-middleware
    (command-app
     (fn [] {})
-    (fn [command version certname producer-ts stream callback]
+    (fn [command version certname producer-ts stream compression callback]
       (dispatch/do-enqueue-command
        q
        command-chan
        (Semaphore. 100)
-       (queue/create-command-req command version certname producer-ts callback stream)))
+       (queue/create-command-req command version certname producer-ts compression callback stream)))
 
     false
     nil)))

--- a/test/puppetlabs/puppetdb/testutils/queue.clj
+++ b/test/puppetlabs/puppetdb/testutils/queue.clj
@@ -50,6 +50,7 @@
                         version
                         (or certname name)
                         (ks/timestamp (now))
+                        ""
                         identity
                         (coerce-to-stream catalog)))
 
@@ -58,6 +59,7 @@
                         version
                         (or certname name)
                         (ks/timestamp (now))
+                        ""
                         identity
                         (coerce-to-stream facts)))
 
@@ -69,6 +71,7 @@
                           2 (json/parse-string command)
                           1 (json/parse-string (json/parse-string command)))
                         (ks/timestamp (now))
+                        ""
                         identity
                         (coerce-to-stream command)))
 
@@ -77,5 +80,6 @@
                         version
                         (or certname name)
                         (ks/timestamp (now))
+                        ""
                         identity
                         (coerce-to-stream command)))


### PR DESCRIPTION
This commit adds support for gzip-compressing commands which the
PuppetDB terminus sends out.  When stockpile persists the commands to
disk, it stores the gzipped json bytes with a .json.gz file extension.
Command payloads are decompressed and parsed from JSON when processed
back out of the queue.

The terminus does not gzip-compress the command content itself.
Instead, to minimize memory usage somewhat and realize a bit better
performance, it passes through its intent for the implementation
upstream from the Puppet::Network::HttpPool.http_instance to perform
the gzip compression.  Corresponding work in Puppet Server and its
upstream clj-http-client library enables the payload to be compressed.