### PR TITLE
(PDB-3255) Bump to clj-i18n 0.6.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
    :password :env/nexus_jenkins_password
    :sign-releases false})
 
-(def i18n-version "0.4.3")
+(def i18n-version "0.6.0")
 
 (def pdb-jvm-opts
   (case (System/getProperty "java.specification.version")


### PR DESCRIPTION
This bump is needed to use the new CI based i18n message generation infrastructure.