### PR TITLE
(PDB-3107) Allow extra headers in commands

### DIFF
--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -128,7 +128,8 @@
              :version s/Str
              :certname s/Str
              :received s/Str
-             :id s/Str}
+             :id s/Str
+             s/Keyword s/Any}
    :body (s/cond-pre s/Str utils/byte-array-class)})
 
 (def queue-message-schema

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -56,6 +56,17 @@
                  {:command "foo" :version 2 :payload "meh"}))
           (is (map? (:annotations parsed))))))
 
+    (testing "should allow extra headers"
+      (let [command {:headers {:command "deactivate node"
+                               :version "3"
+                               :certname "test1"
+                               :received "2015-01-01"
+                               :id "42"
+                               :XExtraHeader "foo"}
+                     :body (json/encode {:certname "test1"
+                                         :producer_timestamp "2015-01-01"})}]
+        (is (map? (parse-command command)))))
+
     (testing "should reject invalid input"
       (is (thrown-with-msg?
            RuntimeException


### PR DESCRIPTION
New Relic's java agent likes to inject extra JMS headers; update our message
schema to allow for unexpected keys so this doesn't bring the world down.