### PR TITLE
(PDB-3297) Don't act as if facts might be arrays

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -138,7 +138,8 @@
      (jdbc/with-transacted-connection scf-read-db
        (let [{:keys [results-query]}
              (query->sql remaining-query entity version paging-options)]
-         (jdbc/call-with-query-rows results-query (comp row-fn munge-fn)))))))
+         (jdbc/call-with-array-converted-query-rows results-query
+                                                    (comp row-fn munge-fn)))))))
 
 ;; Do we still need this, i.e. do we need the pass-through, and the
 ;; strict selectivity in the caller below?
@@ -186,7 +187,7 @@
               resp (http/streamed-response
                     buffer
                     (try (jdbc/with-transacted-connection scf-read-db
-                           (jdbc/call-with-query-rows
+                           (jdbc/call-with-array-converted-query-rows
                             results-query
                             (comp #(http/stream-json % buffer pretty-print)
                                   #(do (when-not (instance? PGobject %)

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -796,7 +796,7 @@
         value-keys [:value_string :value_integer
                     :value_json :value_boolean
                     :value_float]]
-    (jdbc/call-with-query-rows
+    (jdbc/call-with-array-converted-query-rows
      query
      (fn [rows]
        (->> rows
@@ -1088,7 +1088,7 @@
 (defn migrate-through-app
   [table1 table2 column-list munge-fn]
   (let [columns (string/join "," column-list)]
-    (jdbc/call-with-query-rows
+    (jdbc/call-with-array-converted-query-rows
      [(format "select %s from %s" columns (name table1))]
      #(->> %
            (map munge-fn)

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -442,7 +442,7 @@
      (let [rss (sql/result-set-seq rs)]
        (zipmap (map #(select-keys % [:type :title]) rss)
                (for [rowmap rss]
-                 (kitchensink/mapvals #(jdbc/coerce-to-array set %)
+                 (kitchensink/mapvals #(jdbc/convert-any-sql-array % set)
                                       rowmap)))))))
 
 (s/defn new-params-only

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1141,10 +1141,10 @@
            (set (query-to-vec "SELECT title, file FROM catalog_resources WHERE certname_id = (select id from certnames where certname = ?)" certname))))))
 
 (defn tags->set
-  "Converts tags from a vector to a set"
+  "Converts tags from a pg-array to a set of strings"
   [result-set]
   (mapv (fn [result]
-          (update-in result [:tags] set))
+          (update-in result [:tags] #(jdbc/convert-any-sql-array % set)))
         result-set))
 
 (deftest-db change-tags-on-resource


### PR DESCRIPTION
In fact, there only a small number of array items in the current
database, yet we check nearly every value that comes back to see if it
might be an array that needs conversion.  Start stopping that.

Accordingly, don't attempt array conversion in call-with-query-rows, and
add a new call-with-array-converted-query-rows that preserves the old
behavior.  Continue to call the former in the fact related storage code,
but adjust everything else to use the latter to preserve existing
behavior.

As the original motivation, Wyatt noticed non-trivial cost for the
"isa?" test via coerce-to-array when processing facts.