### PR TITLE
(PDB-3323) Make report exists query use index

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1194,8 +1194,8 @@
                 report-hash (shash/report-identity-hash report)]
            (jdbc/with-db-transaction []
              (let [shash (sutils/munge-hash-for-storage report-hash)]
-               (when-not (-> "select 1 from reports where hash = ? limit 1"
-                             (query-to-vec shash)
+               (when-not (-> "select 1 from reports where encode(hash, 'hex'::text) = ? limit 1"
+                             (query-to-vec report-hash)
                              seq)
                  (let [certname-id (certname-id certname)
                        row-map {:hash shash


### PR DESCRIPTION
While this query was correct, it didn't use the index we have in place on this
column, making it very slow.