### PR TITLE
(PDB-3328) Munge package inventory facts in terminus

### DIFF
--- a/test/puppetlabs/puppetdb/integration/fixtures.clj
+++ b/test/puppetlabs/puppetdb/integration/fixtures.clj
@@ -262,8 +262,9 @@
 
 (defn bundle-exec [env & args]
   (let [result (apply sh "bundle" "exec"
-                      (concat args [:env (merge (into {} (System/getenv))
-                                                env)]))]
+                      (concat (map str args)
+                              [:env (merge (into {} (System/getenv))
+                                           env)]))]
     (if (not (#{0 2} (:exit result)))
       (let [message (str "Error running bundle exec " (string/join " " args))]
         (utils/println-err message result)
@@ -304,10 +305,9 @@
               "--trace"
               extra-puppet-args)))))
 
-(defn run-puppet-as [certname puppet-server pdb-server manifest-content & [extra-puppet-args]]
+(defn run-puppet-as [certname puppet-server pdb-server manifest-content & [opts]]
   (run-puppet puppet-server pdb-server manifest-content
-              {:certname certname
-               :extra-puppet-args extra-puppet-args}))
+              (assoc opts :certname certname)))
 
 (defn run-puppet-node-deactivate [pdb-server certname-to-deactivate]
   (install-terminus-into (mri-agent-dir))

--- a/test/puppetlabs/puppetdb/integration/fixtures.clj
+++ b/test/puppetlabs/puppetdb/integration/fixtures.clj
@@ -206,9 +206,8 @@
     (doseq [relative-path terminus-files]
       (let [in (str base-dir "/" relative-path)
             out (str puppet-dir "/" relative-path)]
-        (when-not (fs/exists? out)
-          (println "Copying puppetdb terminus file" in "to" out)
-          (fs/copy+ in out))))))
+        (println "Copying puppetdb terminus file" in "to" out)
+        (fs/copy+ in out)))))
 
 (defn puppet-server-config-with-name [node-name]
   {:main {:certname "localhost"}

--- a/test/puppetlabs/puppetdb/integration/inventory/package_inventory.clj
+++ b/test/puppetlabs/puppetdb/integration/inventory/package_inventory.clj
@@ -1,0 +1,40 @@
+(ns puppetlabs.puppetdb.integration.inventory.package-inventory
+  (:require [clojure.test :refer :all]
+            [puppetlabs.puppetdb.integration.fixtures :as int]
+            [puppetlabs.puppetdb.cheshire :as json]
+            [me.raynes.fs :as fs]))
+
+(deftest ^:integration package-inventory
+  (with-open [pg (int/setup-postgres)
+              pdb (int/run-puppetdb pg {})
+              ps (int/run-puppet-server [pdb] {})]
+
+    (testing "Run agent to send the package inventory fact"
+
+      (let [temp-facterlib (fs/temp-dir "pdb-test-facterlib")
+            custom-fact (str temp-facterlib "/packages.rb")]
+        (spit custom-fact
+              (str "Facter.add(:_puppet_inventory_1) do "
+                   "  setcode do "
+                   "    { 'packages' => [['openssl', '1.0.2g-1ubuntu4.6', 'apt']] }"
+                   "  end "
+                   "end"))
+
+       (int/run-puppet ps pdb
+                       "notify { 'irrelevant manifest': }"
+                       {:certname "agent-with-packages"
+                        :env {"FACTERLIB" temp-facterlib}})))
+
+    (testing "Ensure that facts were stored"
+      (is (pos? (count (int/pql-query pdb "facts { }")))))
+
+    (testing "Ensure the inventory fact was removed"
+      (is (= 0 (count (int/pql-query pdb "facts { name = '_puppet_inventory_1' }")))))
+
+    ;; uncomment this once query support gets merged
+    (comment
+      (testing "Package inventory can be queried"
+        (is (= [{:package_name "openssl"
+                 :version "1.0.2g-1ubuntu4.6"
+                 :provider "apt"}]
+               (int/pql-query pdb "packages { certname = 'agent-with-packages' }")))))))

--- a/test/puppetlabs/puppetdb/integration/reports.clj
+++ b/test/puppetlabs/puppetdb/integration/reports.clj
@@ -114,7 +114,7 @@
                          (str "notify { 'hi':"
                               "  message => 'Hi my_agent' "
                               "}")
-                         ["--noop"])
+                         {:extra-puppet-args ["--noop"]})
 
       ;; This is a bit weird as well; all "skipped" resources during a puppet
       ;; run will end up having events generated for them.  However, during a


### PR DESCRIPTION
This adds terminus support for that package inventory feature. When the
_puppet_inventory_1 fact is seen it is removed, reformatted to be in the tabular
format expected by puppetdb, and placed in a top-level 'package_inventory' key
in the facts command payload.