### PR TITLE
(maint) Fix doc issue with `JSON` example

### DIFF
--- a/documentation/api/query/v4/ast.markdown
+++ b/documentation/api/query/v4/ast.markdown
@@ -233,6 +233,7 @@ end of a key.
 
 For example, given the inventory response
 
+
     {
         "certname" : "mbp.local",
         "timestamp" : "2016-07-11T20:02:33.190Z",


### PR DESCRIPTION
* Without the extra newline the JSON isn't 
highlighted