### PR TITLE
(maint) Update excludes for newer puppetserver

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -143,7 +143,8 @@
                                   [puppetlabs/puppetserver ~puppetserver-version :classifier "test"]
                                   [org.flatland/ordered "1.5.3"]
                                   [org.clojure/test.check "0.9.0"]
-                                  [com.gfredericks/test.chuck "0.2.7" :exclusions [clj-time instaparse joda-time org.clojure/clojure]]
+                                  [com.gfredericks/test.chuck "0.2.7" :exclusions
+                                   [clj-time com.andrewmcveigh/cljs-time instaparse joda-time org.clojure/clojure]]
                                   [environ "1.0.2"]
                                   [riddley "0.1.12"]
                                   [io.forward/yaml "1.0.5"]]


### PR DESCRIPTION
Somehow we have two things that transitively pull in cljs-time; exclude it from
one.