### PR TITLE
(PDB-3330) Add storage of package data

### DIFF
--- a/documentation/api/wire_format/facts_format_v5.markdown
+++ b/documentation/api/wire_format/facts_format_v5.markdown
@@ -16,7 +16,9 @@ allowed anywhere in the set of facts.
      "values": {
          <string>: <any>,
          ...
-         }
+         },
+     "package_inventory": [<package_tuple>, <package_tuple>, ...]
+
     }
 
 The `"certname"` key is the certname the facts are associated with.
@@ -34,7 +36,15 @@ to PuppetDB. This field may be `null`.
 
 Fact names and values **must** be strings.
 
+The `"package_inventory"` keys is optional, if present, must be an array of <package_tuple>.
+
 ## Encoding
 
 The entire fact set is expected to be valid JSON, which mandates UTF-8
 encoding.
+
+### Data type: `<package_tuple>`
+
+An array of three strings:
+
+    [ "<package_name>", "<version>", "<provider>" ]

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -300,18 +300,9 @@
                    certname))))
 
 (defn replace-facts [{:keys [payload version received] :as command} db]
-  (let [validated-payload (upon-error-throw-fatality
-                           (-> (case version
-                                 2 (fact/wire-v2->wire-v5 payload received)
-                                 3 (fact/wire-v3->wire-v5 payload)
-                                 4 (fact/wire-v4->wire-v5 payload)
-                                 payload)
-                               (update :values utils/stringify-keys)
-                               (update :producer_timestamp to-timestamp)
-                               (assoc :timestamp received)))]
-    (-> command
-        (assoc :payload validated-payload)
-        (replace-facts* db))))
+  (replace-facts* (upon-error-throw-fatality
+                   (assoc command :payload (fact/normalize-facts version received payload)))
+                  db))
 
 ;; Node deactivation
 

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -1,6 +1,8 @@
 (ns puppetlabs.puppetdb.scf.hash
   (:require [puppetlabs.puppetdb.cheshire :as json]
-            [puppetlabs.kitchensink.core :as kitchensink]))
+            [puppetlabs.kitchensink.core :as kitchensink]
+            [puppetlabs.puppetdb.facts :refer [package-tuple]]
+            [schema.core :as s]))
 
 (defn generic-identity-string
   "Serialize a data structure into a format that can be hashed for uniqueness
@@ -86,6 +88,15 @@
           (compare (:relationship lhs) (:relationship rhs))
           target-result))
       source-result)))
+
+(s/defn package-similarity-hash :- s/Str
+  "Creates a stable ordering of `packages` and computes a hash over
+  that structure"
+  [packages :- [package-tuple]]
+  (-> packages
+      sort
+      json/generate-string
+      kitchensink/utf8-string->sha1))
 
 (defn catalog-similarity-format
   "Creates catalog map for the given `certname`, `resources` and `edges` with a

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1221,6 +1221,27 @@
      "  foreign key (value_type_id) references value_types (id) match simple"
      "    on update restrict on delete restrict"]))
 
+(defn add-package-inventory []
+  (jdbc/do-commands
+   ["CREATE TABLE package_inventory"
+    "  (id bigint PRIMARY KEY,"
+    "   certname_id bigint not null,"
+    "   name text not null,"
+    "   version text not null,"
+    "   provider text not null)"]
+
+   "CREATE SEQUENCE package_inventory_id_seq CYCLE"
+   "ALTER TABLE package_inventory ALTER COLUMN id SET DEFAULT nextval('package_inventory_id_seq')"
+   "ALTER TABLE certnames ADD COLUMN package_hash bytea"
+
+   ["alter table package_inventory add constraint package_certname_id_fk"
+    "  foreign key (certname_id) references certnames (id) match simple"
+    "  on update restrict on delete restrict"]
+
+   "create index package_name_version_idx on package_inventory using btree (name, version)"
+
+   "create index package_certname_idx on package_inventory using btree (certname_id)"))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1254,7 +1275,8 @@
    53 add-corrective-change-index
    54 drop-resource-events-resource-type-idx
    55 index-certnames-unique-latest-report-id
-   56 merge-fact-values-into-facts})
+   56 merge-fact-values-into-facts
+   57 add-package-inventory})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/test/puppetlabs/puppetdb/facts_test.clj
+++ b/test/puppetlabs/puppetdb/facts_test.clj
@@ -1,6 +1,8 @@
 (ns puppetlabs.puppetdb.facts-test
   (:require [puppetlabs.puppetdb.facts :refer :all]
-            [clojure.test :refer :all]))
+            [clojure.test :refer :all]
+            [puppetlabs.puppetdb.time :refer [from-string to-timestamp]]
+            [schema.core :as s]))
 
 (deftest test-str->num
   (are [n s] (= n (str->num s))
@@ -32,3 +34,31 @@
     (doseq [[r l] data]
       (is (= (string-to-factpath r) l))
       (is (= r (factpath-to-string l))))))
+
+(deftest test-fact-normalization
+  (let [received-str "2017-03-14T14:18:32.635Z"
+        producer-ts "2017-03-14T14:18:32.635Z"
+        example-wire-facts {:certname "foo.com"
+                            :environment "test"
+                            :producer_timestamp producer-ts
+                            :producer "puppetserver"
+                            :values {:foo "1"
+                                     :bar "2"}
+                            :package_inventory [["openssl" "1.1.0e-1" "apt"]]}]
+    (are [version facts] (s/validate facts-schema (normalize-facts version received-str facts))
+      5 example-wire-facts
+      5 (dissoc example-wire-facts :package_inventory)
+      5 (assoc example-wire-facts :values {"foo bar" "1"})
+      4 (dissoc example-wire-facts :package_inventory :producer)
+      3 (-> example-wire-facts
+            (dissoc :package_inventory :producer :producer_timestamp :certname)
+            (assoc :producer-timestamp producer-ts :name "foo.com"))
+      2 (-> example-wire-facts
+            (dissoc :package_inventory :producer :producer_timestamp :certname)
+            (assoc :name "foo.com")))
+
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"does not match schema"
+                          (->> (assoc example-wire-facts :package_inventory [["openssl" "1.1.0e-1"]])
+                               (normalize-facts 5 received-str)
+                               (s/validate facts-schema))))))

--- a/test/puppetlabs/puppetdb/scf/hash_test.clj
+++ b/test/puppetlabs/puppetdb/scf/hash_test.clj
@@ -8,7 +8,11 @@
             [puppetlabs.puppetdb.catalog.utils :as catutils]
             [puppetlabs.puppetdb.examples.reports :refer [reports]]
             [puppetlabs.puppetdb.reports :as reports]
-            [clj-time.core :refer [now]]))
+            [clj-time.core :refer [now]]
+            [clojure.test.check.clojure-test :as cct]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [puppetlabs.puppetdb.generative.generators :refer [string+]]))
 
 (deftest hash-computation
   (testing "generic-identity-*"
@@ -309,3 +313,12 @@
     (is (= sorted-results
            (sort edge-comparator
                  (sort edge-comparator unsorted-results))))))
+
+(def package-tuple-generator
+  (gen/vector (gen/sized (string+)) 3))
+
+(cct/defspec comparing-packages
+  100
+  (prop/for-all [v (gen/vector package-tuple-generator)]
+                (= (package-similarity-hash v)
+                   (package-similarity-hash (shuffle v)))))


### PR DESCRIPTION
This commit adds package inventory to facts storage. Package data is
hashed and will only create/update/delete when the agent submits
changes. Facts containing the same packages should be a noop after
computing the hash.