### PR TITLE
(PDB-3354) Hash strings directly

### DIFF
--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -10,8 +10,11 @@
   instead."
   [data]
   {:post [(string? %)]}
-  (-> (kitchensink/sort-nested-maps data)
-      (json/generate-string)))
+  (if (string? data)
+    data
+    (-> data
+        kitchensink/sort-nested-maps
+        json/generate-string)))
 
 (defn generic-identity-hash
   "Convert a data structure into a serialized format then grab a sha1 hash for

--- a/test/puppetlabs/puppetdb/scf/hash_test.clj
+++ b/test/puppetlabs/puppetdb/scf/hash_test.clj
@@ -12,7 +12,8 @@
             [clojure.test.check.clojure-test :as cct]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
-            [puppetlabs.puppetdb.generative.generators :refer [string+]]))
+            [puppetlabs.puppetdb.generative.generators :refer [string+]]
+            [puppetlabs.kitchensink.core :as kitchensink]))
 
 (deftest hash-computation
   (testing "generic-identity-*"
@@ -40,7 +41,13 @@
         (testing "generic-identity-hash"
           (let [output (generic-identity-hash ["Type" "title" {:foo input}])]
             (is (= output
-                   "c62dab030cfe8c25a4832c5c6302b7f0041264ba")))))))
+                   "c62dab030cfe8c25a4832c5c6302b7f0041264ba"))))))
+
+    (testing "Should hash the string directly (not round-trip through JSON)"
+      (is (= "foo"
+             (generic-identity-string "foo")))
+      (is (= (generic-identity-hash "foo")
+             (kitchensink/utf8-string->sha1 "foo")))))
 
   (testing "resource-identity-hash"
     (testing "should error on bad input"


### PR DESCRIPTION
Before this commit, string values were converted ot JSON and the
results of that were hashed. We can just hash the string directly and
avoid the JSON roundtrip.