### PR TITLE
(PDB-3356) Use a CTE for inactive nodes

### DIFF
--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -42,7 +42,7 @@
          [:is-not (:field col1) nil]
          (->NullExpression col1 false)
 
-         "SELECT table.foo AS foo FROM table WHERE (1 = 1)"
+         "WITH inactive_nodes AS (SELECT certname FROM certnames WHERE (deactivated IS NOT NULL OR expired IS NOT NULL)) SELECT table.foo AS foo FROM table WHERE (1 = 1)"
          (map->Query {:projections {"foo" {:type :string
                                            :queryable? true
                                            :field :table.foo}}
@@ -73,12 +73,9 @@
          (expand-user-query [["=" "prop" "foo"]])))
 
   (is (= [["=" "prop" "foo"]
-          ["in" "certname"
-           ["extract" "certname"
-            ["select_nodes"
-             ["and"
-              ["null?" "deactivated" true]
-              ["null?" "expired" true]]]]]]
+          ["not" ["in" "certname"
+                  ["extract" "certname"
+                   ["select_inactive_nodes"]]]]]
          (expand-user-query [["=" "prop" "foo"]
                              ["=" ["node" "active"] true]])))
   (is (= [["=" "prop" "foo"]


### PR DESCRIPTION
Switch from using a select_nodes subquery for restrictions to active
nodes, to a dedicated CTE containing only inactive nodes. This approach
is faster and less sensitive to memory settings than the previous
approach, particularly on the prospective query for package inventory.