### PR TITLE
(maint) use a common set of certname-based implicit relations

### DIFF
--- a/documentation/api/query/v4/ast.markdown
+++ b/documentation/api/query/v4/ast.markdown
@@ -383,7 +383,9 @@ implicit relationships are supported.
 In PuppetDB, we keep a map of how different entities relate to each
 other, and therefore no data beyond the entity is needed in this case. This is
 different from explicit subqueries, where you must specify how
-two entities are related.
+two entities are related. Implicit subqueries can be used to join any two
+entities that have a `certname` field. Additional relationships are described
+in the endpoint-specific documentation as applicable.
 
 #### Implicit subquery examples
 

--- a/documentation/api/query/v4/catalogs.markdown
+++ b/documentation/api/query/v4/catalogs.markdown
@@ -56,11 +56,8 @@ The following list contains related entities that can be used to constrain the
 result set using implicit subqueries. For more information consult the
 documentation for [subqueries][subqueries].
 
-* [`nodes`][nodes]: node for a catalog.
 * [`producers`][producers]: the master that sent the catalog to PuppetDB.
 * [`environments`][environments]: environment for a catalog.
-* [`edges`][edges]: resource edges received for a catalog.
-* [`resources`][resources]: resources received for a catalog.
 
 ### Response format
 

--- a/documentation/api/query/v4/edges.markdown
+++ b/documentation/api/query/v4/edges.markdown
@@ -42,13 +42,6 @@ See [the AST query language page][ast].
 * `target_title` (string): the target resource title.
 * `target_type` (string, with first letter always capitalized): the target resource type.
 
-### Subquery relationships
-
-The following list contains related entities that can be used to constrain the result set using implicit subqueries. For more information consult the documentation for [subqueries][subqueries].
-
-* [`nodes`][nodes]: node entity for the catalog of an edge.
-* [`catalogs`][catalogs]: catalog entity for an edge.
-
 ### Response format
 
 The response is a JSON array of hashes, where each hash has the form:

--- a/documentation/api/query/v4/events.markdown
+++ b/documentation/api/query/v4/events.markdown
@@ -112,7 +112,6 @@ See [the AST query language page][ast] for the full list of available operators.
 The following list contains related entities that can be used to constrain the result set using implicit subqueries. For more information consult the documentation for [subqueries][subqueries].
 
 * [`reports`][reports]: the report associated with an event.
-* [`nodes`][nodes]: the node associated with an this event.
 * [`environments`][environments]: the environment associated with an event.
 
 ### Response format

--- a/documentation/api/query/v4/fact-contents.markdown
+++ b/documentation/api/query/v4/fact-contents.markdown
@@ -103,8 +103,6 @@ documentation for [subqueries][subqueries].
 
 * [`environment`][environments]: the environment for a fact-content.
 * [`facts`][facts]: the fact where this a fact-content occurs.
-* [`factsets`][factsets]: the factset where a fact-content occurs.
-* [`nodes`][nodes]: the node where a fact-content occurs.
 
 ## Response format
 

--- a/documentation/api/query/v4/facts.markdown
+++ b/documentation/api/query/v4/facts.markdown
@@ -45,9 +45,7 @@ See [the AST query language page][ast].
 The following list contains related entities that can be used to constrain the result set using implicit subqueries. For more information, consult the documentation for [subqueries][subqueries].
 
 * [`environments`][environments]: the environment where a fact occurs.
-* [`factsets`][factsets]: the factset where a fact appears.
 * [`fact_contents`][fact-contents]: expanded fact paths and values for a fact.
-* [`nodes`][nodes]: the node where a fact occurs.
 
 ### Response format
 

--- a/documentation/api/query/v4/factsets.markdown
+++ b/documentation/api/query/v4/factsets.markdown
@@ -51,9 +51,6 @@ See [the AST query language page][ast].
 The following list contains related entities that can be used to constrain the result set using implicit subqueries. For more information, consult the documentation for [subqueries][subqueries].
 
 * [`environments`][environments]: the environment a factset was received from.
-* [`facts`][facts]: fact names and values received from a factset.
-* [`fact_contents`][fact-contents]: factset paths and values received from a factset.
-* [`nodes`][nodes]: the node that a factset was received from.
 * [`producers`][producers]: the master that sent the factset to PuppetDB.
 
 ### Response format

--- a/documentation/api/query/v4/inventory.markdown
+++ b/documentation/api/query/v4/inventory.markdown
@@ -54,20 +54,6 @@ Note: This endpoint supports [dot notation][dotted] on the `facts` and
 
 * `trusted` (json): a JSON hash of trusted data for the node.
 
-### Subquery relationships
-
-The following list contains related entities that can be used to constrain the result set with implicit subqueries. For more information, consult the documentation for [subqueries][subqueries].
-
-* [`environments`][environments]: the environment where a node inventory exists.
-* [`factsets`][factsets]: the factset corresponding to a node inventory's certname.
-* [`catalogs`][catalogs]: the catalog corresponding to a node inventory's certname.
-* [`facts`][facts]: the facts corresponding to a node inventory's certname.
-* [`fact-contents`][fact-contents]: the fact contents corresponding to a node inventory's certname.
-* [`events`][events]: the events corresponding to a node inventory's certname.
-* [`edges`][edges]: the catalog edges corresponding to a node inventory's certname.
-* [`resources`][resources]: the resources corresponding to a node inventory's certname.
-* [`nodes`][nodes]: the node corresponding to an inventory.
-
 ### Response format
 Successful responses will be in `application/json`.
 

--- a/documentation/api/query/v4/nodes.markdown
+++ b/documentation/api/query/v4/nodes.markdown
@@ -83,21 +83,6 @@ The below fields are allowed as filter criteria and are returned in all response
     Note that nodes which are missing a fact referenced by a `not` query will match
     the query.
 
-### Subquery relationships
-
-Here is a list of related entities that can be used to constrain the result set using
-implicit subqueries. For more information, consult the documentation for [subqueries][subqueries].
-
-* [`inventory`][inventory]: inventory for a node.
-* [`factsets`][factsets]: factsets received for a node.
-* [`reports`][reports]: reports received for a node.
-* [`catalogs`][catalogs]: catalogs received for a node.
-* [`facts`][facts]: fact names and values received for a node.
-* [`fact_contents`][fact-contents]: factset paths and values received for a node.
-* [`events`][events]: report events triggered for a node.
-* [`edges`][edges]: catalog edges received for a node.
-* [`resources`][resources]: catalog resources received for a node.
-
 ### Response format
 
 The response is a JSON array of hashes, where each hash has the form:

--- a/documentation/api/query/v4/packages.markdown
+++ b/documentation/api/query/v4/packages.markdown
@@ -45,24 +45,6 @@ entity name in [PQL][pql] or with a `["from" "packages"]` [AST][ast] query.
 * `provider` (string): The name of the provider which the package data came from;
   typically the name of the packaging system. (e.g. `apt`)
 
-### Subquery relationships
-
-The following list contains related entities that can be used to constrain the
-result set by using implicit subqueries. For more information, consult the
-documentation for [subqueries][subqueries].
-
-* [`factsets`] [factsets]
-* [`reports`] [reports]
-* [`catalogs`] [catalogs]
-* [`nodes`] [nodes]
-* [`facts`] [facts]
-* [`fact_contents`] [fact_contents]
-* [`events`] [events]
-* [`edges`] [edges]
-* [`resources`] [resources]
-* [`inventory`] [inventory]
-* [`packages`] [packages]
-
 ### Response format
 
 The response is a JSON array of hashes, where each hash has the form:

--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -127,7 +127,6 @@ documentation for [subqueries][subqueries].
 
 * [`environments`][environments]: environment from where a report was received.
 * [`events`][events]: events received in a report.
-* [`nodes`][nodes]: node from where a report was received.
 * [`producers`][producers]: the master that sent the report to PuppetDB.
 
 ### Response format

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -34,6 +34,19 @@
                               SqlCall SqlRaw
                               {:select s/Any s/Any s/Any}))
 
+(def certname-relations
+  {"factsets" {:columns ["certname"]}
+   "reports" {:columns ["certname"]}
+   "packages" {:columns ["certname"]}
+   "inventory" {:columns ["certname"]}
+   "catalogs" {:columns ["certname"]}
+   "nodes" {:columns ["certname"]}
+   "facts" {:columns ["certname"]}
+   "fact_contents" {:columns ["certname"]}
+   "events" {:columns ["certname"]}
+   "edges" {:columns ["certname"]}
+   "resources" {:columns ["certname"]}})
+
 (def column-schema
   "Column information: [\"value\" {:type :string :field f.value_string ...}]"
   {:type s/Keyword :field field-schema s/Any s/Any})
@@ -174,16 +187,7 @@
                             [:= :fs.certname :certnames.certname]]}
 
     :alias "inventory"
-    :relationships {"factsets" {:columns ["certname"]}
-                    "reports" {:columns ["certname"]}
-                    "catalogs" {:columns ["certname"]}
-                    "nodes" {:columns ["certname"]}
-                    "facts" {:columns ["certname"]}
-                    "fact_contents" {:columns ["certname"]}
-                    "events" {:columns ["certname"]}
-                    "edges" {:columns ["certname"]}
-                    "resources" {:columns ["certname"]}
-                    "packages" {:columns ["certname"]}}
+    :relationships certname-relations
 
     :dotted-fields ["facts\\..*" "trusted\\..*"]
     :entity :inventory
@@ -238,19 +242,7 @@
                                                    :queryable? true
                                                    :field :reports_environment.environment}}
 
-               :relationships {;; Children - direct
-                               "inventory" {:columns ["certname"]}
-                               "factsets" {:columns ["certname"]}
-                               "reports" {:columns ["certname"]}
-                               "catalogs" {:columns ["certname"]}
-                               "packages" {:columns ["certname"]}
-
-                               ;; Children - transitive
-                               "facts" {:columns ["certname"]}
-                               "fact_contents" {:columns ["certname"]}
-                               "events" {:columns ["certname"]}
-                               "edges" {:columns ["certname"]}
-                               "resources" {:columns ["certname"]}}
+               :relationships certname-relations
 
                :selection {:from [:certnames]
                            :left-join [:catalogs
@@ -387,17 +379,10 @@
                                        [:= :fs.environment_id :env.id]]
                            :where [:= :fp.depth 0]}
 
-               :relationships {;; Parents - direct
-                               "factsets" {:columns ["certname"]}
-                               "inventory" {:columns ["certname"]}
-                               ;; Parents - transitive
-                               "nodes" {:columns ["certname"]}
-                               "packages" {:columns ["certname"]}
-                               "environments" {:local-columns ["environment"]
-                                               :foreign-columns ["name"]}
-
-                               ;; Children - direct
-                               "fact_contents" {:columns ["certname" "name"]}}
+               :relationships (merge certname-relations
+                                     {"environments" {:local-columns ["environment"]
+                                                      :foreign-columns ["name"]}
+                                      "fact_contents" {:columns ["certname" "name"]}})
 
                :alias "facts"
                :source-table "facts"
@@ -453,15 +438,10 @@
                                        [:= :fs.environment_id :env.id]]
                            :where [:!= :vt.id 5]}
 
-               :relationships {;; Parents - direct
-                               "facts" {:columns ["certname" "name"]}
-                               "factsets" {:columns ["certname"]}
-
-                               ;; Parents - transitive
-                               "nodes" {:columns ["certname"]}
-                               "packages" {:columns ["certname"]}
-                               "environments" {:local-columns ["environment"]
-                                               :foreign-columns ["name"]}}
+               :relationships (merge certname-relations
+                                     {"facts" {:columns ["certname" "name"]}
+                                      "environments" {:local-columns ["environment"]
+                                                      :foreign-columns ["name"]}})
 
                :alias "fact_nodes"
                :source-table "facts"
@@ -614,16 +594,13 @@
                              :report_statuses
                              [:= :reports.status_id :report_statuses.id]]}
 
-     :relationships {;; Parents - direct
-                     "nodes" {:columns ["certname"]}
-                     "environments" {:local-columns ["environment"]
-                                     :foreign-columns ["name"]}
-                     "producers" {:local-columns ["producer"]
-                                  :foreign-columns ["name"]}
-
-                     ;; Children - direct
-                     "events" {:local-columns ["hash"]
-                               :foreign-columns ["report"]}}
+     :relationships (merge certname-relations
+                           {"environments" {:local-columns ["environment"]
+                                            :foreign-columns ["name"]}
+                            "producers" {:local-columns ["producer"]
+                                         :foreign-columns ["name"]}
+                            "events" {:local-columns ["hash"]
+                                      :foreign-columns ["report"]}})
 
      :alias "reports"
      :subquery? false
@@ -707,16 +684,11 @@
                              :producers
                              [:= :producers.id :c.producer_id]]}
 
-     :relationships {;; Parents - direct
-                     "node" {:columns ["certname"]}
-                     "environments" {:local-columns ["environment"]
-                                     :foreign-columns ["name"]}
-                     "producers" {:local-columns ["producer"]
-                                  :foreign-columns ["name"]}
-
-                     ;; Children - direct
-                     "edges" {:columns ["certname"]}
-                     "resources" {:columns ["certname"]}}
+     :relationships (merge certname-relations
+                           {"environments" {:local-columns ["environment"]
+                                            :foreign-columns ["name"]}
+                            "producers" {:local-columns ["producer"]
+                                         :foreign-columns ["name"]}})
 
      :alias "catalogs"
      :entity :catalogs
@@ -757,11 +729,7 @@
                                    [:= :edges.target :targets.resource]
                                    [:= :certnames.id :targets.certname_id]]]}
 
-               :relationships {;; Parents - direct
-                               "catalogs" {:columns ["certname"]}
-
-                               ;; Parents - transitive
-                               "nodes" {:columns ["certname"]}}
+               :relationships certname-relations
 
                :alias "edges"
                :subquery? false
@@ -899,14 +867,11 @@
                            :left-join [:environments
                                        [:= :reports.environment_id :environments.id]]}
 
-               :relationships {;; Parents - direct
-                               "reports" {:local-columns ["report"]
-                                          :foreign-columns ["hash"]}
-
-                               ;; Parents - transitive
-                               "nodes" {:columns ["certname"]}
-                               "environments" {:local-columns ["environment"]
-                                               :foreign-columns ["name"]}}
+               :relationships (merge certname-relations
+                                     {"reports" {:local-columns ["report"]
+                                                 :foreign-columns ["hash"]}
+                                      "environments" {:local-columns ["environment"]
+                                                      :foreign-columns ["name"]}})
 
                :alias "events"
                :subquery? false
@@ -1004,16 +969,7 @@
                            :left-join [:certnames
                                        [:= :pi.certname_id :certnames.id]]}
 
-               :relationships {"factsets" {:columns ["certname"]}
-                               "reports" {:columns ["certname"]}
-                               "catalogs" {:columns ["certname"]}
-                               "nodes" {:columns ["certname"]}
-                               "facts" {:columns ["certname"]}
-                               "fact_contents" {:columns ["certname"]}
-                               "events" {:columns ["certname"]}
-                               "edges" {:columns ["certname"]}
-                               "resources" {:columns ["certname"]}
-                               "inventory" {:columns ["certname"]}}
+               :relationships certname-relations
 
                :alias "packages"
                :subquery? false
@@ -1064,17 +1020,11 @@
                              :producers
                              [:= :producers.id :factsets.producer_id]]}
 
-     :relationships {;; Parents - direct
-                     "nodes" {:columns ["certname"]}
-                     "environments" {:local-columns ["environment"]
-                                     :foreign-columns ["name"]}
-                     "producers" {:local-columns ["producer"]
-                                  :foreign-columns ["name"]}
-
-                     ;; Children - direct
-                     "facts" {:columns ["certname"]}
-                     "fact_contents" {:columns ["certname"]}
-                     "packages" {:columns ["certname"]}}
+     :relationships (merge certname-relations
+                           {"environments" {:local-columns ["environment"]
+                                            :foreign-columns ["name"]}
+                            "producers" {:local-columns ["producer"]
+                                         :foreign-columns ["name"]}})
 
      :alias "factsets"
      :entity :factsets

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -95,7 +95,7 @@
 
       ;; Simplistic 1 column examples (catalogs example)
       (map->Query {:relationships
-                   {"resources" {:columns ["certname"]}}})
+                   certname-relations})
       ["subquery" "resources"
        ["=" "type" "Class"]]
       ["in" ["certname"]


### PR DESCRIPTION
Centralize definition of certname-based implicit relationships. This
will make us less likely to leave them out or create inconsistencies in
the future.