### PR TITLE
(PE-19944) Update clj-i18n to 0.8.0

### DIFF
--- a/locales/eo.po
+++ b/locales/eo.po
@@ -1,0 +1,20 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Puppet <docs@puppet.com>
+# This file is distributed under the same license as the puppetlabs.puppetdb package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: puppetlabs.puppetdb\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2017-03-22 14:56-0600\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.12\n"
+"Last-Translator: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: eo\n"
+

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def pdb-version "4.4.0-SNAPSHOT")
 (def puppetserver-version "2.7.2")
-(def clj-parent-version "0.4.1")
+(def clj-parent-version "0.6.0")
 
 (defn deploy-info
   "Generate deployment information from the URL supplied and the username and
@@ -11,7 +11,7 @@
    :password :env/nexus_jenkins_password
    :sign-releases false})
 
-(def i18n-version "0.7.1")
+(def i18n-version "0.8.0")
 
 (def pdb-jvm-opts
   (case (System/getProperty "java.specification.version")
@@ -186,6 +186,13 @@
   :test-selectors {:default (complement :integration)
                    :unit (complement :integration)
                    :integration :integration}
+
+  ;; This is used to merge the locales.clj of all the dependencies into a single
+  ;; file inside the uberjar
+  :uberjar-merge-with {"locales.clj"  [(comp read-string slurp)
+                                       (fn [new prev]
+                                         (if (map? prev) [new prev] (conj prev new)))
+                                       #(spit %1 (pr-str %2))]}
 
   :aliases {"gem" ["trampoline" "run" "-m" "puppetlabs.puppetserver.cli.gem"
                    "--config" "./test-resources/puppetserver/puppetserver.conf"]


### PR DESCRIPTION
This commit updates the i18n scaffolding arounding PuppetDB to be in
line with the latest.