### PR TITLE
(maint) allow paging options to be specified in two places

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -162,8 +162,12 @@
                                                           version query warn-experimental)
          paging-options (some-> paging-clauses
                                 (rename-keys {:order-by :order_by})
-                                (update :order_by paging/munge-query-ordering))
-         query-options (merge (dissoc query-map :query) paging-options)]
+                                (update :order_by paging/munge-query-ordering)
+                                utils/strip-nil-values)
+         query-options (->> (dissoc query-map :query)
+                            utils/strip-nil-values
+                            (merge {:limit nil :offset nil :order_by nil}
+                                   paging-options))]
      {:query query :remaining-query remaining-query :entity entity :query-options query-options})))
 
 (pls/defn-validated produce-streaming-body

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -438,3 +438,8 @@
 
 (def supported-content-encodings
   (vec (keys content-encodings->file-extensions)))
+
+(defn strip-nil-values
+  "remove all nil-valued keys from a map"
+  [m]
+  (into {} (filter val m)))

--- a/test/puppetlabs/puppetdb/http/index_test.clj
+++ b/test/puppetlabs/puppetdb/http/index_test.clj
@@ -112,6 +112,15 @@
           (is (= "host2" (:certname (first results))))
           (is (= 2 (count results)))))
 
+      (testing "with limit in the options and offset in the query"
+        (let [results (ordered-query-result
+                        method endpoint
+                        ["from" "nodes" ["order_by" [["certname" "desc"]]]
+                         ["offset" 1]]
+                        {:limit 1})]
+          (is (= "host2" (:certname (first results))))
+          (is (= 1 (count results)))))
+
       (testing "in a subquery"
         (doseq [query [["from" "catalogs"
                         ["in" "certname"


### PR DESCRIPTION
Previously paging options supplied in a query would cause paging options
supplied outside the query to be ignored.