### PR TITLE
(PDB-3285) fix regex queries on nested resource params

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1248,6 +1248,10 @@
    "create index certname_package_reverse_idx on certname_packages using btree (package_id, certname_id)"
    "create index packages_name_idx on packages using btree (name)"))
 
+(defn add-gin-index-on-resource-params-cache []
+  (jdbc/do-commands
+    "create index resource_params_cache_parameters_idx on resource_params_cache using gin (parameters)"))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1282,7 +1286,8 @@
    54 drop-resource-events-resource-type-idx
    55 index-certnames-unique-latest-report-id
    56 merge-fact-values-into-facts
-   57 add-package-tables})
+   57 add-package-tables
+   58 add-gin-index-on-resource-params-cache})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -212,6 +212,16 @@
   [field]
   (hcore/raw (format "%s @> ?" field)))
 
+(defn jsonb-regex
+  "Produce a predicate that matches a regex against a nested value and checks
+   the existence of a (presumably) top-level value. The existence check is
+   necessary because -> is not indexable but ?? is. Assumes a GIN index on the
+   column supplied."
+  [column qmarks]
+  (let [delimited-qmarks (str/join "->" qmarks)]
+    (hcore/raw (format "(%s->%s)::text ~ ?::text and %s ?? ?"
+                       column delimited-qmarks column))))
+
 (defn db-serialize
   "Serialize `value` into a form appropriate for querying against a
   serialized database column."

--- a/test/puppetlabs/puppetdb/http/resources_test.clj
+++ b/test/puppetlabs/puppetdb/http/resources_test.clj
@@ -75,7 +75,16 @@ to the result of the form supplied to this method."
     (testing "dot-style querying for parameters"
       (doseq [[query result] [[["=" "parameters.ensure" "file"] #{foo1 bar1}]
                               [["=" "parameters.owner" "root"] #{foo1 bar1}]
+                              [["=" "parameters.nested.foo" "bar"] #{foo1 bar1}]
+                              [["=" "parameters.boolean" true] #{foo1 bar1}]
+                              [["=" "parameters.numeric" 1337] #{foo1 bar1}]
+                              [["=" "parameters.double" 3.14] #{foo1 bar1}]
                               [["=" "parameters.acl" ["john:rwx" "fred:rwx"]] #{foo1 bar1}]]]
+        (is (= (query-result (query-response method endpoint query)) result))))
+
+    (testing "dot-style querying for regex resource parameters"
+      (doseq [[query result] [[["~" "parameters.owner" "oot"] #{foo1 bar1}]
+                              [["~" "parameters.nested.foo" "ar"] #{foo1 bar1}]]]
         (is (= (query-result (query-response method endpoint query)) result))))
 
     (testing "fact subqueries are supported"

--- a/test/puppetlabs/puppetdb/testutils/resources.clj
+++ b/test/puppetlabs/puppetdb/testutils/resources.clj
@@ -19,6 +19,10 @@
          :parameters (sutils/munge-jsonb-for-storage
                        {"ensure" "file"
                         "owner"  "root"
+                        "nested" {"foo" "bar"}
+                        "boolean" true
+                        "numeric" 1337
+                        "double" 3.14
                         "group"  "root"
                         "acl"    ["john:rwx" "fred:rwx"]})}
         {:resource (sutils/munge-hash-for-storage "02")
@@ -32,7 +36,15 @@
         {:resource (sutils/munge-hash-for-storage "01") :name "group"
          :value (sutils/db-serialize "root")}
         {:resource (sutils/munge-hash-for-storage "01") :name "acl"
-         :value (sutils/db-serialize ["john:rwx" "fred:rwx"])}])
+         :value (sutils/db-serialize ["john:rwx" "fred:rwx"])}
+        {:resource (sutils/munge-hash-for-storage "01") :name "nested"
+         :value (sutils/db-serialize {"foo" "bar"})}
+        {:resource (sutils/munge-hash-for-storage "01") :name "boolean"
+         :value (sutils/db-serialize true)}
+        {:resource (sutils/munge-hash-for-storage "01") :name "numeric"
+         :value (sutils/db-serialize 1337)}
+        {:resource (sutils/munge-hash-for-storage "01") :name "double"
+         :value (sutils/db-serialize 3.14)}])
        (jdbc/insert-multi!
         :certnames
          [{:id 1 :certname "one.local"}
@@ -98,6 +110,10 @@
              :environment (when environment? "DEV")
              :parameters {:ensure "file"
                           :owner  "root"
+                          :nested {:foo "bar"}
+                          :boolean true
+                          :numeric 1337
+                          :double 3.14
                           :group  "root"
                           :acl    ["john:rwx" "fred:rwx"]}}
       :foo2 {:certname   "one.local"
@@ -121,6 +137,10 @@
              :environment (when environment? "PROD")
              :parameters {:ensure "file"
                           :owner  "root"
+                          :nested {:foo "bar"}
+                          :boolean true
+                          :numeric 1337
+                          :double 3.14
                           :group  "root"
                           :acl    ["john:rwx" "fred:rwx"]}}
       :bar2 {:certname   "two.local"


### PR DESCRIPTION
Corrects an issue where resource parameters specified via dot notation
could not be queried via regex.