### PR TITLE
(PDB-3312) Back off population metric db connection on failure

### DIFF
--- a/src/puppetlabs/puppetdb/query/population.clj
+++ b/src/puppetlabs/puppetdb/query/population.clj
@@ -2,15 +2,12 @@
   "Population-wide queries
 
    Contains queries and metrics that apply across an entire population."
-  (:require [puppetlabs.puppetdb.jdbc :refer [query-to-vec
-                                              table-count
-                                              with-transacted-connection]]
+  (:require [puppetlabs.puppetdb.jdbc :as jdbc :refer [query-to-vec]]
             [puppetlabs.puppetdb.metrics.core :as metrics]
             [clojure.core.memoize :as mem]
             [puppetlabs.kitchensink.core :refer [quotient]]
             [metrics.gauges :refer [gauge-fn]]
-            [honeysql.core :as hcore]
-            [honeysql.helpers :as hh]))
+            [clojure.java.jdbc :as sql]))
 
 (defn first-query-result
   "Pick a key out of the first result of a query."
@@ -64,31 +61,58 @@
 (def pct-resource-duplication
   (mem/ttl pct-resource-duplication* :ttl/threshold 60000))
 
+(defn backoff-on-failure
+  "Make a wrapper for f to help with backoff. When everything is working, the
+  wrapper just calls through to `f`. If `f` throws an exception, subsequent
+  invocations of the wrapper will just return `nil` until `backoff-ms` have
+  elapsed."
+  [f backoff-ms]
+  (let [last-fail-time (atom (- (System/currentTimeMillis) backoff-ms))]
+    (fn [& args]
+      (try
+        (if (> (- (System/currentTimeMillis) @last-fail-time) backoff-ms)
+          (apply f args)
+          nil)
+        (catch Exception e
+          (reset! last-fail-time (System/currentTimeMillis))
+          nil)))))
+
+(def get-metrics-db-connection
+  (backoff-on-failure sql/get-connection 5000))
+
+(defn call-with-metrics-db-connection
+  "Call `f` with an open connection to `db-spec` bound to `jdbc/*db*`. Unlike
+  the regular db connection helpers, this version goes through
+  `backoff-on-failure` to avoid long timeouts on every invocation when the
+  database is down. It also doesn't open a transaction, as they aren't very
+  important here."
+  [db-spec f]
+  (when-let [conn (get-metrics-db-connection db-spec)]
+    (try
+      (binding [jdbc/*db* (sql/add-connection db-spec conn)]
+        (f))
+      (finally
+        (.close conn)))))
+
 (defn initialize-population-metrics!
   "Initializes the set of population-wide metrics"
   [registry db]
   (gauge-fn registry ["num-resources"]
             (fn []
-              (with-transacted-connection db
-                (num-resources))))
+              (call-with-metrics-db-connection db num-resources)))
   (gauge-fn registry ["num-inactive-nodes"]
             (fn []
-              (with-transacted-connection db
-                (num-inactive-nodes))))
+              (call-with-metrics-db-connection db num-inactive-nodes)))
   (gauge-fn registry ["num-active-nodes"]
             (fn []
-              (with-transacted-connection db
-                (num-active-nodes))))
+              (call-with-metrics-db-connection db num-active-nodes)))
   (gauge-fn registry ["num-nodes"]
             (fn []
-              (with-transacted-connection db
-                (num-active-nodes))))
+              (call-with-metrics-db-connection db num-active-nodes)))
   (gauge-fn registry ["avg-resources-per-node"]
             (fn []
-              (with-transacted-connection db
-                (avg-resource-per-node))))
+              (call-with-metrics-db-connection db avg-resource-per-node)))
   (gauge-fn registry ["pct-resource-dupes"]
             (fn []
-              (with-transacted-connection db
-                (pct-resource-duplication))))
+              (call-with-metrics-db-connection db pct-resource-duplication)))
   nil)


### PR DESCRIPTION
When doing db queries for the population metrics, don't wait for the connection
to time out every time. Instead, fail fast if the connection failed less than 5
seconds ago. This improves the performance of the dashboard data endpoint when
the database is down, as it reduces the number of times it has to wait for
timeouts to occur.