### PR TITLE
(PDB-3385) Clean up certname_packages when deleting nodes

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -215,6 +215,7 @@
   "Delete the given host from the db"
   [certname]
   {:pre [certname]}
+  (jdbc/delete! :certname_packages ["certname_id in (select id from certnames where certname=?)" certname])
   (jdbc/delete! :certnames ["certname=?" certname]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -243,6 +244,7 @@
   [time]
   {:pre [(kitchensink/datetime? time)]}
   (let [ts (to-timestamp time)]
+    (jdbc/delete! :certname_packages ["certname_id in (select id from certnames where deactivated < ? OR expired < ?)" ts ts])
     (jdbc/delete! :certnames ["deactivated < ? OR expired < ?" ts ts])))
 
 (defn activate-node!


### PR DESCRIPTION
I tried the purge-nodes query on our big dataset: it took ~2.5s to purge 800 nodes (1%) and ~22 s to purge 8k (10%). Subquery vs. CTE form makes no difference in this case. 

I also tried a relational-ier "delete using" version of the query, but I got the same query plan (and perf) as the subquery. 