### PR TITLE
(PDB-3394) Add support for package purge

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1240,7 +1240,7 @@
                  (jdbc/in-clause rm-pids))
          (cons factset-id rm-pids)))
 
-      (insert-facts! (certname-to-factset-id certname)
+      (insert-facts! factset-id
                      (map paths->ids new-pathstrs)
                      new-values)
 


### PR DESCRIPTION
This commit adds the ability to purge all packages for a given
node. If a node previously had packages stored and either the packages
list is gone (i.e. package support is disabled) or null/empty, all
packages associated to that node with be disassociated from the node.