### PR TITLE
(SERVER-1745) Add integration test for Puppet Server metrics

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def pdb-version "5.0.0-SNAPSHOT")
-(def puppetserver-version "2.7.2")
-(def clj-parent-version "0.6.0")
+(def puppetserver-version "5.0.0-master-20170329_182047-ga16e296")
+(def clj-parent-version "0.6.1")
 
 (defn deploy-info
   "Generate deployment information from the URL supplied and the username and

--- a/test/puppetlabs/puppetdb/integration/puppetserver_metrics.clj
+++ b/test/puppetlabs/puppetdb/integration/puppetserver_metrics.clj
@@ -1,0 +1,40 @@
+(ns puppetlabs.puppetdb.integration.puppetserver-metrics
+  (:require [clojure.test :refer :all]
+            [puppetlabs.puppetdb.integration.fixtures :as int]
+            [puppetlabs.puppetdb.cheshire :as json]
+            [puppetlabs.puppetdb.testutils.services :as svc-utils]))
+
+(deftest ^:integration puppetserver-http-client-metrics
+  (with-open [pg (int/setup-postgres)
+              pdb (int/run-puppetdb pg {})
+              ps (int/run-puppet-server [pdb] {})]
+    (testing "Run puppet using exported resources and puppetdb_query function"
+      (int/run-puppet-as "exporter" ps pdb
+                         (str
+                          "$counts = puppetdb_query(['from', 'catalogs',"
+                          "                            ['extract', [['function', 'count']]]])"
+                          "@@notify { 'hello world': }"))
+
+      ;; Collecting resources triggers a `facts find` and `resource search`
+      (int/run-puppet-as "collector" ps pdb "Notify <<| |>>"))
+
+    (testing "Puppet Server status endpoint contains expected puppetdb metrics"
+
+      (let [all-svcs-status (svc-utils/get-ssl "https://localhost:8140/status/v1/services")]
+        (is (= 200 (:status all-svcs-status)))
+        ;; in older versions of Puppet Server (pre-5.0), the `master` status
+        ;; didn't exist. Since these tests are run against multiple versions
+        ;; of Puppet Server, this ensures that we're only testing that the
+        ;; `master` status has appropriate content on the right versions.
+        (when (some? (get-in all-svcs-status [:body :master]))
+          (let [resp (svc-utils/get-ssl "https://localhost:8140/status/v1/services/master?level=debug")]
+            (is (= 200 (:status resp)))
+
+            (let [metrics (get-in resp [:body :status :experimental :http-client-metrics])]
+              (is (= #{["puppetdb" "command" "replace_catalog"]
+                       ["puppetdb" "command" "replace_facts"]
+                       ["puppetdb" "command" "store_report"]
+                       ["puppetdb" "facts" "find"]
+                       ["puppetdb" "query"]
+                       ["puppetdb" "resource" "search"]}
+                     (set (map :metric-id metrics)))))))))))


### PR DESCRIPTION
Add integration test that the http client metrics specified in the PuppetDB
termini show up in the Puppet Server master status endpoint.

This commit also bumps the Puppet Server version to a `voom` release based off
current master of Puppet Server, which will be what eventually goes into
Puppet Server 5.