### PR TITLE
(PDB-3322) Redact sensitive parameters in terminus

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -32,6 +32,21 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
     hash
   end
 
+  def redact_sensitive_params(hash)
+    resources = hash['resources']
+    resources.each do |resource|
+      sensitive_params = resource['sensitive_parameters']
+      unless sensitive_params.nil?
+        parameters = resource['parameters']
+        sensitive_params.each do |sensitive_param|
+          parameters.delete sensitive_param
+        end
+        resource.delete 'sensitive_parameters'
+      end
+    end
+    nil
+  end
+
   def munge_catalog(catalog, extra_request_data = {})
     profile("Munge catalog", [:puppetdb, :catalog, :munge]) do
       data = profile("Convert catalog to JSON data hash", [:puppetdb, :catalog, :convert_to_hash]) do
@@ -54,6 +69,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
       add_environment(data, extra_request_data[:environment])
       add_producer_timestamp(data, extra_request_data[:producer_timestamp])
       add_producer(data, Puppet[:node_name_value])
+      redact_sensitive_params(data)
 
       data
     end


### PR DESCRIPTION
A resource parameter marked Sensitive()

  notify {'hi':  message => Sensitive('there')}

will show up in the terminus
like this:

        input = {...
                 'environment'=>'production',
                 'resources'=>
                 [...
                  {'type'=>'Notify',
                   'title'=>'hi',
                   'tags'=>Puppet::Util::TagSet.new(['notify', 'hi', 'class']),
                   'file'=> 'site.pp',
                   'line'=>1,
                   'exported'=>false,
                   'parameters'=>{:message=>'there'},
                   'sensitive_parameters'=>[:message]}],
                 'edges'=>
                 [{'source'=>'Stage[main]', 'target'=>'Class[Settings]'},
                  {'source'=>'Stage[main]', 'target'=>'Class[main]'},
                  {'source'=>'Class[main]', 'target'=>'Notify[hi]'}],
                 'classes'=>['settings']}

Remove any sensitive values from 'parameters', and remove
'sensitive_parameters' before sending data to PuppetDB.

Aside from the fact that we don't want senstitive parameters to be
stored in (or even make it to) PuppetDB, the 'sensitive_parameters'
element can cause command processing to fail, e.g. when an existing
parameter becomes sensitive.  Add an integration test for that.