### PR TITLE
(PDB-3421) do-commands: pass vector to db-do-commands, not list

### DIFF
--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -32,14 +32,15 @@
 
 (defn do-commands
   "Runs the given commands in a transaction on the database given
-  by (jdbc/db).  If a command is a vector, it will be converted to a
-  string via (apply str v)."
+  by (jdbc/db).  If a command is a seq, converts it to a string
+  via (clojure.string/join command)."
   [& commands]
   (sql/db-do-commands *db* true
-                      (for [c commands]
-                        (if (vector? c)
-                          (apply str c)
-                          c))))
+                      (mapv #(cond
+                               (string? %) %
+                               (seq %) (string/join %)
+                               :else %)
+                            commands)))
 
 (defn do-prepared
   "Executes an optionally parametrized sql expression in a transaction on the


### PR DESCRIPTION
db-do-commands doesn't appear to care right now, but but let's follow
the documented API anyway.