### PR TITLE
(PDB-3427) Ignore order of resource_events in generative tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def pdb-version "4.4.1-SNAPSHOT")
+(def pdb-version "5.0.0-SNAPSHOT")
 (def puppetserver-version "2.7.2")
 (def clj-parent-version "0.6.0")
 

--- a/test/puppetlabs/puppetdb/generative/submit_command.clj
+++ b/test/puppetlabs/puppetdb/generative/submit_command.clj
@@ -76,7 +76,8 @@
               (-> row
                   (update :logs #(json/parse (str %) true))
                   (update :metrics #(json/parse (str %) true))
-                  (update :resource_events #(json/parse (str %) true)))))))
+                  (update :resource_events #(json/parse (str %) true))
+                  (update-in [:resource_events :data] #(into #{} %)))))))
 
 (defn all-nodes [db]
   (qeng/stream-query-result :v4


### PR DESCRIPTION
The database can return these in arbitrary orders, at times.