### PR TITLE
(PDB-3427) Ignore order of resource_events in generative tests

### DIFF
--- a/test/puppetlabs/puppetdb/generative/submit_command.clj
+++ b/test/puppetlabs/puppetdb/generative/submit_command.clj
@@ -76,7 +76,8 @@
               (-> row
                   (update :logs #(json/parse (str %) true))
                   (update :metrics #(json/parse (str %) true))
-                  (update :resource_events #(json/parse (str %) true)))))))
+                  (update :resource_events #(json/parse (str %) true))
+                  (update-in [:resource_events :data] #(into #{} %)))))))
 
 (defn all-nodes [db]
   (qeng/stream-query-result :v4


### PR DESCRIPTION
The database can return these in arbitrary orders, at times.