### PR TITLE
fix configure_postgres link

### DIFF
--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -3,7 +3,7 @@ title: "PuppetDB 4.4: Contributing to PuppetDB"
 layout: default
 ---
 
-[configure_postgres]: ./configure.html#using-postgresql
+[configure_postgres]: ./configure.markdown#using-postgresql
 
 # How to contribute
 


### PR DESCRIPTION
Switch from:
https://github.com/puppetlabs/puppetdb/blob/master/documentation/configure.html#using-postgresql
to:
https://github.com/puppetlabs/puppetdb/blob/master/documentation/configure.markdown#using-postgresql