### PR TITLE
(maint) clean up the error messages around unknown fields

### DIFF
--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -167,8 +167,7 @@
 
   This hash is useful for situations where you'd like to determine
   whether or not two reports contain the same things (certname,
-  configuration version, timestamps, events).
-  "
+  configuration version, timestamps, events)."
   [{:keys [certname puppet_version report_format configuration_version
            start_time end_time producer_timestamp resource_events transaction_uuid] :as report}]
   (generic-identity-hash

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -288,6 +288,17 @@
     (subs s 1 (dec (count s)))
     s))
 
+(defn quoted
+  [s]
+  (str "'" s "'"))
+
+(defn comma-separated-keywords
+  [words]
+  (let [quoted-words (map quoted words)]
+    (if (> (count quoted-words) 2)
+      (str (string/join ", " (butlast quoted-words)) ", " "and " (last quoted-words))
+      (string/join " and " quoted-words))))
+
 (defn parse-matchfields
   [s]
   (string/replace s #"match\((\".*\")\)" "$1"))

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -482,7 +482,7 @@
 
                  ["in" "certname" ["extract" ["nothing" "nothing2" "certname"] ["select_resources"
                                                                                 ["=" "type" "Class"]]]]
-                 #"Can't extract unknown 'resources' fields: 'nothing', 'nothing2'.*Acceptable fields are.*"
+                 #"Can't extract unknown 'resources' fields 'nothing' and 'nothing2'.*Acceptable fields are.*"
 
                  ;; In-query for invalid fields should throw an error
                  ["in" "nothing" ["extract" "certname" ["select_resources"
@@ -491,7 +491,7 @@
 
                  ["in" ["certname" "nothing" "nothing2"] ["extract" "certname" ["select_resources"
                                                                                 ["=" "type" "Class"]]]]
-                 #"Can't match on unknown 'events' fields: 'nothing', 'nothing2' for 'in'.*Acceptable fields are.*")))
+                 #"Can't match on unknown 'events' fields 'nothing' and 'nothing2' for 'in'.*Acceptable fields are.*")))
 
 (deftest-http-app invalid-subqueries
   [[version endpoint] endpoints
@@ -518,7 +518,7 @@
                    #"Can't extract unknown 'events' field 'nothing'.*Acceptable fields are.*"
 
                    ["extract" ["certname" "nothing" "nothing2"] ["~" "certname" ".*"]]
-                   #"Can't extract unknown 'events' fields: 'nothing', 'nothing2'.*Acceptable fields are.*")))
+                   #"Can't extract unknown 'events' fields 'nothing' and 'nothing2'.*Acceptable fields are.*")))
 
 (deftest-http-app invalid-queries
   [[version endpoint] endpoints

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -242,20 +242,20 @@
                 ;; Extract using invalid fields should throw an error
                 ["in" "certname" ["extract" "nothing" ["select_resources"
                                                         ["=" "type" "Class"]]]]
-                "Can't extract unknown 'resources' field 'nothing'. Acceptable fields are: [\"certname\",\"environment\",\"exported\",\"file\",\"line\",\"parameters\",\"resource\",\"tag\",\"tags\",\"title\",\"type\"]"
+                "Can't extract unknown 'resources' field 'nothing'. Acceptable fields are 'certname', 'environment', 'exported', 'file', 'line', 'parameters', 'resource', 'tag', 'tags', 'title', and 'type'"
 
                 ["in" "certname" ["extract" ["nothing" "nothing2" "certname"] ["select_resources"
                                                                                ["=" "type" "Class"]]]]
-                "Can't extract unknown 'resources' fields: 'nothing', 'nothing2'. Acceptable fields are: [\"certname\",\"environment\",\"exported\",\"file\",\"line\",\"parameters\",\"resource\",\"tag\",\"tags\",\"title\",\"type\"]"
+                "Can't extract unknown 'resources' fields 'nothing' and 'nothing2'. Acceptable fields are 'certname', 'environment', 'exported', 'file', 'line', 'parameters', 'resource', 'tag', 'tags', 'title', and 'type'"
 
                 ;; In-query for invalid fields should throw an error
                 ["in" "nothing" ["extract" "certname" ["select_resources"
                                                         ["=" "type" "Class"]]]]
-                "Can't match on unknown 'facts' field 'nothing' for 'in'. Acceptable fields are: [\"certname\",\"environment\",\"name\",\"value\"]"
+                "Can't match on unknown 'facts' field 'nothing' for 'in'. Acceptable fields are 'certname', 'environment', 'name', and 'value'"
 
                 ["in" ["name" "nothing" "nothing2"] ["extract" "certname" ["select_resources"
                                                                             ["=" "type" "Class"]]]]
-                "Can't match on unknown 'facts' fields: 'nothing', 'nothing2' for 'in'. Acceptable fields are: [\"certname\",\"environment\",\"name\",\"value\"]")))
+                "Can't match on unknown 'facts' fields 'nothing' and 'nothing2' for 'in'. Acceptable fields are 'certname', 'environment', 'name', and 'value'")))
 
 (def versioned-invalid-queries
   (omap/ordered-map
@@ -268,7 +268,7 @@
                 #"Can't extract unknown 'facts' field 'nothing'.*Acceptable fields are.*"
 
                 ["extract" ["certname" "nothing" "nothing2"] ["~" "certname" ".*"]]
-                #"Can't extract unknown 'facts' fields: 'nothing', 'nothing2'.*Acceptable fields are.*")))
+                #"Can't extract unknown 'facts' fields 'nothing' and 'nothing2'.*Acceptable fields are.*")))
 
 (deftest-http-app invalid-projections
   [[version endpoint] facts-endpoints

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -566,7 +566,7 @@
      #"Can't extract unknown 'nodes' field 'nothing'.*Acceptable fields are.*"
 
      ["extract" ["certname" "nothing" "nothing2"] ["~" "certname" ".*"]]
-     #"Can't extract unknown 'nodes' fields: 'nothing', 'nothing2'.*Acceptable fields are.*"))
+     #"Can't extract unknown 'nodes' fields 'nothing' and 'nothing2'.*Acceptable fields are.*"))
 
 (deftest-http-app invalid-projections
   [[version endpoint] endpoints

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -726,7 +726,7 @@
     #"Can't extract unknown 'reports' field 'nothing'.*Acceptable fields are.*"
 
     ["extract" ["certname" "nothing" "nothing2"] ["~" "certname" ".*"]]
-    #"Can't extract unknown 'reports' fields: 'nothing', 'nothing2'.*Acceptable fields are.*"))
+    #"Can't extract unknown 'reports' fields 'nothing' and 'nothing2'.*Acceptable fields are.*"))
 
 (deftest-http-app invalid-projections
   [[version endpoint] endpoints

--- a/test/puppetlabs/puppetdb/http/resources_test.clj
+++ b/test/puppetlabs/puppetdb/http/resources_test.clj
@@ -194,17 +194,17 @@ to the result of the form supplied to this method."
             response (query-response method endpoint query)]
         (is (= http/status-bad-request (:status response)))
         (is (= (:headers response) {"Content-Type" http/error-response-content-type}))
-        (is (re-find #"'sourceline' is not a queryable object for resources, known queryable objects are" (:body response))))
+        (is (re-find #"'sourceline' is not a queryable object for resources. Known queryable objects are" (:body response))))
       (let [query ["~" "sourcefile" "foo"]
             response (query-response method endpoint query)]
         (is (= http/status-bad-request (:status response)))
         (is (= (:headers response) {"Content-Type" http/error-response-content-type}))
-        (is (re-find #"'sourcefile' is not a queryable object for resources, known queryable objects are" (:body response))))
+        (is (re-find #"'sourcefile' is not a queryable object for resources. Known queryable objects are" (:body response))))
       (let [query ["=" "sourcefile" "/foo/bar"]
             response (query-response method endpoint query)]
         (is (= http/status-bad-request (:status response)))
         (is (= (:headers response) {"Content-Type" http/error-response-content-type}))
-        (is (re-find #"'sourcefile' is not a queryable object for resources, known queryable objects are" (:body response)))))
+        (is (re-find #"'sourcefile' is not a queryable object for resources. Known queryable objects are" (:body response)))))
 
     (testing "query by file and line is supported"
       (let [query ["=" "file" "/foo/bar"]
@@ -350,7 +350,7 @@ to the result of the form supplied to this method."
                       #"Can't extract unknown 'resources' field 'nothing'.*Acceptable fields are.*"
 
                       ["extract" ["certname" "nothing" "nothing2"] ["~" "certname" ".*"]]
-                      #"Can't extract unknown 'resources' fields: 'nothing', 'nothing2'.*Acceptable fields are.*")))
+                      #"Can't extract unknown 'resources' fields 'nothing' and 'nothing2'.*Acceptable fields are.*")))
 
 (deftest-http-app invalid-queries
   [[version endpoint] endpoints

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -148,7 +148,7 @@
 
 (deftest test-valid-query-fields
   (is (thrown-with-msg? IllegalArgumentException
-                        #"'foo' is not a queryable object for resources, known queryable objects are.*"
+                        #"'foo' is not a queryable object for resources. Known queryable objects are.*"
                         (compile-user-query->sql resources-query ["=" "foo" "bar"]))))
 
 (deftest test-valid-subqueries


### PR DESCRIPTION
These messages are surfaced in the console when invalid PQL is supplied.
This change fixes a comma splice and changes the vector in the error
message to a comma separated string.