### PR TITLE
(PDB-3458) Change the puppetserver-version to SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def pdb-version "5.0.0-SNAPSHOT")
-(def puppetserver-version "5.0.0-master-20170329_182047-ga16e296")
+(def puppetserver-version "5.0.0-master-SNAPSHOT")
 (def clj-parent-version "0.6.1")
 
 (defn deploy-info


### PR DESCRIPTION
The current version, 5.0.0-master-20170329_182047-ga16e296, prevents
use of lein installed versions, and it sounds like we don't need a
specific jar, just some 5.0.0 snapshot.