### PR TITLE
(PDB-3058) Disallow null bytes from resource event fields

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1157,13 +1157,21 @@
     (dissoc row-map :environment_id)
     row-map))
 
+(defn replace-null-bytes [x]
+  (if-not (string? x)
+    x
+    (let [^String s x]
+      (if (= -1 (.indexOf s (int \u0000)))
+        s
+        (.replace s \u0000 \ufffd)))))
+
 (defn normalize-resource-event
   "Prep `event` for comparison/computation of a hash"
   [event]
   (-> event
       (update :timestamp to-timestamp)
-      (update :old_value sutils/db-serialize)
-      (update :new_value sutils/db-serialize)
+      (update :old_value (comp sutils/db-serialize replace-null-bytes))
+      (update :new_value (comp sutils/db-serialize replace-null-bytes))
       (assoc :containing_class (find-containing-class (:containment_path event)))))
 
 (defn normalize-report

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1347,6 +1347,17 @@
       (is (= (shash/report-identity-hash (normalize-report z-report))
              (shash/report-identity-hash (normalize-report offset-report))))))
 
+  (deftest-db report-with-null-bytes-in-events
+    (store-example-report!
+     (-> report
+         (assoc-in [:resource_events :data 0 :new_value] "foo\u0000bar")
+         (assoc-in [:resource_events :data 0 :old_value] "foo\u0000bar"))
+     timestamp)
+
+    (is (= [{:old_value "\"foo\ufffdbar\""
+             :new_value "\"foo\ufffdbar\""}]
+           (query-to-vec ["SELECT old_value, new_value from resource_events where old_value ~ 'foo'"]))))
+
   (deftest-db report-storage-with-environment
     (is (nil? (environment-id "DEV")))
 
@@ -1358,13 +1369,13 @@
            [{:certname (:certname report)
              :environment_id (environment-id "DEV")}])))
 
- (deftest-db report-storage-with-producer
-   (let [prod-id (ensure-producer "bar.com")]
-     (store-example-report! (assoc report :producer "bar.com") timestamp)
+  (deftest-db report-storage-with-producer
+    (let [prod-id (ensure-producer "bar.com")]
+      (store-example-report! (assoc report :producer "bar.com") timestamp)
 
-     (is (= (query-to-vec ["SELECT certname, producer_id FROM reports"])
-            [{:certname (:certname report)
-              :producer_id prod-id}]))))
+      (is (= (query-to-vec ["SELECT certname, producer_id FROM reports"])
+             [{:certname (:certname report)
+               :producer_id prod-id}]))))
 
   (deftest-db report-storage-with-status
     (is (nil? (status-id "unchanged")))


### PR DESCRIPTION
There's a broader issue with null bytes from the input leaking through the
database at times, but this is the specific instance we've seen in the field. A
broader fix will be forthcoming.