### PR TITLE
(PDB-2583) Reduce the number of DB connections used in tests

### DIFF
--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -100,7 +100,16 @@
                        configure-read-db)]
         (is (= (get-in config [:read-database :classname]) "something"))
         (is (= "more stuff" (get-in config [:read-database :subprotocol])))
-        (is (= "stuff" (get-in config [:read-database :subname])))))))
+        (is (= "stuff" (get-in config [:read-database :subname])))))
+
+    (testing "max-pool-size defaults to 25"
+      (let [config (-> {:database {:classname "something"
+                                   :subname "stuff"
+                                   :subprotocol "more stuff"}}
+                       (configure-section :database write-database-config-in write-database-config-out)
+                       configure-read-db)]
+        (is (= (get-in config [:read-database :maximum-pool-size]) 25))
+        (is (= (get-in config [:database :maximum-pool-size]) 25))))))
 
 (deftest garbage-collection
   (let [config-with (fn [base-config]

--- a/test/puppetlabs/puppetdb/jdbc_test.clj
+++ b/test/puppetlabs/puppetdb/jdbc_test.clj
@@ -51,15 +51,6 @@
                            (full-sql-exception-msg ex)))]
                (is (re-find #"read-only.*transaction" msg)))))))))
 
-  (testing "max connections setting defaults to 25"
-    (call-with-antonym-test-database
-      (fn []
-        (with-open [data-source (-> *db*
-                                    defaulted-read-db-config
-                                    subject/pooled-datasource
-                                    :datasource)]
-          (is (= 25 (.getMaximumPoolSize data-source)))))))
-
   (testing "max connections setting takes effect"
     (call-with-antonym-test-database
       (fn []

--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -53,7 +53,8 @@
    :subprotocol "postgresql"
    :subname (format "//%s:%s/%s" (:host test-env) (:port test-env) database)
    :user (get-in test-env [:user :name])
-   :password (get-in test-env [:user :password])})
+   :password (get-in test-env [:user :password])
+   :maximum-pool-size 5})
 
 (defn subname->validated-db-name [subname]
   (let [sep (.lastIndexOf subname "/")]


### PR DESCRIPTION
This lowers the connection pool to a size of 5. We will use as many as
4 connection pools concurrently depending on the test, so this should
reduce the "high water mark" from ~100 to ~20.