### PR TITLE
(PDB-3461) Disable the sensitive parameters test

### DIFF
--- a/test/puppetlabs/puppetdb/integration/sensitive_params.clj
+++ b/test/puppetlabs/puppetdb/integration/sensitive_params.clj
@@ -46,7 +46,12 @@
       (finally
         (Files/deleteIfExists pgpass)))))
 
-(deftest ^:integration sensitive-parameter-redaction
+;;
+;; Disabling this due to issues with the Jenkins test
+;; instances. PDB-3461 covers the infrastructure related change needed
+;; to fix this test. This should be uncommented once that is complete.
+;;
+#_(deftest ^:integration sensitive-parameter-redaction
   (with-open [pg (int/setup-postgres)
               pdb (int/run-puppetdb pg {})
               ps (int/run-puppet-server-as "my_puppetserver" [pdb] {})]


### PR DESCRIPTION
This test is currently failing due to an incorrect version of the
PostgreSQL client installed on the Jenkins test machines. Once that
issue has been fixed (tracked as PDB-3461) this commit can be reverted
and the test re-enabled.