### PR TITLE
(maint) Simplify synchronized-command-processing integration helper

### DIFF
--- a/test/puppetlabs/puppetdb/integration/soft_fail/soft_write_fail.clj
+++ b/test/puppetlabs/puppetdb/integration/soft_fail/soft_write_fail.clj
@@ -17,9 +17,4 @@
             (int/run-puppet ps pdb "Notify <<| |>>"))))
 
     (testing "Agent run should succeed for manifest which exports resources"
-      ;; This puppet run will work, but since puppetdb isn't actually running we
-      ;; it's fruitless to wait for the commands to be processed. Instead specify a short
-      ;; timeout and see that it gets triggered.
-      (is (thrown+? [:kind ::int/command-processing-timeout]
-            (int/run-puppet ps pdb "@@notify { 'exported notify': }"
-                            {:timeout 500}))))))
+      (int/run-puppet ps pdb "@@notify { 'exported notify': }"))))


### PR DESCRIPTION
Instead of trying to track the number of expected commands, just use the
existing 'wait-for-server-processing' helper. This should eliminate some
intermittent race conditions caused by the previous approach.