### PR TITLE
(PDB-3420) Exclude inactive and expired nodes in root query endpoint

### DIFF
--- a/documentation/api/query/curl.markdown
+++ b/documentation/api/query/curl.markdown
@@ -92,7 +92,7 @@ Many query strings will contain characters like `[` and `]`, which must be URL-e
 If you do this with an endpoint that accepts `GET` requests, **you must also use the `-G` or `--get` option.** This is because `curl` defaults to `POST` requests when the `--data-urlencode` option is present.
 
     curl -G http://localhost:8080/pdb/query/v4/nodes \
-      --data-urlencode 'query=["=", ["node", "active"], true]'
+      --data-urlencode 'query=["=", "node_state", "active"]'
 
 ## Pretty querying of PuppetDB
 

--- a/documentation/api/query/v4/ast.markdown
+++ b/documentation/api/query/v4/ast.markdown
@@ -210,7 +210,7 @@ status counts for active certname by status, you can query the events endpoint
 with:
 
     ["extract", [["function", "count"], "status", "certname"],
-      ["=", ["node", "active"], true], ["group_by", "status", "certname"]]
+      ["group_by", "status", "certname"]]
 
 To get the average uptime for your nodes:
 
@@ -612,20 +612,15 @@ starting with "up" and value less than 100:
             ["~>", "path", ["up.*"]],
             ["<", "value", 100]]]]]
 
-To use a subquery to restrict a query to active nodes only, you can use this
-query:
+Queries are restricted to active nodes by default; to make this explicit, the
+special "node_state" field may be queried using the values "active", "inactive",
+or "any". For example, to list all catalogs from inactive nodes, use this on the
+/catalogs endpoint:
 
-    ["in", "certname",
-      ["extract", "certname",
-        ["select_nodes",
-          ["and", ["null?", "deactivated", true],
-                  ["null?", "expired", true]]]]]
+    ["=", "node_state", "inactive"] 
 
-For the previous query, we also allow the shorthand
-
-    ["=", ["node", "active"], true]
-
-and its counterpart with `false`.
+This expands internally into comparisons against each node's deactivation and
+expiration time; a node is consider inactive if either field is set.
 
 #### Explicit subquery examples (with the `from` operator)
 

--- a/documentation/api/query/v4/events.markdown
+++ b/documentation/api/query/v4/events.markdown
@@ -189,11 +189,10 @@ To retrieve latest events that are tied to the class found in your update.pp fil
     ["and", ["=", "latest_report?", true],
       ["~", "file", "update.pp"]]
 
-To retrieve event status counts for each active node:
+To retrieve event status counts for each node:
 
     curl -X GET http://localhost:8080/pdb/query/v4/events --data-urlencode \
     'query=["extract", [["function", "count"], "status","certname"],
-                       ["=", ["node","active"], true],
                        ["group_by","status","certname"]]'
 
 ## Paging

--- a/documentation/api/query/v4/index.markdown
+++ b/documentation/api/query/v4/index.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 4.4: Root endpoint"
+title: "PuppetDB 5.0: Root endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/index.html"
 ---
@@ -20,6 +20,11 @@ single endpoint.
 This will return any known entity based on the required `query` field. Unlike
 other endpoints, the [entity][entities] must be supplied using a query with the [`from`][from]
 operator or a [PQL][pql] query string.
+
+Like all other PDB query endpoints, query results from the root query endpoint
+will be restricted to active nodes by default. To target only inactive nodes,
+you can specify `node_state = 'inactive'`; for all both active and inactive, use
+`node_state = 'any'`.
 
 ### URL parameters
 

--- a/documentation/api/query/v4/index.markdown
+++ b/documentation/api/query/v4/index.markdown
@@ -13,9 +13,7 @@ canonical: "/puppetdb/latest/api/query/v4/index.html"
 [ast]: ./ast.html
 
 The root query endpoint can be used to retrieve any known entities from a
-single endpoint. Unlike the various entity-specific endpoints, the root
-endpoint will always return data for deactivated and expired nodes, so users
-must explicitly include them if required.
+single endpoint.
 
 ## `/pdb/query/v4`
 

--- a/src/puppetlabs/puppetdb/http/handlers.clj
+++ b/src/puppetlabs/puppetdb/http/handlers.clj
@@ -58,9 +58,10 @@
   (cmdi/ANY "" []
             (-> (comp (http-q/query-handler version)
                       (fn [req]
-                        (if (some-> req :puppetdb-query :ast_only http-q/coerce-to-boolean)
-                          req
-                          (http-q/restrict-query-to-active-nodes req))))
+                        (cond
+                          (some-> req :puppetdb-query :ast_only http-q/coerce-to-boolean) req
+                          (= ["from" "packages"] (some->> req :puppetdb-query :query (take 2))) req
+                          :else (http-q/restrict-query-to-active-nodes req))))
                 (http-q/extract-query-pql {:optional (conj paging/query-params "ast_only")
                                            :required ["query"]}))))
 

--- a/src/puppetlabs/puppetdb/http/handlers.clj
+++ b/src/puppetlabs/puppetdb/http/handlers.clj
@@ -56,7 +56,11 @@
 (pls/defn-validated root-routes :- bidi-schema/RoutePair
   [version :- s/Keyword]
   (cmdi/ANY "" []
-            (-> (http-q/query-handler version)
+            (-> (comp (http-q/query-handler version)
+                      (fn [req]
+                        (if (some-> req :puppetdb-query :ast_only http-q/coerce-to-boolean)
+                          req
+                          (http-q/restrict-query-to-active-nodes req))))
                 (http-q/extract-query-pql {:optional (conj paging/query-params "ast_only")
                                            :required ["query"]}))))
 

--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -66,6 +66,7 @@
 (defn is-active-node-criteria? [criteria]
   (cm/match [criteria]
     [["=" ["node" "active"] _]] criteria
+    [["=" "node_state" _]] criteria
     :else false))
 
 (defn find-active-node-restriction-criteria
@@ -134,7 +135,7 @@
               :query
               find-active-node-restriction-criteria)
     req
-    (restrict-query ["=" ["node" "active"] true] req)))
+    (restrict-query ["=" "node_state" "active"] req)))
 
 
 (defn restrict-query-to-node

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -480,6 +480,7 @@
          {:where  "catalog_resources.environment = ?"
           :params [value]}
 
+         ;; TODO handle node_state here?
          ;; {in,}active nodes.
          [["node" "active"]]
          {:where (format "catalogs.certname IN (%s)" (certname-names-query value))}
@@ -555,6 +556,7 @@
            {:where "facts.environment = ?"
             :params [value]}
 
+           ;; TODO handle node_state here?
            [["node" "active"]]
            {:where (format "facts.certname IN (%s)" (certname-names-query value))}
 

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -1366,13 +1366,25 @@
               ["and" ["=" "depth" 0] [op "value" value]])
 
             [["=" ["node" "active"] value]]
-            (if value
-              ["not" ["in" "certname"
-                      ["extract" "certname"
-                       ["select_inactive_nodes"]]]]
-              ["in" "certname"
-               ["extract" "certname"
-                ["select_inactive_nodes"]]])
+            (expand-query-node ["=" "node_state" (if value "active" "inactive")])
+
+            [["or" ["=" ["node" "active"] true]
+              ["=" ["node" "active"] false]]]
+            (expand-query-node ["=" "node_state" "any"])
+
+            [["or" ["=" ["node" "active"] false]
+                   ["=" ["node" "active"] true]]]
+            (expand-query-node ["=" "node_state" "any"])
+
+            [["=" "node_state" value]]
+            (case (str/lower-case (str value))
+              "active" ["not" ["in" "certname"
+                               ["extract" "certname"
+                                ["select_inactive_nodes"]]]]
+              "inactive" ["in" "certname"
+                          ["extract" "certname"
+                           ["select_inactive_nodes"]]]
+              "any" [])
 
             [[(op :guard #{"=" "~"}) ["parameter" param-name] param-value]]
             ["in" "resource"
@@ -1984,6 +1996,7 @@
             (let [{:keys [alias dotted-fields] :as query-context} (:query-context (meta node))
                   qfields (queryable-fields query-context)]
               (when-not (or (vec? field)
+                            (= "node_state" field)
                             (contains? (set qfields) field)
                             (some #(re-matches % field) (map re-pattern dotted-fields)))
                 {:node node

--- a/test/puppetlabs/puppetdb/http/index_test.clj
+++ b/test/puppetlabs/puppetdb/http/index_test.clj
@@ -193,9 +193,29 @@
     (testing "nodes"
       (testing "query should return only active nodes"
         (doseq [query [["from" "nodes"]
-                       "nodes {}"]]
+                       ["from" "nodes" ["=" ["node" "active"] true]]
+                       ["from" "nodes" ["=" "node_state" "active"]]
+                       "nodes {}"
+                       "nodes { node_state = 'active' }"]]
           (is (= (set (mapv :certname (query-result method endpoint query {})))
                  #{"host1" "host2" "host3"}))))
+
+      (testing "query should return only inactive nodes when specified"
+        (doseq [query [["from" "nodes" ["or"
+                                        ["=" ["node" "active"] false]]]
+                       ["from" "nodes" ["=" "node_state" "inactive"]]
+                       "nodes { node_state = 'inactive' }"]]
+          (is (= (set (mapv :certname (query-result method endpoint query {})))
+                 #{"host4"}))))
+
+      (testing "query should return all nodes when specified"
+        (doseq [query [["from" "nodes" ["or"
+                                        ["=" ["node" "active"] true]
+                                        ["=" ["node" "active"] false]]]
+                       ["from" "nodes" ["=" "node_state" "any"]]
+                       "nodes { node_state = 'any' }"]]
+          (is (= (set (mapv :certname (query-result method endpoint query {})))
+                 #{"host1" "host2" "host3" "host4"}))))
 
       (testing "broad regexp query should return all active nodes"
         (doseq [query [["from" "nodes" ["~" "certname" "^host"]]

--- a/test/puppetlabs/puppetdb/testutils/http.clj
+++ b/test/puppetlabs/puppetdb/testutils/http.clj
@@ -41,11 +41,15 @@
 
 (defn convert-response
   [response]
-  (-> response
-      :body
-      slurp-unless-string
-      (json/parse-string true)
-      vec))
+  (let [body-string
+        (-> response
+            :body
+            slurp-unless-string)]
+    (try
+      (vec (json/parse-string body-string true))
+      (catch Exception e
+        (println "Error parsing repsonse string as json. Response string is:\n    " body-string)
+        (throw e)))))
 
 (defn ordered-query-result
   ([method endpoint] (ordered-query-result method endpoint nil))

--- a/test/puppetlabs/puppetdb/testutils/nodes.clj
+++ b/test/puppetlabs/puppetdb/testutils/nodes.clj
@@ -88,3 +88,6 @@
      :web2    web2
      :db      db
      :puppet  puppet}))
+
+(defn deactivate-node [certname]
+  (scf-store/deactivate-node! certname))


### PR DESCRIPTION
Previously, queries to the root endpoint (which includes all PQL queries)
included all expired and deactivated nodes. This is different from all the other
query endpoints, and practically never what you want to do.

With this change, the root query endpoint modifies queries in the same way as
the other query endpoints to exclude inactive and expired nodes.