### PR TITLE
(PDB-3318) Better defaults for node-ttl, node-purge-ttl

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -362,7 +362,8 @@ For example, a value of `30d` would set the time-to-live to 30 days, and a value
 Nodes will be checked for staleness every `gc-interval` minutes. Manual
 deactivation will continue to work as always.
 
-If unset or set to 0s, auto-expiration of nodes is disabled.
+If unset, nodes are auto-expired after 7 days of inactivity. If set to 0s,
+auto-expiration of nodes is disabled.
 
 ### `node-purge-ttl`
 
@@ -370,7 +371,8 @@ Automatically delete nodes that have been deactivated or expired for the
 specified amount of time. This will also delete all facts, catalogs, and reports
 for the relevant nodes. This TTL may be specified the same way as `node-ttl` above.
 
-If unset or set to 0s, auto-deletion of nodes is disabled.
+If unset, nodes are purged after 14 days. If set to 0s, auto-deletion of nodes
+is disabled.
 
 ### `report-ttl`
 

--- a/documentation/maintain_and_tune.markdown
+++ b/documentation/maintain_and_tune.markdown
@@ -47,7 +47,7 @@ For example, `http://localhost:8080/pdb/dashboard/index.html?height=240&pollingI
 
 When you remove a node from your Puppet deployment, it should be marked as **deactivated** in PuppetDB. This will ensure that any resources exported by that node will stop appearing in the catalogs served to the remaining agent nodes.
 
-* PuppetDB can automatically mark nodes that haven't checked in recently as **expired**. Expiration is simply the automatic version of deactivation; the distinction is important only for record keeping. Expired nodes behave the same as deactivated nodes. To enable this, use the [`node-ttl` setting][node_ttl].
+* PuppetDB can automatically mark nodes that haven't checked in recently as **expired**. Expiration is simply the automatic version of deactivation; the distinction is important only for record keeping. Expired nodes behave the same as deactivated nodes. By default, nodes are expired after 7 days of inactivity; to configure this, use the [`node-ttl` setting][node_ttl].
 * If you prefer to manually deactivate nodes, use the following command on your puppet master:
 
         $ sudo puppet node deactivate <node> [<node> ...]

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -80,8 +80,8 @@
            {:gc-interval (pls/defaulted-maybe s/Int 60)
             :dlo-compression-interval s/Int
             :report-ttl (pls/defaulted-maybe String "14d")
-            :node-purge-ttl (pls/defaulted-maybe String "0s")
-            :node-ttl (pls/defaulted-maybe String "0s")})))
+            :node-purge-ttl (pls/defaulted-maybe String "14d")
+            :node-ttl (pls/defaulted-maybe String "7d")})))
 
 (def database-config-out
   "Schema for parsed/processed database config"

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -136,10 +136,22 @@
                                [:database :node-ttl])]
           (is (pl-time/period? node-ttl))
           (is (= (time/days 10) (time/days (pl-time/to-days node-ttl))))))
-      (testing "should default to zero (no expiration)"
+      (testing "should default to 7 days"
         (let [node-ttl (get-in (config-with {}) [:database :node-ttl])]
           (is (pl-time/period? node-ttl))
-          (is (= 0 (pl-time/to-seconds node-ttl))))))
+          (is (= 7 (pl-time/to-days node-ttl))))))
+
+    (testing "node-purge-ttl"
+      (testing "should parse node-purge-ttl and return a Pl-Time/Period object"
+        (let [node-purge-ttl (get-in (config-with {:database {:node-purge-ttl "10d"}})
+                               [:database :node-purge-ttl])]
+          (is (pl-time/period? node-purge-ttl))
+          (is (= (time/days 10) (time/days (pl-time/to-days node-purge-ttl))))))
+      (testing "should default to 14 days"
+        (let [node-purge-ttl (get-in (config-with {}) [:database :node-purge-ttl])]
+          (is (pl-time/period? node-purge-ttl))
+          (is (= 14 (pl-time/to-days node-purge-ttl))))))
+
     (testing "report-ttl"
       (testing "should parse report-ttl and produce report-ttl"
         (let [report-ttl (get-in (config-with {:database {:report-ttl "10d"}})


### PR DESCRIPTION
Default node-ttl to 7 days and node-purge-ttl to 14 days. This helps keep cruft
from piling up in the database in the default configuration, without user
intervention.