### PR TITLE
(PDB-3467) Bump to clj-parent 0.7.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def pdb-version "5.0.0-SNAPSHOT")
 (def puppetserver-version "5.0.0-master-SNAPSHOT")
-(def clj-parent-version "0.7.0")
+(def clj-parent-version "0.7.1")
 
 (defn deploy-info
   "Generate deployment information from the URL supplied and the username and


### PR DESCRIPTION
The key fix for this bump is the bump in cheshire to 5.7.1 that fixes
a memory issue (holding onto the head of a lazy-seq).