### PR TITLE
(PDB-3467) Bump cheshire version to 5.7.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,7 @@
 
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [puppetlabs/i18n ~i18n-version]
-                 [cheshire "5.6.1"]
+                 [cheshire "5.7.1"]
                  [org.clojure/core.match "0.3.0-alpha4" :exclusions [org.clojure/tools.analyzer.jvm]]
                  [org.clojure/math.combinatorics "0.1.1"]
                  [org.clojure/math.numeric-tower "0.0.4"]


### PR DESCRIPTION
Fixes an issue where cheshire hold onto the head of a seq while write it to a
stream.