### PR TITLE
(PDB-3501) make dashed queries work

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -2037,16 +2037,6 @@
 
             :else nil))
 
-(defn dashes-to-underscores
-  "Convert field names with dashes to underscores"
-  [node state]
-  (cm/match [node]
-            [[(op :guard binary-operators) (field :guard string?) value]]
-            {:node (with-meta [op (utils/dashes->underscores field) value]
-                     (meta node))
-             :state state}
-            :else {:node node :state state}))
-
 (defn valid-operator?
   [operator]
   (or (contains? #{"from" "in" "extract" "subquery" "and"
@@ -2073,7 +2063,7 @@
                                              []
                                              [(annotate-with-context context)
                                               validate-query-fields
-                                              dashes-to-underscores ops-to-lower])]
+                                              ops-to-lower])]
     (when (seq errors)
       (throw (IllegalArgumentException. (str/join \newline errors))))
 

--- a/test/puppetlabs/puppetdb/http/inventory_test.clj
+++ b/test/puppetlabs/puppetdb/http/inventory_test.clj
@@ -33,7 +33,7 @@
            :operatingsystem "Debian"
            :some_version "1.3.7+build.11.e0f985a"
            :uptime_seconds 4000
-           :my_weird_fact {:blah {:dotted.thing {(keyword "quoted\"thing") "foo"}}}}})
+           :my_weird_fact {:blah {:dotted.thing {:dashed-thing {(keyword "quoted\"thing") "foo"}}}}}})
 
 (def inventory2
   {:certname "foo.com"
@@ -88,7 +88,7 @@
       ["~" "trusted.foo.baz" "ba.*"]
       #{response1}
 
-      ["=" "facts.my_weird_fact.blah.\"dotted.thing\".\"quoted\"thing\"" "foo"]
+      ["=" "facts.my_weird_fact.blah.\"dotted.thing\".\"dashed-thing\".\"quoted\"thing\"" "foo"]
       #{response1})))
 
 (deftest-http-app inventory-queries

--- a/test/puppetlabs/puppetdb/pql/parser_test.clj
+++ b/test/puppetlabs/puppetdb/pql/parser_test.clj
@@ -546,6 +546,7 @@
          "facts.operatingsystem.κόσμε"
          "facts.\"quoted field\".foo"
          "facts.\"field.with.dot\".foo"
+         "facts.\"field-with-dash\".foo"
          "trusted.authenticated"
          "parameters.😁"
          "latest_report?")


### PR DESCRIPTION
For some ancient reason we were converting all dashes in field names to
underscores. Stop doing that so PQL queries with dashes in fact paths
work.