### PR TITLE
(MAINT) Drop the number of selectors/acceptors for puppetserver testing

### DIFF
--- a/test-resources/integration-puppetdb.conf
+++ b/test-resources/integration-puppetdb.conf
@@ -35,8 +35,8 @@ jetty: {
 
   ssl-protocols: ["TLSv1", "TLSv1.1"]
 
-  acceptor-threads: 8
-  selector-threads: 8
+  acceptor-threads: 4
+  selector-threads: 4
   max-threads: 32
 }
 


### PR DESCRIPTION
This commit drops the number of acceptors and selectors used for Puppet
Server testing.  The bump to the new Jetty version results in an
implicit bump in the number of selectors used internally by Jetty.  This
commit drops that number down in order to avoid having the combination
of selector and acceptor threads exceed the max-threads that are
configured.