### PR TITLE
Revert "(PDB-3503) Add the jruby dev dep puppetserver now expects"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -136,8 +136,6 @@
 
   :profiles {:dev {:resource-paths ["test-resources"],
                    :dependencies [[ring-mock]
-                                  ;; puppetserver now expects jruby-deps
-                                  [puppetlabs/jruby-deps "1.7.26-1"]
                                   [puppetlabs/trapperkeeper :classifier "test"]
                                   [puppetlabs/kitchensink :classifier "test"]
                                   [puppetlabs/trapperkeeper-webserver-jetty9 "2.0.0" :classifier "test"]


### PR DESCRIPTION
This reverts commit 054eb944a5add455b2526c03e1cfd9c457aa3900.  The
commit should no longer be required now that the latest puppetserver
repo jars include their own jruby dependencies again.