### PR TITLE
(maint) Use a real scope object for terminus testing

### DIFF
--- a/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 require 'puppet/indirector/resource/puppetdb'
 require 'json'
 
+require 'puppetlabs_spec_helper/puppetlabs_spec_helper'
+
 describe Puppet::Resource::Puppetdb do
   before :each do
     Puppet::Util::Puppetdb.stubs(:server_urls).returns 'https://localhost:0'
@@ -18,7 +20,8 @@ describe Puppet::Resource::Puppetdb do
       # The API for creating scope objects is different between Puppet 2.7 and
       # 3.0. The scope here isn't really used for anything relevant, so it's
       # easiest to make it a stub to run against both versions of Puppet.
-      scope = stub('scope', :source => nil, :environment => 'production')
+      scope = Puppet::Parser::Scope.new(PuppetlabsSpec::PuppetInternals.compiler)
+      scope.stubs(:environment).returns('production')
       args = { :host => host, :filter => nil, :scope => scope }
       Puppet::Resource.indirection.search(type, args)
     end


### PR DESCRIPTION
Changes coming in Puppet 5.0.0 change how Puppet::Parser::Resource
instances set default values; in specific they do so upon object
construction which requires a functioning(ish) scope object. The
Puppetdb terminus specs were relying on the scope object being
relatively simple and easily stubbed but this change in defaults makes
it much harder to treat the scope object as an easily stubbed object.

To simplify stubbing and potentially reduce future breakage this commit
changes the scope stubbing to partially stub a full scope object instead
of creating a pure stub object and adding methods as necessary. By using
a full scope object we can let the internal APIs of Puppet handle
implementation changes.