### PR TITLE
(PDB-3506) acceptance: install openjdk 8 on jessie

### DIFF
--- a/acceptance/setup/pre_suite/15_setup_repos.rb
+++ b/acceptance/setup/pre_suite/15_setup_repos.rb
@@ -1,6 +1,14 @@
 def initialize_repo_on_host(host, os, nightly)
   case os
   when :debian
+
+    # For openjdk8
+    if host['platform'].version == '8'
+      create_remote_file(host,
+                         "/etc/apt/sources.list.d/jessie-backports.list",
+                         "deb http://httpredir.debian.org/debian jessie-backports main")
+    end
+
     if options[:type] == 'aio' then
       if nightly
         ## PC1 repos
@@ -18,8 +26,8 @@ def initialize_repo_on_host(host, os, nightly)
       on host, "curl -O http://apt.puppetlabs.com/puppetlabs-release-$(lsb_release -sc).deb"
       on host, "dpkg -i puppetlabs-release-$(lsb_release -sc).deb"
     end
-      on host, "apt-get update"
-      on host, "apt-get install debian-archive-keyring"
+    on host, "apt-get update"
+    on host, "apt-get install debian-archive-keyring"
   when :redhat
     if options[:type] == 'aio' then
       /^(el|centos)-(\d+)-(.+)$/.match(host.platform)

--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -47,7 +47,13 @@ unless (test_config[:skip_presuite_provisioning])
       if test_config[:install_type] == :git then
         case os
         when :debian
-          on database, "apt-get install -y --force-yes openjdk-7-jre-headless rake unzip"
+          if database['platform'].variant == 'debian' &&
+             database['platform'].version == '8'
+            on database, "apt-get install -y rake unzip"
+            on database, "apt-get install -y -t jessie-backports openjdk-8-jre-headless"
+          else
+            on database, "apt-get install -y rake unzip openjdk-8-jre-headless"
+          end
         when :redhat
           on database, "yum install -y java-1.7.0-openjdk rubygem-rake unzip"
         when :fedora


### PR DESCRIPTION
Install openjdk-8-jre-headless on jessie from backports, since we've
dropped support for openjdk 7, and now require openjdk 8.