### PR TITLE
Revert "(PDB-3395) bypass costly join on paged packages aggregate queries"

### DIFF
--- a/resources/puppetlabs/puppetdb/pql/pql-grammar.ebnf
+++ b/resources/puppetlabs/puppetdb/pql/pql-grammar.ebnf
@@ -28,7 +28,7 @@ extract = <lbracket>, [<whitespace>], [extractfields], [<whitespace>], <rbracket
 <extractfields> = fieldlist;
 
 (* Filtering *)
-<where> = <lbrace>, [<whitespace>], [expression], [<whitespace>], [groupbyclause, [<whitespace>]], {pagingclause, [<whitespace>]} , {<whitespace>}, <rbrace>;
+<where> = <lbrace>, [<whitespace>], [expression], [<whitespace>], [groupbyclause | {pagingclause, [<whitespace>]}], {<whitespace>}, <rbrace>;
 
 (* Static list of entity types *)
 <entity> = 'facts' |

--- a/src/puppetlabs/puppetdb/query/event_counts.clj
+++ b/src/puppetlabs/puppetdb/query/event_counts.clj
@@ -167,8 +167,7 @@
                                             (if (:distinct_resources query-options)
                                               ;;The query engine does not support distinct-resources!
                                               (events/query->sql will-union? version query distinct-opts)
-                                              (qe/compile-user-query->sql qe/report-events-query
-                                                                          ["from" "events" query])))
+                                              (qe/compile-user-query->sql qe/report-events-query query)))
            count-by-sql                    (get-count-by-sql event-sql count_by group-by)
            event-count-sql                 (get-event-count-sql count-by-sql group-by)
            sql                             (get-filtered-sql event-count-sql counts-filter-where)

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -82,49 +82,6 @@
                     (:queryable? projection-value))]
      (keyword projection-key))))
 
-(defn legacy-engine-query-context
-  "Parse a query and possibly some paging clauses from a query to the legacy
-   engine. Required because top-level paging options supplied in the query are
-   not otherwise handled by the engine, so they must be merged with
-   param-supplied paging options and dealt with at the top level."
-  [version query warn]
-  (cm/match
-    query
-    ["from" (entity-str :guard #(string? %)) & remaining-query]
-    (let [remaining-query (cm/match
-                            remaining-query
-
-                            [(c :guard eng/paging-clause?) & clauses]
-                            (let [paging-clauses (eng/create-paging-map (cons c clauses))]
-                              {:paging-clauses paging-clauses :query []})
-
-                            [(q :guard vector?)]
-                            {:query q}
-
-                            [(q :guard vector?) & clauses]
-                            (let [paging-clauses (eng/create-paging-map clauses)]
-                              {:query q :paging-clauses paging-clauses})
-
-                            []
-                            {:query []}
-                            :else (throw
-                                    (IllegalArgumentException.
-                                      (str
-                                        (tru "Your `from` query accepts an optional query only as a second argument.")
-                                        " "
-                                        (tru "Check your query and try again.")))))
-          entity (keyword (utils/underscores->dashes entity-str))]
-      (when warn
-        (eng/warn-experimental entity))
-      {:remaining-query (:query remaining-query)
-       :paging-clauses (:paging-clauses remaining-query)})
-
-    :else (throw (IllegalArgumentException.
-                   (str
-                     (trs "Your initial query must be of the form: [\"from\",<entity>,(<optional-query>)].")
-                     " "
-                     (trs "Check your query and try again."))))))
-
 (defn query->sql
   "Converts a vector-structured `query` to a corresponding SQL query which will
    return nodes matching the `query`."
@@ -135,27 +92,17 @@
           (or (not (:include_total paging-options))
               (jdbc/valid-jdbc-query? (:count-query %)))]}
 
+  (cond
+    (= :aggregate-event-counts entity)
+    (aggregate-event-counts/query->sql version query paging-options)
 
-  (if (or (= :aggregate-event-counts entity)
-          (= :event-counts entity)
-          (and (= :events entity) (:distinct_resources paging-options)))
+    (= :event-counts entity)
+    (event-counts/query->sql version query paging-options)
 
-    (let [{:keys [remaining-query paging-clauses]} (legacy-engine-query-context version query true)
-          paging-clauses (some-> paging-clauses
-                                 (rename-keys {:order-by :order_by})
-                                 (update :order_by paging/munge-query-ordering)
-                                 utils/strip-nil-values)
-          paging-options (merge paging-options (utils/strip-nil-values paging-clauses))]
-      (cond
-        (= :aggregate-event-counts entity)
-        (aggregate-event-counts/query->sql version remaining-query paging-options)
+    (and (= :events entity) (:distinct_resources paging-options))
+    (events/legacy-query->sql false version query paging-options)
 
-        (= :event-counts entity)
-        (event-counts/query->sql version remaining-query paging-options)
-
-        (and (= :events entity) (:distinct_resources paging-options))
-        (events/legacy-query->sql false version remaining-query paging-options)))
-
+    :else
     (let [query-rec (get-in @entity-fn-idx [entity :rec])
           columns (orderable-columns query-rec)]
       (paging/validate-order-by! columns paging-options)
@@ -190,11 +137,11 @@
    (let [{:keys [scf-read-db url-prefix warn-experimental pretty-print]
           :or {warn-experimental true
                pretty-print false}} options
-         {:keys [query entity]} (eng/parse-query-context version query warn-experimental)
+         {:keys [remaining-query entity]} (eng/parse-query-context version query warn-experimental)
          munge-fn (get-munge-fn entity version paging-options url-prefix)]
      (jdbc/with-transacted-connection scf-read-db
        (let [{:keys [results-query]}
-             (query->sql query entity version paging-options)]
+             (query->sql remaining-query entity version paging-options)]
          (jdbc/call-with-array-converted-query-rows results-query
                                                     (comp row-fn munge-fn)))))))
 
@@ -213,11 +160,17 @@
   ([version query-map] (user-query->engine-query version query-map false))
   ([version query-map warn-experimental]
    (let [query (:query query-map)
-         {:keys [query entity]} (eng/parse-query-context
-                                  version query warn-experimental)
+         {:keys [remaining-query entity paging-clauses]} (eng/parse-query-context
+                                                          version query warn-experimental)
+         paging-options (some-> paging-clauses
+                                (rename-keys {:order-by :order_by})
+                                (update :order_by paging/munge-query-ordering)
+                                utils/strip-nil-values)
          query-options (->> (dissoc query-map :query)
-                            utils/strip-nil-values)]
-     {:query query :entity entity :query-options query-options})))
+                            utils/strip-nil-values
+                            (merge {:limit nil :offset nil :order_by nil}
+                                   paging-options))]
+     {:query query :remaining-query remaining-query :entity entity :query-options query-options})))
 
 (pls/defn-validated produce-streaming-body
   "Given a query, and database connection, return a Ring response with
@@ -230,12 +183,12 @@
   (let [{:keys [scf-read-db url-prefix warn-experimental pretty-print]
          :or {warn-experimental true
               pretty-print false}} options
-        {:keys [query entity query-options]} (user-query->engine-query version query-map warn-experimental)]
+        {:keys [query remaining-query entity query-options]} (user-query->engine-query version query-map warn-experimental)]
 
     (try
       (jdbc/with-transacted-connection scf-read-db
         (let [munge-fn (get-munge-fn entity version query-options url-prefix)
-              {:keys [results-query count-query]} (-> query
+              {:keys [results-query count-query]} (-> remaining-query
                                                       coerce-from-json
                                                       (query->sql entity version query-options))
               query-error (promise)

--- a/test/puppetlabs/puppetdb/pql_test.clj
+++ b/test/puppetlabs/puppetdb/pql_test.clj
@@ -220,25 +220,6 @@
       ["name" ["function" "count"]]
       ["group_by" "name"]]]
 
-    "facts[name, count()] { group by name limit 100 offset 100 }"
-    ["from" "facts"
-     ["extract"
-      ["name" ["function" "count"]]
-      ["group_by" "name"]]
-     ["limit" 100]
-     ["offset" 100]]
-
-    "package_inventory[package_name, version, provider, count()]{
-     [package_name, version, provider] in packages[package_name, version, provider]
-     { limit 100 offset 100 } group by package_name, version, provider}"
-    ["from" "package_inventory"
-     ["extract" ["package_name" "version" "provider" ["function" "count"]]
-      ["in" ["package_name" "version" "provider"]
-       ["from" "packages"
-        ["extract" ["package_name" "version" "provider"]]
-        ["limit"100] ["offset" 100]]]
-      ["group_by" "package_name" "version" "provider"]]]
-
     "facts[name, count(value)] { certname ~ 'web.*' group by name }"
     ["from" "facts"
      ["extract" ["name" ["function" "count" "value"]]


### PR DESCRIPTION
@wkalt This is causing very strange failures in pe-ext tests, indicating that this had unintended consequences. I'm going to revert it for now; can you take a look at the failures and re-open when you get a handle on them?