### PR TITLE
(PDB-3515) Add edges_certname_fkey constraint

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -147,6 +147,24 @@
        (= (:relname (first results))
           index))))
 
+(pls/defn-validated constraint-exists? :- s/Bool
+  ([table :- s/Str
+    constraint :- s/Str]
+   (let [schema (current-schema)]
+     (constraint-exists? schema table constraint)))
+
+  ([schema :- s/Str
+    table :- s/Str
+    constraint :- s/Str]
+
+   (let [query (str "select count(*)"
+                    "  from information_schema.constraint_column_usage"
+                    "  where table_schema = ?"
+                    "  and table_name = ?"
+                    "  and constraint_name = ?")
+         results (jdbc/query-to-vec [query schema table constraint])]
+     (pos? (:count (first results))))))
+
 (defn to-jdbc-varchar-array
   "Takes the supplied collection and transforms it into a
   JDBC-appropriate VARCHAR array."


### PR DESCRIPTION
We had this before, but it was lost in a migration which rewrote the certnames
table but neglected to restore all of the foreign key constraints. This adds it
back in a special startup function; nominally this would be in a migration, but
we've already consumed the following migration numbers in newer versions. The
corresponding change in the new code will use a migration.