### PR TITLE
(PDB-3518) fix latest report id index problems

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -263,7 +263,9 @@
                                        [:= :certnames.certname :fs.certname]
 
                                        :reports
-                                       [:= :certnames.latest_report_id :reports.id]
+                                       [:and
+                                        [:= :certnames.certname :reports.certname]
+                                        [:= :certnames.latest_report_id :reports.id]]
 
                                        [:environments :catalog_environment]
                                        [:= :catalog_environment.id :catalogs.environment_id]
@@ -935,7 +937,9 @@
                                                    :field (hsql-hash-as-str :reports.hash)}}
                :selection {:from [:certnames]
                            :join [:reports
-                                  [:= :reports.id :certnames.latest_report_id]]}
+                                  [:and
+                                   [:= :certnames.certname :reports.certname]
+                                   [:= :certnames.latest_report_id :reports.id]]]}
 
                :alias "latest_report"
                :subquery? false

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1163,6 +1163,11 @@
     "create index fact_values_value_float_idx on fact_values(value_float)"
     "create index fact_values_value_integer_idx on fact_values(value_integer)"))
 
+(defn add-corrective-change-index
+  []
+  (jdbc/do-commands
+    "CREATE INDEX resource_events_status_for_corrective_change_idx ON resource_events (status) WHERE corrective_change"))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1192,7 +1197,8 @@
    49 add-corrective-change-columns
    50 remove-historical-catalogs
    51 fact-values-value-to-jsonb
-   52 resource-params-cache-parameters-to-jsonb})
+   52 resource-params-cache-parameters-to-jsonb
+   53 add-corrective-change-index})
 
 
 (def desired-schema-version (apply max (keys migrations)))

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1168,6 +1168,11 @@
   (jdbc/do-commands
     "CREATE INDEX resource_events_status_for_corrective_change_idx ON resource_events (status) WHERE corrective_change"))
 
+(defn drop-resource-events-resource-type-idx
+  []
+  (jdbc/do-commands
+    "DROP INDEX IF EXISTS resource_events_resource_type_idx"))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1198,7 +1203,8 @@
    50 remove-historical-catalogs
    51 fact-values-value-to-jsonb
    52 resource-params-cache-parameters-to-jsonb
-   53 add-corrective-change-index})
+   53 add-corrective-change-index
+   54 drop-resource-events-resource-type-idx})
 
 
 (def desired-schema-version (apply max (keys migrations)))

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1037,6 +1037,12 @@
   (jdbc/do-commands
     "CREATE INDEX idx_certnames_latest_report_id on certnames(latest_report_id)"))
 
+(defn index-certnames-unique-latest-report-id
+  []
+  (jdbc/do-commands
+    "DROP INDEX IF EXISTS idx_certnames_latest_report_id"
+    "CREATE UNIQUE INDEX idx_certnames_latest_report_id on certnames(latest_report_id)"))
+
 (defn add-producer-to-reports-catalogs-and-factsets
   []
   (jdbc/do-commands
@@ -1204,8 +1210,8 @@
    51 fact-values-value-to-jsonb
    52 resource-params-cache-parameters-to-jsonb
    53 add-corrective-change-index
-   54 drop-resource-events-resource-type-idx})
-
+   54 drop-resource-events-resource-type-idx
+   55 index-certnames-unique-latest-report-id})
 
 (def desired-schema-version (apply max (keys migrations)))
 


### PR DESCRIPTION
First, this backports several indexes to LTS so we can get up to the official version of this index. Then we have a change to the query engine to make queries that don't break the planner's brain. 