### PR TITLE
(PDB-3527) Use #to_a method, not #to_data_hash when converting TagSets

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -28,7 +28,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   end
 
   def hashify_tags(hash)
-    hash["resources"] = hash["resources"].map { |resource| resource["tags"] = resource["tags"].to_data_hash; resource }
+    hash["resources"] = hash["resources"].map { |resource| resource["tags"] = resource["tags"].to_a; resource }
     hash
   end
 

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -709,6 +709,33 @@ describe Puppet::Resource::Catalog::Puppetdb do
           'transaction_uuid', 'environment', 'producer_timestamp', "code_id",
           "job_id", "catalog_uuid", "producer"]
       end
+
+      context 'when dealing with TagSets' do
+        let(:resource_hashes) do
+          {
+            'resources' => [
+              {'type' => 'Stage',
+              'title' => :main,
+              'tags' => Puppet::Util::TagSet.new(['stage']),
+              'exported' => false,
+              'parameters' => {:name => 'main'}},
+             {'type' => 'Class',
+              'title' => 'Settings',
+              'tags' => Puppet::Util::TagSet.new(['class', 'settings']),
+              'exported' => false},
+             {'type' => 'Class',
+              'title' => :main,
+              'tags' => Puppet::Util::TagSet.new(['class']),
+              'exported' => false,
+              'parameters' => {:name => 'main'}}
+            ]
+          }
+        end
+
+        it "should convert TagSet for resource['tags']" do
+          subject.hashify_tags(resource_hashes)['resources'].each { |resource| resource['tags'].should be_an Array }
+        end
+      end
     end
 
     describe "#redact_sensitive_params" do
@@ -716,7 +743,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
       let(:has_secret?) {
         lambda { |r| r['parameters'] && r['parameters'][:message] == secret}
       }
-      let(:input) {{'tags' => Puppet::Util::TagSet.new(['settings']),
+      let(:input) {{'tags' => ['settings'],
                     'name' => 'my_agent',
                     'version' => 1490991352,
                     'code_id' => nil,
@@ -727,21 +754,21 @@ describe Puppet::Resource::Catalog::Puppetdb do
                     'resources' =>
                     [{'type' => 'Stage',
                       'title' => :main,
-                      'tags' => Puppet::Util::TagSet.new(['stage']),
+                      'tags' => ['stage'],
                       'exported' => false,
                       'parameters' => {:name => 'main'}},
                      {'type' => 'Class',
                       'title' => 'Settings',
-                      'tags' => Puppet::Util::TagSet.new(['class', 'settings']),
+                      'tags' => ['class', 'settings'],
                       'exported' => false},
                      {'type' => 'Class',
                       'title' => :main,
-                      'tags' => Puppet::Util::TagSet.new(['class']),
+                      'tags' => ['class'],
                       'exported' => false,
                       'parameters' => {:name => 'main'}},
                      {'type' => 'Notify',
                       'title' => 'hi',
-                      'tags' => Puppet::Util::TagSet.new(['notify', 'hi', 'class']),
+                      'tags' => ['notify', 'hi', 'class'],
                       'file' =>  'site.pp',
                       'line' => 1,
                       'exported' => false,

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -733,7 +733,9 @@ describe Puppet::Resource::Catalog::Puppetdb do
         end
 
         it "should convert TagSet for resource['tags']" do
-          subject.hashify_tags(resource_hashes)['resources'].each { |resource| resource['tags'].should be_an Array }
+          subject.hashify_tags(resource_hashes)['resources'].each do |resource|
+            resource['tags'].should be_an Array
+          end
         end
       end
     end


### PR DESCRIPTION
The `Puppet::Util::TagSet` class has a method named `#to_data_hash`. It
returns an `Array` instead of a `Hash`. PuppetDB assumes that the hash
returned from a call to `Puppet::Resource::Catalog#to_data_hash` contains
tag sets and calls the `#to_data_hash` to convert them into an `Array`.
This now breaks because the bug that caused the hash to contain tag sets
was fixed in PUP-7381.

This commit changes the call to `#to_data_hash` to instead be a call to
`#to_a`. Both the `Puppet::Util::TagSet` and the `Array` class implements
this method which means that PuppetDB will be capable of munging catalogs
produced both before and after PUP-7381.