### PR TITLE
(maint) Use string keys in terminus data munging code

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -77,15 +77,15 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   end
 
   Relationships = {
-    :before    => {:direction => :forward, :relationship => 'before'},
-    :require   => {:direction => :reverse, :relationship => 'required-by'},
-    :notify    => {:direction => :forward, :relationship => 'notifies'},
-    :subscribe => {:direction => :reverse, :relationship => 'subscription-of'},
+    'before'    => {:direction => :forward, :relationship => 'before'},
+    'require'   => {:direction => :reverse, :relationship => 'required-by'},
+    'notify'    => {:direction => :forward, :relationship => 'notifies'},
+    'subscribe' => {:direction => :reverse, :relationship => 'subscription-of'},
   }
 
   # Metaparams that may contain arrays, but whose semantics are
   # fundamentally unordered
-  UnorderedMetaparams = [:alias, :audit, :before, :check, :notify, :require, :subscribe, :tag]
+  UnorderedMetaparams = ['alias', 'audit', 'before', 'check', 'notify', 'require', 'subscribe', 'tag']
 
   # Change the name field to certname
   #

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -137,7 +137,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
 
       it "should leave an existing parameters hash alone" do
         msg = "with up so floating many bells down"
-        resource[:message] = msg
+        resource['message'] = msg
 
         result = subject.add_parameters_if_missing(catalog_data_hash)
         resource = result['resources'].find do |res|
@@ -145,7 +145,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         end
 
         resource.should_not be_nil
-        resource['parameters'].should == {:message => msg}
+        resource['parameters'].should == {'message' => msg}
       end
     end
 
@@ -277,9 +277,9 @@ describe Puppet::Resource::Catalog::Puppetdb do
         end
 
         resource.should_not be_nil
-        resource['parameters'][:command].should == '/bin/true'
-        resource['parameters'][:path].should == ['/foo/goo', '/foo/bar']
-        resource['parameters'][:audit].should == 'path'
+        resource['parameters']['command'].should == '/bin/true'
+        resource['parameters']['path'].should == ['/foo/goo', '/foo/bar']
+        resource['parameters']['audit'].should == 'path'
       end
 
       it "should sort unordered metaparams with array values" do
@@ -291,8 +291,8 @@ describe Puppet::Resource::Catalog::Puppetdb do
         end
 
         resource.should_not be_nil
-        resource['parameters'][:audit].should == 'path'
-        resource['parameters'][:tag].should == ['a', 'b', 'c']
+        resource['parameters']['audit'].should == 'path'
+        resource['parameters']['tag'].should == ['a', 'b', 'c']
       end
     end
 


### PR DESCRIPTION
Puppet has changed its to_data_hash code to emit json-compatible data. This
means that all map keys are now strings, where some used to be symbols.