### PR TITLE
(maint) Workaround PUP-7605

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -225,6 +225,11 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
       resources.each do |resource|
         real_resource = catalog.resource(resource['type'], resource['title'])
 
+        # Workaround for PUP-7605
+        if real_resource.nil? && resource['title'] == 'main'
+          real_resource = catalog.resource(resource['type'], :main)
+        end
+
         # Resources with composite namevars can't be referred to by
         # anything other than their title when declaring
         # relationships. Trying to snag the :alias for these resources


### PR DESCRIPTION
Puppet is stringifying all resource titles in catalog.to_data_hash now, but
catalog.resource(type, title) can't accept string titles in all case. It special
cases :main, so apply the inverse special case here.