### PR TITLE
(PDB-2950) Require PostgreSQL >= 9.6

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -388,7 +388,7 @@ module PuppetDBExtensions
       # get the pg server up and running
       class { 'postgresql::globals':
           manage_package_repo => true,
-          version             => '9.4',
+          version             => '9.6',
       }->
       class { '::postgresql::server':
         ip_mask_allow_all_users => '0.0.0.0/0',

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -288,7 +288,8 @@
   This function will return true iff any migrations were run."
   [db-conn-pool config]
   (jdbc/with-db-connection db-conn-pool
-    (scf-store/validate-database-version #(utils/flush-and-exit 1))
+    (scf-store/validate-database-version (get-in config [:database :min-required-version] [9 6])
+                                         #(utils/flush-and-exit 1))
     @sutils/db-metadata
     (let [migrated? (migrate! db-conn-pool)]
       (indexes! config)

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1433,11 +1433,11 @@
 
 (defn db-unsupported-msg
   "Returns a string with an unsupported message if the DB is not supported,
-  nil otherwise."
-  []
-  (when (sutils/db-version-older-than? [9 4])
-    (str "PostgreSQL DB versions older than 9.4 are no longer supported."
-         "  Please upgrade Postgres and restart PuppetDB.")))
+  nil otherwise. min-version is a vector like [9 6]"
+  [min-version]
+  (when (sutils/db-version-older-than? min-version)
+    (trs "PostgreSQL DB versions older than {0}.{1} are no longer supported. Please upgrade Postgres and restart PuppetDB."
+         (first min-version) (second min-version))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
@@ -1555,8 +1555,8 @@
   "Check the currently configured database and if it isn't supported,
   notify the user and call fail-fn.  Then (if fail-fn returns) notify
   the user if the database is deprecated."
-  [fail-fn]
-  (when-let [msg (db-unsupported-msg)]
+  [min-pg-version fail-fn]
+  (when-let [msg (db-unsupported-msg min-pg-version)]
     (let [msg (utils/attention-msg msg)]
       (utils/println-err msg)
       (log/error msg)


### PR DESCRIPTION
- Update the minimum version vector to [9 6].

- Refactor version check functions to allow the minimum version to be overriden
  if necessary (temporary internal hook, for use by PE)

- Fix a bug that was preventing version-check test assertions from running