### PR TITLE
(PDB-3541) Don't hang on unsupported database

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -282,17 +282,21 @@
   context)
 
 (defn initialize-schema
-  "Ensure the database is migrated to the latest version, and warn if
-  it's deprecated, log and exit if it's unsupported.
-
-  This function will return true iff any migrations were run."
+  "Ensures the database is migrated to the latest version, and returns
+  true iff any migrations were run.  Throws
+  {:type ::unsupported-database :current version :oldest version} if
+  the current database is not supported."
   [db-conn-pool config]
   (jdbc/with-db-connection db-conn-pool
-    (scf-store/validate-database-version #(utils/flush-and-exit 1))
-    @sutils/db-metadata
-    (let [migrated? (migrate! db-conn-pool)]
-      (indexes! config)
-      migrated?)))
+    (let [current (:version @sutils/db-metadata)]
+      (when (neg? (compare current scf-store/oldest-supported-db))
+        (throw+ {:type ::unsupported-database
+                 :current current
+                 :oldest scf-store/oldest-supported-db}))
+      @sutils/db-metadata
+      (let [migrated? (migrate! db-conn-pool)]
+        (indexes! config)
+        migrated?))))
 
 (defn init-with-db
   "All initialization operations needing a database connection should
@@ -300,9 +304,10 @@
   `write-db-config` that will hang until it is able to make a
   connection to the database. This covers the case of the database not
   being fully started when PuppetDB starts. This connection pool will
-  be opened and closed within the body of this function.
-
-  This function will return true iff any migrations were run."
+  be opened and closed within the body of this function.  Returns true
+  iff any migrations were run.  Throws
+  {:type ::unsupported-database :current version :oldest version} if the
+  current database is not supported."
   [write-db-config config]
   (loop [db-spec (assoc write-db-config
                         ;; Block waiting to grab a connection
@@ -321,6 +326,8 @@
       (recur db-spec))))
 
 (defn start-puppetdb
+  "Throws {:type ::unsupported-database :current version :oldest version} if
+  the current database is not supported."
   [context config service get-registered-endpoints]
   {:pre [(map? context)
          (map? config)]
@@ -400,6 +407,15 @@
                :clean-lock clean-lock
                :command-loader command-loader)))))
 
+(defn db-unsupported-msg
+  "Returns a message describing which databases are supported."
+  [current oldest]
+  (trs "PostgreSQL {0}.{1} is no longer supported.  Please upgrade to {2}.{3}."
+       (first current)
+       (second current)
+       (first oldest)
+       (second oldest)))
+
 (defprotocol PuppetDBServer
   (shared-globals [this])
   (set-url-prefix [this url-prefix])
@@ -422,14 +438,25 @@
   that trapperkeeper will call on exit."
   PuppetDBServer
   [[:DefaultedConfig get-config]
-   [:WebroutingService add-ring-handler get-registered-endpoints]]
+   [:WebroutingService add-ring-handler get-registered-endpoints]
+   [:ShutdownService shutdown-on-error]]
   (init [this context]
 
         (doseq [{:keys [reporter]} (vals metrics/metrics-registries)]
           (jmx-reporter/start reporter))
         (assoc context :url-prefix (atom nil)))
   (start [this context]
-         (start-puppetdb context (get-config) this get-registered-endpoints))
+         (try+
+          (start-puppetdb context (get-config) this get-registered-endpoints)
+          (catch [:type ::unsupported-database] {:keys [current oldest]}
+            (let [msg (db-unsupported-msg current oldest)
+                  attn (utils/attention-msg msg)]
+              (utils/println-err attn)
+              (log/error attn)
+              ;; Until TK-445 is resolved, we won't be able to avoid the
+              ;; backtrace on exit this causes.
+              (shutdown-on-error (service-id this)
+                                 #(throw (Exception. msg)))))))
 
   (stop [this context]
         (doseq [{:keys [reporter]} (vals metrics/metrics-registries)]

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1425,19 +1425,11 @@
   {:pre [(kitchensink/datetime? time)]}
   (jdbc/delete! :reports ["producer_timestamp < ?" (to-timestamp time)]))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Database support/deprecation
-
-(defn db-unsupported-msg
-  "Returns a string with an unsupported message if the DB is not supported,
-  nil otherwise."
-  []
-  (when (sutils/db-version-older-than? [9 4])
-    (str "PostgreSQL DB versions older than 9.4 are no longer supported."
-         "  Please upgrade Postgres and restart PuppetDB.")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
+
+(def oldest-supported-db [9 4])
 
 (pls/defn-validated add-certname!
   "Add the given host to the db"
@@ -1547,17 +1539,6 @@
   [report :- reports/report-wireformat-schema
    received-timestamp :- pls/Timestamp]
   (add-report!* report received-timestamp true))
-
-(defn validate-database-version
-  "Check the currently configured database and if it isn't supported,
-  notify the user and call fail-fn.  Then (if fail-fn returns) notify
-  the user if the database is deprecated."
-  [fail-fn]
-  (when-let [msg (db-unsupported-msg)]
-    (let [msg (utils/attention-msg msg)]
-      (utils/println-err msg)
-      (log/error msg)
-      (fail-fn))))
 
 (def ^:dynamic *orphaned-path-gc-limit* 200)
 

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -51,24 +51,6 @@
 (def db-metadata
   (delay (db-metadata-fn)))
 
-(pls/defn-validated db-version? :- s/Bool
-  "Returns true if the version list you pass matches the version of the current
-   database."
-  [version :- db-version]
-  (= (:version @db-metadata) version))
-
-(pls/defn-validated db-version-older-than? :- s/Bool
-  "Returns true if the current database version is older than the version list
-   you pass it."
-  [version :- db-version]
-  (neg? (compare (:version @db-metadata) version)))
-
-(pls/defn-validated db-version-newer-than? :- s/Bool
-  "Returns true if the current database version is newer than the version list
-   you pass it."
-  [version :- db-version]
-  (pos? (compare (:version @db-metadata) version)))
-
 (defn sql-current-connection-table-names
   "Returns the names of all of the tables in the public schema of the
   current connection's database.  This is most useful for debugging /

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1796,51 +1796,6 @@
         (is (= #{}
                (set (query-resource-events :latest ["=" "report" report1-hash] {}))))))))
 
-(defn with-db-version [db version f]
-  (with-redefs [sutils/db-metadata (delay {:database db
-                                           :version version})]
-    f))
-
-(deftest-db test-db-unsupported-msg
-  (testing "should return a string if db is unsupported"
-    (are [db version result]
-      (with-db-version db version
-        (fn []
-          (is (= result (db-unsupported-msg)))))
-      "PostgreSQL" [8 1] "PostgreSQL DB versions older than 9.4 are no longer supported. Please upgrade Postgres and restart PuppetDB."
-      "PostgreSQL" [8 2] "PostgreSQL DB versions older than 9.4 are no longer supported. Please upgrade Postgres and restart PuppetDB."
-      "PostgreSQL" [8 3] "PostgreSQL DB versions older than 9.4 are no longer supported. Please upgrade Postgres and restart PuppetDB."
-      "PostgreSQL" [8 4] "PostgreSQL DB versions older than 9.4 are no longer supported. Please upgrade Postgres and restart PuppetDB."
-      "PostgreSQL" [9 0] "PostgreSQL DB versions older than 9.4 are no longer supported. Please upgrade Postgres and restart PuppetDB."
-      "PostgreSQL" [9 1] "PostgreSQL DB versions older than 9.4 are no longer supported. Please upgrade Postgres and restart PuppetDB."
-      "PostgreSQL" [9 2] "PostgreSQL DB versions older than 9.4 are no longer supported. Please upgrade Postgres and restart PuppetDB."
-      "PostgreSQL" [9 3] "PostgreSQL DB versions older than 9.4 are no longer supported. Please upgrade Postgres and restart PuppetDB."
-      "PostgreSQL" [9 4] nil)))
-
-(def not-supported-regex #"PostgreSQL DB versions older than 9.4 are no longer supported. Please upgrade Postgres and restart PuppetDB.")
-
-(deftest-db test-unsupported-fail
-  (testing "unsupported postgres version"
-    (let [fail? (atom false)]
-      (with-db-version "PostgreSQL" [9 3]
-        (fn []
-          (pllog/with-log-output log
-            (is (re-find not-supported-regex
-                         (tu/with-err-str
-                           (validate-database-version #(reset! fail? true)))))
-            (is (true? @fail?))
-            (is (re-find not-supported-regex (last (first @log)))))))))
-  (testing "supported postgres version"
-    (let [fail? (atom false)]
-      (with-db-version "PostgreSQL" [9 4]
-        (fn []
-          (pllog/with-log-output log
-            (is (str/blank?
-                 (tu/with-err-str
-                   (validate-database-version #(reset! fail? true)))))
-            (is (false? @fail?))
-            (is (empty? @log))))))))
-
 (deftest test-catalog-schemas
   (is (= (:basic catalogs) (s/validate catalog-schema (:basic catalogs)))))
 


### PR DESCRIPTION
Instead of calling System/exit, use the trapperkeeper shutdown service
to shut down when an unsupported database is detected.  Previously pdb
would just hang.

One drawback to this approach is that it looks like the only way to
get trapperkeeper to shut down and exit with a non-zero status is to
throw an exception, and we'd prefer to avoid the backtrace since the
problem has already been described in the log and on stderr.

Hopefully trapperkeeper will add something more suitable, and then we
can use it.