### PR TITLE
(PDB-3518) More specific join for certname->reports

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -257,7 +257,9 @@
                                        [:= :certnames.certname :fs.certname]
 
                                        :reports
-                                       [:= :certnames.latest_report_id :reports.id]
+                                       [:and
+                                        [:= :certnames.certname :reports.certname]
+                                        [:= :certnames.latest_report_id :reports.id]]
 
                                        [:environments :catalog_environment]
                                        [:= :catalog_environment.id :catalogs.environment_id]
@@ -899,7 +901,9 @@
                                                    :field (hsql-hash-as-str :reports.hash)}}
                :selection {:from [:certnames]
                            :join [:reports
-                                  [:= :reports.id :certnames.latest_report_id]]}
+                                  [:and
+                                   [:= :certnames.certname :reports.certname]
+                                   [:= :certnames.latest_report_id :reports.id]]]}
 
                :alias "latest_report"
                :subquery? false


### PR DESCRIPTION
Previously, queries which cross certnames and reports via latest_report_id would
sometimes get a degenerate query plan due to the presence of
idx_certnames_latest_report_id. The planner was led to believe that this index
made starting with a filtered version of the reports table and then joining that
to certnames was a good plan; it is not.

By adding an additional condition to the join which touches the certname table,
we encourage the planner to deal directly with rows which include both report.id
and certname.certname. The most direct way to do this is to scan down certnames
and pull each latest_report using the main report id index. This is the plan it
makes now, and it's a lot faster.