### PR TITLE
(PDB-3549) Update acceptance to use puppet5-nightly

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -265,11 +265,14 @@ module PuppetDBExtensions
   end
 
   def get_package_version(host, version = nil)
-
     if version == 'latest'
       return 'latest'
     elsif version.nil?
       version = PuppetDBExtensions.config[:package_build_version].to_s
+      # If no version was defined, default to latest.
+      if version == ''
+        return 'latest'
+      end
     end
 
     # version can look like:
@@ -335,7 +338,7 @@ module PuppetDBExtensions
       expected_version = get_package_version(host)
 
       Beaker::Log.notify "Expecting package version: '#{expected_version}', actual version: '#{installed_version}'"
-      if installed_version != expected_version
+      if installed_version != expected_version and expected_version != 'latest'
         raise RuntimeError, "Installed version '#{installed_version}' did not match expected version '#{expected_version}'"
       end
     end

--- a/acceptance/setup/pre_suite/15_setup_repos.rb
+++ b/acceptance/setup/pre_suite/15_setup_repos.rb
@@ -11,13 +11,10 @@ def initialize_repo_on_host(host, os, nightly)
 
     if options[:type] == 'aio' then
       if nightly
-        ## PC1 repos
-        on host, "curl -O http://apt.puppetlabs.com/puppetlabs-release-pc1-$(lsb_release -sc).deb"
-        on host, "dpkg -i puppetlabs-release-pc1-$(lsb_release -sc).deb"
+        ## puppet5 repos
+        on host, "curl -O http://apt.puppetlabs.com/puppet5-nightly-release-$(lsb_release -sc).deb"
+        on host, "dpkg -i puppet5-nightly-release-$(lsb_release -sc).deb"
 
-        ## Nightly repos
-        on host, "curl -o /etc/apt/sources.list.d/pl-puppetserver-latest-$(lsb_release -sc).list http://nightlies.puppetlabs.com/puppetserver-latest/repo_configs/deb/pl-puppetserver-latest-$(lsb_release -sc).list"
-        on host, "curl -o /etc/apt/sources.list.d/pl-puppet-agent-latest-$(lsb_release -sc).list http://nightlies.puppetlabs.com/puppet-agent-latest/repo_configs/deb/pl-puppet-agent-latest-$(lsb_release -sc).list"
       else
         on host, "curl -O http://apt.puppetlabs.com/puppetlabs-release-pc1-$(lsb_release -sc).deb"
         on host, "dpkg -i puppetlabs-release-pc1-$(lsb_release -sc).deb"
@@ -36,13 +33,10 @@ def initialize_repo_on_host(host, os, nightly)
       arch = $3
 
       if nightly
-        ## PC1 repos
-        on host, "curl -O http://yum.puppetlabs.com/puppetlabs-release-pc1-#{variant}-#{version}.noarch.rpm"
-        on host, "rpm -i puppetlabs-release-pc1-#{variant}-#{version}.noarch.rpm"
+        ## puppet5 repos
+        on host, "curl -O http://yum.puppetlabs.com/puppet5-nightly/puppet5-nightly-release-#{variant}-#{version}.noarch.rpm"
+        on host, "rpm -i puppet5-nightly-release-#{variant}-#{version}.noarch.rpm"
 
-        ## Nightly repos
-        on host, "curl -o /etc/yum.repos.d/pl-puppetserver-latest-#{variant}-#{version}-#{arch}.repo http://nightlies.puppetlabs.com/puppetserver-latest/repo_configs/rpm/pl-puppetserver-latest-#{variant}-#{version}-#{arch}.repo"
-        on host, "curl -o /etc/yum.repos.d/pl-puppet-agent-latest-#{variant}-#{version}-#{arch}.repo http://nightlies.puppetlabs.com/puppet-agent-latest/repo_configs/rpm/pl-puppet-agent-latest-#{variant}-#{version}-#{arch}.repo"
       else
         on host, "curl -O http://yum.puppetlabs.com/puppetlabs-release-pc1-#{variant}-#{version}.noarch.rpm"
         on host, "rpm -i puppetlabs-release-pc1-#{variant}-#{version}.noarch.rpm"

--- a/acceptance/setup/pre_suite/80_add_dev_repo.rb
+++ b/acceptance/setup/pre_suite/80_add_dev_repo.rb
@@ -1,6 +1,7 @@
 install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
 repo_config_dir = 'tmp/repo_configs'
-if (test_config[:install_type] == :package and not test_config[:skip_presuite_provisioning])
+if (test_config[:install_type] == :package and test_config[:package_build_version] and not test_config[:skip_presuite_provisioning])
+  # do not install the dev_repo if a package_build_version has not been specified.
   databases.each do |database|
     install_puppetlabs_dev_repo database, 'puppetdb', test_config[:package_build_version],
                                 repo_config_dir, install_opts

--- a/acceptance/setup/pre_suite/80_add_dev_repo.rb
+++ b/acceptance/setup/pre_suite/80_add_dev_repo.rb
@@ -1,6 +1,9 @@
 install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
 repo_config_dir = 'tmp/repo_configs'
-if (test_config[:install_type] == :package and test_config[:package_build_version] and not test_config[:skip_presuite_provisioning])
+if (test_config[:install_type] == :package \
+   and test_config[:package_build_version] \
+   and not test_config[:skip_presuite_provisioning])
+then
   # do not install the dev_repo if a package_build_version has not been specified.
   databases.each do |database|
     install_puppetlabs_dev_repo database, 'puppetdb', test_config[:package_build_version],


### PR DESCRIPTION
Replace previous usage of `PC1` nightlies with `puppet5`.

Add support for the use case where the puppetdb build version is not specified. In this case, the version of puppetdb published in the `puppet5-nightly` repo will be installed.