### PR TITLE
(PDB-3548) Document the removal of support for jvm < 8

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -826,21 +826,19 @@ authentication. Authorized clients must be signed by the CA that corresponds to 
 ### `cipher-suites`
 
 Optional. A comma-separated list of cryptographic ciphers to allow for
-incoming SSL connections. Valid names are listed in the [official JDK
-cryptographic providers
-documentation](http://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html#SupportedCipherSuites). Note that you must use the all-caps cipher suite name.
+incoming SSL connections. Valid names are listed in the
+[official JVM cryptographic providers documentation](http://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SupportedCipherSuites). Note
+that you must use the all-caps cipher suite name.
 
-If not supplied, PuppetDB uses the default cipher suites for your
-local system on JDK versions older than 1.7.0u6. On newer JDK
-versions, PuppetDB will use only non-DHE cipher suites.
+If not supplied, PuppetDB will use only non-DHE cipher suites.
 
 ### `ssl-protocols`
 
 Optional. A comma-separated list of protocols to allow for incoming
-SSL connections. Valid names are listed in the [official JDK
-cryptographic protocol
-documentation](http://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider). Note that you must use the names with verbatim capitalization. For
-example: `TLSv1, TLSv1.1, TLSv1.2`.
+SSL connections. Valid names are listed in the
+[official JVM cryptographic protocol documentation](http://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider). Note
+that you must use the names with verbatim capitalization. For example:
+`TLSv1, TLSv1.1, TLSv1.2`.
 
 If not supplied, PuppetDB uses a default of `TLSv1, TLSv1.1, TLSv1.2`. By default, SSLv3 is not included in that list due to known vulnerabilities. Users wanting to use SSLv3 need to explicitly specify it in their list.
 

--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -66,7 +66,7 @@ through PuppetDB's query APIs (see the navigation sidebar for details).
 System requirements
 -----
 
-### \*nix server with JDK 1.7+ (Debian) or JDK 1.8+ (RHEL-derived)
+### \*nix server with JVM 1.8+
 
 #### Standard install: RHEL, CentOS, Debian, and Ubuntu
 
@@ -85,12 +85,12 @@ following operating systems:
 
 #### Custom install: Any Unix-like OS
 
-If you're willing to do some manual configuration, PuppetDB can run on any
-Unix-like OS with JDK 1.7 or higher, including:
+If you're willing to do some manual configuration, PuppetDB can run on
+any Unix-like OS with JVM 8 or newer, including:
 
-* Recent MacOS X versions (using built-in Java 1.8 support)
-* Nearly any Linux distribution (using Java 1.8)
-* Nearly any \*nix system running a recent Oracle-provided 1.8 JDK
+* Recent MacOS X versions (using built-in support)
+* Nearly any Linux distribution using OpenJDK 8 or Oracle JDK 8
+* Nearly any \*nix distribution using OpenJDK 8 or Oracle JDK 8
 
 [See here for advanced installation instructions.][install_advanced]
 

--- a/documentation/install_from_source.markdown
+++ b/documentation/install_from_source.markdown
@@ -27,13 +27,13 @@ Step 1: Installation prerequisites
 
 Use your system's package tools to ensure that the following prerequisites are installed:
 
-* (Optional) Puppet Server 2.x or higher
+* (Optional) Puppet Server 2.x or newer
 * A working Puppet agent or server setup (for ssl-setup to succeed)
-* Facter, version 3 or higher
-* JDK 1.7 or higher
+* Facter, version 3 or newer
+* JDK 8 or newer
 * [Leiningen][]
 * Git (for checking out the source code)
-* Rake (version 0.9.6 or higher)
+* Rake (version 0.9.6 or newer)
 
 Step 2, option A: Install from source
 -----


### PR DESCRIPTION
Update the documentation, and remove support for jvm versions older
than 8.  Have pdb exit with an error if an unsupported jvm is
detected, and unify the failure handling with the recent changes
related to unsupported postgres versions.

After this, "run services" will initiate a tk shutdown-on-error when
it detects an unsupported jvm, as it does for an unsupported
postgresql, instead of calling (System/exit 1).

cf. PDB-3541 a8559cfebeb35eb3e1fca6338b90e069b4b0ff1e