### PR TITLE
(PDB-3558) depend on puppet 5

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -1,11 +1,11 @@
 ezbake: {
   pe: {}
   foss: {
-    redhat: { dependencies: ["puppet (>= 5.0.0) | puppet-agent (>= 5.0.0)"],
+    redhat: { dependencies: ["puppet (>= 4.99.0) | puppet-agent (>= 4.99.0)"],
               preinst:  ["if rpm -q puppetdb | grep ^puppetdb-2.* > /dev/null && [ $1 -eq 2 ] ; then tar -czf /tmp/puppetdb-upgrade-config-files.tgz -C /etc/puppetdb/conf.d config.ini database.ini jetty.ini ; fi" ],
               postinst: ["/opt/puppetlabs/server/bin/puppetdb config-migration",
                          "/opt/puppetlabs/server/bin/puppetdb ssl-setup"] },
-    debian: { dependencies: ["puppet (>= 5.0.0) | puppet-agent (>= 5.0.0)"],
+    debian: { dependencies: ["puppet (>= 4.99.0) | puppet-agent (>= 4.99.0)"],
               preinst:  ["if [ $1 = 'upgrade' ] && [ ${2%%.*} -le 2 ] ; then tar -czf /tmp/puppetdb-upgrade-config-files.tgz -C /etc/puppetdb/conf.d config.ini database.ini jetty.ini ; fi"],
               postinst: ["/opt/puppetlabs/server/bin/puppetdb config-migration",
                          "/opt/puppetlabs/server/bin/puppetdb ssl-setup"] }

--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -1,12 +1,11 @@
 ezbake: {
   pe: {}
   foss: {
-    redhat: { dependencies: ["puppet >= 3.8.1", "puppet < 5.0.0"],
+    redhat: { dependencies: ["puppet (>= 5.0.0) | puppet-agent (>= 5.0.0)"],
               preinst:  ["if rpm -q puppetdb | grep ^puppetdb-2.* > /dev/null && [ $1 -eq 2 ] ; then tar -czf /tmp/puppetdb-upgrade-config-files.tgz -C /etc/puppetdb/conf.d config.ini database.ini jetty.ini ; fi" ],
               postinst: ["/opt/puppetlabs/server/bin/puppetdb config-migration",
                          "/opt/puppetlabs/server/bin/puppetdb ssl-setup"] },
-    debian: { dependencies: ["puppet (>= 3.8.1-1puppetlabs1)  | puppet-agent",
-                             "puppet (<< 5.0.0-1puppetlabs1) | puppet-agent"],
+    debian: { dependencies: ["puppet (>= 5.0.0) | puppet-agent (>= 5.0.0)"],
               preinst:  ["if [ $1 = 'upgrade' ] && [ ${2%%.*} -le 2 ] ; then tar -czf /tmp/puppetdb-upgrade-config-files.tgz -C /etc/puppetdb/conf.d config.ini database.ini jetty.ini ; fi"],
               postinst: ["/opt/puppetlabs/server/bin/puppetdb config-migration",
                          "/opt/puppetlabs/server/bin/puppetdb ssl-setup"] }

--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -1,7 +1,7 @@
 ezbake: {
   pe: {}
   foss: {
-    redhat: { dependencies: ["puppet (>= 4.99.0) | puppet-agent (>= 4.99.0)"],
+    redhat: { dependencies: ["puppet >= 4.99.0 or puppet-agent >= 4.99.0"],
               preinst:  ["if rpm -q puppetdb | grep ^puppetdb-2.* > /dev/null && [ $1 -eq 2 ] ; then tar -czf /tmp/puppetdb-upgrade-config-files.tgz -C /etc/puppetdb/conf.d config.ini database.ini jetty.ini ; fi" ],
               postinst: ["/opt/puppetlabs/server/bin/puppetdb config-migration",
                          "/opt/puppetlabs/server/bin/puppetdb ssl-setup"] },

--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -1,11 +1,11 @@
 ezbake: {
   pe: {}
   foss: {
-    redhat: { dependencies: ["puppet >= 4.99.0 or puppet-agent >= 4.99.0"],
+    redhat: { dependencies: ["puppet-agent >= 4.99.0"],
               preinst:  ["if rpm -q puppetdb | grep ^puppetdb-2.* > /dev/null && [ $1 -eq 2 ] ; then tar -czf /tmp/puppetdb-upgrade-config-files.tgz -C /etc/puppetdb/conf.d config.ini database.ini jetty.ini ; fi" ],
               postinst: ["/opt/puppetlabs/server/bin/puppetdb config-migration",
                          "/opt/puppetlabs/server/bin/puppetdb ssl-setup"] },
-    debian: { dependencies: ["puppet (>= 4.99.0) | puppet-agent (>= 4.99.0)"],
+    debian: { dependencies: ["puppet-agent (>= 4.99.0)"],
               preinst:  ["if [ $1 = 'upgrade' ] && [ ${2%%.*} -le 2 ] ; then tar -czf /tmp/puppetdb-upgrade-config-files.tgz -C /etc/puppetdb/conf.d config.ini database.ini jetty.ini ; fi"],
               postinst: ["/opt/puppetlabs/server/bin/puppetdb config-migration",
                          "/opt/puppetlabs/server/bin/puppetdb ssl-setup"] }


### PR DESCRIPTION
- Puppet Server, PDB, and Puppet will all be released at version '5' and
  require version 5 of each other. Update the dependency expressed in PDB.
  Support both 'puppet' and 'puppet-agent' in case distros ship a puppet 5 and
  PDB can depend on that.
- for PDB specifically, requiring puppet 5 means that we can rely on puppet 5
  semantics in the various puppetdb termini. This will allow us to remove some
  processing done in the terminus that is no longer necessary, possibly
  optimizing performance, but cetainly optimizing maintainability.

Signed-off-by: Moses Mendoza <moses@puppet.com>