### PR TITLE
(PDB-3566) Fix the catch-all for command processing errors

### DIFF
--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -233,10 +233,12 @@
 
 (defmacro upon-error-throw-fatality
   [& body]
-  `(try+
+  `(try
     ~@body
-    (catch Throwable e#
-      (throw+ (fatality e#)))))
+    (catch Exception e1#
+      (throw+ (fatality e1#)))
+    (catch AssertionError e2#
+      (throw+ (fatality e2#)))))
 
 ;; ## Command submission
 


### PR DESCRIPTION
The top-level exception handler used in command processing threads missed most
ExceptionInfo exceptions; this includes schema validation errors.