### PR TITLE
(RE-8458) Update tests to use the puppet repos

### DIFF
--- a/acceptance/setup/pre_suite/15_setup_repos.rb
+++ b/acceptance/setup/pre_suite/15_setup_repos.rb
@@ -16,8 +16,8 @@ def initialize_repo_on_host(host, os, nightly)
         on host, "dpkg -i puppet5-nightly-release-$(lsb_release -sc).deb"
 
       else
-        on host, "curl -O http://apt.puppetlabs.com/puppetlabs-release-pc1-$(lsb_release -sc).deb"
-        on host, "dpkg -i puppetlabs-release-pc1-$(lsb_release -sc).deb"
+        on host, "curl -O http://apt.puppetlabs.com/puppet-release-$(lsb_release -sc).deb"
+        on host, "dpkg -i puppet-release-$(lsb_release -sc).deb"
       end
     else
       on host, "curl -O http://apt.puppetlabs.com/puppetlabs-release-$(lsb_release -sc).deb"
@@ -38,8 +38,8 @@ def initialize_repo_on_host(host, os, nightly)
         on host, "rpm -i puppet5-nightly-release-#{variant}-#{version}.noarch.rpm"
 
       else
-        on host, "curl -O http://yum.puppetlabs.com/puppetlabs-release-pc1-#{variant}-#{version}.noarch.rpm"
-        on host, "rpm -i puppetlabs-release-pc1-#{variant}-#{version}.noarch.rpm"
+        on host, "curl -O http://yum.puppetlabs.com/puppet/puppet-release-#{variant}-#{version}.noarch.rpm"
+        on host, "rpm -i puppet-release-#{variant}-#{version}.noarch.rpm"
       end
     else
       on host, "yum clean all -y"

--- a/acceptance/setup/pre_suite/80_add_dev_repo.rb
+++ b/acceptance/setup/pre_suite/80_add_dev_repo.rb
@@ -1,4 +1,3 @@
-install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
 repo_config_dir = 'tmp/repo_configs'
 if (test_config[:install_type] == :package \
    and test_config[:package_build_version] \
@@ -7,6 +6,6 @@ then
   # do not install the dev_repo if a package_build_version has not been specified.
   databases.each do |database|
     install_puppetlabs_dev_repo database, 'puppetdb', test_config[:package_build_version],
-                                repo_config_dir, install_opts
+                                repo_config_dir, options
   end
 end

--- a/resources/puppetlabs/puppetdb/benchmark/samples/facts/pg2.vm.json
+++ b/resources/puppetlabs/puppetdb/benchmark/samples/facts/pg2.vm.json
@@ -9253,8 +9253,8 @@
             "gem"
         ],
         [
-            "puppetlabs-release-pc1",
-            "1.1.0-4jessie",
+            "puppet-release",
+            "1.0.0-1jessie",
             "apt"
         ],
         [


### PR DESCRIPTION
In order to test against the right set of packages, we need to update
these tests to hit the new repos. Rather than pin to puppet 5, we're
just going to pin to the rolling puppet repos. This will change
automatically to puppet6 once we change these repos to point to puppet6.