### PR TITLE
(PDB-3611) Rewrite and/or of uniform in/extract to union/intersect 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -82,7 +82,7 @@
 
                  ;; Database connectivity
                  [com.zaxxer/HikariCP "2.4.3" :exclusions [org.slf4j/slf4j-api]]
-                 [honeysql "0.6.3"]
+                 [honeysql "0.7.0"]
                  [org.postgresql/postgresql "9.4.1208.jre7"]
 
                  ;; MQ connectivity

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -1261,6 +1261,13 @@
     {:node (assoc node :value qmarks :field column)
      :state (reduce conj state parameters)}))
 
+
+;; This was removed in HoneySQL 0.7.0, changing its parameter requirements for
+;; queries including numbers. Restore the old behavior here.
+(extend-protocol hformat/ToSql
+  java.lang.Number
+  (to-sql [x] (str x)))
+
 (defn extract-params
   "Extracts the node's expression value, puts it in state
    replacing it with `?`, used in a prepared statement"


### PR DESCRIPTION
Postgres has a really hard time with queries like this:
```sql
  select x from t1
  where x in (select x from t2)
  and x in (select x from t3)
```
We tend to generate these a lot. But it deals better with
```sql
  select x from t1
  where x in (select x from t2
              intersect
              select x from t3)
```
which is the same. The same goes for or->union. This change does that rewriting.