### PR TITLE
(docs) update mismatched version number in heading (in 4.4).

### DIFF
--- a/documentation/ha.markdown
+++ b/documentation/ha.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 4.2: PuppetDB HA"
+title: "PuppetDB 4.4: PuppetDB HA"
 layout: default
 ---
 


### PR DESCRIPTION
this version also is mismatched on this page.