### PR TITLE
(MAINT) Change status logger to debug level

### DIFF
--- a/resources/ext/config/logback.xml
+++ b/resources/ext/config/logback.xml
@@ -48,7 +48,7 @@
     </appender>
 
     <!-- without additivity="false", the status log messages will be sent to every other appender as well-->
-    <logger name="puppetlabs.trapperkeeper.services.status.status-debug-logging" additivity="false">
+    <logger name="puppetlabs.trapperkeeper.services.status.status-debug-logging" level="debug" additivity="false">
         <appender-ref ref="STATUS"/>
     </logger>
 


### PR DESCRIPTION
I noticed this problem in `puppetserver`, and I'm going around updating the other projects that use `tk-status`'s periodic status logging

---
This commit changes the status logger's logging level to debug. This logback logger picks up log messages from the `tk-status` periodic logging feature, if it is enabled.

The periodic status logging feature in `tk-status` logs at the `debug` level, so
unless the logback root logger is set to `debug`, for the status logger to inherit from,
no periodic status log messages will appear. 

This change has no affect on any of the the other logging that the app does