### PR TITLE
(PDB-3611) Deduplicate fact values (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,9 @@ matrix:
   include:
     # terminus unit tests (spec tests)
     - env: >
-        NAME=rspec-puppet-4.0
+        NAME=rspec-puppet4
         PDB_TEST_LANG=ruby
-        PUPPET_VERSION=4.0.0
-
-    - env: >
-        NAME=rspec-puppet-latest
-        PDB_TEST_LANG=ruby
-        PUPPET_VERSION=latest
+        PUPPET_VERSION=4.10.4
 
     # pdb unit tests
     - env: >
@@ -46,44 +41,20 @@ matrix:
 
     # pdb + terminus + puppetserver + puppet integration tests
     - env: >
-        NAME=integration-stable-openjdk7
+        NAME=integration-puppet4-openjdk7
         PDB_TEST_LANG=clojure
         PDB_TEST_SELECTOR=:integration
-        PUPPET_VERSION=4.8.0
+        PUPPET_VERSION=4.10.4
         PUPPETSERVER_VERSION=2.7.2
       jdk: openjdk7
 
     - env: >
-        NAME=integration-stable-openjdk8
+        NAME=integration-puppet4-openjdk8
         PDB_TEST_LANG=clojure
         PDB_TEST_SELECTOR=:integration
-        PUPPET_VERSION=4.8.0
+        PUPPET_VERSION=4.10.4
         PUPPETSERVER_VERSION=2.7.2
       jdk: openjdk8
-
-    - env: >
-        NAME=integration-latest-puppet-openjdk8
-        PDB_TEST_LANG=clojure
-        PDB_TEST_SELECTOR=:integration
-        PUPPET_VERSION=latest
-        PUPPETSERVER_VERSION=2.7.2
-      jdk: openjdk8
-
-    - env: >
-        NAME=integration-stable-oraclejdk8
-        PDB_TEST_LANG=clojure
-        PDB_TEST_SELECTOR=:integration
-        PUPPET_VERSION=4.8.0
-        PUPPETSERVER_VERSION=2.7.2
-      jdk: oraclejdk8
-
-    - env: >
-        NAME=integration-latest-puppet-oraclejdk8
-        PDB_TEST_LANG=clojure
-        PDB_TEST_SELECTOR=:integration
-        PUPPET_VERSION=latest
-        PUPPETSERVER_VERSION=2.7.2
-      jdk: oraclejdk8
 
 before_install: ext/travisci/install_puppetserver.sh
 script: ext/travisci/test.sh

--- a/documentation/api/admin/v1/summary-stats.markdown
+++ b/documentation/api/admin/v1/summary-stats.markdown
@@ -34,18 +34,23 @@ The response is a JSON map containing the following keys:
 * `node_activity` (json): Counts of active and inactive nodes.
 * `fact_path_counts_by_depth` (json): Number of fact paths for each fact path
   depth represented in the database.
-* `num_shared_fact_paths` (json): The number of fact paths that are
-  shared across multiple nodes i.e. if one path is shared across three
-  nodes, and another across five, then this will report 2 shared
-  paths.
-* `num_unshared_fact_paths` (json): The number of fact paths that are
-  not shared across multiple nodes.
-* `fact_path_sharing` (json): The 0th through 20th 20-quantiles of the
-  number of nodes sharing each given fact_path.
-* `string_fact_value_bytes` (json): 0th through 20th 20-quantiles of the
-  byte length of string-valued facts.
-* `structured_fact_value_bytes` (json): 0th through 20th 20-quantiles of the
-  byte length of structured facts.
+* `num_shared_value_path_combos` (json): The number of fact value/fact path
+  combinations that are shared across multiple nodes.
+* `num_shared_name_value_combos` (json): The number of fact name/fact value
+  combinations that are shared across multiple nodes.
+* `num_unshared_value_path_combos` (json): The number of fact value/fact path
+  combinations that are only present on one node.
+* `num_unshared_name_value_combos` (json): The number of fact name/fact value
+  combinations that are only present on one node.
+* `num_times_paths_values_shared_given_sharing` (json): Across fact path/fact
+  value combinations shared across multiple nodes, the 0th through 20th
+  20-quantiles of the number of nodes sharing.
+* `num_unique_fact_values_over_nodes` (json): Across all nodes, the 0th through
+  20th 20-quantiles of the number of unique fact values.
+* `string_fact_value_character_lengths` (json): 0th through 20th 20-quantiles of the
+  character length of string-valued facts.
+* `structured_fact_value_character_lengths` (json): 0th through 20th 20-quantiles of the
+  character length of structured facts.
 * `report_metric_size_dist` (json): 0th through 20th 20-quantiles of the
   character lengths of report metrics.
 * `report_log_size_dist` (json): 0th through 20th 20-quantiles of the character

--- a/src/puppetlabs/puppetdb/facts.clj
+++ b/src/puppetlabs/puppetdb/facts.clj
@@ -7,7 +7,9 @@
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.utils :as utils]
             [schema.core :as s]
-            [puppetlabs.puppetdb.time :refer [to-timestamp]]))
+            [puppetlabs.puppetdb.time :refer [to-timestamp]]
+            [puppetlabs.puppetdb.package-util :refer [package-tuple hashed-package-tuple
+                                                      package-tuple-hash]]))
 
 ;; SCHEMA
 
@@ -24,18 +26,6 @@
 
 (def fact-set-schema
   {s/Str s/Any})
-
-(def package-tuple
-  [(s/one s/Str "package_name")
-   (s/one s/Str "version")
-   (s/one s/Str "provider")])
-
-(def hashed-package-tuple
-  (conj package-tuple
-        (s/one s/Str "package_hash")))
-
-(defn package-tuple-hash [hashed-package-tuple]
-  (nth hashed-package-tuple 3))
 
 (def facts-schema
   {:certname String

--- a/src/puppetlabs/puppetdb/facts.clj
+++ b/src/puppetlabs/puppetdb/facts.clj
@@ -39,13 +39,13 @@
    (s/optional-key :package_inventory) [package-tuple]})
 
 (def valuemap-schema
-  {:value_float (s/maybe Double)
+  {:value_hash s/Str
+   :value_float (s/maybe Double)
    :value_string (s/maybe s/Str)
    :value_integer (s/maybe s/Int)
    :value_boolean (s/maybe s/Bool)
    :value (s/maybe s/Any)
-   :value_type_id s/Int
-   :large_value_hash (s/maybe s/Str)})
+   :value_type_id s/Int})
 
 ;; GLOBALS
 
@@ -134,33 +134,26 @@
    (nil? data) 4
    (coll? data) 5))
 
-(def ^:const large-value-threshold 50)
-
 (defn value->valuemap
   [value]
   (let [type-id (value-type-id value)
-        specific-value-key (case type-id
-                             0 :value_string
-                             1 :value_integer
-                             2 :value_float
-                             3 :value_boolean
-                             ;; 4 is nil, doesn't have a key, or a jsonb rep
-                             ;; 5 is value, handled universally below
-                             nil)
-        jsonb (when-not (nil? value)
-                (sutils/munge-jsonb-for-storage value))
-        hash (when (and jsonb
-                        (>= (count (.getValue jsonb)) large-value-threshold))
-               (hash/generic-identity-hash value))]
-    (merge {:value_type_id type-id
-            :large_value_hash hash
-            :value jsonb
-            :value_string nil
-            :value_integer nil
-            :value_float nil
-            :value_boolean nil}
-           (when specific-value-key
-             {specific-value-key value}))))
+        initial-map {:value_type_id type-id
+                     :value_hash (hash/generic-identity-hash value)
+                     :value_string nil
+                     :value_integer nil
+                     :value_float nil
+                     :value_boolean nil
+                     :value nil}]
+    (if (nil? value)
+      initial-map
+      (let [value-keyword (case type-id
+                            0 :value_string
+                            1 :value_integer
+                            2 :value_float
+                            3 :value_boolean
+                            5 :value)]
+        (assoc initial-map value-keyword value
+          :value (sutils/munge-jsonb-for-storage value))))))
 
 (defn flatten-facts-with
   "Returns a collection of (leaf-fn path leaf) for all of the paths

--- a/src/puppetlabs/puppetdb/facts.clj
+++ b/src/puppetlabs/puppetdb/facts.clj
@@ -3,7 +3,9 @@
             [clojure.set :as set]
             [clojure.string :as str]
             [puppetlabs.kitchensink.core :as kitchensink]
+            [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.schema :as pls]
+            [puppetlabs.puppetdb.scf.hash :as hash]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.utils :as utils]
             [schema.core :as s]
@@ -35,6 +37,15 @@
    :producer_timestamp (s/cond-pre s/Str pls/Timestamp)
    :producer (s/maybe s/Str)
    (s/optional-key :package_inventory) [package-tuple]})
+
+(def valuemap-schema
+  {:value_float (s/maybe Double)
+   :value_string (s/maybe s/Str)
+   :value_integer (s/maybe s/Int)
+   :value_boolean (s/maybe s/Bool)
+   :value (s/maybe s/Any)
+   :value_type_id s/Int
+   :large_value_hash (s/maybe s/Str)})
 
 ;; GLOBALS
 
@@ -111,7 +122,45 @@
   (let [encodedpath (map encode-factpath-element factpath)]
     (str/join factpath-delimiter encodedpath)))
 
+(pls/defn-validated value-type-id :- s/Int
+  "Given a piece of standard hierarchical data, returns the type as an id."
+  [data :- s/Any]
+  (cond
+   (keyword? data) 0
+   (string? data) 0
+   (integer? data) 1
+   (float? data) 2
+   (kitchensink/boolean? data) 3
+   (nil? data) 4
+   (coll? data) 5))
+
 (def ^:const large-value-threshold 50)
+
+(defn value->valuemap
+  [value]
+  (let [type-id (value-type-id value)
+        specific-value-key (case type-id
+                             0 :value_string
+                             1 :value_integer
+                             2 :value_float
+                             3 :value_boolean
+                             ;; 4 is nil, doesn't have a key, or a jsonb rep
+                             ;; 5 is value, handled universally below
+                             nil)
+        jsonb (when-not (nil? value)
+                (sutils/munge-jsonb-for-storage value))
+        hash (when (and jsonb
+                        (>= (count (.getValue jsonb)) large-value-threshold))
+               (hash/generic-identity-hash value))]
+    (merge {:value_type_id type-id
+            :large_value_hash hash
+            :value jsonb
+            :value_string nil
+            :value_integer nil
+            :value_float nil
+            :value_boolean nil}
+           (when specific-value-key
+             {specific-value-key value}))))
 
 (defn flatten-facts-with
   "Returns a collection of (leaf-fn path leaf) for all of the paths
@@ -154,10 +203,12 @@
    :name (first path)
    :depth (dec (count path))})
 
-(defn facts->paths-and-values
-  "Returns [path value] pairs for all facts. i.e. ([\"foo#~bar\" vm] ...)"
-  [facts]
-  (flatten-facts-with (fn [fp leaf] [fp leaf]) facts))
+(pls/defn-validated facts->paths-and-valuemaps
+  :- [(s/pair fact-path "path" valuemap-schema "valuemap")]
+  "Returns [path valuemap] pairs for all
+  facts. i.e. ([\"foo#~bar\" vm] ...)"
+  [facts :- fact-set-schema]
+  (flatten-facts-with (fn [fp leaf] [fp (value->valuemap leaf)]) facts))
 
 (pls/defn-validated unstringify-value
   "Converts a stringified value from the database into its real value and type.

--- a/src/puppetlabs/puppetdb/package_util.clj
+++ b/src/puppetlabs/puppetdb/package_util.clj
@@ -1,0 +1,17 @@
+(ns puppetlabs.puppetdb.package-util
+  (:require [schema.core :as s]))
+
+;;; small utilities for manipulating package data; in a separate file to untangle
+;;; a dependency loop.
+
+(def package-tuple
+  [(s/one s/Str "package_name")
+   (s/one s/Str "version")
+   (s/one s/Str "provider")])
+
+(def hashed-package-tuple
+  (conj package-tuple
+        (s/one s/Str "package_hash")))
+
+(defn package-tuple-hash [hashed-package-tuple]
+  (nth hashed-package-tuple 3))

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -439,10 +439,11 @@
         sql (format "SELECT %s FROM (
                       SELECT fs.certname,
                              fp.name as name,
-                             f.value,
+                             fv.value,
                              env.environment
                       FROM factsets fs
                         INNER JOIN facts as f on fs.id = f.factset_id
+                        INNER JOIN fact_values as fv on f.fact_value_id = fv.id
                         INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
                         LEFT OUTER JOIN environments as env on fs.environment_id = env.id
                       WHERE depth = 0) AS facts

--- a/src/puppetlabs/puppetdb/query/summary_stats.clj
+++ b/src/puppetlabs/puppetdb/query/summary_stats.clj
@@ -27,22 +27,64 @@
     group by depth
     order by depth"
 
-   :num_shared_fact_paths
-   ["select count(*) from (select fact_path_id from facts"
-    "                        group by fact_path_id having count(*) > 1)"
-    "  foo"]
+   :num_shared_value_path_combos
+   "select count(f.fact_value_id)
+    from (select fact_value_id
+    from facts
+    group by fact_path_id, fact_value_id
+    having count(*) > 1) as f"
 
-   :num_unshared_fact_paths
-   ["select count(fact_path_id) from (select fact_path_id from facts"
-    "                        group by fact_path_id having count(*) = 1)"
-    "  foo"]
+   :num_shared_name_value_combos
+   "select count(f.name)
+    from (select name, fact_value_id
+    from facts
+    inner join fact_paths fp on facts.fact_path_id = fp.id
+    group by fact_value_id, name
+    having count(*) > 1) as f"
 
-   :fact_path_sharing
-   ["select percentile_cont(Array[0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30,"
-    "                             0.35, 0.40, 0.45, 0.50, 0.55, 0.60,"
-    "                             0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 1])"
-    "  within group (order by n) quantiles"
-    "  from (select count(*) as n from facts group by fact_path_id) foo"]
+   :num_unshared_value_path_combos
+   "select count(f.fact_value_id)
+    from (select fact_value_id
+    from facts
+    group by fact_path_id, fact_value_id
+    having count(*) = 1) as f"
+
+   :num_unshared_name_value_combos
+   "select count(f.name)
+    from (select name, fact_value_id
+    from facts
+    inner join fact_paths fp on facts.fact_path_id = fp.id
+    group by fact_value_id, name
+    having count(*) = 1) as f"
+
+   :num_times_paths_values_shared_given_sharing
+   "select percentile_cont(Array[0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30,
+    0.35, 0.40, 0.45, 0.50, 0.55, 0.60,
+    0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 1])
+    within group (order by c) quantiles
+    from
+    (select fv.id, vt.type, f.c
+    from fact_values fv inner join value_types vt on fv.value_type_id = vt.id
+    inner join
+    (select fact_value_id, count(*) as c
+    from facts
+    group by fact_path_id, fact_value_id
+    having count(*) > 1
+    order by c desc) as f on f.fact_value_id = fv.id
+    order by f.c) foo"
+
+   :num_unique_fact_values_over_nodes
+   "select percentile_cont(Array[0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30,
+    0.35, 0.40, 0.45, 0.50, 0.55, 0.60,
+    0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 1])
+    within group (order by c) quantiles
+    from
+    (select count(*) as c, factset_id from
+    (select factset_id, f.fact_value_id, f.fact_path_id from facts f
+    inner join (select fact_value_id, fact_path_id from facts
+    group by fact_path_id, fact_value_id having count(*) = 1) foo
+    on f.fact_value_id=foo.fact_value_id and f.fact_path_id=foo.fact_path_id) bar
+    group by factset_id) baz"
 
    :string_fact_value_bytes
    "select percentile_cont(Array[0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30,
@@ -50,7 +92,7 @@
     0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 1])
     within group (order by length) quantiles
     from
-    (select pg_column_size(value_string) as length from facts
+    (select pg_column_size(value_string) as length from fact_values
     where value_type_id = 0) foo"
 
    :structured_fact_value_bytes
@@ -59,7 +101,7 @@
     0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 1])
     within group (order by length) quantiles
     from
-    (select pg_column_size(value) as length from facts
+    (select pg_column_size(value) as length from fact_values
     where value_type_id = 5) foo"
 
    :report_metric_size_dist
@@ -82,7 +124,7 @@
 
    :fact_values_by_type
    "select vt.type, count(*)
-    from facts f inner join value_types vt on f.value_type_id = vt.id
+    from fact_values fv inner join value_types vt on fv.value_type_id = vt.id
     group by vt.type"
 
    :num_associated_factsets_over_fact_paths
@@ -140,7 +182,6 @@
   [get-shared-globals]
   (let [{:keys [scf-read-db] :as db} (get-shared-globals)]
     (jdbc/with-transacted-connection scf-read-db
-      (-> (ks/mapvals #(jdbc/query-to-vec (if (vector? %) (apply str %) %))
-                      metadata-queries)
+      (-> (ks/mapvals jdbc/query-to-vec metadata-queries)
           (assoc :version (v/version))
           http/json-response))))

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -48,11 +48,11 @@
    "resources" {:columns ["certname"]}})
 
 (def column-schema
-  "Column information: [\"value\" {:type :string :field f.value_string ...}]"
+  "Column information: [\"value\" {:type :string :field fv.value_string ...}]"
   {:type s/Keyword :field field-schema s/Any s/Any})
 
 (def projection-schema
-  "Named projection: [\"value\" {:type :string :field f.value_string ...}]"
+  "Named projection: [\"value\" {:type :string :field fv.value_string ...}]"
   [(s/one s/Str "name") (s/one column-schema "column")])
 
 (s/defrecord Query
@@ -144,59 +144,65 @@
 
 (def inventory-query
   "Query for inventory"
-  (map->Query
-   {:projections {"certname" {:type :string
-                              :queryable? true
-                              :field :certnames.certname}
-                  "timestamp" {:type :timestamp
-                               :queryable? true
-                               :field :fs.timestamp}
-                  "environment" {:type :string
-                                 :queryable? true
-                                 :field :environments.environment}
-                  "facts" {:type :json
-                           :queryable? true
-                           :field {:select [[(h/json-object-agg :name :value)
-                                             :facts]]
-                                   :from [[{:select [:fp.name  :f.value]
-                                            :from [[:facts :f]]
-                                            :join [[:fact_paths :fp]
-                                                   [:= :fp.id :f.fact_path_id]
-                                                   [:value_types :vt]
-                                                   [:= :vt.id :f.value_type_id]]
-                                            :where [:and
-                                                    [:= :fp.depth 0]
-                                                    [:= :f.factset_id :fs.id]]}
-                                           :facts_data]]}}
-                  "trusted" {:type :queryable-json
-                             :queryable? true
-                             :field  {:select [[:f.value :trusted]]
-                                      :from [[:facts :f]]
-                                      :join [[:fact_paths :fp]
-                                             [:= :fp.id :f.fact_path_id]
-                                             [:value_types :vt]
-                                             [:= :vt.id :f.value_type_id]]
-                                      :where [:and
-                                              [:= :fp.depth 0]
-                                              [:= :f.factset_id :fs.id]
-                                              [:= :fp.name (hcore/raw "'trusted'")]]}}}
+  (map->Query {:projections {"certname" {:type :string
+                                         :queryable? true
+                                         :field :certnames.certname}
+                             "timestamp" {:type :timestamp
+                                          :queryable? true
+                                          :field :fs.timestamp}
+                             "environment" {:type :string
+                                            :queryable? true
+                                            :field :environments.environment}
+                             "facts" {:type :json
+                                      :queryable? true
+                                      :field {:select [[(h/json-object-agg :name :value) :facts]]
+                                              :from [[{:select [:fp.name  :fv.value]
+                                                       :from [[:facts :f]]
+                                                       :join [[:fact_values :fv]
+                                                              [:= :fv.id :f.fact_value_id]
 
-    :selection {:from [[:factsets :fs]]
-                :left-join [:environments
-                            [:= :fs.environment_id :environments.id]
+                                                              [:fact_paths :fp]
+                                                              [:= :fp.id :f.fact_path_id]
 
-                            :producers
-                            [:= :fs.producer_id :producers.id]
+                                                              [:value_types :vt]
+                                                              [:= :vt.id :fv.value_type_id]]
+                                                       :where [:and
+                                                               [:= :fp.depth 0]
+                                                               [:= :f.factset_id :fs.id]]}
+                                                      :facts_data]]}}
+                             "trusted" {:type :queryable-json
+                                        :queryable? true
+                                        :field  {:select [[:fv.value :trusted]]
+                                                 :from [[:facts :f]]
+                                                 :join [[:fact_values :fv]
+                                                        [:= :fv.id :f.fact_value_id]
 
-                            :certnames
-                            [:= :fs.certname :certnames.certname]]}
+                                                        [:fact_paths :fp]
+                                                        [:= :fp.id :f.fact_path_id]
 
-    :alias "inventory"
-    :relationships certname-relations
+                                                        [:value_types :vt]
+                                                        [:= :vt.id :fv.value_type_id]]
+                                                 :where [:and
+                                                         [:= :fp.depth 0]
+                                                         [:= :f.factset_id :fs.id]
+                                                         [:= :fp.name (hcore/raw "'trusted'")]]}}}
 
-    :dotted-fields ["facts\\..*" "trusted\\..*"]
-    :entity :inventory
-    :subquery? false}))
+               :selection {:from [[:factsets :fs]]
+                           :left-join [:environments
+                                       [:= :fs.environment_id :environments.id]
+
+                                       :producers
+                                       [:= :fs.producer_id :producers.id]
+
+                                       :certnames
+                                       [:= :fs.certname :certnames.certname]]}
+
+              :alias "inventory"
+              :relationships certname-relations
+
+              :dotted-fields ["facts\\..*" "trusted\\..*"]
+              :entity :inventory
+              :subquery? false}))
 
 (def nodes-query
   "Query for nodes entities, mostly used currently for subqueries"
@@ -309,10 +315,14 @@
                :selection {:from [[:fact_paths :fp]]
                            :join [[:facts :f]
                                   [:= :f.fact_path_id :fp.id]
+
+                                  [:fact_values :fv]
+                                  [:= :f.fact_value_id :fv.id]
+
                                   [:value_types :vt]
-                                  [:= :f.value_type_id :vt.id]]
+                                  [:= :fv.value_type_id :vt.id]]
                            :modifiers [:distinct]
-                           :where [:!= :f.value_type_id 5]}
+                           :where [:!= :fv.value_type_id 5]}
 
                :relationships {;; Children - direct
                                "facts" {:columns ["name"]}
@@ -340,7 +350,7 @@
                                      :field :fp.path}
                              "value" {:type :multi
                                       :queryable? true
-                                      :field :f.value}
+                                      :field :fv.value}
                              "depth" {:type :integer
                                       :queryable? false
                                       :query-only? true
@@ -354,19 +364,19 @@
                              "value_integer" {:type :integer
                                               :query-only? true
                                               :queryable? false
-                                              :field :f.value_integer}
+                                              :field :fv.value_integer}
                              "value_float" {:type :float
                                             :query-only? true
                                             :queryable? false
-                                            :field :f.value_float}
+                                            :field :fv.value_float}
                              "value_string" {:type :string
                                             :query-only? true
                                             :queryable? false
-                                            :field :f.value_string}
+                                            :field :fv.value_string}
                              "value_boolean" {:type :boolean
                                               :query-only? true
                                               :queryable? false
-                                              :field :f.value_boolean}
+                                              :field :fv.value_boolean}
                              "name" {:type :string
                                      :queryable? true
                                      :field :fp.name}
@@ -378,10 +388,15 @@
                :selection {:from [[:factsets :fs]]
                            :join [[:facts :f]
                                   [:= :fs.id :f.factset_id]
+
+                                  [:fact_values :fv]
+                                  [:= :f.fact_value_id :fv.id]
+
                                   [:fact_paths :fp]
                                   [:= :f.fact_path_id :fp.id]
+
                                   [:value_types :vt]
-                                  [:= :vt.id :f.value_type_id]]
+                                  [:= :vt.id :fv.value_type_id]]
                            :left-join [[:environments :env]
                                        [:= :fs.environment_id :env.id]]
                            :where [:= :fp.depth 0]}
@@ -403,7 +418,7 @@
                                      :field :fp.path}
                              "value" {:type :multi
                                       :queryable? true
-                                      :field :f.value}
+                                      :field :fv.value}
                              "certname" {:type :string
                                          :queryable? true
                                          :field :fs.certname}
@@ -415,20 +430,20 @@
                                             :field :env.environment}
                              "value_integer" {:type :integer
                                               :queryable? false
-                                              :field :f.value_integer
+                                              :field :fv.value_integer
                                               :query-only? true}
                              "value_float" {:type :float
                                             :queryable? false
-                                            :field :f.value_float
+                                            :field :fv.value_float
                                             :query-only? true}
                              "value_string" {:type :string
                                             :query-only? true
                                             :queryable? false
-                                            :field :f.value_string}
+                                            :field :fv.value_string}
                              "value_boolean" {:type :boolean
                                               :query-only? true
                                               :queryable? false
-                                              :field :f.value_boolean}
+                                              :field :fv.value_boolean}
                              "type" {:type :string
                                      :queryable? false
                                      :field :vt.type
@@ -437,10 +452,15 @@
                :selection {:from [[:factsets :fs]]
                            :join [[:facts :f]
                                   [:= :fs.id :f.factset_id]
+
+                                  [:fact_values :fv]
+                                  [:= :f.fact_value_id :fv.id]
+
                                   [:fact_paths :fp]
                                   [:= :f.fact_path_id :fp.id]
+
                                   [:value_types :vt]
-                                  [:= :f.value_type_id :vt.id]]
+                                  [:= :fv.value_type_id :vt.id]]
                            :left-join [[:environments :env]
                                        [:= :fs.environment_id :env.id]]
                            :where [:!= :vt.id 5]}
@@ -1015,15 +1035,12 @@
                :field {:select [(h/row-to-json :facts_data)]
                        :from [[{:select [[(json-agg-row :t) :data]
                                          [(hsql-hash-as-href "factsets.certname" :factsets :facts) :href]]
-                                :from [[{:select [:fp.name (h/scast :f.value :jsonb)]
+                                :from [[{:select [:fp.name (h/scast :fv.value :jsonb)]
                                          :from [[:facts :f]]
-                                         :join [[:fact_paths :fp]
-                                                [:= :fp.id :f.fact_path_id]
-                                                [:value_types :vt]
-                                                [:= :vt.id :f.value_type_id]]
-                                         :where [:and
-                                                 [:= :depth 0]
-                                                 [:= :f.factset_id :factsets.id]]}
+                                         :join [[:fact_values :fv] [:= :fv.id :f.fact_value_id]
+                                                [:fact_paths :fp] [:= :fp.id :f.fact_path_id]
+                                                [:value_types :vt] [:= :vt.id :fv.value_type_id]]
+                                         :where [:and [:= :depth 0] [:= :f.factset_id :factsets.id]]}
                                         :t]]}
                                :facts_data]]}}
       "certname" {:type :string
@@ -1691,7 +1708,7 @@
         coalesce-fact-values (fn [col]
                                (if (and (= "facts" (:source-table query-rec))
                                         (= "value" col))
-                                 (h/coalesce :f.value_integer :f.value_float)
+                                 (h/coalesce :fv.value_integer :fv.value_float)
                                  (or (get-in query-rec [:projections col :field])
                                      col)))]
     (if-let [calls (seq
@@ -1710,13 +1727,13 @@
 (defn- fv-variant [x]
   (case x
     :integer {:type :integer
-              :field :f.value_integer}
+              :field :fv.value_integer}
     :float {:type :float
-            :field :f.value_float}
+            :field :fv.value_float}
     :string {:type :string
-             :field :f.value_string}
+             :field :fv.value_string}
     :boolean {:type :boolean
-              :field :f.value_boolean}))
+              :field :fv.value_boolean}))
 
 (defn user-node->plan-node
   "Create a query plan for `node` in the context of the given query (as `query-rec`)"
@@ -2143,24 +2160,24 @@
   isn't."
   [column :- column-schema
    projection :- projection-schema]
-  ;; For now we have to assume it's f.*, etc.
+  ;; For now we have to assume it's fv.*, etc.
   (let [[proj-name proj-info] projection
         multi-col? (= :multi (:type column))
         multi-proj? (= :multi (:type proj-info))]
     (cond
       (and multi-col? multi-proj?)
       (do
-        (assert (= (:field column) :f.value))
-        (assert (= (:field proj-info) :f.value))
+        (assert (= (:field column) :fv.value))
+        (assert (= (:field proj-info) :fv.value))
         [column projection])
       multi-col?
       (do
-        (assert (= (:field column) :f.value))
+        (assert (= (:field column) :fv.value))
         [(merge column (fv-variant (:type proj-info)))
          projection])
       multi-proj?
       (do
-        (assert (= (:field proj-info) :f.value))
+        (assert (= (:field proj-info) :fv.value))
         [column
          [proj-name (merge proj-info (fv-variant (:type column)))]])
       :else

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -11,11 +11,8 @@
   instead."
   [data]
   {:post [(string? %)]}
-  (if (string? data)
-    data
-    (-> data
-        kitchensink/sort-nested-maps
-        json/generate-string)))
+  (-> (kitchensink/sort-nested-maps data)
+      (json/generate-string)))
 
 (defn generic-identity-hash
   "Convert a data structure into a serialized format then grab a sha1 hash for

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -1,8 +1,8 @@
 (ns puppetlabs.puppetdb.scf.hash
   (:require [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.kitchensink.core :as kitchensink]
-            [puppetlabs.puppetdb.facts :refer [package-tuple hashed-package-tuple
-                                               package-tuple-hash]]
+            [puppetlabs.puppetdb.package-util :refer [package-tuple hashed-package-tuple
+                                                      package-tuple-hash]]
             [schema.core :as s]))
 
 (defn generic-identity-string

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1309,6 +1309,9 @@
       value jsonb
     );"
 
+   ;; Do this early to help with the value_hash update queries below
+   "ALTER TABLE fact_values ADD CONSTRAINT fact_values_pkey PRIMARY KEY (id);"
+
    "CREATE TABLE facts_transform (
        factset_id bigint NOT NULL,
        fact_path_id bigint NOT NULL,
@@ -1321,8 +1324,8 @@
        SELECT distinct value, value_integer, value_float, value_string, value_boolean, value_type_id FROM facts")
 
 
-  ;; Handle null fv.value separately; allowing them here
-  ;; to an intractable query plan
+  ;; Handle null fv.value separately; allowing them here leads to an intractable
+  ;; query plan
   (log/info (trs "[3/6] Reconstructing facts to refer to fact_value..."))
   (jdbc/do-commands
    "INSERT INTO facts_transform (factset_id, fact_path_id, fact_value_id)
@@ -1371,7 +1374,6 @@
    "ALTER TABLE facts_transform rename to facts"
 
    "ALTER TABLE fact_values alter column value_hash set not null"
-   "ALTER TABLE fact_values ADD CONSTRAINT fact_values_pkey PRIMARY KEY (id);"
    "ALTER TABLE fact_values ADD CONSTRAINT fact_values_value_hash_key UNIQUE (value_hash);"
    "CREATE INDEX fact_values_value_float_idx ON fact_values USING btree (value_float);"
    "CREATE INDEX fact_values_value_integer_idx ON fact_values USING btree (value_integer);")

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1343,7 +1343,7 @@
   (jdbc/call-with-query-rows
    ["select id, value::text from fact_values"]
    (fn [rows]
-     (doseq [batch (partition-all 5000 rows)]
+     (doseq [batch (partition-all 500 rows)]
        (let [ids (map :id rows)
              hashes (map #(-> (:value %)
                               json/parse

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1452,13 +1452,11 @@
     (log/info (trs "Creating additional index `fact_paths_path_trgm`"))
     (jdbc/do-commands
      "CREATE INDEX fact_paths_path_trgm ON fact_paths USING gist (path gist_trgm_ops)"))
-  (jdbc/do-commands
-   "drop index if exists fact_values_string_trgm")
-  (when-not (sutils/index-exists? "facts_value_string_trgm")
-    (log/info (trs "Creating additional index `facts_value_string_trgm`"))
+
+  (when-not (sutils/index-exists? "fact_values_string_trgm")
+    (log/info (trs "Creating additional index `fact_values_string_trgm`"))
     (jdbc/do-commands
-     ["create index facts_value_string_trgm on facts"
-      "  using gin (value_string gin_trgm_ops)"]))
+      "CREATE INDEX fact_values_string_trgm ON fact_values USING gin (value_string gin_trgm_ops)"))
 
   (when-not (sutils/index-exists? "packages_name_trgm")
     (log/info (trs "Creating additional index `packages_name_trgm`"))

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -59,7 +59,8 @@
             [clj-time.core :refer [now]]
             [puppetlabs.puppetdb.jdbc :as jdbc :refer [query-to-vec]]
             [puppetlabs.puppetdb.config :as conf]
-            [puppetlabs.i18n.core :refer [trs]]))
+            [puppetlabs.i18n.core :refer [trs]]
+            [puppetlabs.puppetdb.scf.hash :as hash]))
 
 (defn init-through-2-3-8
   []
@@ -1288,6 +1289,85 @@
     "ALTER TABLE certnames ADD COLUMN latest_report_timestamp timestamp with time zone"
     "CREATE INDEX idx_certnames_latest_report_timestamp ON certnames(latest_report_timestamp)"))
 
+(defn rededuplicate-facts []
+  (jdbc/do-commands
+   "CREATE SEQUENCE fact_values_id_seq;"
+
+   ;; will add not-null constraint on value_hash below; we don't have all the
+   ;; values for this yet
+   "CREATE TABLE fact_values (
+      id bigint DEFAULT nextval('fact_values_id_seq'::regclass) NOT NULL,
+      value_hash bytea,
+      value_type_id bigint NOT NULL,
+      value_integer bigint,
+      value_float double precision,
+      value_string text,
+      value_boolean boolean,
+      value jsonb
+    );"
+
+   "CREATE TABLE facts_transform (
+       factset_id bigint NOT NULL,
+       fact_path_id bigint NOT NULL,
+       fact_value_id bigint NOT NULL
+    );"
+
+   "INSERT INTO fact_values (value_type_id, value_integer, value_float, value_string, value_boolean, value)
+       SELECT distinct value_type_id, value_integer, value_float, value_string, value_boolean, value FROM facts"
+
+   "INSERT INTO facts_transform (factset_id, fact_path_id, fact_value_id)
+       SELECT f.factset_id, f.fact_path_id, fv.id
+         FROM facts f
+        INNER JOIN fact_values fv
+                ON fv.value_type_id = f.value_type_id
+               AND fv.value_integer IS NOT DISTINCT FROM f.value_integer
+               AND fv.value_float   IS NOT DISTINCT FROM f.value_float
+               AND fv.value_string  IS NOT DISTINCT FROM f.value_string
+               AND fv.value_boolean IS NOT DISTINCT FROM f.value_boolean
+               AND fv.value         IS NOT DISTINCT FROM f.value")
+
+  ;; populate fact_values.value_hash
+  (jdbc/call-with-query-rows
+   ["select id, value::text from fact_values"]
+   (fn [rows]
+     (doseq [{:keys [id value] :as row} rows]
+       (jdbc/update! "fact_values"
+                     {:value_hash (-> value
+                                      json/parse
+                                      hash/generic-identity-hash
+                                      sutils/munge-hash-for-storage)}
+                     ["id=?" id]))))
+
+  (jdbc/do-commands
+   "DROP TABLE facts"
+   "ALTER TABLE facts_transform rename to facts"
+
+   "ALTER TABLE fact_values alter column value_hash set not null"
+   "ALTER TABLE fact_values ADD CONSTRAINT fact_values_pkey PRIMARY KEY (id);"
+   "ALTER TABLE fact_values ADD CONSTRAINT fact_values_value_hash_key UNIQUE (value_hash);"
+   "CREATE INDEX fact_values_value_float_idx ON fact_values USING btree (value_float);"
+   "CREATE INDEX fact_values_value_integer_idx ON fact_values USING btree (value_integer);"
+
+   "ALTER TABLE facts ADD CONSTRAINT facts_factset_id_fact_path_id_fact_key UNIQUE (factset_id, fact_path_id);"
+   "CREATE INDEX facts_fact_path_id_idx ON facts USING btree (fact_path_id);"
+   "CREATE INDEX facts_fact_value_id_idx ON facts USING btree (fact_value_id);"
+
+   "ALTER TABLE facts ADD CONSTRAINT fact_path_id_fk
+      FOREIGN KEY (fact_path_id)
+      REFERENCES fact_paths(id);"
+
+   "ALTER TABLE facts ADD CONSTRAINT fact_value_id_fk
+      FOREIGN KEY (fact_value_id)
+      REFERENCES fact_values(id)
+      ON UPDATE RESTRICT
+      ON DELETE RESTRICT;"
+
+   "ALTER TABLE facts ADD CONSTRAINT factset_id_fk
+     FOREIGN KEY (factset_id)
+     REFERENCES factsets(id)
+     ON UPDATE CASCADE
+     ON DELETE CASCADE;"))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1326,7 +1406,8 @@
    58 add-gin-index-on-resource-params-cache
    59 improve-facts-factset-id-index
    60 fix-missing-edges-fk-constraint
-   61 add-latest-report-timestamp-to-certnames})
+   61 add-latest-report-timestamp-to-certnames
+   62 rededuplicate-facts})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1351,12 +1351,12 @@
    ["select id, value::text from fact_values"]
    (fn [rows]
      (doseq [batch (partition-all 500 rows)]
-       (let [ids (map :id rows)
+       (let [ids (map :id batch)
              hashes (map #(-> (:value %)
                               json/parse
                               hash/generic-identity-hash
                               sutils/munge-hash-for-storage)
-                         rows)]
+                         batch)]
          (jdbc/do-prepared
           "update fact_values set value_hash = in_data.hash
             from (select unnest(?) as id, unnest(?) as hash) in_data

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1292,6 +1292,7 @@
     "CREATE INDEX idx_certnames_latest_report_timestamp ON certnames(latest_report_timestamp)"))
 
 (defn rededuplicate-facts []
+  (log/info (trs "[1/6] Creating new fact storage tables..."))
   (jdbc/do-commands
    "CREATE SEQUENCE fact_values_id_seq;"
 
@@ -1312,13 +1313,18 @@
        factset_id bigint NOT NULL,
        fact_path_id bigint NOT NULL,
        fact_value_id bigint NOT NULL
-    );"
+    );")
 
+  (log/info (trs "[2/6] Copying unique fact values into fact_values"))
+  (jdbc/do-commands
    "INSERT INTO fact_values (value, value_integer, value_float, value_string, value_boolean, value_type_id)
-       SELECT distinct value, value_integer, value_float, value_string, value_boolean, value_type_id FROM facts"
+       SELECT distinct value, value_integer, value_float, value_string, value_boolean, value_type_id FROM facts")
 
-   ;; Handle null fv.value separately; allowing them here
-   ;; to an intractable query plan
+
+  ;; Handle null fv.value separately; allowing them here
+  ;; to an intractable query plan
+  (log/info (trs "[3/6] Reconstructing facts to refer to fact_value..."))
+  (jdbc/do-commands
    "INSERT INTO facts_transform (factset_id, fact_path_id, fact_value_id)
        SELECT f.factset_id, f.fact_path_id, fv.id
          FROM facts f
@@ -1340,6 +1346,7 @@
         WHERE f.value IS NULL AND fv.value IS NULL")
 
   ;; populate fact_values.value_hash
+  (log/info (trs "[4/6] Computing fact value hashes..."))
   (jdbc/call-with-query-rows
    ["select id, value::text from fact_values"]
    (fn [rows]
@@ -1357,6 +1364,8 @@
           [(sutils/array-to-param "bigint" Long ids)
            (sutils/array-to-param "bytea" PGobject hashes)])))))
 
+
+  (log/info (trs "[5/6] Indexing fact_values table..."))
   (jdbc/do-commands
    "DROP TABLE facts"
    "ALTER TABLE facts_transform rename to facts"
@@ -1365,8 +1374,10 @@
    "ALTER TABLE fact_values ADD CONSTRAINT fact_values_pkey PRIMARY KEY (id);"
    "ALTER TABLE fact_values ADD CONSTRAINT fact_values_value_hash_key UNIQUE (value_hash);"
    "CREATE INDEX fact_values_value_float_idx ON fact_values USING btree (value_float);"
-   "CREATE INDEX fact_values_value_integer_idx ON fact_values USING btree (value_integer);"
+   "CREATE INDEX fact_values_value_integer_idx ON fact_values USING btree (value_integer);")
 
+  (log/info (trs "[6/6] Indexing facts table..."))
+  (jdbc/do-commands
    "ALTER TABLE facts ADD CONSTRAINT facts_factset_id_fact_path_id_fact_key UNIQUE (factset_id, fact_path_id);"
    "CREATE INDEX facts_fact_path_id_idx ON facts USING btree (fact_path_id);"
    "CREATE INDEX facts_fact_value_id_idx ON facts USING btree (fact_value_id);"

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1305,7 +1305,7 @@
       value_float double precision,
       value_string text,
       value_boolean boolean,
-      value jsonb not null
+      value jsonb
     );"
 
    "CREATE TABLE facts_transform (
@@ -1317,17 +1317,27 @@
    "INSERT INTO fact_values (value, value_integer, value_float, value_string, value_boolean, value_type_id)
        SELECT distinct value, value_integer, value_float, value_string, value_boolean, value_type_id FROM facts"
 
+   ;; Handle null fv.value separately; allowing them here
+   ;; to an intractable query plan
+   "INSERT INTO facts_transform (factset_id, fact_path_id, fact_value_id)
+       SELECT f.factset_id, f.fact_path_id, fv.id
+         FROM facts f
+        INNER JOIN fact_values fv
+                ON fv.value_type_id = f.value_type_id
+               AND fv.value = f.value
+               AND fv.value_integer IS NOT DISTINCT FROM f.value_integer
+               AND fv.value_float   IS NOT DISTINCT FROM f.value_float
+               AND fv.value_string  IS NOT DISTINCT FROM f.value_string
+               AND fv.value_boolean IS NOT DISTINCT FROM f.value_boolean
+        WHERE f.value IS NOT NULL AND fv.value IS NOT NULL"
 
    "INSERT INTO facts_transform (factset_id, fact_path_id, fact_value_id)
        SELECT f.factset_id, f.fact_path_id, fv.id
          FROM facts f
         INNER JOIN fact_values fv
                 ON fv.value_type_id = f.value_type_id
-               AND fv.value_integer IS NOT DISTINCT FROM f.value_integer
-               AND fv.value_float   IS NOT DISTINCT FROM f.value_float
-               AND fv.value_string  IS NOT DISTINCT FROM f.value_string
-               AND fv.value_boolean IS NOT DISTINCT FROM f.value_boolean
-               AND fv.value         = f.value")
+               AND fv.value IS NOT DISTINCT FROM f.value
+        WHERE f.value IS NULL AND fv.value IS NULL")
 
   ;; populate fact_values.value_hash
   (jdbc/call-with-query-rows

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -692,14 +692,15 @@
           (handle-message (queue/store-command q (facts->command-req (version-kwd->num version) command)))
           (is (= (query-to-vec
                   "SELECT fp.path as name,
-                          COALESCE(f.value_string,
-                                   cast(f.value_integer as text),
-                                   cast(f.value_boolean as text),
-                                   cast(f.value_float as text),
+                          COALESCE(fv.value_string,
+                                   cast(fv.value_integer as text),
+                                   cast(fv.value_boolean as text),
+                                   cast(fv.value_float as text),
                                    '') as value,
                           fs.certname
                    FROM factsets fs
                      INNER JOIN facts as f on fs.id = f.factset_id
+                     INNER JOIN fact_values as fv on f.fact_value_id = fv.id
                      INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
                    WHERE fp.depth = 0
                    ORDER BY name ASC")
@@ -737,14 +738,15 @@
 
             (is (= (query-to-vec
                     "SELECT fp.path as name,
-                          COALESCE(f.value_string,
-                                   cast(f.value_integer as text),
-                                   cast(f.value_boolean as text),
-                                   cast(f.value_float as text),
+                          COALESCE(fv.value_string,
+                                   cast(fv.value_integer as text),
+                                   cast(fv.value_boolean as text),
+                                   cast(fv.value_float as text),
                                    '') as value,
                           fs.certname
                    FROM factsets fs
                      INNER JOIN facts as f on fs.id = f.factset_id
+                     INNER JOIN fact_values as fv on f.fact_value_id = fv.id
                      INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
                    WHERE fp.depth = 0
                    ORDER BY fp.path ASC")
@@ -774,14 +776,15 @@
                  [(with-env {:certname certname :timestamp tomorrow})]))
           (is (= (query-to-vec
                   "SELECT fp.path as name,
-                          COALESCE(f.value_string,
-                                   cast(f.value_integer as text),
-                                   cast(f.value_boolean as text),
-                                   cast(f.value_float as text),
+                          COALESCE(fv.value_string,
+                                   cast(fv.value_integer as text),
+                                   cast(fv.value_boolean as text),
+                                   cast(fv.value_float as text),
                                    '') as value,
                           fs.certname
                    FROM factsets fs
                      INNER JOIN facts as f on fs.id = f.factset_id
+                     INNER JOIN fact_values as fv on f.fact_value_id = fv.id
                      INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
                    WHERE fp.depth = 0
                    ORDER BY name ASC")
@@ -804,14 +807,15 @@
                  [{:certname certname :deactivated nil}]))
           (is (= (query-to-vec
                   "SELECT fp.path as name,
-                          COALESCE(f.value_string,
-                                   cast(f.value_integer as text),
-                                   cast(f.value_boolean as text),
-                                   cast(f.value_float as text),
+                          COALESCE(fv.value_string,
+                                   cast(fv.value_integer as text),
+                                   cast(fv.value_boolean as text),
+                                   cast(fv.value_float as text),
                                    '') as value,
                           fs.certname
                    FROM factsets fs
                      INNER JOIN facts as f on fs.id = f.factset_id
+                     INNER JOIN fact_values as fv on f.fact_value_id = fv.id
                      INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
                    WHERE fp.depth = 0
                    ORDER BY name ASC")
@@ -833,14 +837,15 @@
                  [{:certname certname :deactivated tomorrow}]))
           (is (= (query-to-vec
                   "SELECT fp.path as name,
-                          COALESCE(f.value_string,
-                                   cast(f.value_integer as text),
-                                   cast(f.value_boolean as text),
-                                   cast(f.value_float as text),
+                          COALESCE(fv.value_string,
+                                   cast(fv.value_integer as text),
+                                   cast(fv.value_boolean as text),
+                                   cast(fv.value_float as text),
                                    '') as value,
                           fs.certname
                    FROM factsets fs
                      INNER JOIN facts as f on fs.id = f.factset_id
+                     INNER JOIN fact_values as fv on f.fact_value_id = fv.id
                      INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
                    WHERE fp.depth = 0
                    ORDER BY name ASC")
@@ -870,16 +875,17 @@
 
       (is (= (query-to-vec
               "SELECT fp.path as name,
-                          COALESCE(f.value_string,
-                                   cast(f.value_integer as text),
-                                   cast(f.value_boolean as text),
-                                   cast(f.value_float as text),
+                          COALESCE(fv.value_string,
+                                   cast(fv.value_integer as text),
+                                   cast(fv.value_boolean as text),
+                                   cast(fv.value_float as text),
                                    '') as value,
                           fs.certname,
                           e.environment,
                           fs.producer_timestamp
                    FROM factsets fs
                      INNER JOIN facts as f on fs.id = f.factset_id
+                     INNER JOIN fact_values as fv on f.fact_value_id = fv.id
                      INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
                      INNER JOIN environments as e on fs.environment_id = e.id
                    WHERE fp.depth = 0
@@ -906,15 +912,16 @@
 
       (is (= (query-to-vec
               "SELECT fp.path as name,
-                          COALESCE(f.value_string,
-                                   cast(f.value_integer as text),
-                                   cast(f.value_boolean as text),
-                                   cast(f.value_float as text),
+                          COALESCE(fv.value_string,
+                                   cast(fv.value_integer as text),
+                                   cast(fv.value_boolean as text),
+                                   cast(fv.value_float as text),
                                    '') as value,
                           fs.certname,
                           e.environment
                    FROM factsets fs
                      INNER JOIN facts as f on fs.id = f.factset_id
+                     INNER JOIN fact_values as fv on f.fact_value_id = fv.id
                      INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
                      INNER JOIN environments as e on fs.environment_id = e.id
                    WHERE fp.depth = 0
@@ -1048,6 +1055,156 @@
 
             (is (true? @first-message?))
             (is (true? @second-message?))))))))
+
+(defn thread-id []
+  (.getId (Thread/currentThread)))
+
+(deftest fact-path-update-race
+  ;; Simulates two update commands being processed for two different
+  ;; machines at the same time.  Before we lifted fact paths into
+  ;; facts, the race tested here could result in a constraint
+  ;; violation when the two updates left behind an orphaned row.
+  (let [certname-1 "some_certname1"
+        certname-2 "some_certname2"
+        producer-1 "some_producer1"
+        producer-2 "some_producer2"
+        ;; facts for server 1, has the same "mytimestamp" value as the
+        ;; facts for server 2
+        facts-1a {:certname certname-1
+                  :environment nil
+                  :values {"domain" "mydomain1.com"
+                           "operatingsystem" "Debian"
+                           "mytimestamp" "1"}
+                  :producer_timestamp (-> 2 days ago)
+                  :producer producer-1}
+        facts-2a {:certname certname-2
+                  :environment nil
+                  :values {"domain" "mydomain2.com"
+                           "operatingsystem" "Debian"
+                           "mytimestamp" "1"}
+                  :producer_timestamp (-> 2 days ago)
+                  :producer producer-2}
+
+        ;; same facts as before, but now certname-1 has a different
+        ;; fact value for mytimestamp (this will force a new fact_value
+        ;; that is only used for certname-1
+        facts-1b {:certname certname-1
+                  :environment nil
+                  :values {"domain" "mydomain1.com"
+                           "operatingsystem" "Debian"
+                           "mytimestamp" "1b"}
+                  :producer_timestamp (-> 1 days ago)
+                  :producer producer-1}
+
+        ;; with this, certname-1 and certname-2 now have their own
+        ;; fact_value for mytimestamp that is different from the
+        ;; original mytimestamp that they originally shared
+        facts-2b {:certname certname-2
+                  :environment nil
+                  :values {"domain" "mydomain2.com"
+                           "operatingsystem" "Debian"
+                           "mytimestamp" "2b"}
+                  :producer_timestamp (-> 1 days ago)
+                  :producer producer-2}
+
+        ;; this fact set will disassociate mytimestamp from the facts
+        ;; associated to certname-1, it will do the same thing for
+        ;; certname-2
+        facts-1c {:certname certname-1
+                  :environment nil
+                  :values {"domain" "mydomain1.com"
+                           "operatingsystem" "Debian"}
+                  :producer_timestamp (now)
+                  :producer producer-1}
+        facts-2c {:certname certname-2
+                  :environment nil
+                  :values {"domain" "mydomain2.com"
+                           "operatingsystem" "Debian"}
+                  :producer_timestamp (now)
+                  :producer producer-2}
+
+        ;; Wait for two threads to countdown before proceeding
+        latch (java.util.concurrent.CountDownLatch. 2)
+
+        ;; I'm modifying delete-pending-path-id-orphans! so that I can
+        ;; coordinate access between the two threads, I'm storing the
+        ;; reference to the original delete-pending-path-id-orphans!
+        ;; here, so that I can delegate to it once I'm done
+        ;; coordinating
+        storage-delete-pending-path-id-orphans!
+        scf-store/delete-pending-path-id-orphans!]
+
+    (with-message-handler {:keys [handle-message dlo delay-pool q]}
+      (jdbc/with-db-transaction []
+        (scf-store/add-certname! certname-1)
+        (scf-store/add-certname! certname-2)
+        (scf-store/add-facts! {:certname certname-1
+                               :values (:values facts-1a)
+                               :timestamp (now)
+                               :environment nil
+                               :producer_timestamp (:producer_timestamp facts-1a)
+                               :producer producer-1})
+        (scf-store/add-facts! {:certname certname-2
+                               :values (:values facts-2a)
+                               :timestamp (now)
+                               :environment nil
+                               :producer_timestamp (:producer_timestamp facts-2a)
+                               :producer producer-2}))
+      ;; At this point, there will be 4 fact_value rows, 1 for
+      ;; mytimestamp, 1 for the operatingsystem, 2 for domain
+      (with-redefs [scf-store/delete-pending-path-id-orphans!
+                    (fn [& args]
+                      ;; Once this has been called, it will countdown
+                      ;; the latch and block
+                      (.countDown latch)
+                      ;; After the second command has been executed and
+                      ;; it has decremented the latch, the await will no
+                      ;; longer block and both threads will begin
+                      ;; running again
+                      (.await latch)
+                      ;; Execute the normal delete-pending-path-id-orphans!
+                      ;; function (unchanged)
+                      (apply storage-delete-pending-path-id-orphans! args))]
+        (let [first-message? (atom false)
+              second-message? (atom false)
+              fut-1 (future
+                      (handle-message (queue/store-command q (facts->command-req 4 facts-1b)))
+                      (reset! first-message? true))
+              fut-2 (future
+                      (handle-message (queue/store-command q (facts->command-req 4 facts-2b)))
+                      (reset! second-message? true))]
+          ;; The two commands are being submitted in future, ensure they
+          ;; have both completed before proceeding
+          @fut-2
+          @fut-1
+          ;; At this point there are 6 fact values, the original
+          ;; mytimestamp, the two new mytimestamps, operating system and
+          ;; the two domains
+          (is (true? @first-message?))
+          (is (true? @second-message?))
+          ;; Submit another factset that does NOT include mytimestamp,
+          ;; this disassociates certname-1's fact_value (which is 1b)
+          (handle-message (queue/store-command q (facts->command-req 4 facts-1c)))
+          (reset! first-message? true)
+
+          ;; Do the same thing with certname-2. Since the reference to 1b
+          ;; and 2b has been removed, mytimestamp's path is no longer
+          ;; connected to any fact values. The original mytimestamp value
+          ;; of 1 is still in the table. It's now attempting to delete
+          ;; that fact path, when the mytimestamp 1 value is still in
+          ;; there.
+          (handle-message (queue/store-command q (facts->command-req 4 facts-2c)))
+          (is (= 0 (task-count delay-pool)))
+
+          ;; Can we see the orphaned value '1', and does the global gc remove it.
+          (is (= 1 (count
+                    (query-to-vec
+                     "select id from fact_values where value_string = '1'"))))
+          (scf-store/garbage-collect! *db*)
+          (is (zero?
+               (count
+                (query-to-vec
+                 "select id from fact_values where value_string = '1'")))))))))
 
 (deftest concurrent-catalog-updates
   (testing "Should allow only one replace catalogs update for a given cert at a time"

--- a/test/puppetlabs/puppetdb/scf/hash_test.clj
+++ b/test/puppetlabs/puppetdb/scf/hash_test.clj
@@ -12,8 +12,7 @@
             [clojure.test.check.clojure-test :as cct]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
-            [puppetlabs.puppetdb.generative.generators :refer [string+]]
-            [puppetlabs.kitchensink.core :as kitchensink]))
+            [puppetlabs.puppetdb.generative.generators :refer [string+]]))
 
 (deftest hash-computation
   (testing "generic-identity-*"
@@ -41,13 +40,7 @@
         (testing "generic-identity-hash"
           (let [output (generic-identity-hash ["Type" "title" {:foo input}])]
             (is (= output
-                   "c62dab030cfe8c25a4832c5c6302b7f0041264ba"))))))
-
-    (testing "Should hash the string directly (not round-trip through JSON)"
-      (is (= "foo"
-             (generic-identity-string "foo")))
-      (is (= (generic-identity-hash "foo")
-             (kitchensink/utf8-string->sha1 "foo")))))
+                   "c62dab030cfe8c25a4832c5c6302b7f0041264ba")))))))
 
   (testing "resource-identity-hash"
     (testing "should error on bad input"

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -904,4 +904,55 @@
                                    :same nil}]}
                schema-diff))))))
 
+(deftest migration-62-rededuplicate-facts
+  (jdbc/with-db-connection *db*
+    (clear-db-for-testing!)
+    (fast-forward-to-migration! 61)
 
+    (jdbc/insert! :environments {:id 0 :environment "testing"})
+
+    (jdbc/insert! :certnames {:certname "a.com"})
+    (jdbc/insert! :certnames {:certname "b.com"})
+
+    (jdbc/insert! :factsets {:id 0
+                             :certname "a.com"
+                             :timestamp (to-timestamp (now))
+                             :producer_timestamp (to-timestamp (now))
+                             :environment_id 0
+                             :hash (sutils/munge-hash-for-storage "abcd1234")})
+
+    (jdbc/insert! :factsets {:id 1
+                             :certname "b.com"
+                             :timestamp (to-timestamp (now))
+                             :producer_timestamp (to-timestamp (now))
+                             :environment_id 0
+                             :hash (sutils/munge-hash-for-storage "1234abcd")})
+
+    (doseq [[id name] [[0 "string_fact"]
+                       [1 "int_fact"]
+                       [2 "float_fact"]
+                       [3 "bool_fact"]
+                       [4 "null_fact"]
+                       [5 "json_fact"]]]
+      (jdbc/insert! :fact_paths {:id id :depth 0 :name name :path name}))
+
+    (doseq [[fact-path-id value-type-id value_key value]
+            [[0 0 :value_string "string_value"]
+             [1 1 :value_integer 42]
+             [2 2 :value_float 4.2]
+             [3 3 :value_boolean false]
+             [4 4 :value_null nil]
+             [5 5 :value_json {:foo "bar"}]]
+            factset-id [0 1]]
+      (let [row {:factset_id factset-id
+                 :fact_path_id fact-path-id
+                 :value_type_id value-type-id
+                 :value (sutils/munge-jsonb-for-storage value)}]
+        (jdbc/insert! :facts (case value_key
+                               (:value_null :value_json) row
+                               (assoc row value_key value)))))
+
+    (apply-migration-for-testing! 62)
+
+    (is (= 6 (:count (first (jdbc/query-to-vec "select count(*) from fact_values")))))
+    (is (= 12 (:count (first (jdbc/query-to-vec "select count(*) from facts")))))))

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -852,8 +852,8 @@
   (indexes! (:database *db*))
   (let [idxs (:indexes (schema-info-map *db*))]
     (is (= {:schema "public"
-            :table "facts"
-            :index "facts_value_string_trgm"
+            :table "fact_values"
+            :index "fact_values_string_trgm"
             :index_keys ["value_string"]
             :type "gin"
             :unique? false
@@ -861,7 +861,7 @@
             :is_partial false
             :primary? false
             :user "pdb_test"}
-           (get idxs ["facts" ["value_string"]])))))
+           (get idxs ["fact_values" ["value_string"]])))))
 
 (deftest migration-60-fix-missing-edges-fk-constraint
   (jdbc/with-db-connection *db*

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -23,7 +23,6 @@
             [puppetlabs.puppetdb.testutils.reports :refer :all]
             [puppetlabs.puppetdb.testutils.events :refer :all]
             [puppetlabs.puppetdb.random :as random]
-            [puppetlabs.puppetdb.scf.hash :as hash]
             [puppetlabs.puppetdb.scf.storage :refer :all]
             [clojure.test :refer :all]
             [clojure.math.combinatorics :refer [combinations subsets]]
@@ -449,64 +448,6 @@
           (is (= 7 (:c (first
                         (query-to-vec
                          "select count(id) as c from fact_paths"))))))))))
-
-(deftest large-value-hash
-  (let [facts-now (fn [c v]
-                    {:certname c :values v
-                     :environment nil
-                     :timestamp (now)
-                     :producer_timestamp (now)
-                     :producer nil})
-        hex-hash-for (fn [x]
-                       (-> x
-                           hash/generic-identity-hash
-                           sutils/munge-hash-for-storage
-                           sutils/parse-db-hash))
-        bytes->hex (fn [x]
-                     (apply str (map #(format "%02x" %) x)))
-        db-items (fn [col]
-                   (->> (format (str "select path, %s, large_value_hash"
-                                     "  from facts"
-                                     "  inner join fact_paths on id = fact_path_id")
-                                (name col))
-                        query-to-vec
-                        (map (fn [row]
-                               (update row :large_value_hash bytes->hex)))))
-        by-path #(compare (:path %1) (:path %2))
-        threshold facts/large-value-threshold
-        large-str (apply str (repeat (* 2 threshold) \x))
-        large-str-hex (hex-hash-for large-str)]
-
-    (is (> threshold 20))
-
-    (testing "strings have a suitable large_value_hash when expected"
-      (with-test-db
-        (add-certname! "somehost")
-        (add-facts! (facts-now "somehost" {"small" "x" "large" large-str}))
-        (is (= [{:path "large"
-                 :value_string large-str
-                 :large_value_hash large-str-hex}
-                {:path "small"
-                 :value_string "x"
-                 :large_value_hash ""}]
-               (sort by-path (db-items :value_string))))))
-
-    (testing "structured values have a suitable large_value_hash when expected"
-      (with-test-db
-        (let [large-val [large-str]
-              large-val-hex (hex-hash-for large-val)]
-          (add-certname! "somehost")
-          (add-facts! (facts-now "somehost" {"small" ["x"] "large" large-val}))
-          (is (= [{:path "large"
-                   :value large-val
-                   :large_value_hash large-val-hex}
-                  {:path "large#~0"
-                   :value large-str
-                   :large_value_hash large-str-hex}
-                  {:path "small" :value ["x"] :large_value_hash ""}
-                  {:path "small#~0" :value "x" :large_value_hash ""}]
-                 (sort by-path (map #(update % :value sutils/parse-db-json)
-                                    (db-items :value))))))))))
 
 (defn package-seq
   "Return all facts and their values for a given certname as a map"

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -1,12 +1,11 @@
 (ns puppetlabs.puppetdb.scf.storage-test
   (:require [clojure.java.jdbc :as sql]
             [clojure.set :as set]
-            [puppetlabs.i18n.core :refer [trs]]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.reports :as report]
             [puppetlabs.puppetdb.scf.hash :as shash]
             [puppetlabs.puppetdb.facts :as facts
-             :refer [path->pathmap string-to-factpath]]
+             :refer [path->pathmap string-to-factpath value->valuemap]]
             [puppetlabs.puppetdb.schema :as pls :refer [defn-validated]]
             [puppetlabs.puppetdb.scf.migrate :as migrate]
             [clojure.walk :as walk]
@@ -75,16 +74,14 @@
     certname]
    {:as-arrays? true}
    (fn [[col-names & rows]]
-     (into {} (for [[path type-id v vstr vint vfloat vbool] rows]
-                (condp = type-id
-                  db-fv-string [path vstr]
-                  db-fv-int [path vint]
-                  db-fv-float [path vfloat]
-                  db-fv-bool [path vbool]
-                  db-fv-struct [path (sutils/parse-db-json v)]
-                  db-fv-nil [path (sutils/parse-db-json v)]
-                  (throw (Exception. (trs "Unexpected value type {0}"
-                                          type-id)))))))))
+     (doall
+      (into {} (for [[path type-id v vstr vint vfloat vbool] rows]
+                 (case type-id
+                   0 [path vstr]
+                   1 [path vint]
+                   2 [path vfloat]
+                   3 [path vbool]
+                   (4 5) [path (sutils/parse-db-json v)])))))))
 
 (deftest-db large-fact-update
   (testing "updating lots of facts"
@@ -146,59 +143,6 @@
                               (map :name)
                               set)]
         (is (= stored-names (set (keys facts))))))))
-
-(deftest basic-compare-fv-to-row-behavior
-  (let [changes compare-fv-to-row
-        value-row (fn [x hash]
-                    (let [type-id (fact-value-type-id x)]
-                      [type-id
-                       hash
-                       (sutils/munge-jsonb-for-storage x)
-                       (when (= type-id db-fv-string) x)
-                       (when (= type-id db-fv-int) x)
-                       (when (= type-id db-fv-float) x)
-                       (when (= type-id db-fv-bool) x)]))]
-
-    (are [x y] (= {:changed? false} (apply changes x (value-row y nil)))
-         "x" "x"
-         0 0
-         1.1 1.1
-         true true
-         false false
-         [0] [0]
-         {:x "y"} {:x "y"})
-
-    (are [x y] (= {:changed? true} (apply changes x (value-row y nil)))
-         "x" 0
-         "x" "y"
-         0 "x"
-         0 1
-         1.1 "x"
-         1.1 2.2
-         true "x"
-         true false
-         [0] "x"
-         [0] []
-         [0] [1]
-         [0] [0 1]
-         {:x "y"} "x"
-         {:x "y"} {}
-         {:x "y"} {"a" "b"}
-         {:x "y"} {:a "b" :c "d"})
-
-    (let [old (apply str (repeat (inc facts/large-value-threshold) \x))
-          new (apply str (repeat (inc facts/large-value-threshold) \y))
-          old-hash (storage-hash old)
-          new-hash (storage-hash new)]
-      (is (= {:changed? true :hash new-hash}
-             (apply changes new (value-row old old-hash)))))
-
-    (let [old (into {} (for [i (range facts/large-value-threshold)] [i 0]))
-          new (into {} (for [i (range facts/large-value-threshold)] [i 1]))
-          old-hash (storage-hash old)
-          new-hash (storage-hash new)]
-      (is (= {:changed? true :hash new-hash}
-             (apply changes new (value-row old old-hash)))))))
 
 (deftest-db fact-persistence
   (testing "Persisted facts"
@@ -345,34 +289,7 @@
                            :timestamp (now)
                            :producer producer})
           (let [{new-hash :hash} (first (query-to-vec (format "SELECT %s AS hash FROM factsets where certname=?" (sutils/sql-hash-as-str "hash")) certname))]
-            (is (not= old-hash new-hash)))))
-
-      (testing "update facts with one of each type"
-        (let [old-facts {:certname certname
-                         :values {"string" "foo"
-                                  "integer" 1
-                                  "float" 11.1
-                                  "boolean" true
-                                  "structured" [0 1]}
-                         :environment "DEV"
-                         :producer_timestamp (now)
-                         :timestamp (now)
-                         :producer producer}
-              new-facts {:certname certname
-                         :values {"string" "bar"
-                                  "integer" 2
-                                  "float" 11.2
-                                  "boolean" false
-                                  "structured" {"x" "y"}}
-                         :environment "DEV"
-                         :producer_timestamp (now)
-                         :timestamp (now)
-                         :producer producer}]
-          (replace-facts! old-facts)
-          (replace-facts! new-facts)
-          (let [expected (assoc (:values new-facts) "structured" {:x "y"})
-                observed (factset-map certname)]
-            (is (= expected observed))))))))
+            (is (not= old-hash new-hash))))))))
 
 (deftest-db fact-persistance-with-environment
   (testing "Persisted facts"

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -140,11 +140,7 @@
                  "fqdn" "myhost.mydomain.com"
                  "hostname" "myhost"
                  "kernel" "Linux"
-                 "operatingsystem" "Debian"
-                 "excitement?" true
-                 "version" 1
-                 "temperature" 273.16
-                 "binary" [0 1]}
+                 "operatingsystem" "Debian"}
           producer "bar.com"]
       (add-certname! certname)
 

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -55,43 +55,33 @@
     (testing "creates new row for non-existing producer"
       (is (= 2 (ensure-producer prod2))))))
 
-(defn factset-map
-  "Returns a map of fact names to values for certname."
-  [certname]
-  (jdbc/call-with-query-rows
-   [(str "select fp.path,"
-         "       f.value_type_id,"
-         "       f.value,"
-         "       f.value_string,"
-         "       f.value_integer,"
-         "       f.value_float,"
-         "       f.value_boolean"
-         "  from factsets fs"
-         "  inner join facts as f on fs.id = f.factset_id"
-         "  inner join fact_paths as fp on f.fact_path_id = fp.id"
-         "  where fp.depth = 0 and fs.certname = ?")
-    certname]
-   {:as-arrays? true}
-   (fn [[col-names & rows]]
-     (doall
-      (into {} (for [[path type-id v vstr vint vfloat vbool] rows]
-                 (case type-id
-                   0 [path vstr]
-                   1 [path vint]
-                   2 [path vfloat]
-                   3 [path vbool]
-                   (4 5) [path (sutils/parse-db-json v)])))))))
+(defn-validated factset-map :- {s/Str s/Str}
+  "Return all facts and their values for a given certname as a map"
+  [certname :- String]
+  (let [result (jdbc/query
+                ["SELECT fp.path as name,
+                    COALESCE(fv.value_string,
+                             cast(fv.value_integer as text),
+                             cast(fv.value_boolean as text),
+                             cast(fv.value_float as text),
+                             '') as value
+                    FROM factsets fs
+                    INNER JOIN facts as f on fs.id = f.factset_id
+                    INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
+                    INNER JOIN fact_values as fv on f.fact_value_id = fv.id
+                    WHERE fp.depth = 0 AND fs.certname = ?"
+                 certname])]
+    (zipmap (map :name result)
+            (map :value result))))
 
 (deftest-db large-fact-update
   (testing "updating lots of facts"
     (let [certname "scale.com"
-          n1 10000
-          n2 11000
-          facts1 (zipmap (take n1 (repeatedly #(random/random-string 10)))
-                         (take n1 (repeatedly #(random/random-string 10))))
+          facts1 (zipmap (take 10000 (repeatedly #(random/random-string 10)))
+                         (take 10000 (repeatedly #(random/random-string 10))))
           timestamp1 (-> 2 days ago)
-          facts2 (zipmap (take n2 (repeatedly #(random/random-string 10)))
-                         (take n2 (repeatedly #(random/random-string 10))))
+          facts2 (zipmap (take 11000 (repeatedly #(random/random-string 10)))
+                         (take 11000 (repeatedly #(random/random-string 10))))
           timestamp2 (-> 1 days ago)
           producer "bar.com"]
       (add-certname! certname)
@@ -102,9 +92,9 @@
                    :producer_timestamp timestamp1
                    :producer producer})
 
-      (testing (str n1 " facts stored")
-        (is (= n1
-               (->> (query-to-vec "SELECT count(*) as c from facts")
+      (testing "10000 facts stored"
+        (is (= 10000
+               (->> (query-to-vec "SELECT count(*) as c from fact_values")
                     first
                     :c))))
 
@@ -115,9 +105,9 @@
                       :producer_timestamp timestamp2
                       :producer producer})
 
-      (testing (str n2 " facts stored")
-        (is (= n2
-               (->> (query-to-vec "SELECT count(*) as c from facts")
+      (testing "11000 facts stored"
+        (is (= 11000
+               (->> (query-to-vec "SELECT count(*) as c from fact_values")
                     first
                     :c)))))))
 
@@ -169,6 +159,26 @@
                    :environment nil
                    :producer_timestamp previous-time
                    :producer producer})
+      (testing "should have entries for each fact"
+        (is (= (query-to-vec
+                "SELECT fp.path as name,
+                        COALESCE(fv.value_string,
+                                 cast(fv.value_integer as text),
+                                 cast(fv.value_boolean as text),
+                                 cast(fv.value_float as text),
+                                 '') as value,
+                        fs.certname
+                 FROM factsets fs
+                   INNER JOIN facts as f on fs.id = f.factset_id
+                   INNER JOIN fact_values as fv on f.fact_value_id = fv.id
+                   INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
+                 WHERE fp.depth = 0
+                 ORDER BY name")
+               [{:certname certname :name "domain" :value "mydomain.com"}
+                {:certname certname :name "fqdn" :value "myhost.mydomain.com"}
+                {:certname certname :name "hostname" :value "myhost"}
+                {:certname certname :name "kernel" :value "Linux"}
+                {:certname certname :name "operatingsystem" :value "Debian"}])))
 
       (testing "should have entries for each fact"
         (is (= facts (factset-map certname)))
@@ -200,7 +210,24 @@
                              :timestamp reference-time
                              :producer producer})
             (testing "should have only the new facts"
-              (is (= new-facts (factset-map certname))))
+              (is (= (query-to-vec
+                      "SELECT fp.path as name,
+                              COALESCE(fv.value_string,
+                                       cast(fv.value_integer as text),
+                                       cast(fv.value_boolean as text),
+                                       cast(fv.value_float as text),
+                                       '') as value
+                       FROM factsets fs
+                         INNER JOIN facts as f on fs.id = f.factset_id
+                         INNER JOIN fact_values as fv on f.fact_value_id = fv.id
+                         INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
+                       WHERE fp.depth = 0
+                       ORDER BY name")
+                     [{:name "domain" :value "mynewdomain.com"}
+                      {:name "fqdn" :value "myhost.mynewdomain.com"}
+                      {:name "hostname" :value "myhost"}
+                      {:name "kernel" :value "Linux"}
+                      {:name "uptime_seconds" :value "3600"}])))
             (testing "producer_timestamp should store current time"
               (is (= (query-to-vec "SELECT producer_timestamp FROM factsets")
                      [{:producer_timestamp (to-timestamp reference-time)}])))
@@ -319,13 +346,14 @@
                (into {} (map (juxt :name :value)
                              (query-to-vec
                               "SELECT fp.path as name,
-                                      COALESCE(f.value_string,
-                                               cast(f.value_integer as text),
-                                               cast(f.value_boolean as text),
-                                               cast(f.value_float as text),
+                                      COALESCE(fv.value_string,
+                                               cast(fv.value_integer as text),
+                                               cast(fv.value_boolean as text),
+                                               cast(fv.value_float as text),
                                                '') as value
                                FROM factsets fs
                                  INNER JOIN facts as f on fs.id = f.factset_id
+                                 INNER JOIN fact_values as fv on f.fact_value_id = fv.id
                                  INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
                                WHERE fp.depth = 0
                                ORDER BY name")))))
@@ -349,13 +377,14 @@
                (into {} (map (juxt :name :value)
                              (query-to-vec
                               "SELECT fp.path as name,
-                                      COALESCE(f.value_string,
-                                               cast(f.value_integer as text),
-                                               cast(f.value_boolean as text),
-                                               cast(f.value_float as text),
+                                      COALESCE(fv.value_string,
+                                               cast(fv.value_integer as text),
+                                               cast(fv.value_boolean as text),
+                                               cast(fv.value_float as text),
                                                '') as value
                                FROM factsets fs
                                  INNER JOIN facts as f on fs.id = f.factset_id
+                                 INNER JOIN fact_values as fv on f.fact_value_id = fv.id
                                  INNER JOIN fact_paths as fp on f.fact_path_id = fp.id
                                WHERE fp.depth = 0
                                ORDER BY name")))))
@@ -364,7 +393,7 @@
                  :environment_id (environment-id "DEV")}]
                (query-to-vec "SELECT certname, environment_id FROM factsets")))))))
 
-(deftest fact-path-gc
+(deftest fact-path-value-gc
   (letfn [(facts-now [c v]
             {:certname c :values v
              :environment nil :timestamp (now) :producer_timestamp (now) :producer nil})
@@ -376,17 +405,17 @@
           (db-vals []
             (set (mapv :value (query-to-vec
                                ;; Note: currently can't distinguish 10 from "10".
-                               "SELECT COALESCE(f.value_string,
-                                                cast(f.value_integer as text),
-                                                cast(f.value_boolean as text),
-                                                cast(f.value_float as text),
+                               "SELECT COALESCE(fv.value_string,
+                                                cast(fv.value_integer as text),
+                                                cast(fv.value_boolean as text),
+                                                cast(fv.value_float as text),
                                                 '') as value
-                                  FROM facts f"))))]
+                                  FROM fact_values fv"))))]
     (testing "during add/replace (generally)"
       (with-test-db
         ;; Keep resetting the db facts to match the current state of
         ;; @fact-x and @facts-y, and then verify that fact_paths always
-        ;; contains exactly the set of keys across both, and facts
+        ;; contains exactly the set of keys across both, and fact_values
         ;; contains exactly the set of values across both.
         (let [facts-x (atom  {"a" "1" "b" "2" "c" "3"})
               facts-y (atom  {})]
@@ -416,7 +445,6 @@
           (is (= (db-vals) (values @facts-x @facts-y)))
           ;; CLEAR ALL THE FACTS!?
           (replace-facts! (facts-now "c-y" {})))))
-
     (testing "during replace, when value is only referred to by the same factset"
       (with-test-db
         (let [facts {"a" "1" "b" "1"}]
@@ -447,7 +475,30 @@
           (delete-orphaned-paths! 3)
           (is (= 7 (:c (first
                         (query-to-vec
-                         "select count(id) as c from fact_paths"))))))))))
+                         "select count(id) as c from fact_paths"))))))))
+    (testing "values - globally, incrementally"
+      (with-test-db
+        (jdbc/insert! :fact_values
+                      (update-in (value->valuemap "foo")
+                                 [:value_hash] sutils/munge-hash-for-storage))
+        (delete-orphaned-values! 0)
+        (is (= (db-vals) #{"foo"}))
+        (delete-orphaned-values! 1)
+        (is (empty? (db-vals)))
+        (jdbc/insert! :fact_values
+                      (update-in (value->valuemap "foo")
+                                 [:value_hash] sutils/munge-hash-for-storage))
+        (delete-orphaned-values! 11)
+        (is (empty? (db-vals)))
+        (jdbc/insert-multi!
+               :fact_values
+               (for [x (range 10)] (update-in (value->valuemap (str "foo-" x))
+                                              [:value_hash]
+                                              sutils/munge-hash-for-storage)))
+        (delete-orphaned-values! 3)
+        (is (= 7 (:c (first
+                      (query-to-vec
+                       "select count(id) as c from fact_values")))))))))
 
 (defn package-seq
   "Return all facts and their values for a given certname as a map"
@@ -887,9 +938,13 @@
                  :environment "ENV3"
                  :producer_timestamp (-> 2 days ago)
                  :producer "bar.com"}))
-  (let [factset-id (:id (first (query-to-vec ["SELECT id from factsets"])))]
+  (let [factset-id (:id (first (query-to-vec ["SELECT id from factsets"])))
+        fact-value-ids (set (map :id (query-to-vec ["SELECT id from fact_values"])))]
+
+    (is (= (:c (first (query-to-vec ["SELECT count(id) as c FROM fact_values"]))) 7))
     (is (= (:c (first (query-to-vec ["SELECT count(id) as c FROM fact_paths"]))) 7))
     (delete-certname-facts! certname)
+    (is (= (:c (first (query-to-vec ["SELECT count(id) as c FROM fact_values"]))) 0))
     (is (= (:c (first (query-to-vec ["SELECT count(id) as c FROM fact_paths"]))) 0))))
 
 (deftest-db catalog-bad-input

--- a/test/puppetlabs/puppetdb/scf/storage_utils_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_utils_test.clj
@@ -37,10 +37,10 @@
 
 (deftest test-index-exists?
   (with-test-db
-    (testing "test to see if an index doesn't exist"
+    (testing "test to see if an index doesn't exists"
       (is (false? (index-exists? "somerandomname"))))
     (testing "test to see if an index does exist"
-      (jdbc/do-commands "CREATE INDEX foobar ON facts(value_float)")
+      (jdbc/do-commands "CREATE INDEX foobar ON fact_values(value_float)")
       (is (true? (index-exists? "foobar"))))))
 
 (deftest dotted-query-to-path


### PR DESCRIPTION
Previously, we had changed fact storage to put the value in the facts table, in
order to simplify storage and sidestep the problematic garbage collection issues
when fact values had their own table. But this proved to make queries too slow,
especially when dealing with queries which have multiple conditions on facts.