### PR TITLE
(maint) Documentation markup fix

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -619,7 +619,7 @@ This sets the time (in minutes) for a connection to remain idle before sending a
 
 If not supplied, the default setting is 45 minutes.
 
-###`statements-cache-size`
+### `statements-cache-size`
 
 **Note**: This setting is deprecated and ignored by PuppetDB. It will be removed
 from PuppetDB in a future release.


### PR DESCRIPTION
This fix a rendering problem caused by the missing space:
https://docs.puppet.com/puppetdb/latest/configure.html#conn-keep-alive-1