### PR TITLE
(PDB-3620) Use string 'alias' metaparameters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 puppet_branch = ENV['PUPPET_VERSION'] || "master"
-#oldest_supported_puppet = "5.0.0"
+oldest_supported_puppet = "5.0.0"
 beaker_version = ENV['BEAKER_VERSION']
 
 def location_for(place, fake_version = nil)
@@ -35,19 +35,15 @@ group :test do
   # docker-api 1.32.0 requires ruby 2.0.0
   gem 'docker-api', '1.31.0'
 
-  # case puppet_branch
-  # when "latest"
-  #   gem 'puppet', ">= #{oldest_supported_puppet}", :require => false
-  # when "oldest"
-  #   gem 'puppet', oldest_supported_puppet, :require => false
-  # else
-  #   gem 'puppet', :git => 'https://github.com/puppetlabs/puppet.git',
-  #     :branch => puppet_branch, :require => false
-  # end
-
-  # PDB 5 requires Puppet 5, which is not yet released, so always get it from git for now
-  gem 'puppet', :git => 'https://github.com/puppetlabs/puppet.git',
+  case puppet_branch
+  when "latest"
+    gem 'puppet', ">= #{oldest_supported_puppet}", :require => false
+  when "oldest"
+    gem 'puppet', oldest_supported_puppet, :require => false
+  else
+    gem 'puppet', :git => 'https://github.com/puppetlabs/puppet.git',
       :branch => puppet_branch, :require => false
+  end
 
   gem 'mocha', '~> 1.0'
 end

--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -238,6 +238,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
         # is both an optimization and a safeguard.
         next if real_resource.key_attributes.count > 1
 
+        # Symbol is correct in this context
         aliases = [real_resource[:alias]].flatten.compact
 
         # Non-isomorphic resources aren't unique based on namevar, so we can't
@@ -259,7 +260,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
           end
         end
 
-        resource['parameters'][:alias] = aliases unless aliases.empty?
+        resource['parameters']['alias'] = aliases unless aliases.empty?
       end
     end
 
@@ -306,7 +307,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
     profile("Map aliases to title (resource count: #{resources.count})",
             [:puppetdb, :aliases, :map_to_title]) do
       resources.each do |resource|
-        names = Array(resource['parameters'][:alias]) || []
+        names = Array(resource['parameters']['alias']) || []
         resource_hash = {'type' => resource['type'], 'title' => resource['title']}
         names.each do |name|
           alias_array = [resource['type'], name]

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -162,7 +162,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         end
 
         resource.should_not be_nil
-        resource['parameters'][:alias].should include(name)
+        resource['parameters']['alias'].should include(name)
       end
 
       context "with resource types that provide #title_patterns" do
@@ -203,8 +203,8 @@ describe Puppet::Resource::Catalog::Puppetdb do
             #  this test should cover other resource types that fall into
             #  this category as well.
             resource.should_not be_nil
-            resource['parameters'][:alias].should_not be_nil
-            resource['parameters'][:alias].should include('/tmp/foo')
+            resource['parameters']['alias'].should_not be_nil
+            resource['parameters']['alias'].should include('/tmp/foo')
           end
         end
       end
@@ -218,7 +218,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
         end
 
         resource.should_not be_nil
-        resource['parameters'][:alias].should be_nil
+        resource['parameters']['alias'].should be_nil
       end
 
       describe "for resources with composite namevars" do
@@ -237,7 +237,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
           end
 
           resource.should_not be_nil
-          resource['parameters'][:alias].should be_nil
+          resource['parameters']['alias'].should be_nil
         end
       end
 
@@ -255,7 +255,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
           end
 
           resource.should_not be_nil
-          resource['parameters'][:alias].should == ['something awesome']
+          resource['parameters']['alias'].should == ['something awesome']
         end
       end
     end
@@ -565,6 +565,26 @@ describe Puppet::Resource::Catalog::Puppetdb do
 
         edge = {'source' => {'type' => 'Notify', 'title' => 'noone'},
                 'target' => {'type' => 'Notify', 'title' => 'anyone'},
+                'relationship' => 'required-by'}
+
+        result['edges'].should include(edge)
+      end
+
+      it "should produce an edge when referencing an aliased resource that supports composite namevars" do
+        Puppet[:code] = <<-MANIFEST
+        package { 'foo':
+          ensure => present,
+          alias => 'bar'
+        }
+        notify { 'hello':
+          require => Package['bar']
+        }
+        MANIFEST
+
+        result = subject.munge_catalog(catalog, Time.now.utc)
+
+        edge = {'source' => {'type' => 'Package', 'title' => 'foo'},
+                'target' => {'type' => 'Notify', 'title' => 'hello'},
                 'relationship' => 'required-by'}
 
         result['edges'].should include(edge)


### PR DESCRIPTION
In Puppet 5, Catalog#to_data_hash will only emit data types that are
safe for JSON, YAML, etc, and in particular will never emit Symbols.

When synthesizing an edge from any resource to an aliased resource:

    require => Package['my_alias']

puppetdb would fail to find the target resource in the catalog. And that
was because it was looking for the `:alias` parameter in the catalog
hash, which didn't exist.

This commit updates the add_namevar_alias and map_aliases_to_titles to
use the String form of 'alias'. It adds a unit test demonstrating the
problem, and updates other tests that relied on the previous symbol
behavior.

Note the terminus behaves different if the resource specifying the
`alias` metaparam has multiple namevars (eg Package) or not.