### PR TITLE
(maint) Install apt-transport-https in acceptance test

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -383,6 +383,16 @@ module PuppetDBExtensions
     CGI.escape(Time.rfc2822(result.stdout).iso8601)
   end
 
+  def enable_https_apt_sources(host)
+    manifest = <<-EOS
+      if ($facts['osfamily'] == 'Debian']) {
+        package { 'apt-transport-https': ensure => installed }
+      }
+    EOS
+
+    apply_manifest_on(host, manifest)
+  end
+
   def postgres_manifest
     manifest = <<-EOS
       # get the pg server up and running

--- a/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
+++ b/acceptance/setup/pre_suite/90_install_devel_puppetdb.rb
@@ -7,6 +7,7 @@ step "Install development build of PuppetDB on the PuppetDB server" do
       Log.notify("Install puppetdb from source")
       Log.error database
 
+      enable_https_apt_sources(database)
       install_postgres(database)
       install_puppetdb_via_rake(database)
       start_puppetdb(database)


### PR DESCRIPTION
This seems to be required for jessie, when install postgres packages from pgdg.