### PR TITLE
(maint) Update EZBake to 1.5.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -174,7 +174,7 @@
                                                [puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl nil]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "1.4.0"]]}
+                      :plugins [[puppetlabs/lein-ezbake "1.5.1"]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}
              :test {:jvm-opts ~(if need-permgen?


### PR DESCRIPTION
This version of EZBake stores the build metadata (including the deployed
snapshot version and fully-resolved versions of all snapshot
dependencies) in a persistent location, rather than one that gets
deleted after two weeks.