### PR TITLE
(PDB-3643) Fix fact dedupe migration with null values

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1309,6 +1309,9 @@
    "create index reports_job_id_idx on reports(job_id) where job_id is not null"
    "create index catalogs_job_id_idx on catalogs(job_id) where job_id is not null"))
 
+(defn maybe-parse-json [s]
+  (some-> s json/parse))
+
 (defn rededuplicate-facts []
   (log/info (trs "[1/7] Cleaning up unreferenced facts..."))
   (jdbc/do-commands
@@ -1378,7 +1381,7 @@
      (doseq [batch (partition-all 500 rows)]
        (let [ids (map :id batch)
              hashes (map #(-> (:value %)
-                              json/parse
+                              maybe-parse-json
                               hash/generic-identity-hash
                               sutils/munge-hash-for-storage)
                          batch)]

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -948,7 +948,10 @@
       (let [row {:factset_id factset-id
                  :fact_path_id fact-path-id
                  :value_type_id value-type-id
-                 :value (sutils/munge-jsonb-for-storage value)}]
+                 ;; reduplicated facts code stored sql NULL for nil values in
+                 ;; this column, not json null
+                 :value (some-> value sutils/munge-jsonb-for-storage)}]
+
         (jdbc/insert! :facts (case value_key
                                (:value_null :value_json) row
                                (assoc row value_key value)))))


### PR DESCRIPTION
In the flat fact storage code, null fact values were stored as sql null instead
of json null. Update the migration code to account for this.