### PR TITLE
(PDB-3058) Disallow null bytes from resource event fields

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1337,13 +1337,21 @@
     (dissoc row-map :environment_id)
     row-map))
 
+(defn replace-null-bytes [x]
+  (if-not (string? x)
+    x
+    (let [^String s x]
+      (if (= -1 (.indexOf s (int \u0000)))
+        s
+        (.replace s \u0000 \ufffd)))))
+
 (defn normalize-resource-event
   "Prep `event` for comparison/computation of a hash"
   [event]
   (-> event
       (update :timestamp to-timestamp)
-      (update :old_value sutils/db-serialize)
-      (update :new_value sutils/db-serialize)
+      (update :old_value (comp sutils/db-serialize replace-null-bytes))
+      (update :new_value (comp sutils/db-serialize replace-null-bytes))
       (assoc :containing_class (find-containing-class (:containment_path event)))))
 
 (defn normalize-report


### PR DESCRIPTION
There's a broader issue with null bytes from the input leaking through the
database at times, but this is the specific instance we've seen in the field. A
broader fix will be forthcoming.