### PR TITLE
(PE-21799) Ensuring gc_packages runs

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -362,6 +362,7 @@
                             ["purge_nodes" {:batch_limit limit}])))
              (when (some-> (:report-ttl config) seconds-pos?)
                "purge_reports")
+             "gc_packages"
              "other"])))
 
 (defn collect-garbage


### PR DESCRIPTION
I've added gc_packages to the scheduled garbage collection (not currently included):

```
2017-09-01 01:24:12,766 INFO [p.p.c.services] Starting database garbage collection
2017-09-01 01:24:12,772 INFO [p.p.c.services] Finished database garbage collection
2017-09-01 02:24:12,773 INFO [p.p.c.services] Starting sweep of stale nodes (threshold: 7 days)
2017-09-01 02:24:12,780 INFO [p.p.c.services] Finished sweep of stale nodes (threshold: 7 days)
2017-09-01 02:24:12,780 INFO [p.p.c.services] Starting purge deactivated and expired nodes (threshold: 5 minutes)
2017-09-01 02:24:12,781 INFO [p.p.c.services] Finished purge deactivated and expired nodes (threshold: 5 minutes)
2017-09-01 02:24:12,781 INFO [p.p.c.services] Starting sweep of stale reports (threshold: 14 days)
2017-09-01 02:24:12,783 INFO [p.p.c.services] Finished sweep of stale reports (threshold: 14 days)
2017-09-01 02:24:12,784 INFO [p.p.c.services] Starting database garbage collection
2017-09-01 02:24:12,790 INFO [p.p.c.services] Finished database garbage collection
```