### PR TITLE
(maint) Ensure the benchmark tool creates the requested number of hosts

### DIFF
--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -513,6 +513,7 @@
                                                          threads)
         populate-finished-ch (start-populate-queue mq-ch numhosts run-interval pdb-host
                                                    catalogs reports facts)
+        _ (<!! populate-finished-ch)
         _ (start-simulation-loop numhosts run-interval nummsgs rand-perc
                                  simulation-threads command-send-ch mq-ch)
         join-fn (fn join-benchmark


### PR DESCRIPTION
The 'mq-ch' queue is populated by both 'start-populate-queue' and 'start-simulation-loop' concurrently. When the user specifies arguments like "--nummsgs 1 --numhosts 20", the expected 20 hosts are not loaded because the simulation loop requeues the early hosts before the later ones have been populated the first time. In total there are 20 commands processed but host-0, host-1, ... see 2 or more messages each while ..., host-18, host19 see zero. When trying to load a large number of nodes, facts or catalogs the user is forced to specify a larger value for 'numhosts' than really needed and incur the cost of repeated processing of the early hosts.

This commit makes sure that every host in enqueued once before the simulation loop starts.