### PR TITLE
(maint) change install_mode to install_type

### DIFF
--- a/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
+++ b/acceptance/setup/pre_suite/70_install_released_puppetdb.rb
@@ -1,8 +1,8 @@
 # We skip this step entirely unless we are running in :upgrade mode.
-OLDEST_SUPPORTED_UPGRADE="2.3.8"
+OLDEST_SUPPORTED_UPGRADE="4.0.0"
 
-if ([:upgrade_oldest, :upgrade_latest].include? test_config[:install_mode] and not test_config[:skip_presuite_provisioning])
-  install_target = test_config[:install_mode] == :upgrade_latest ? 'latest' : OLDEST_SUPPORTED_UPGRADE
+if ([:upgrade_oldest, :upgrade_latest].include? test_config[:install_type] and not test_config[:skip_presuite_provisioning])
+  install_target = test_config[:install_type] == :upgrade_latest ? 'latest' : OLDEST_SUPPORTED_UPGRADE
   step "Install most recent released PuppetDB on the PuppetDB server for upgrade test" do
     databases.each do |database|
       enable_https_apt_sources(database)


### PR DESCRIPTION
Per https://github.com/puppetlabs/ci-job-configs/blob/master/jenkii/cinext-jenkinsmaster-enterprise-prod-1/projects/puppetdb.yaml#L24,L27 , this is using the wrong keyword.