### PR TITLE
(maint) Update version determination

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -295,8 +295,12 @@ module PuppetDBExtensions
     elsif host['platform'].include?('fedora')
       version_tag = host['platform'].match(/^fedora-(\d+)/)[1]
       "#{version}.fc#{version_tag}"
-    elsif host['platform'].include?('ubuntu') or host['platform'].include?('debian')
-      "#{version}puppetlabs1"
+    elsif host['platform'].include?('ubuntu-16.04')
+      "#{version}xenial"
+    elsif host['platform'].include?('debian-8')
+      "#{version}jessie"
+    elsif host['platform'].include?('debian-9')
+      "#{version}stretch"
     else
       raise ArgumentError, "Unsupported platform: '#{host['platform']}'"
     end


### PR DESCRIPTION
With the move to the new ezbake packaging, we've fixed a long-standing
bug where we had packages with the same name but different content as we
didn't include the codename in the release field. This however breaks
the method of puppetdb installations, so update the version
determination.