### PR TITLE
(PE-22668) Add job_id from the latest report to nodes endpoint.

### DIFF
--- a/documentation/api/query/v4/nodes.markdown
+++ b/documentation/api/query/v4/nodes.markdown
@@ -78,6 +78,8 @@ The below fields are allowed as filter criteria and are returned in all response
 
 * `latest_report_hash` (string): a hash of the latest report for the node.
 
+* `latest_report_job_id` (string): the job id associated with the latest report (not present if the run wasn't part of a job).
+
 * `["fact", <FACT NAME>]` (string, number, Boolean): the value of `<FACT NAME>` for a node. Inequality operators are allowed, and will skip non-numeric values.
 
     Note that nodes which are missing a fact referenced by a `not` query will match
@@ -100,7 +102,8 @@ The response is a JSON array of hashes, where each hash has the form:
      "latest_report_status": <string>,
      "latest_report_noop": <boolean>,
      "latest_report_noop_pending": <boolean>,
-     "latest_report_hash": <string>
+     "latest_report_hash": <string>,
+     "latest_report_job_id": <string or null>
     }
 
 At least one of the `_timestamp` fields will be non-null.
@@ -158,7 +161,8 @@ of `["=", "certname", "<NODE>"]`.
         "latest_report_status": "success",
         "latest_report_noop": false,
         "latest_report_noop_pending": true,
-        "latest_report_hash": "2625d1b601e98ed1e281ccd79ca8d16b9f74fea6"
+        "latest_report_hash": "2625d1b601e98ed1e281ccd79ca8d16b9f74fea6",
+        "latest_report_job_id": null
     }
 
 ### URL parameters / query operators / query fields

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -243,6 +243,9 @@
                              "latest_report_corrective_change" {:type :boolean
                                                                 :queryable? true
                                                                 :field :reports.corrective_change}
+                             "latest_report_job_id" {:type :string
+                                                     :queryable? true
+                                                     :field :reports.job_id}
                              "cached_catalog_status" {:type :string
                                                       :queryable? true
                                                       :field :reports.cached_catalog_status}

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -47,7 +47,7 @@
                :catalog_environment :facts_environment :report_environment
                :latest_report_status :latest_report_hash :latest_report_noop
                :latest_report_noop_pending :cached_catalog_status
-               :latest_report_corrective_change} (keyset res))
+               :latest_report_corrective_change :latest_report_job_id} (keyset res))
           (str "Query was: " query))
       (is (= (set expected) (set (mapv :certname result)))
           (str "Query was: " query)))
@@ -87,6 +87,15 @@
 
     (testing "all nodes have last corrective_change status null"
       (is-query-result' ["null?" "latest_report_corrective_change" true] [db puppet web1 web2]))
+
+    (testing "query on last job_id returns an empty result"
+      (is-query-result' ["=" "latest_report_job_id" "1234567890"] []))
+
+    (testing "query on last job_id returns web1"
+      (is-query-result' ["=" "latest_report_job_id" "0987654321"] [web1]))
+
+    (testing "all nodes have last job_id null"
+      (is-query-result' ["null?" "latest_report_job_id" true] [db puppet web2]))
 
     (testing "regular expressions are supported for name"
       (is-query-result' ["~" "certname" "web\\d+.example.com"] [web1 web2])

--- a/test/puppetlabs/puppetdb/testutils/nodes.clj
+++ b/test/puppetlabs/puppetdb/testutils/nodes.clj
@@ -81,7 +81,10 @@
     (scf-store/replace-catalog! (assoc web1-catalog :certname web1) (now))
     (scf-store/replace-catalog! (assoc puppet-catalog :certname puppet) (plus (now) (seconds 1)))
     (scf-store/replace-catalog! (assoc db-catalog :certname db) (plus (now) (seconds 2)))
-    (scf-store/add-report! (basic-report-for-node web1) (now))
+    (scf-store/add-report! (-> web1
+                               basic-report-for-node
+                               (assoc :job_id "0987654321"))
+                           (now))
     (scf-store/add-report! (basic-report-for-node puppet) (plus (now) (seconds 2)))
     (scf-store/add-report! (basic-report-for-node db) (plus (now) (seconds 3)))
     {:web1    web1


### PR DESCRIPTION
In order to be able to display the job-id successfully on the PE Overview table, the job-id needs to be available in the pdb payload when a given report was the result of running from the orchestrator.