### PR TITLE
(PDB-3734) Ensure that resource indirection uses existing resource type

### DIFF
--- a/puppet/lib/puppet/indirector/resource/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/resource/puppetdb.rb
@@ -57,7 +57,10 @@ class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
             Puppet::Parser::Resource::Param.new(:name => name, :value => value)
           end
           attrs = {:parameters => params, :scope => scope}
-          result = Puppet::Parser::Resource.new(res['type'], res['title'], attrs)
+
+          t = res['type']
+          t = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, t) unless t == 'class' || t == 'node'
+          result = Puppet::Parser::Resource.new(t, res['title'], attrs)
           result.collector_id = "#{res['certname']}|#{res['type']}|#{res['title']}"
           result
         end


### PR DESCRIPTION
Before this commit, the resource type would be passed to `Resource#new`
in string form. This is problematic since it may result in the load of
a Ruby resource type which then is in conflict with genereated Pcore
resource type.

This commit ensures that the indirection uses the same logic as Puppet
when creating new resources.