### PR TITLE
(PDB-3745) Increase autovacuum vacuum scale factor

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1496,11 +1496,12 @@
 
   {::vacuum-analyze #{"factsets"}})
 
-(defn autovacuum-vacuum-scale-factor-factsets-catalogs-certnames []
+(defn autovacuum-vacuum-scale-factor-factsets-catalogs-certnames-reports []
   (jdbc/do-commands
     "ALTER TABLE factsets  SET ( autovacuum_vacuum_scale_factor=0.80 );"
     "ALTER TABLE catalogs  SET ( autovacuum_vacuum_scale_factor=0.75 );"
-    "ALTER TABLE certnames SET ( autovacuum_vacuum_scale_factor=0.75 );"))
+    "ALTER TABLE certnames SET ( autovacuum_vacuum_scale_factor=0.75 );"
+    "ALTER TABLE reports   SET ( autovacuum_vacuum_scale_factor=0.01 );"))
 
 (def migrations
   "The available migrations, as a map from migration version to migration function."
@@ -1546,7 +1547,7 @@
    64 rededuplicate-facts
    65 varchar-columns-to-text
    66 jsonb-facts
-   67 autovacuum-vacuum-scale-factor-factsets-catalogs-certnames})
+   67 autovacuum-vacuum-scale-factor-factsets-catalogs-certnames-reports})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1496,6 +1496,12 @@
 
   {::vacuum-analyze #{"factsets"}})
 
+(defn autovacuum-vacuum-scale-factor-factsets-catalogs-certnames []
+  (jdbc/do-commands
+    "ALTER TABLE factsets  SET ( autovacuum_vacuum_scale_factor=0.80 );"
+    "ALTER TABLE catalogs  SET ( autovacuum_vacuum_scale_factor=0.75 );"
+    "ALTER TABLE certnames SET ( autovacuum_vacuum_scale_factor=0.75 );"))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1539,7 +1545,8 @@
    63 add-job-id
    64 rededuplicate-facts
    65 varchar-columns-to-text
-   66 jsonb-facts})
+   66 jsonb-facts
+   67 autovacuum-vacuum-scale-factor-factsets-catalogs-certnames})
 
 (def desired-schema-version (apply max (keys migrations)))
 


### PR DESCRIPTION
Prior to this commit, the factsets, catalogs, and certnames tables
were autovacuumed far too frequently.

This commit changes the percentage change before the table
is considered for autovacuuming.  The way these tables are
inserted and updated apparently moves the counter for changes
forward when the rows can't be reclaimed.