### PR TITLE
(PE-22860) Optimize event queries with the latest_report? parameter

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -896,7 +896,11 @@
                                             :field :environments.environment}
                              "latest_report?" {:type :boolean
                                                :queryable? true
-                                               :query-only? true}}
+                                               :query-only? true}
+                             "report_id" {:type :bigint
+                                          :queryable? false
+                                          :query-only? true
+                                          :field :events.report_id}}
                :selection {:from [[:resource_events :events]]
                            :join [:reports
                                   [:= :events.report_id :reports.id]]
@@ -937,6 +941,16 @@
                :alias "latest_report"
                :subquery? false
                :source-table "latest_report"}))
+
+(def latest-report-id-query
+  "Usually used as a subquery of reports"
+  (map->Query {:projections {"latest_report_id" {:type :bigint
+                                                 :queryable? true
+                                                 :field :certnames.latest_report_id}}
+               :selection {:from [:certnames]}
+               :alias "latest_report_id"
+               :subquery? false
+               :source-table "latest_report_id"}))
 
 (def environments-query
   "Basic environments query, more useful when used with subqueries"
@@ -1335,6 +1349,7 @@
    "select_nodes" nodes-query
    "select_inactive_nodes" inactive-nodes-query
    "select_latest_report" latest-report-query
+   "select_latest_report_id" latest-report-id-query
    "select_params" resource-params-query
    "select_reports" reports-query
    "select_inventory" inventory-query
@@ -1489,9 +1504,9 @@
                                       ["select_latest_report"]]]
 
                                     :events
-                                    ["in" "report"
-                                     ["extract" "latest_report_hash"
-                                      ["select_latest_report"]]]
+                                    ["in" "report_id"
+                                     ["extract" "latest_report_id"
+                                      ["select_latest_report_id"]]]
 
                                     (throw (IllegalArgumentException.
                                             (tru "Field 'latest_report?' not supported on endpoint ''{0}''" entity))))]


### PR DESCRIPTION
The original SQL query to get event counts from the latest report was

````
SELECT * 
  FROM (SELECT containing_class,
	       SUM(CASE WHEN status = 'failure' THEN 1 ELSE 0 END) AS failures,
	       SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END) AS skips,
               SUM(CASE WHEN (status = 'success' and coalesce(corrective_change, false) = false) THEN 1 ELSE 0 END) AS intentional_successes,
	       SUM(CASE WHEN (status = 'success' and corrective_change = true) THEN 1 ELSE 0 END) AS corrective_successes,
	       SUM(CASE WHEN (status = 'noop' and coalesce(corrective_change, false) = false) THEN 1 ELSE 0 END) AS intentional_noops,
	       SUM(CASE WHEN (status = 'noop' and corrective_change = true) THEN 1 ELSE 0 END) AS corrective_noops 
          FROM (SELECT DISTINCT certname, status, corrective_change, containing_class
                  FROM (WITH inactive_nodes AS
                         (SELECT certname FROM certnames WHERE (deactivated IS NOT NULL OR expired IS NOT NULL))
                         SELECT message AS message, old_value AS old_value, reports.receive_time AS report_receive_time, events.corrective_change AS corrective_change, containment_path AS containment_path,
                                reports.certname AS certname, timestamp AS timestamp, reports.end_time AS run_end_time, reports.configuration_version AS configuration_version, new_value AS new_value,
                                resource_title AS resource_title, status AS status, property AS property, resource_type AS resource_type, line AS line, environments.environment AS environment,
                                containing_class AS containing_class, reports.start_time AS run_start_time, file AS file, encode(reports.hash::bytea, 'hex') AS report
                           FROM resource_events events
                                INNER JOIN reports ON events.report_id = reports.id
                                LEFT JOIN environments ON reports.environment_id = environments.id
                           WHERE ((encode(reports.hash::bytea, 'hex')) in  ( SELECT encode(reports.hash::bytea, 'hex') AS latest_report_hash FROM certnames INNER JOIN reports ON (certnames.certname = reports.certname AND certnames.latest_report_id = reports.id) ) )) distinct_events) events
	                  GROUP BY containing_class) count_results WHERE intentional_successes > '0' ORDER BY containing_class
````
The where condition was suboptimal
````
WHERE ((encode(reports.hash::bytea, 'hex')) in
        ( SELECT encode(reports.hash::bytea, 'hex') AS latest_report_hash
            FROM certnames
                 INNER JOIN reports ON
                   (certnames.certname = reports.certname AND
                    certnames.latest_report_id = reports.id) )
````
The current PR changes that to
````
WHERE events.report_id IN (SELECT certnames.latest_report_id FROM certnames)
````

The original query is very expensive on datasets with a lot of nodes (e.g. 100,000).
The same optimization is implemented for `aggregate-event-counts`, `event-counts` and `events` endpoints.