### PR TITLE
(MAINT) Enable benchmarking via clojure

### DIFF
--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -477,8 +477,8 @@
   pass nummsgs), and :stop, function to request termination of the benchmark
   process and and wait for it to stop cleanly. These functions return true if
   shutdown happened cleanly, or false if there was a timeout."
-  [args]
-  (let [{:keys [config rand-perc numhosts nummsgs threads] :as options} (validate-cli! args)
+  [options]
+  (let [{:keys [config rand-perc numhosts nummsgs threads] :as options} options
         _ (logutils/configure-logging! (get-in config [:global :logging-config]))
         {:keys [catalogs reports facts]} (load-data-from-options options)
         _ (warn-missing-data catalogs reports facts)
@@ -544,7 +544,12 @@
     {:stop stop-fn
      :join join-fn}))
 
+(defn benchmark-wrapper [args]
+  (->  args
+       validate-cli!
+       benchmark))
+
 (defn -main [& args]
-  (when-let [{:keys [join]} (benchmark args)]
+  (when-let [{:keys [join]} (benchmark-wrapper args)]
     (println-err (trs "Press ctrl-c to stop"))
     (join)))

--- a/test/puppetlabs/puppetdb/cli/benchmark_test.clj
+++ b/test/puppetlabs/puppetdb/cli/benchmark_test.clj
@@ -42,7 +42,7 @@
                   ;; we'd rather have the exception.
                   utils/try+-process-cli! (fn [body] (body))
                   benchmark/benchmark-shutdown-timeout tu/default-timeout-ms]
-      (f submitted-records (benchmark/benchmark cli-args)))))
+      (f submitted-records (benchmark/benchmark-wrapper cli-args)))))
 
 (defn benchmark-nummsgs
   [config & cli-args]


### PR DESCRIPTION
I've moved the `validate-cli` call to the `main` method of the benchmark namespace.

This allows me to call the benchmark function from elsewhere and pass in my options map.  With this change, I can pass an already loaded config without having to read anything from disk.