### PR TITLE
(RE-9732) Use artifactory instead of nexus (4.2.3.x branch)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -96,8 +96,8 @@
 
   :jvm-opts ~pdb-jvm-opts
 
-  :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
-                 ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
+  :repositories [["releases" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-releases__local/"]
+                 ["snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-snapshots__local/"]]
 
   :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]
             [lein-cloverage "1.0.6" :exclusions [org.clojure/clojure]]
@@ -116,8 +116,8 @@
                 :config-dir "ext/config/foss"
                 }
 
-  :deploy-repositories [["releases" ~(deploy-info "http://nexus.delivery.puppetlabs.net/content/repositories/releases/")]
-                        ["snapshots" ~(deploy-info "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/")]]
+  :deploy-repositories [["releases" ~(deploy-info "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-releases__local/")]
+                        ["snapshots" ~(deploy-info "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-snapshots__local/")]]
 
   ;; By declaring a classifier here and a corresponding profile below we'll get an additional jar
   ;; during `lein jar` that has all the code in the test/ directory. Downstream projects can then


### PR DESCRIPTION
Previously would send releases and snapshots to nexus, we want to ship these to artifactory instead.
Tested [here](https://artifactory.delivery.puppetlabs.net/artifactory/webapp/#/search/quick/eyJzZWFyY2giOiJxdWljayIsInF1ZXJ5IjoicHVwcGV0ZGItNC4yLjMuOC0yMDE3MTExNi4xOTQiLCJzZWxlY3RlZFJlcG9zaXRvcmllcyI6WyJjbG9qdXJlLXNuYXBzaG90c19fbG9jYWwiXX0=)