### PR TITLE
(PDB-3695) speed up package gc

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -836,7 +836,7 @@
    (:gc-packages performance-metrics)
    (jdbc/delete!
     :packages
-    ["id NOT IN (SELECT package_id from certname_packages)"])))
+    ["not exists (select * from certname_packages cp where cp.package_id = packages.id)"])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Facts


### PR DESCRIPTION
"delete where not in" is a bad query in postgres. See discussion on SO for
alternatives:
https://stackoverflow.com/questions/15959061/delete-records-which-do-not-have-a-match-in-another-table