### PR TITLE
(PDB-3311) Improve error handling for index row size exception

### DIFF
--- a/src/puppetlabs/puppetdb/command/dlo.clj
+++ b/src/puppetlabs/puppetdb/command/dlo.clj
@@ -79,7 +79,9 @@
                                    (into-array Object [(if (zero? i) "" "\n")
                                                        (- n i)
                                                        time]))
-                          (.printStackTrace exception out))
+                          (if (string? exception)
+                            (.print out exception)
+                            (.printStackTrace exception out)))
                         attempts))))
 
 (defn- strip-metadata-suffix

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -470,3 +470,24 @@
   "remove all nil-valued keys from a map"
   [m]
   (into {} (filter val m)))
+
+(defn fatality
+  "Create an object representing a fatal exception cause - object representing
+   the cause of the failure, indicating that retries should not be attempted"
+  [cause]
+  {:fatal true :cause cause})
+
+(defmacro upon-error-throw-fatality
+  [& body]
+  `(try
+    ~@body
+    (catch Exception e1#
+      (throw+ (fatality e1#)))
+    (catch AssertionError e2#
+      (throw+ (fatality e2#)))))
+
+(defn fatal?
+  "Tests if the supplied exception is a fatal command-processing
+  exception or not."
+  [exception]
+  (:fatal exception))

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -162,7 +162,7 @@
             (is (empty? (fs/list-dir (:path dlo))))))
 
         (testing "when a fatal error occurs should be discarded to the dead letter queue"
-          (with-redefs [process-command-and-respond! (fn [& _] (throw+ (fatality (Exception. "fatal error"))))]
+          (with-redefs [process-command-and-respond! (fn [& _] (throw+ (utils/fatality (Exception. "fatal error"))))]
             (with-message-handler {:keys [handle-message dlo delay-pool q]}
               (let [discards (discard-count)]
                 (handle-message (queue/store-command q (catalog->command-req 5 v5-catalog)))
@@ -171,7 +171,7 @@
               (is (= 2 (count (fs/list-dir (:path dlo))))))))
 
         (testing "when a schema error occurs should be discarded to the dead letter queue"
-          (with-redefs [process-command-and-respond! (fn [& _] (upon-error-throw-fatality
+          (with-redefs [process-command-and-respond! (fn [& _] (utils/upon-error-throw-fatality
                                                                 (function-that-needs-int-via-schema "string")))]
             (with-message-handler {:keys [handle-message dlo delay-pool q]}
               (let [discards (discard-count)]
@@ -181,7 +181,7 @@
               (is (= 2 (count (fs/list-dir (:path dlo))))))))
 
         (testing "when a precondition error occurs should be discarded to the dead letter queue"
-          (with-redefs [process-command-and-respond! (fn [& _] (upon-error-throw-fatality
+          (with-redefs [process-command-and-respond! (fn [& _] (utils/upon-error-throw-fatality
                                                                 (function-that-needs-int-via-precondition "string")))]
             (with-message-handler {:keys [handle-message dlo delay-pool q]}
               (let [discards (discard-count)]
@@ -330,8 +330,8 @@
   (testing "fatal errors are not retried"
     (let [e (try+ (call-with-quick-retry 0
                                          (fn []
-                                           (throw+ (fatality (Exception. "fatal error")))))
-                  (catch fatal? e e))]
+                                           (throw+ (utils/fatality (Exception. "fatal error")))))
+                  (catch utils/fatal? e e))]
       (is (= true (:fatal e)))))
 
   (testing "errors surfaces when no more retries are left"


### PR DESCRIPTION
Sometimes users make a puppet error where they try to extract a fact
value with '$facts["foo"]' instead of '${facts["foo"]}' during string interpolation, which causes the
entire factset to be embedded in the catalog. If the factset is large,
this results in data that is too big for a postgres btree index, which
produces a confusing error message.

Intercept those error messages and print something more comprehensible
and divert those messages straight to the DLO, since retrying them
will always fail.