### PR TITLE
(PDB-3779) Fix inappropriate restriction to active nodes

### DIFF
--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -1951,6 +1951,10 @@
     (is (= status http/status-not-found))
     (is (= {:error "No information is known about factset foo"} (json/parse-string body true)))))
 
+(deftest-http-app no-certname-entity-test
+  []
+  (is-query-result "/v4" ["from" "fact_paths"] #{}))
+
 (deftest developer-pretty-print
   (let [facts-body (fn [pretty?]
                      (with-test-db


### PR DESCRIPTION
Stop restricting queries to active nodes when there is no node
associated with the relevant entity, e.g environments, fact_paths,
packages.

fact_names is special (unqueryable) and is already avoiding this issue
via other means.