### PR TITLE
(maint) Add build_tar: FALSE to build_defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,3 +1,4 @@
 ---
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
+build_tar: FALSE


### PR DESCRIPTION
Our automation is attempting to sign tarballs that aren't there. This will make sure we don't try to do that.