### PR TITLE
(maint) Bump to ezbake 1.7.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -144,7 +144,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "1.7.2"
+                      :plugins [[puppetlabs/lein-ezbake "1.7.3"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}


### PR DESCRIPTION
This commit updates to the latest version of ezbake, which will set build_tar to false, preventing the nightlies job from attempting to sign tars that don't exist.