### PR TITLE
(maint) Bump to ezbake 1.7.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -176,7 +176,7 @@
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "1.7.2"]]}
+                      :plugins [[puppetlabs/lein-ezbake "1.7.3"]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}
              :test {:jvm-opts ~(if need-permgen?


### PR DESCRIPTION
This commit updates to the latest version of ezbake, which will set build_tar to false, preventing the nightlies job from attempting to sign tars that don't exist.