### PR TITLE
(maint) Bump to ezbake 1.7.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -144,7 +144,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "1.7.3"
+                      :plugins [[puppetlabs/lein-ezbake "1.7.4"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}


### PR DESCRIPTION
This commit updates to the latest version of ezbake, which will allow clojure projects' repo-target to be interpreted by the packaging repo, ensuring builds get shipped to the correct repos.