### PR TITLE
(maint) Bump to ezbake 1.7.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -176,7 +176,7 @@
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "1.7.3"]]}
+                      :plugins [[puppetlabs/lein-ezbake "1.7.4"]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}
              :test {:jvm-opts ~(if need-permgen?


### PR DESCRIPTION
This commit updates to the latest version of ezbake, which will allow clojure projects' repo-target to be interpreted by the packaging repo, ensuring builds get shipped to the correct repos.