### PR TITLE
(EZ-118) Clojure projects not shipping to puppet5-nightly

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -121,7 +121,8 @@
                        :build-type "foss"
                        :main-namespace "puppetlabs.puppetdb.main"
                        :start-timeout 14400
-                       :repo-target "PC1"
+                       :repo-target "puppet5"
+                       :nonfinal-repo-target "puppet5-nightly"
                        :logrotate-enabled false}
                 :config-dir "ext/config/foss"
                 }


### PR DESCRIPTION
This PR updates the repo-target and nonfinal-repo-target and bumps to the newest version of ezbake so that puppet5 components ship to the correct repos.