### PR TITLE
(maint) update docs with correct syntax for facts blacklist

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -246,9 +246,9 @@ PuppetDB stores its data in PostgreSQL.
 
 ### Facts Blacklist
 
-Optional. Set by declaring `facts-blacklist` in the PuppetDB configuration file. If you provide a comma-separated string of fact names (in the case of an INI config file) or a list of fact names (in the case of a HOCON config file), PuppetDB ignores those facts on ingestion.
+Optional. Set by declaring `facts-blacklist` in the PuppetDB configuration file. If you provide comma-separated fact names (in the case of an INI config file) or a list of fact names (in the case of a HOCON config file), PuppetDB ignores those facts on ingestion.
 
- * INI: `"fact1, fact2, fact3"`
+ * INI: `fact1, fact2, fact3`
  * HOCON: `["fact1", "fact2", "fact3"]`
 
 ### Using PostgreSQL


### PR DESCRIPTION
Fixes incorrect syntax in the docs for facts blacklist in ini files.