### PR TITLE
(docs) Add 5.1.4 release notes.

### DIFF
--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -18,7 +18,7 @@ canonical: "/puppetdb/latest/release_notes.html"
 
 ## 5.1.4
 
-PuppetDB 5.1.4 is a bug-fix release.
+PuppetDB 5.1.4 is a bug-fix release, and adds packages for Debian 9 ("Stretch").
 
 ### Bug fixes
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -16,18 +16,26 @@ canonical: "/puppetdb/latest/release_notes.html"
 [stockpile]: https://github.com/puppetlabs/stockpile
 [queue_support_guide]: ./pdb_support_guide.html#message-queue
 
+## 5.1.4
+
+PuppetDB 5.1.4 is a bug-fix release.
+
+### Bug fixes
+
+-   PuppetDB's `jackson-databind` dependency is updated to 2.9.1, which contains a fix to a security issue. This library is only used in the structured logging module, so most users should be unaffected.
+
 5.1.3
 -----
 
 PuppetDB 5.1.3 includes bugfixes and performance improvements.
 
 ### Bug Fixes
-* A recent fact data migration should no longer crash when the existing 
+* A recent fact data migration should no longer crash when the existing
   data has unexpected null value representations.
   ([PDB-3692](https://tickets.puppetlabs.com/browse/PDB-3692))
 
 ### Improvements
-* An optional facts blacklist feature has been added to the PDB config file 
+* An optional facts blacklist feature has been added to the PDB config file
   that allows users to specify facts that will be ignored during ingestion.
   ([PDB-3630](https://tickets.puppetlabs.com/browse/PDB-3630))
 
@@ -348,7 +356,7 @@ encouraged to upgrade to this release.
 * When storing reports, PuppetDB first queries the database to see if a report
   with the same hashcode is already present. This database query was erroneously
   not using the index on the hash column, resulting in increased report storage
-  time. It has been updated so that the index will take effect as intended. 
+  time. It has been updated so that the index will take effect as intended.
   ([PDB-3323](https://tickets.puppetlabs.com/browse/PDB-3323))
 
 ### Contributors
@@ -358,7 +366,7 @@ Jessykah Bird, Russell Mull
 4.3.1
 -----
 
-PuppetDB 4.3.1 was a PE-only bugfix release. 
+PuppetDB 4.3.1 was a PE-only bugfix release.
 
 4.3.0
 -----


### PR DESCRIPTION
Add release notes for PuppetDB 5.1.4.

All other changes are line endings modified by the text editor.

> PuppetDB 5.1.4 is a minor bug-fix release.