### PR TITLE
(docs) Fix Markdown, formatting, and ToC issues.

### DIFF
--- a/documentation/_puppetdb_nav.html
+++ b/documentation/_puppetdb_nav.html
@@ -31,7 +31,6 @@
     * [Load testing]({{puppetdb}}/load_testing_tool.html)
 * **Troubleshooting**
     * [General Support Guide]({{puppetdb}}/pdb_support_guide.html)
-    * [Low catalog duplication]({{puppetdb}}/trouble_low_catalog_duplication.html)
     * [Session logging]({{puppetdb}}/trouble_session_logging.html)
 * **PQL - Puppet Query Language**
     * [Tutorial]({{puppetdb}}/api/query/tutorial-pql.html)

--- a/documentation/api/admin/v1/cmd.markdown
+++ b/documentation/api/admin/v1/cmd.markdown
@@ -22,22 +22,22 @@ The maintenance operations must be triggered by a POST.
 The POST request should specify `Content-Type: application/json` and
 the request body should look like this:
 
-  ``` json
-  {"version" : 1, "payload" : [REQUESTED_OPERATION, ...]}
-  ```
+``` json
+{"version" : 1, "payload" : [REQUESTED_OPERATION, ...]}
+```
 
 where valid `REQUESTED_OPERATION`s are `"expire_nodes"`,
 `"purge_nodes"`, `"purge_reports"`, `"gc_packages"`, and `"other"`.
 In addition, a purge_nodes operation can be structured like this to
 specify a batch_limit:
 
-  ``` json
-  ["purge_nodes" {"batch_limit" : 50}]
-  ```
+``` json
+["purge_nodes" {"batch_limit" : 50}]
+```
 
 When specified, the `batch_limit` restricts the maximum number of
 nodes purged to the value specified, and if not specified, the limit
-will be the [`node-purge-gc-batch-limit`][config-purge-batch-limit].
+will be the [`node-purge-gc-batch-limit`][config-purge-limit].
 
 An empty payload vector requests all maintenance operations.
 
@@ -50,18 +50,18 @@ An empty payload vector requests all maintenance operations.
 The response type will be `application/json`, and upon success will
 include this JSON map:
 
-  ``` json
-  {"ok": true}
-  ```
+``` json
+{"ok": true}
+```
 
 If any other maintenance operation is already in progress the HTTP
 response status will be 409 (conflict), will include a map like this
 
-  ``` json
-  {"kind": "conflict",
-   "msg": "Another cleanup is already in progress",
-   "details": null}
-  ```
+``` json
+{"kind": "conflict",
+ "msg": "Another cleanup is already in progress",
+ "details": null}
+```
 
 and no additional maintenance will be performed.  The `msg` and
 `details` may or may not vary, but the `kind` will always be
@@ -71,12 +71,12 @@ and no additional maintenance will be performed.  The `msg` and
 
 [Using `curl` from localhost][curl]:
 
-  ``` sh
-  $ curl -X POST http://localhost:8080/pdb/admin/v1/cmd \
-        -H 'Accept: application/json' \
-        -H 'Content-Type: application/json' \
-        -d '{"command": "clean",
-             "version": 1,
-             "payload": ["expire_nodes", "purge_nodes"]}'
-  {"ok": true}
-  ```
+``` sh
+$ curl -X POST http://localhost:8080/pdb/admin/v1/cmd \
+       -H 'Accept: application/json' \
+       -H 'Content-Type: application/json' \
+       -d '{"command": "clean",
+            "version": 1,
+            "payload": ["expire_nodes", "purge_nodes"]}'
+{"ok": true}
+```

--- a/documentation/api/query/curl.markdown
+++ b/documentation/api/query/curl.markdown
@@ -37,15 +37,16 @@ Any node managed by Puppet agent will already have all of these, and you can
 reuse them for contacting PuppetDB. You can also generate a new cert on the CA
 Puppet master with the `puppet cert generate` command.
 
-**Note:** If you have turned on [certificate whitelisting][whitelist], you must
+> **Note:** If you have turned on [certificate whitelisting][whitelist], you must
 make sure to authorize the certificate you are using:
-
-    curl 'https://<your.puppetdb.server>:8081/pdb/query/v4/nodes' \
-      --tlsv1 \
-      --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem \
-      --cert /etc/puppetlabs/puppet/ssl/certs/<node>.pem \
-      --key /etc/puppetlabs/puppet/ssl/private_keys/<node>.pem
-
+>
+> ```
+> curl 'https://<your.puppetdb.server>:8081/pdb/query/v4/nodes' \
+>   --tlsv1 \
+>   --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem \
+>   --cert /etc/puppetlabs/puppet/ssl/certs/<node>.pem \
+>   --key /etc/puppetlabs/puppet/ssl/private_keys/<node>.pem
+> ```
 
 ### Using an RBAC token (PE only)
 
@@ -60,7 +61,7 @@ can reuse the CA certificate for contacting PuppetDB. You can read more about
 generating RBAC tokens and how they work in the
 [PE documention]({{pe}}/rbac_token_auth.html).
 
-**Note:** The token the user is for must have the correct permissions for
+> **Note:** The token the user is for must have the correct permissions for
 viewing (`nodes:view_data:*`) or editing (`nodes:edit_data:*`) node data
 depending on the operation.
 

--- a/documentation/api/query/tutorial-pql.markdown
+++ b/documentation/api/query/tutorial-pql.markdown
@@ -58,7 +58,7 @@ only accept unencrypted traffic from `localhost`.
 This requires that you specify a certificate (issued by the same CA PuppetDB
 trusts), a private key, and a CA certificate.
 
-**Note**: The PuppetDB CLI can be configured using a config file at
+> **Note**: The PuppetDB CLI can be configured using a config file at
 `$HOME/.puppetlabs/client-tools/puppetdb.conf` with default values for the
 server urls and SSL credentials.
 

--- a/documentation/api/query/v4/ast.markdown
+++ b/documentation/api/query/v4/ast.markdown
@@ -21,6 +21,7 @@ canonical: "/puppetdb/latest/api/query/v4/ast.html"
 [pql]: ./pql.html
 [urlencode]: http://en.wikipedia.org/wiki/Percent-encoding
 [to-char]: http://www.postgresql.org/docs/9.6/static/functions-formatting.html
+[prefix]: 
 
 ## Summary
 
@@ -37,7 +38,7 @@ largely based on the AST query language.
 
 An AST query string passed to the `query` URL parameter of a REST endpoint must be a [URL-encoded][urlencode]
 JSON array, which may contain scalar data types (usually strings) and additional arrays, that describes a
-complex _comparison operation_ in [_prefix notation_][prefix] with an **operator** first and its **arguments** following.
+complex _comparison operation_ in _prefix notation_ with an **operator** first and its **arguments** following.
 
 That is, before being URL-encoded, all AST query strings follow this form:
 

--- a/documentation/api/query/v4/inventory.markdown
+++ b/documentation/api/query/v4/inventory.markdown
@@ -16,6 +16,8 @@ canonical: "/puppetdb/latest/api/query/v4/inventory.html"
 [edges]: ./edges.html
 [resources]: ./resources.html
 [nodes]: ./nodes.html
+[query]: ./query.html
+[ast]: ./ast.html
 
 The `/inventory` endpoint enables an alternative query syntax for digging into
 structured facts, and can be used instead of the `facts`, `fact-contents`, and
@@ -33,12 +35,11 @@ Inventories for deactivated nodes are not included in the response.
   supported operators and fields. For general information about queries, see
   [our guide to query structure.][query]
 
-
 ### Query operators
 
 See [the AST query language page][ast] for the full list of available operators.
 
-Note: This endpoint supports [dot notation][dotted] on the `facts` and
+> **Note:** This endpoint supports [dot notation][dotted] on the `facts` and
 `trusted` response fields.
 
 ### Query fields
@@ -55,6 +56,7 @@ Note: This endpoint supports [dot notation][dotted] on the `facts` and
 * `trusted` (json): a JSON hash of trusted data for the node.
 
 ### Response format
+
 Successful responses will be in `application/json`.
 
 The result will be a JSON array with one entry per certname. Each entry is of

--- a/documentation/api/query/v4/packages.markdown
+++ b/documentation/api/query/v4/packages.markdown
@@ -97,12 +97,11 @@ The array is unsorted by default.
 
     puppet query "package_inventory[certname]{ package_name ~ 'openssl' and version ~ '1\.0\.1[\-a-f]' }"
 
-## `/pdb/query/v4/package-inventory/<CERTNAME>
+## `/pdb/query/v4/package-inventory/<CERTNAME>`
 
 This will return all packages installed on the provided certname. It behaves
 exactly like a call to `/pdb/query/v4/packages` with a query string of `["=",
 "certname", <CERTNAME>]`.
-
 
 ## Paging
 

--- a/documentation/api/query/v4/pql.markdown
+++ b/documentation/api/query/v4/pql.markdown
@@ -48,7 +48,7 @@ only accept unencrypted traffic from `localhost`.
 This requires that you specify a certificate (issued by the same CA PuppetDB
 trusts), a private key, and a CA certificate.
 
-**Note**: The PuppetDB CLI can be configured using a config file at
+> **Note**: The PuppetDB CLI can be configured using a config file at
 `$HOME/.puppetlabs/client-tools/puppetdb.conf` with default values for the
 server urls and SSL credentials.
 

--- a/documentation/api/query/v4/query.markdown
+++ b/documentation/api/query/v4/query.markdown
@@ -13,6 +13,7 @@ canonical: "/puppetdb/latest/api/query/v4/query.html"
 [paging]: ./paging.html
 [entities]: ./entities.html
 [root]: ./index.html
+[pql]: ./pql.html
 
 ## Summary
 

--- a/documentation/api/wire_format/facts_format_v5.markdown
+++ b/documentation/api/wire_format/facts_format_v5.markdown
@@ -4,8 +4,6 @@ layout: default
 canonical: "/puppetdb/latest/api/wire_format/facts_format_v5.html"
 ---
 
-## Facts wire format: Version 5
-
 Facts are represented as JSON. Unless otherwise noted, `null` is not
 allowed anywhere in the set of facts.
 

--- a/documentation/community_add_ons.markdown
+++ b/documentation/community_add_ons.markdown
@@ -5,7 +5,7 @@ canonical: "/puppetdb/latest/community_add_ons.html"
 ---
 
 
-**None of the following projects are published by or endorsed by Puppet Labs.** They are linked to here for informational purposes only.
+**None of the following projects are published by or endorsed by Puppet.** They are linked to here for informational purposes only.
 
 [nagios]: https://github.com/jasonhancock/nagios-puppetdb
 [dashboard]: ./maintain_and_tune.html#monitor-the-performance-dashboard

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -15,9 +15,6 @@ canonical: "/puppetdb/latest/configure.html"
 [node-ttl]: #node-ttl
 [admin-cmd]: api/admin/v1/cmd.html
 
-Summary
------
-
 PuppetDB has three main groups of settings:
 
 * The init script's configuration file, which sets the JVM heap size and the location of PuppetDB's main config file.

--- a/documentation/connect_puppet_apply.markdown
+++ b/documentation/connect_puppet_apply.markdown
@@ -18,7 +18,7 @@ canonical: "/puppetdb/latest/connect_puppet_apply.html"
 [settings_namespace]: {{puppet}}/lang_facts_and_builtin_vars.html#puppet-master-variables
 [package_repos]: {{puppet}}/puppet_collections.html
 
-> Note: To use PuppetDB, the nodes at your site must be running Puppet version 3.8.1 or later.
+> **Note:** To use PuppetDB, the nodes at your site must be running Puppet version 3.8.1 or later.
 
 PuppetDB can be used with standalone Puppet deployments where each node runs `puppet apply`. Once connected to PuppetDB, `puppet apply` will do the following:
 
@@ -53,7 +53,7 @@ Currently, Puppet needs extra Ruby plugins in order to use PuppetDB. Unlike cust
 
 * First, ensure that the appropriate [Puppet Collection repository][package_repos]
   repository is enabled. You can use a [package][] resource to do this or the
-  `apt::source` (from the [puppetlabs-apt][apt] module) and [`yumrepo`][] types.
+  `apt::source` (from the [puppetlabs-apt][apt] module) and [`yumrepo`][yumrepo] types.
 * Next, use Puppet to ensure that the `puppetdb-termini` package is installed:
 
 ~~~ ruby

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -12,6 +12,7 @@ layout: default
 [requirements]: ./index.html#standard-install-rhel-centos-debian-and-ubuntu
 [install_module]: ./install_via_module.html
 [module]: http://forge.puppet.com/puppetlabs/puppetdb
+[keystore_instructions]: ./postgres_ssl.html
 
 > **Note:** If you are running Puppet Enterprise version 3.0 or later, you do
 > not need to install PuppetDB, as it is already installed as part of PE.

--- a/documentation/known_issues.markdown
+++ b/documentation/known_issues.markdown
@@ -10,7 +10,7 @@ Bugs and feature requests
 
 [tracker]: https://tickets.puppetlabs.com/browse/PDB
 
-PuppetDB's bugs and feature requests are managed in [Puppet Labs' issue tracker][tracker]. Search this database if you're having problems and please report any new issues to us!
+PuppetDB's bugs and feature requests are managed in [Puppet's issue tracker][tracker]. Search this database if you're having problems and please report any new issues to us!
 
 Broader issues
 -----

--- a/documentation/pdb_client_tools.markdown
+++ b/documentation/pdb_client_tools.markdown
@@ -4,11 +4,9 @@ layout: default
 ---
 
 [installpuppet]: {{puppet}}/install_pre.html
-[repos]: {{puppet}}/puppet_collections.html
+[repos]: {{puppet}}/puppet_platform.html
 [export]: ./anonymization.html
 [installpeclienttools]: {{pe}}/install_pe_client_tools.html
-
-# PuppetDB CLI
 
 ## Installation
 
@@ -28,20 +26,22 @@ your Puppet master server. If you run `puppet agent --test`, it should
 successfully complete a run, ending with `Notice: Applied catalog in X.XX
 seconds`.
 
-**Note:** it is helpful to add the Puppet bin, `/opt/puppetlabs/bin`, and man,
+> **Note:** It is helpful to add the Puppet bin, `/opt/puppetlabs/bin`, and man,
 `/opt/puppetlabs/client/tools/share/man`, directories to your `PATH` and
 `MANPATH` directories respectively. For example,
-
-    $ export PATH=/opt/puppetlabs/bin:$PATH
-    $ export MANPATH=/opt/puppetlabs/client/tools/share/man:$MANPATH
-
-The rest of this documentation assumes that these two directories have been
+>
+> ```bash
+> $ export PATH=/opt/puppetlabs/bin:$PATH
+> $ export MANPATH=/opt/puppetlabs/client/tools/share/man:$MANPATH
+> ```
+>
+> The rest of this documentation assumes that these two directories have been
 added to their proper path configurations.
 
-### Step 2: Enable the Puppet Collection package repository
+### Step 2: Enable the Puppet Platform package repository
 
 If you didn't already use it to install Puppet, you will need to
-[enable the Puppet Collection package repository][repos] for your system.
+[enable the Puppet Platform package repository][repos] for your system.
 
 ### Step 3: Install and configure the PuppetDB CLI
 

--- a/documentation/pdb_support_guide.markdown
+++ b/documentation/pdb_support_guide.markdown
@@ -12,8 +12,6 @@ layout: default
 [dbvis]: https://www.dbvis.com/
 [stockpile]: https://github.com/puppetlabs/stockpile
 
-## Support and Troubleshooting for PuppetDB
-
 This is a technical guide for troubleshooting PuppetDB (PDB) and understanding
 its internals.
 
@@ -206,8 +204,8 @@ prior to log examination:
 
 Check the postgres logs for:
 
-    * Postgres errors (marked "ERROR") coming from the puppetdb database
-    * Slow queries
+* Postgres errors (marked "ERROR") coming from the puppetdb database
+* Slow queries
 
 Slow queries are the main concern here, since most errors here have already
 been seen in the PDB logs. Slow queries frequently occur on deletes related to
@@ -240,7 +238,7 @@ meaningful options to look at are typically `work_mem`, `shared_buffers`, and
 `effective_cache_size`. Consult the [PostgreSQL documentation][postgres-config]
 for information on these settings.
 
-### PDB dashboard screenshot
+### PDB dashboard
 
 There are a few things to watch for in the PDB dashboard:
 

--- a/documentation/puppetdb_connection.markdown
+++ b/documentation/puppetdb_connection.markdown
@@ -11,9 +11,6 @@ canonical: "/puppetdb/latest/puppetdb_connection.html"
 
 The `puppetdb.conf` file contains the hostname and port of the [PuppetDB][puppetdb_root] server. It is only used if you are using PuppetDB and have [connected your Puppet master to it][connect_to_puppetdb].
 
-Summary
------
-
 The Puppet master makes HTTPS connections to PuppetDB to store catalogs, facts, and new reports. It also uses PuppetDB to answer queries, such as those necessary to support exported resources. If the PuppetDB instance is down, depending on the configuration of the Puppet master, it could cause the Puppet run to fail. This document discusses configuration options for the `puppetdb.conf` file, including settings to make the PuppetDB terminus more tolerant of failures.
 
 ## Location
@@ -89,7 +86,7 @@ The default value in PE is true.
 
 #### `sticky_read_failover`
 
-**Note: For use with Puppet Enterprise only.**
+> **Note:** For use with Puppet Enterprise only.
 
 When using multiple `server_urls`, this flag can be set to `true` to cause queries to be made to the last PuppetDB instance that was successfully contacted.
 
@@ -97,7 +94,7 @@ The default value is false.
 
 #### `command_broadcast`
 
-**Note: For use with Puppet Enterprise only.**
+> **Note:** For use with Puppet Enterprise only.
 
 When set to `true` in installations using multiple `server_urls`, commands are sent to all configured PuppetDB instances. 
 
@@ -106,7 +103,7 @@ In open source Puppet and PE versions earlier than 2016.5, the default setting i
 
 #### `min_successful_submissions`
 
-**Note: For use with Puppet Enterprise only.**
+> **Note:** For use with Puppet Enterprise only.
 
 When writing data (submitting commands) to PuppetDB, this is the minimum number of machines to which the command must be successfully sent to consider the write successful. If the configured number of machines cannot be reached, Puppet runs will fail.
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -644,11 +644,11 @@ handling, and improves the speed of removing old reports and node expiration and
 
 * Allow configuration of AciveMQ Broker's memoryLimit. For PuppetDB instances
   with larger amount of memory and heavy load, this can improve performance.
-  More information in the [config docs][./configure.html#memory-usage]
+  More information in the [config docs](./configure.html#memory-usage)
   ([PDB-2726](https://tickets.puppetlabs.com/browse/PDB-2726)).
 
 * Preliminary support for HUP signal handling. Note that due to
-  [AMQ-5263][https://issues.apache.org/jira/browse/AMQ-5263] there is
+  [AMQ-5263](https://issues.apache.org/jira/browse/AMQ-5263) there is
   a possibility of a crash when HUPed. We've observed this race
   condition when under heavy load and repeatedly HUPed. This will be
   fixed and more robust in a future release


### PR DESCRIPTION
Several parts of the documentation have invalid or inconsistent Markdown
formatting, broken links, or errors in heading levels or heading contents.
This results in issues when rendering these docs on GitHub or
puppet.com/docs.

This PR resolves these issues. It does not attempt to validate, resolve
issues with, or update any of the surrounding content.