### PR TITLE
(docs)(DOCUMENT-809) Fix typos in PDB client tools docs.

### DIFF
--- a/documentation/pdb_client_tools.markdown
+++ b/documentation/pdb_client_tools.markdown
@@ -91,8 +91,8 @@ necessary configuration items are `server_urls` and `cacert`.
 
 **Note:** You can still use certificate authentication with the PE version (see
 below for an example configuration) but setting `cert` and `key` in the PuppetDB
-CLI configuration will prevent you from using token authentication (i.e.
-certicate authentication takes precendence over token authentication).
+CLI configuration will prevent you from using token authentication (for example,
+certificate authentication takes precendence over token authentication).
 
 ```json
 {

--- a/documentation/pdb_client_tools.markdown
+++ b/documentation/pdb_client_tools.markdown
@@ -98,7 +98,7 @@ certicate authentication takes precendence over token authentication).
 {
   "puppetdb": {
     "server_urls": "https://<PUPPETDB_HOST>:8081",
-    "cacert": "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
+    "cacert": "/etc/puppetlabs/puppet/ssl/certs/ca.pem"
   }
 }
 ```


### PR DESCRIPTION
Fix a typo causing errors in an example, and fix a spelling error in and clarify a related note.