### PR TITLE
(docs)(DOCUMENT-813) Fix errors in PQL example

### DIFF
--- a/documentation/api/query/tutorial-pql.markdown
+++ b/documentation/api/query/tutorial-pql.markdown
@@ -97,8 +97,8 @@ The PuppetDB terminus includes the `puppetdb_query` function, which can be used
 to query PuppetDB from within a Puppet manifest. For example,
 
     $debian_nodes_query = 'nodes[certname]{facts{name = "operatingsystem" and value = "Debian"}}'
-    $debian_nodes = puppetdb_query($debian_nodes_query).each |$value| { $value["certname"] }
-    Notify {"Debian nodes":
+    $debian_nodes = puppetdb_query($debian_nodes_query).map |$value| { $value["certname"] }
+    notify {"Debian nodes":
         message => "Your debian nodes are ${join($debian_nodes, ', ')}",
     }
 


### PR DESCRIPTION
(via PR #2431 by @Nekototori)

> .each doesn't change the result to store in the variable. It keeps
> any changes/output isolated. Need .map to use the result outside
> of the iterator per the example.
>
> Also, no capital on `notify`.

(retargeted at 5.1.x, and amended the commit message for CI)