### PR TITLE
(PDB-3830) Decrement queue depth when discarding a message

### DIFF
--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -473,7 +473,9 @@
   (-> cmdref
       (queue/cons-attempt ex)
       (dlo/discard-cmdref q dlo))
-  (mark-both-metrics! (:command cmdref) (:version cmdref) :discarded))
+  (let [{:keys [command version]} cmdref]
+    (mark-both-metrics! command version :discarded)
+    (update-counter! :depth command version dec!)))
 
 (defn process-delete-cmdref
   "Processes a command ref marked for deletion. This is similar to


### PR DESCRIPTION
Prior to this commit, when a message is discarded it had no effect
on the command queue depth metrics.

After this commit, when a message is discarded we decrement the
queue depth metric.