### PR TITLE
(maint) Add project name to build defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,4 +1,5 @@
 ---
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
+project: 'puppetdb'
 build_tar: FALSE


### PR DESCRIPTION
This commit adds 'puppetdb' as the project name. Previously, when attempting to ship tarballs, the packaging repo was unable to find any retrieved tarballs because it expected them in the form <project>-<version>.tar.gz, but there was no project set.