### PR TITLE
(maint) Add project name to build defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,7 +1,7 @@
 ---
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
 packaging_repo: 'packaging'
-
+project: 'puppetdb'
 repo_name: 'puppet5'
 nonfinal_repo_name: 'puppet5-nightly'
 repo_link_target: 'puppet'


### PR DESCRIPTION
This commit adds 'puppetdb' as the project name. Previously, when attempting to ship tarballs, the packaging repo was unable to find any retrieved tarballs because it expected them in the form <project>-<version>.tar.gz, but ther was no project set.