### PR TITLE
(PDB-3840) Clean up additional orphaned facts

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1315,7 +1315,9 @@
 (defn rededuplicate-facts []
   (log/info (trs "[1/8] Cleaning up unreferenced facts..."))
   (jdbc/do-commands
-   "DELETE FROM facts WHERE factset_id NOT IN (SELECT id FROM factsets)")
+   "DELETE FROM facts WHERE factset_id NOT IN (SELECT id FROM factsets)"
+   "DELETE FROM facts WHERE fact_path_id NOT IN (SELECT id FROM fact_paths)"
+   "DELETE FROM facts WHERE fact_value_id NOT IN (SELECT id FROM fact_values)")
 
   (log/info (trs "[2/8] Creating new fact storage tables..."))
   (jdbc/do-commands


### PR DESCRIPTION
Prior to this commit the facts table could still contain orphaned facts if an entry on the facts table had no reference in the fact_paths or fact_values table.

After this commit we remove any facts that don't have a matching id on the fact_paths table and the fact_values table.