### PR TITLE
Revert "(maint) Add build_tar: FALSE to build_defaults"

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,4 +2,3 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 project: 'puppetdb'
-build_tar: FALSE


### PR DESCRIPTION
This reverts commit f9733e1b0adcd2fd6b998f6aa817e7bb1cf88488.
We were fixing a symptom of a problem, rather than the problem itself (see
RE-10238).