### PR TITLE
Revert "(maint) Add build_tar: FALSE to build_defaults"

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -6,4 +6,3 @@ repo_name: 'puppet5'
 nonfinal_repo_name: 'puppet5-nightly'
 repo_link_target: 'puppet'
 nonfinal_repo_link_target: 'puppet-nightly'
-build_tar: FALSE


### PR DESCRIPTION
This reverts commit f9733e1b0adcd2fd6b998f6aa817e7bb1cf88488.
We were fixing a symptom of a problem, rather than the problem itself (see RE-10238).