### PR TITLE
(PDB-3838) Optimize fact queries which constrain to a single name

### DIFF
--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -57,9 +57,9 @@
   (let [request (get-request endpoint (json/generate-string query))
         {:keys [status body]} (*app* request)
         actual-result (parse-result body)]
-    (is (= (count actual-result) (count expected-results)))
-    (is (= (set actual-result) expected-results))
-    (is (= status http/status-ok))))
+    (is (= (count expected-results) (count actual-result)))
+    (is (= expected-results (set actual-result)))
+    (is (= http/status-ok status))))
 
 (defn compare-structured-response
   "compare maps that may have been stringified differently."


### PR DESCRIPTION
Previously, all queries to the facts endpoint generated brute-force fallback sql
which extracted all fact names and values using jsonb_each and filtered the
resulting tuple. This is very slow.

This change optimizes queries which constrain the fact name to a single value,
the most common way of using the facts endpoint. It does this by rewriting the
facts query-rec to explicitly extract the indicated value using the jsonb ->
operator.