### PR TITLE
(PDB-3873) Accommodate puppet's recent resource tag optimizations

### DIFF
--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -59,7 +59,8 @@ describe processor do
           :tags => [],
           :provider => "foo",
           :type => "foo",
-          :title => "foo" })
+          :title => "foo",
+          :merge_into => nil})
     }
 
     let (:status) {
@@ -334,7 +335,8 @@ describe processor do
                    :tags => [],
                    :provider => "foo",
                    :type => "Notify",
-                   :title => "Hello there" })
+                   :title => "Hello there",
+                   :merge_into => nil})
           notify_status = Puppet::Resource::Status.new(notify_resource)
           notify_status.changed = false
           subject.add_resource_status(notify_status)


### PR DESCRIPTION
Accommodate the resource tag optimizations in
d2e6af6cf0d4745cd838184b50fde0f6e970cf7f by setting
:merge_into => nil in the stubs.

Thanks to Patrick Carlisle for suggesting the fix.