### PR TITLE
(PDB-3884) Update logback configuration

### DIFF
--- a/resources/ext/config/logback.xml
+++ b/resources/ext/config/logback.xml
@@ -1,4 +1,4 @@
-<configuration scan="true">
+<configuration scan="true" scanPeriod="60 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %-5p [%c{2}] %m%n</pattern>

--- a/resources/ext/config/logback.xml
+++ b/resources/ext/config/logback.xml
@@ -1,7 +1,7 @@
 <configuration scan="true" scanPeriod="60 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5p [%c{2}] %m%n</pattern>
         </encoder>
     </appender>
 
@@ -16,7 +16,7 @@
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
-            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5p [%c{2}] %m%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
This commit updates the logback configuration bundled with puppetdb
packages to implement the following improvements:

  - Set `scanPeriod="60 seconds"` so that settings like log levels can be
    toggled without requiring a service restart.

  - Use RFC 3339 compliant timestamps that include the offset from UTC.