### PR TITLE
(PDB-3852) Fix broken structured facts queries

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -1170,10 +1170,11 @@
         :from [[(-plan->sql subquery) :sub]]}]))
 
   JsonContainsExpression
-  (-plan->sql [{:keys [field column-data]}]
+  (-plan->sql [{:keys [field column-data array-in-path]}]
     (su/json-contains (if (instance? SqlRaw (:field column-data))
                         (-> column-data :field :s)
-                        field)))
+                        field)
+                      array-in-path))
 
   FnBinaryExpression
   (-plan->sql [{:keys [value function args operator]}]
@@ -1277,9 +1278,15 @@
   [{:keys [field value] :as node} state]
   (let [[column & path] (map utils/maybe-strip-escaped-quotes
                              (su/dotted-query->path field))]
-    {:node (assoc node :value "?" :field column)
-     :state (conj state (su/munge-jsonb-for-storage
-                          (path->nested-map path value)))}))
+    (if (some #(re-matches #"^\d+$" %) path)
+      {:node (assoc node :value ["?" "?"] :field column :array-in-path true)
+       :state (reduce conj state [(doto (PGobject.)
+                                    (.setType "text[]")
+                                    (.setValue (str "{" (string/join "," (map #(string/replace % "'" "''") path)) "}")))
+                                  (su/munge-jsonb-for-storage value)])}
+      {:node (assoc node :value "?" :field column :array-in-path false)
+       :state (conj state (su/munge-jsonb-for-storage
+                           (path->nested-map path value)))})))
 
 (defn parse-dot-query-with-array-elements
   "Transforms a dotted query into a JSON structure appropriate
@@ -1288,7 +1295,7 @@
   (let [[column & path] (->> field
                              su/dotted-query->path
                              (map utils/maybe-strip-escaped-quotes)
-                             (su/expand-array-access-in-path))
+                             su/expand-array-access-in-path)
         qmarks (repeat (count path) "?")
         parameters (concat path [(su/munge-jsonb-for-storage value)
                                  (first path)])]
@@ -1422,9 +1429,26 @@
   [node]
   (cm/match [node]
 
+            [[(op :guard #{"=" ">" "<" "<=" ">=" "~"}) (column :guard validate-dotted-field) value]]
+            ;; (= :inventory (get-in (meta node) [:query-context :entity]))
+            (when (string/includes? column "match(")
+              (let [[head & path] (->> column
+                                       utils/parse-matchfields
+                                       su/dotted-query->path
+                                       (map utils/maybe-strip-escaped-quotes))
+                    path (if (= head "trusted") (cons head path) path)
+                    fact_paths (->> (jdbc/query-to-vec "SELECT path_array FROM fact_paths WHERE (path ~ ? AND path IS NOT NULL)"
+                                                       (doto (PGobject.)
+                                                         (.setType "text")
+                                                         (.setValue (string/join "#~" (utils/split-indexing path)))))
+                                    (map :path_array)
+                                    (map (fn [path] (if (= (first path) "trusted") path (cons "facts" path))))
+                                    (map #(string/join "." %)))]
+                (into ["or"] (map #(vector op % value) fact_paths))))
+
             [["extract" (columns :guard numeric-fact-functions?) (expr :guard no-type-restriction?)]]
             (when (= :facts (get-in meta node [:query-context :entity]))
-            ["extract" columns ["and" ["=" ["function" "jsonb_typeof" "value"] "number"] expr]])
+              ["extract" columns ["and" ["=" ["function" "jsonb_typeof" "value"] "number"] expr]])
 
             [[(op :guard #{"=" "<" ">" "<=" ">="}) "value" (value :guard #(number? %))]]
             ["and" ["=" ["function" "jsonb_typeof" "value"] "number"] [op "value" value]]

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -225,8 +225,10 @@
    (format "%s = ANY(?)" (first (hfmt/format column)))))
 
 (defn json-contains
-  [field]
-  (hcore/raw (format "%s @> ?" field)))
+  [field array-in-path]
+  (if array-in-path
+    (hcore/raw (format "%s #> ? = ?" field))
+    (hcore/raw (format "%s @> ?" field))))
 
 (defn fn-binary-expression
   "Produce a predicate that compares the result of a function against a
@@ -236,7 +238,7 @@
     (hcore/raw (format "%s(%s) %s ?" function fargs op))))
 
 (defn jsonb-path-binary-expression
-  "Produce a predicate that compares agains4t nested value with op and checks the
+  "Produce a predicate that compares against nested value with op and checks the
   existence of a (presumably) top-level value. The existence check is necessary
   because -> is not indexable (with GIN) but ?? is. Assumes a GIN index on the
   column supplied."


### PR DESCRIPTION
This commit fixes structured facts queries that descend into arrays and
those that contain regexes.

Regexes on structured facts queries have been fixed by querying the
database for all paths that match the given path regex and then adding
the results from that into the original user-query with an "or"
statement around the returned paths.

Queries that descend into arrays have been fixed by examining the query
and using the #> operator instead of the @> operator in the where
clause.