### PR TITLE
(docs) Add 5.2.3 release notes

### DIFF
--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -16,6 +16,12 @@ canonical: "/puppetdb/latest/release_notes.html"
 [stockpile]: https://github.com/puppetlabs/stockpile
 [queue_support_guide]: ./pdb_support_guide.html#message-queue
 
+## 5.2.3
+
+PuppetDB 5.2.3 is a minor bug-fix release.
+
+-   [All issues resolved in PuppetDB 5.2.3](https://tickets.puppetlabs.com/issues/?jql=fixVersion%20%3D%20%27PDB%205.2.3%27)
+
 ## 5.2.2
 
 PuppetDB 5.2.2 is a bug-fix release.


### PR DESCRIPTION
No tickets in PDB 5.2.3 are marked as requiring release notes, so in lieu of notes I'm linking to the JIRA search for issues with that fixVersion.