### PR TITLE
(PDB-3652) Change format of non-kitchensink :cli-errors

### DIFF
--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -203,8 +203,8 @@
   [{db-config :database :or {db-config {}} :as config}]
   (when (str/blank? (:subname db-config))
     (throw+
-     {:kind ::cli-error
-      :msg
+     {:type ::cli-error
+      :message
       (str "PuppetDB requires PostgreSQL."
            "  The [database] section must contain an appropriate"
            " \"//host:port/database\" subname setting.")}))
@@ -420,7 +420,7 @@
 (defn hook-tk-parse-config-data
   "This is a robert.hooke compatible hook that is designed to intercept
    trapperkeeper configuration before it is used, so that we may munge &
-   customize it.  It may throw {:kind ::cli-error :msg m}."
+   customize it.  It may throw {:type ::cli-error :message m}."
   [f args]
   (adjust-and-validate-tk-config (f args)))
 

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -69,7 +69,7 @@
         ;; Valid config
         (is (= cfg (validate-db-settings cfg)))
         ;; Empty config
-        (is (thrown+-with-msg? [:kind ::conf/cli-error] req-re
+        (is (thrown+-with-msg? [:type ::conf/cli-error] req-re
                                (validate-db-settings {})))))
 
     (testing "the read-db defaulted to the specified write-db"


### PR DESCRIPTION
This is needed to match the format of exception data that trapperkeeper expects. Kitchensink cli-errors are explicitly caught and handled, as a result their format doesn't need to change.