### PR TITLE
(PDB-3963) Use proper gem-list from puppetserver

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,6 +32,15 @@
               nil))
           clojure.string/trim))
 
+(def puppetserver-test-dep-gem-list
+  (when puppetserver-test-dep-ver
+    (let [maj-ver (-> (re-matches #"^([0-9]+)\..*" puppetserver-test-dep-ver)
+                      second
+                      Integer/parseInt)]
+      (if (>= maj-ver 6)
+        "jruby-gem-list.txt"
+        "gem-list.txt"))))
+
 (def puppetserver-test-deps
   (when puppetserver-test-dep-ver
     `[[puppetlabs/puppetserver ~puppetserver-test-dep-ver]
@@ -275,6 +284,7 @@
                    "--config" "./test-resources/puppetserver/puppetserver.conf"]
             "install-gems" ["with-profile" "install-gems"
                             "trampoline" "run" "-m" "puppetlabs.puppetdb.integration.install-gems"
+                            ~puppetserver-test-dep-gem-list
                             "--config" "./test-resources/puppetserver/puppetserver.conf"]
             "clean" ~(pdb-run-clean pdb-clean-paths)
             "distclean" ~(pdb-run-clean pdb-distclean-paths)})

--- a/src-gems/puppetlabs/puppetdb/integration/install_gems.clj
+++ b/src-gems/puppetlabs/puppetdb/integration/install_gems.clj
@@ -10,16 +10,17 @@
   (let [jruby-config (jruby-puppet-core/initialize-and-create-jruby-config config)]
     (jruby-core/cli-run! jruby-config "gem" args)))
 
-(defn install-gems [config _]
+(defn install-gems [gem-list-name config _]
   (gem-run! config "install" "facter")
   (gem-run! config "install" "hiera")
 
   ;; Install the puppetserver vendored gems listed inside its jar; this is where
   ;; ezbake gets them
-  (let [gem-list (string/split (slurp (io/resource "ext/build-scripts/gem-list.txt")) #"\n")]
+  (let [gem-list (string/split (slurp (io/resource (str "ext/build-scripts/" gem-list-name))) #"\n")]
     (doseq [[gem version] (map #(string/split % #"\s") gem-list)]
       (gem-run! config "install" gem "--version" version))))
 
 (defn -main
   [& args]
-  (cli/run install-gems args))
+  (let [[gem-list-name & others] args]
+    (cli/run (partial install-gems gem-list-name) others)))


### PR DESCRIPTION
Prior to this commit (due to a file name change in puppetserver), the
integration tests were broken between master branches.

This commit makes it possible for the puppetdb master branch to run
against master as well as the tagged releases of puppetserver by
choosing the proper file name depending on puppetserver's version.