### PR TITLE
(PDB-3938) Update to clj-parent 2.0.2 for pdbext rbac-client dep

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def pdb-version "5.3.0-SNAPSHOT")
-(def clj-parent-version "2.0.1")
+(def clj-parent-version "2.0.2")
 
 (defn pdb-run-sh [& args]
   (apply vector


### PR DESCRIPTION
pdbext needs rbac 0.9.0 in order to be able to upgrade to clj-parent
2.0, clojure 1.9, etc.