### PR TITLE
(PDB-3268) Don't migrate on schema_migration query failures

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1564,13 +1564,10 @@
           results (jdbc/with-db-transaction []  (query-to-vec query))]
       (apply sorted-set (map :version results)))
     (catch java.sql.SQLException e
-      (let [message (.getMessage e)
-            sql-state (.getSQLState e)]
-        (if (and (or (= sql-state "42P01") ; postgresql: undefined_table
-                     (= sql-state "42501")) ; hsqldb: user lacks privilege or object not found
-                 (re-find #"(?i)schema_migrations" message))
-          (sorted-set)
-          (throw e))))))
+      (let [sql-state (.getSQLState e)]
+        (if (= sql-state "42P01") ; postgresql: undefined_table
+            (sorted-set)
+            (throw e))))))
 
 (defn pending-migrations
   "Returns a collection of pending migrations, ordered from oldest to latest."


### PR DESCRIPTION
Previously, we were catching an old hsqldb error as well
as a regex match on any error containing 'schema_migrations'.
We only intended to catch the error that says the database does
not exist so that we know when to apply the first migration to
initialize the database.

This commit removes the old checks for errors that we don't want to
catch.