### PR TITLE
(PDB-3948) Fix transient failure of pretty print

### DIFF
--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -1960,9 +1960,9 @@
                             (assoc-in [:developer :pretty-print] (str pretty?)))
                         (fn []
                           (let [facts {:certname "foo"
-                                       :timestamp reference-time
+                                       :timestamp (now)
                                        :environment "DEV"
-                                       :producer_timestamp reference-time
+                                       :producer_timestamp (now)
                                        :producer "bar"
                                        :values{"foo" "bar"
                                                "baz" "bax"}}]


### PR DESCRIPTION
Previously, it was possible for garbage collection to run in the middle
of the developer-pretty-print test, which if it ran in between adding
the cert and facts and the test checks would clean them out of the database.

This commit changes the test to use the timestamp now so that even if
garbage collection runs, the facts will remain.