### PR TITLE
(MAINT) Use jruby-gem-list for all versions >= 5.3.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -34,12 +34,12 @@
 
 (def puppetserver-test-dep-gem-list
   (when puppetserver-test-dep-ver
-    (let [maj-ver (-> (re-matches #"^([0-9]+)\..*" puppetserver-test-dep-ver)
-                      second
-                      Integer/parseInt)]
-      (if (>= maj-ver 6)
-        "jruby-gem-list.txt"
-        "gem-list.txt"))))
+    (let [[major minor] (->> (re-matches #"^([0-9]+)\.([0-9]+)\..*" puppetserver-test-dep-ver)
+                             #([(nth 1 %) (nth 2 %)])
+                             (map #(Integer/parseInt %)))]
+      (if (neg? (compare [major minor] [5 3]))
+        "gem-list.txt"
+        "jruby-gem-list.txt"))))
 
 (def puppetserver-test-deps
   (when puppetserver-test-dep-ver


### PR DESCRIPTION
This reverts commit d27a8cfadf097cd07ce9c78dc58292087b41d1d8.
Then just changes the gem-list file name to read from