### PR TITLE
(maint) Bump to ezbake 1.8.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -153,7 +153,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "1.8.1"
+                      :plugins [[puppetlabs/lein-ezbake "1.8.6"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}


### PR DESCRIPTION
This commit bumps ezbake to 1.8.6, which is required to use packaging as a gem.