### PR TITLE
(PDB-3928) Add regex to facts-blacklist

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -4,6 +4,7 @@ layout: default
 canonical: "/puppetdb/latest/configure.html"
 ---
 
+[java-patterns]: https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
 [logback]: http://logback.qos.ch/manual/configuration.html
 [dashboard]: ./maintain_and_tune.html#monitor-the-performance-dashboard
 [repl]: ./repl.html
@@ -255,13 +256,6 @@ PuppetDB stores its data in PostgreSQL.
 >
 > Depending on demand, Oracle support may be forthcoming in a future version of PuppetDB. This hasn't been decided yet.
 
-### Facts Blacklist
-
-Optional. Set by declaring `facts-blacklist` in the PuppetDB configuration file. If you provide comma-separated fact names (in the case of an INI config file) or a list of fact names (in the case of a HOCON config file), PuppetDB ignores those facts on ingestion.
-
- * INI: `fact1, fact2, fact3`
- * HOCON: `["fact1", "fact2", "fact3"]`
-
 ### Using PostgreSQL
 
 Before using the PostgreSQL backend, you must set up a PostgreSQL
@@ -447,6 +441,32 @@ alone.
 The maximum time to wait (in milliseconds) to acquire a connection
 from the pool of database connections. If not supplied, defaults to
 1000.
+
+### `facts-blacklist`
+
+Optional.  A list of fact names to be ignored whenever submitted.  The
+`facts-blacklist-type` determines whether the names are matched
+literally or as [Java regular expresions][java-patterns].
+
+The names must be comma-separated in an INI configuration file, or a
+list in a HOCON file:
+
+ * INI: `facts-blacklist = fact1, fact2, fact3`
+ * HOCON: `facts-blacklist = ["fact1", "fact2", "fact3"]`
+
+When matching lterally, the entire fact name (not including the path)
+must completely match one of the `facts-blacklist` entries in order to
+be blacklisted.  When matching regular expressions, the name must
+match the entire pattern.  For example the pattern "xyz" will not
+match the fact "123xyzabc", but ".*xyz.*" will.
+
+### `facts-blacklist-type`
+
+Optional.  When set to `literal` (or not set) the `facts-blacklist`
+names will be matched literally.  When set to `regex` (the only other
+legal value), the names will be matched as [Java regular
+expresions][java-patterns].  See the `facts-blacklist` description
+above for additional information.
 
 ## Deprecated settings
 

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -296,12 +296,23 @@
 
 ;; Fact replacement
 
+(defn rm-facts-by-regex [facts-blacklist fact-map]
+  (let [blacklisted? (fn [fact-name]
+                       (some #(re-matches % fact-name) facts-blacklist))]
+    (apply dissoc fact-map (filter blacklisted? (keys fact-map)))))
+
 (defn replace-facts*
-  [{:keys [payload id received] :as command} start-time db facts-blacklist]
+  [{:keys [payload id received] :as command} start-time db
+   {:keys [facts-blacklist facts-blacklist-type] :as blacklist-config}]
   (let [{:keys [certname package_inventory] :as fact-data} payload
         producer-timestamp (:producer_timestamp fact-data)
+        blacklisting? (seq blacklist-config)
+        rm-blacklisted (when blacklisting?
+                         (case facts-blacklist-type
+                           "regex" (partial rm-facts-by-regex facts-blacklist)
+                           "literal" #(apply dissoc % facts-blacklist)))
         trimmed-facts (cond-> fact-data
-                        (seq facts-blacklist) (update :values #(apply dissoc % facts-blacklist))
+                        blacklisting? (update :values rm-blacklisted)
                         (seq package_inventory) (update :package_inventory distinct))]
     (jdbc/with-transacted-connection' db :repeatable-read
       (scf-storage/maybe-activate-node! certname producer-timestamp)
@@ -309,12 +320,12 @@
     (log-command-processed-messsage id received start-time :replace-facts certname)))
 
 (defn replace-facts
-  [{:keys [payload version received] :as command} start-time db facts-blacklist]
+  [{:keys [payload version received] :as command} start-time db blacklist-config]
   (replace-facts* (upon-error-throw-fatality
                     (assoc command :payload (fact/normalize-facts version received payload)))
                   start-time
                   db
-                  facts-blacklist))
+                  blacklist-config))
 
 ;; Node deactivation
 
@@ -387,12 +398,12 @@
 (defn process-command!
   "Takes a command object and processes it to completion. Dispatch is
    based on the command's name and version information"
-  [{command-name :command version :version delete? :delete? :as command} db facts-blacklist]
+  [{command-name :command version :version delete? :delete? :as command} db blacklist-config]
   (when-not delete?
     (let [start (now)]
       (condp supported-command-version? [command-name version]
         "replace catalog" (replace-catalog command start db)
-        "replace facts" (replace-facts command start db facts-blacklist)
+        "replace facts" (replace-facts command start db blacklist-config)
         "store report" (store-report command start db)
         "deactivate node" (deactivate-node command start db)))))
 
@@ -443,11 +454,11 @@
 (def quick-retry-count 4)
 
 (defn process-command-and-respond!
-  [{:keys [callback] :as cmd} db response-pub-chan stats-atom facts-blacklist]
+  [{:keys [callback] :as cmd} db response-pub-chan stats-atom blacklist-config]
   (try
     (let [result (call-with-quick-retry quick-retry-count
                   (fn []
-                    (process-command! cmd db facts-blacklist)))]
+                    (process-command! cmd db blacklist-config)))]
       (swap! stats-atom update :executed-commands inc)
       (callback {:command cmd :result result})
       (async/>!! response-pub-chan
@@ -491,7 +502,7 @@
   "Parses, processes and acknowledges a successful command ref and
   updates the relevant metrics. Any exceptions that arise are
   unhandled and expected to be caught by the caller."
-  [cmdref q scf-write-db response-chan stats facts-blacklist]
+  [cmdref q scf-write-db response-chan stats blacklist-config]
   (let [{:keys [command version] :as cmd} (queue/cmdref->cmd q cmdref)
         retries (count (:attempts cmdref))]
     (if-not cmd
@@ -512,7 +523,7 @@
          [(global-metric :processing-time)
           (cmd-metric command version :processing-time)]
 
-         (process-command-and-respond! cmd scf-write-db response-chan stats facts-blacklist)
+         (process-command-and-respond! cmd scf-write-db response-chan stats blacklist-config)
          (mark-both-metrics! command version :processed))
 
         (queue/ack-command q cmd)
@@ -559,7 +570,7 @@
   that fail via (delay-message msg), and discarding messages that have
   fatal errors or have exceeded their maximum allowed attempts."
   [q command-chan dlo delay-pool scf-write-db response-chan stats
-   facts-blacklist stop-status]
+   blacklist-config stop-status]
   (fn [{:keys [certname command version received delete? id] :as cmdref}]
     (try+
 
@@ -575,7 +586,7 @@
        (process-delete-cmdref cmdref q scf-write-db response-chan stats)
        (let [retries (count (:attempts cmdref))]
          (try+
-          (process-cmdref cmdref q scf-write-db response-chan stats facts-blacklist)
+          (process-cmdref cmdref q scf-write-db response-chan stats blacklist-config)
           (catch fatal? obj
             (mark! (global-metric :fatal))
             (let [ex (:cause obj)]
@@ -655,7 +666,10 @@
                                       scf-write-db
                                       response-chan
                                       (:stats context)
-                                      (get-in (get-config) [:database :facts-blacklist])
+                                      (-> (get-config)
+                                          :database
+                                          (select-keys [:facts-blacklist
+                                                        :facts-blacklist-type]))
                                       (:stop-status context))]
 
       (doto (Thread. (fn []

--- a/src/puppetlabs/puppetdb/schema.clj
+++ b/src/puppetlabs/puppetdb/schema.clj
@@ -7,8 +7,9 @@
             [clojure.string :as str]
             [schema.utils :as su]
             [cheshire.custom :as json]
-            [slingshot.slingshot :refer [throw+]]))
-
+            [slingshot.slingshot :refer [throw+]])
+  (:import
+  (java.util.regex Pattern)))
 
 (defrecord DefaultedMaybe [schema default]
   s/Schema
@@ -62,6 +63,12 @@
   "True if `x` is a JodaTime Period"
   [x]
   (instance? org.joda.time.Period x))
+
+(def Blacklist
+  "Schema type for facts-blacklist"
+  (s/if coll?
+    (s/if #(-> % first string?) [s/Str] [s/Regex])
+    s/Str))
 
 (def Timestamp
   "Schema type for JodaTime timestamps"


### PR DESCRIPTION
This commit adds support for regex in the facts-blacklist config 
option. Given a valid regex pattern it will not store facts where
a pattern matches a fact name. This is controlled by the use of a
:facts-blacklist-type flag which defaults to 'regular'. The default
preserves the existing facts-blacklist behavior. Setting this flag
to 'regex' allows a user to submit valid java regex patterns for use.