### PR TITLE
Change config data retrieval in acceptance tests

### DIFF
--- a/acceptance/tests/security/puppetdb-ssl-setup/no-puppet-certs.rb
+++ b/acceptance/tests/security/puppetdb-ssl-setup/no-puppet-certs.rb
@@ -4,7 +4,7 @@ test_name "puppetdb ssl-setup with no puppet certs" do
   db_confd = "#{puppetdb_confdir(database)}/conf.d"
   bin_loc = "#{puppetdb_bin_dir(database)}"
 
-  ssl_dir = on(database, puppet_master("--configprint ssldir")).stdout.chomp
+  ssl_dir = on(database, "puppet config print ssldir --section master").stdout.chomp
 
   step "backup jetty.ini and puppetdb ssl certs" do
     on database, "cp #{db_confd}/jetty.ini #{db_confd}/jetty.ini.bak.ssl_setup_tests"

--- a/acceptance/tests/security/puppetdb-ssl-setup/nonprod-environment.rb
+++ b/acceptance/tests/security/puppetdb-ssl-setup/nonprod-environment.rb
@@ -1,5 +1,5 @@
 test_name "puppetdb ssl-setup on nonproduction environment" do
-  confdir = on(database, puppet_master("--configprint confdir")).stdout.chomp
+  confdir = on(database, "puppet config print confdir --section master").stdout.chomp
   bin_loc = "#{puppetdb_bin_dir(database)}"
   step "back up existing puppet.conf" do
     on database, "cp #{confdir}/puppet.conf #{confdir}/puppet.conf.bak"


### PR DESCRIPTION
This changes the way we retrieve config data in our acceptance tests to make it compatible with changes to the puppet cli that are being made in 6.0.0.