### PR TITLE
(maint) Bump to ezbake 1.8.7

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -153,7 +153,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetdb ~pdb-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "1.8.1"
+                      :plugins [[puppetlabs/lein-ezbake "1.8.7"
                                  :exclusions [org.clojure/clojure]]]}
              :testutils {:source-paths ^:replace ["test"]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}


### PR DESCRIPTION
This commit bumps to the latest ezbake version. This version adds a Gemfile to
the resulting package build and makes use of the packaging gem, rather than
cloning the packaging repo.