### PR TITLE
(maint) Add ability to create orphaned facts to dev utils tool

### DIFF
--- a/util/pdb/pdb
+++ b/util/pdb/pdb
@@ -8,7 +8,16 @@ if __name__ == '__main__':
     pdb = PuppetDB()
     subcommand = sys.argv[1]
     if subcommand == 'simulate':
-        nhosts, interval = sys.argv[2:]
-        pdb.simulate(int(nhosts), int(interval))
+        args = sys.argv[2:]
+        if len(args) == 2:
+            nhosts, interval = args
+            pdb.simulate(int(nhosts), int(interval))
+        elif len(args) == 3:
+            nhosts, interval, orphans = args
+            # bool(orphans) below will be set to True on any non empty string
+            pdb.simulate(int(nhosts), int(interval), bool(orphans))
+        else:
+            raise ValueError('called with unsupported number of args')
+
     if subcommand == 'query':
         pdb.query(sys.argv[2])

--- a/util/pdb/puppetdb.py
+++ b/util/pdb/puppetdb.py
@@ -106,15 +106,15 @@ class PuppetDB(object):
     def prepare_sample(self):
         """ interactively prepare a simulation seed set """
 
-    def simulate(self, numhosts, runinterval, events_per_report=4,
-                 opts=DEFAULT_MUTATION_OPTS):
+    def simulate(self, numhosts, runinterval, orphans=False,
+                 events_per_report=4, opts=DEFAULT_MUTATION_OPTS):
         """Submit simulated commands to PDB, targeting equivalence to a given
         number of hosts, run interval, and mutation rate. Record selected
         metrics in a log file on an interval.
         """
         if not self.commands:
             self.commands = Commands()
-        s = CommandPipe(self.commands, numhosts, runinterval)
+        s = CommandPipe(self.commands, numhosts, runinterval, orphans)
         t = datetime.now().isoformat()
         outputfile = 'simulation-logs-%s-%s-%s.txt' % (numhosts,
                                                        runinterval, t)


### PR DESCRIPTION
This adds the ability to create orphaned facts so we can test fact_path gc queries. There is still some work that needs to be done to consolidate all of this into one command. For the time being you need to run this tool twice in order to create the orphaned facts. Once like './pdb simulate 100 10 true' where the true flag creates the extra nested facts, followed by './pdb simulate 100 10' which will recreate the facts without the extra nested ones which results in the orphans being created. 

There is also an issue where this script seems to hang after it has submitted it's facts. This appears to be unrelated to this pr and will be addressed later. 