### PR TITLE
(maint) Add packaging bootstrap/implode warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -70,3 +70,12 @@ begin
 rescue LoadError => e
   puts "Error loading packaging rake tasks: #{e}"
 end
+
+namespace :package do
+  task :bootstrap do
+    puts 'Bootstrap is no longer needed, using packaging-as-a-gem'
+  end
+  task :implode do
+    puts 'Implode is no longer needed, using packaging-as-a-gem'
+  end
+end


### PR DESCRIPTION
Since we have lots of different parts of our infrastructure which still
use package:implode and package:bootstrap we cannot exactly remove them
entirely yet. This commit adds empty warnings back in order to make sure
that the tasks don't fail during any of our pipelines.