### PR TITLE
(PDB-4020) Return the last successful reponse with command_broadcast

### DIFF
--- a/puppet/lib/puppet/util/puppetdb/http.rb
+++ b/puppet/lib/puppet/util/puppetdb/http.rb
@@ -162,6 +162,7 @@ module Puppet::Util::Puppetdb
     def self.broadcast_action(path_suffix, server_urls, http_callback)
       response = nil
       response_error = nil
+      last_success = nil
       config = Puppet::Util::Puppetdb.config
       successful_submit_count = 0
 
@@ -180,15 +181,16 @@ module Puppet::Util::Puppetdb
           response_error = check_http_response(response, server_url, route)
           if response_error.nil?
             successful_submit_count += 1
+            last_success = response
           end
         end
       end
 
-      if successful_submit_count < config.min_successful_submissions
+      if successful_submit_count < config.min_successful_submissions or last_success.nil?
         raise_request_error(response, response_error, path_suffix)
       end
 
-      response
+      last_success
     end
 
     # Setup an http connection, provide a block that will do something with that http


### PR DESCRIPTION
Prior to this PR, the http submission with command_broadcast=true
always returned the last response. As a result, a `:server_error` would be returned if
the last connection produced a 503 response, even if there was a successful PuppetDB response and the minimum successful responses have been met. 

As a result, any configuration with `command_broadcast=true` and the last PuppetDB in the instance in the `server_urls` in maintenance mode would result in failed agent runs for the duration of the maintenance mode. 

This PR changes the behavior to send the last successful response when the minimum successful submissions have been met.