### PR TITLE
(PDB-4104) Change oldest supported version to access to deb9 packages

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -271,7 +271,7 @@ module PuppetDBExtensions
 
   def oldest_supported
     # account for special case where bionic doesn't have builds before 5.2.4
-    return is_bionic ? '5.2.4' : '5.0.0'
+    return is_bionic ? '5.2.4' : '5.1.1'
   end
 
   def get_testing_branch(version)


### PR DESCRIPTION
Before this commit acceptance tests on debian 9 would fail due to
there not being packages made for that platform before pdb version 5.1.1