### PR TITLE
Updated version numbers in the 6.0 release.

### DIFF
--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Contributing to PuppetDB"
+title: "PuppetDB: Contributing to PuppetDB"
 layout: default
 ---
 

--- a/documentation/anonymization.markdown
+++ b/documentation/anonymization.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Export, import and anonymization"
+title: "PuppetDB: Export, import and anonymization"
 layout: default
 ---
 

--- a/documentation/community_add_ons.markdown
+++ b/documentation/community_add_ons.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Community projects and add-ons"
+title: "PuppetDB: Community projects and add-ons"
 layout: default
 canonical: "/puppetdb/latest/community_add_ons.html"
 ---

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Configuring PuppetDB"
+title: "PuppetDB: Configuring PuppetDB"
 layout: default
 canonical: "/puppetdb/latest/configure.html"
 ---

--- a/documentation/connect_puppet_apply.markdown
+++ b/documentation/connect_puppet_apply.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Connecting standalone Puppet nodes to PuppetDB"
+title: "PuppetDB: Connecting standalone Puppet nodes to PuppetDB"
 layout: default
 canonical: "/puppetdb/latest/connect_puppet_apply.html"
 ---

--- a/documentation/connect_puppet_master.markdown
+++ b/documentation/connect_puppet_master.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Connecting Puppet masters to PuppetDB"
+title: "PuppetDB: Connecting Puppet masters to PuppetDB"
 layout: default
 canonical: "/puppetdb/latest/connect_puppet_master.html"
 ---

--- a/documentation/ha.markdown
+++ b/documentation/ha.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: PuppetDB HA"
+title: "PuppetDB: PuppetDB HA"
 layout: default
 ---
 

--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -97,13 +97,13 @@ any Unix-like OS with JVM 8 or newer, including:
 
 [See here for advanced installation instructions.][install_advanced]
 
-### Puppet 5.0.0
+### Puppet 6.0.0
 
-Your site's Puppet masters must be running Puppet Server 5.0.0 or later.
+Your site's Puppet masters must be running Puppet Server 6.0.0 or later.
 [You will need to connect your Puppet masters to PuppetDB after installing it][connect].
 If you wish to use PuppetDB with
 [standalone nodes that are running puppet apply][apply], every node
-must be running 5.0.0 or later.
+must be running 6.0.0 or later.
 
 ### PostgreSQL 9.6
 

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Installing PuppetDB from packages"
+title: "PuppetDB: Installing PuppetDB from packages"
 layout: default
 ---
 

--- a/documentation/install_from_source.markdown
+++ b/documentation/install_from_source.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Installing PuppetDB from source"
+title: "PuppetDB: Installing PuppetDB from source"
 layout: default
 ---
 

--- a/documentation/install_via_module.markdown
+++ b/documentation/install_via_module.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Installing PuppetDB via Puppet module"
+title: "PuppetDB: Installing PuppetDB via Puppet module"
 layout: default
 ---
 

--- a/documentation/known_issues.markdown
+++ b/documentation/known_issues.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Known issues"
+title: "PuppetDB: Known issues"
 layout: default
 canonical: "/puppetdb/latest/known_issues.html"
 ---

--- a/documentation/load_testing_tool.markdown
+++ b/documentation/load_testing_tool.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Load testing"
+title: "PuppetDB: Load testing"
 layout: default
 ---
 

--- a/documentation/logging.markdown
+++ b/documentation/logging.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2 » Logging Configuration"
+title: "PuppetDB: Logging Configuration"
 layout: default
 ---
 

--- a/documentation/maintain_and_tune.markdown
+++ b/documentation/maintain_and_tune.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2 » Maintaining and tuning"
+title: "PuppetDB: Maintaining and tuning"
 layout: default
 canonical: "/puppetdb/latest/maintain_and_tune.html"
 ---

--- a/documentation/pdb_client_tools.markdown
+++ b/documentation/pdb_client_tools.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: PuppetDB CLI"
+title: "PuppetDB: PuppetDB CLI"
 layout: default
 ---
 

--- a/documentation/pdb_support_guide.markdown
+++ b/documentation/pdb_support_guide.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Support and Troubleshooting Guide"
+title: "PuppetDB: Support and Troubleshooting Guide"
 layout: default
 ---
 

--- a/documentation/postgres_ssl.markdown
+++ b/documentation/postgres_ssl.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Setting up SSL for PostgreSQL"
+title: "PuppetDB: Setting up SSL for PostgreSQL"
 layout: default
 canonical: "/puppetdb/latest/postgres_ssl.html"
 ---

--- a/documentation/puppetdb-faq.markdown
+++ b/documentation/puppetdb-faq.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2 » FAQ"
+title: "PuppetDB: FAQ"
 layout: default
 subtitle: "Frequently asked questions"
 ---

--- a/documentation/puppetdb_connection.markdown
+++ b/documentation/puppetdb_connection.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Configuring a Puppet/PuppetDB connection"
+title: "PuppetDB: Configuring a Puppet/PuppetDB connection"
 layout: default
 canonical: "/puppetdb/latest/puppetdb_connection.html"
 ---

--- a/documentation/repl.markdown
+++ b/documentation/repl.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Debugging with remote REPL"
+title: "PuppetDB: Debugging with remote REPL"
 layout: default
 canonical: "/puppetdb/latest/repl.html"
 ---

--- a/documentation/scaling_recommendations.markdown
+++ b/documentation/scaling_recommendations.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Scaling recommendations"
+title: "PuppetDB: Scaling recommendations"
 layout: default
 canonical: "/puppetdb/latest/scaling_recommendations.html"
 ---

--- a/documentation/trouble_session_logging.markdown
+++ b/documentation/trouble_session_logging.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2 » Troubleshooting » Session Logging"
+title: "PuppetDB: Troubleshooting » Session Logging"
 layout: default
 canonical: "/puppetdb/latest/trouble_session_logging.html"
 ---

--- a/documentation/upgrade.markdown
+++ b/documentation/upgrade.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Upgrading PuppetDB"
+title: "PuppetDB: Upgrading PuppetDB"
 layout: default
 ---
 

--- a/documentation/using.markdown
+++ b/documentation/using.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2 » Using PuppetDB"
+title: "PuppetDB: Using PuppetDB"
 layout: default
 canonical: "/puppetdb/latest/using.html"
 ---

--- a/documentation/versioning_policy.markdown
+++ b/documentation/versioning_policy.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Versioning policy"
+title: "PuppetDB: Versioning policy"
 layout: default
 canonical: "/puppetdb/latest/versioning_policy.html"
 ---


### PR DESCRIPTION
There are some version numbers in the following files that I left for you to update to 6.0 or not because I wasn't positive on the changes:

Index.markdown
Contributing.md
Connect_puppet_master.markdown
