### PR TITLE
(maint) Fix Linux Docker scripts on Windows builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+docker/puppetdb/*                                        text  eol=lf
+docker/puppetdb/conf.d/*                                 text  eol=lf
+docker/puppetdb/logging/*                                text  eol=lf
+docker/puppetdb-postgres/*                               text  eol=lf
+docker/puppetdb-postgres/docker-entrypoint-initdb.d/*    text  eol=lf

--- a/docker/puppetdb-postgres/Dockerfile
+++ b/docker/puppetdb-postgres/Dockerfile
@@ -19,5 +19,6 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.dockerfile="/Dockerfile"
 
 COPY docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
+RUN chmod +x /docker-entrypoint-initdb.d/extensions.sh
 
 COPY Dockerfile /

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -49,6 +49,7 @@ VOLUME /etc/puppetlabs/puppet/ssl/
 # doesn't need a separate volume.
 
 COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
 
 EXPOSE 8080 8081
 


### PR DESCRIPTION
 - Typically the contents of Linux files should have LF line endings,
   as is the case with scripts being copied into Linux containers such
   as the ENTRYPOINT script.

   When cloning git source on Windows, files normally end with CRLF.
   The correct way to guarantee line endings remain Linux compatible is
   to add .gitattributes entries as these override any git client
   specific settings that may otherwise break line endings

 - Further, note that while git metadata understands the +x execute
   bit on non-Windows platforms, when checking out code on Windows there
   is no way to represent this information and it's lost.

   When copying files into a Docker image, scripts lose their ability
   to execute.

   The only way to address this is to +x the scripts inside the
   Dockerfile