### PR TITLE
6.0.x mergeup to master

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+docker/puppetdb/*                                        text  eol=lf
+docker/puppetdb/conf.d/*                                 text  eol=lf
+docker/puppetdb/logging/*                                text  eol=lf
+docker/puppetdb-postgres/*                               text  eol=lf
+docker/puppetdb-postgres/docker-entrypoint-initdb.d/*    text  eol=lf

--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -271,7 +271,7 @@ module PuppetDBExtensions
 
   def oldest_supported
     # account for special case where bionic doesn't have builds before 5.2.4
-    return is_bionic ? '5.2.4' : '5.0.0'
+    return is_bionic ? '5.2.4' : '5.1.1'
   end
 
   def get_testing_branch(version)

--- a/docker/ci/build
+++ b/docker/ci/build
@@ -16,8 +16,12 @@ function build_and_test_image() {
   : ===
   : === build and test $container_name
   : ===
-  bundle exec puppet-docker build "$container_name" --no-cache --repository puppet --version "$version" --build-arg postgres_version="$postgres_version"
-  bundle exec puppet-docker spec "$container_name"
+  bundle exec puppet-docker build "$container_name" --no-cache --repository puppet --version "$version" --no-latest --build-arg postgres_version="$postgres_version"
+  if [[ "$container_name" == 'puppetdb-postgres' ]]; then
+    bundle exec puppet-docker spec "$container_name" --image "puppet/$container_name/$postgres_version"
+  else
+    bundle exec puppet-docker spec "$container_name" --image "puppet/$container_name/$version"
+  fi
 }
 
 function push_image() {
@@ -26,7 +30,7 @@ function push_image() {
   : ===
   : === push $container_name
   : ===
-  bundle exec puppet-docker push "$container_name" --repository puppet --version "$container_version"
+  bundle exec puppet-docker push "$container_name" --repository puppet --version "$container_version" --no-latest
 }
 
 : ===

--- a/docker/puppetdb-postgres/Dockerfile
+++ b/docker/puppetdb-postgres/Dockerfile
@@ -19,5 +19,6 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.dockerfile="/Dockerfile"
 
 COPY docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
+RUN chmod +x /docker-entrypoint-initdb.d/extensions.sh
 
 COPY Dockerfile /

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 ARG vcs_ref
 ARG build_date
-ARG version="5.1.5"
+ARG version="6.0.0"
 
 ENV PUPPETDB_VERSION="$version"
 ENV DUMB_INIT_VERSION="1.2.1"
@@ -27,11 +27,11 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y wget netcat lsb-release ca-certificates && \
-    wget https://apt.puppetlabs.com/puppet5-release-"$UBUNTU_CODENAME".deb && \
+    wget https://apt.puppetlabs.com/puppet6-release-"$UBUNTU_CODENAME".deb && \
     wget https://github.com/Yelp/dumb-init/releases/download/v"$DUMB_INIT_VERSION"/dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
-    dpkg -i puppet5-release-"$UBUNTU_CODENAME".deb && \
+    dpkg -i puppet6-release-"$UBUNTU_CODENAME".deb && \
     dpkg -i dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
-    rm puppet5-release-"$UBUNTU_CODENAME".deb dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
+    rm puppet6-release-"$UBUNTU_CODENAME".deb dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
     apt-get update && \
     apt-get install --no-install-recommends -y puppet-agent puppetdb="$PUPPETDB_VERSION"-1"$UBUNTU_CODENAME" && \
     apt-get clean && \
@@ -49,6 +49,7 @@ VOLUME /etc/puppetlabs/puppet/ssl/
 # doesn't need a separate volume.
 
 COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
 
 EXPOSE 8080 8081
 

--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Contributing to PuppetDB"
+title: "PuppetDB: Contributing to PuppetDB"
 layout: default
 ---
 

--- a/documentation/anonymization.markdown
+++ b/documentation/anonymization.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Export, import and anonymization"
+title: "PuppetDB: Export, import and anonymization"
 layout: default
 ---
 

--- a/documentation/community_add_ons.markdown
+++ b/documentation/community_add_ons.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Community projects and add-ons"
+title: "PuppetDB: Community projects and add-ons"
 layout: default
 canonical: "/puppetdb/latest/community_add_ons.html"
 ---

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Configuring PuppetDB"
+title: "PuppetDB: Configuring PuppetDB"
 layout: default
 canonical: "/puppetdb/latest/configure.html"
 ---

--- a/documentation/connect_puppet_apply.markdown
+++ b/documentation/connect_puppet_apply.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Connecting standalone Puppet nodes to PuppetDB"
+title: "PuppetDB: Connecting standalone Puppet nodes to PuppetDB"
 layout: default
 canonical: "/puppetdb/latest/connect_puppet_apply.html"
 ---

--- a/documentation/connect_puppet_master.markdown
+++ b/documentation/connect_puppet_master.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Connecting Puppet masters to PuppetDB"
+title: "PuppetDB: Connecting Puppet masters to PuppetDB"
 layout: default
 canonical: "/puppetdb/latest/connect_puppet_master.html"
 ---

--- a/documentation/ha.markdown
+++ b/documentation/ha.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: PuppetDB HA"
+title: "PuppetDB: PuppetDB HA"
 layout: default
 ---
 

--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2 overview"
+title: "PuppetDB overview"
 layout: default
 ---
 
@@ -97,13 +97,13 @@ any Unix-like OS with JVM 8 or newer, including:
 
 [See here for advanced installation instructions.][install_advanced]
 
-### Puppet 5.0.0
+### Puppet 6.0.0
 
-Your site's Puppet masters must be running Puppet Server 5.0.0 or later.
+Your site's Puppet masters must be running Puppet Server 6.0.0 or later.
 [You will need to connect your Puppet masters to PuppetDB after installing it][connect].
 If you wish to use PuppetDB with
 [standalone nodes that are running puppet apply][apply], every node
-must be running 5.0.0 or later.
+must be running 6.0.0 or later.
 
 ### PostgreSQL 9.6
 

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Installing PuppetDB from packages"
+title: "PuppetDB: Installing PuppetDB from packages"
 layout: default
 ---
 

--- a/documentation/install_from_source.markdown
+++ b/documentation/install_from_source.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Installing PuppetDB from source"
+title: "PuppetDB: Installing PuppetDB from source"
 layout: default
 ---
 

--- a/documentation/install_via_module.markdown
+++ b/documentation/install_via_module.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Installing PuppetDB via Puppet module"
+title: "PuppetDB: Installing PuppetDB via Puppet module"
 layout: default
 ---
 

--- a/documentation/known_issues.markdown
+++ b/documentation/known_issues.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Known issues"
+title: "PuppetDB: Known issues"
 layout: default
 canonical: "/puppetdb/latest/known_issues.html"
 ---

--- a/documentation/load_testing_tool.markdown
+++ b/documentation/load_testing_tool.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Load testing"
+title: "PuppetDB: Load testing"
 layout: default
 ---
 

--- a/documentation/logging.markdown
+++ b/documentation/logging.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2 » Logging Configuration"
+title: "PuppetDB: Logging Configuration"
 layout: default
 ---
 

--- a/documentation/maintain_and_tune.markdown
+++ b/documentation/maintain_and_tune.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2 » Maintaining and tuning"
+title: "PuppetDB: Maintaining and tuning"
 layout: default
 canonical: "/puppetdb/latest/maintain_and_tune.html"
 ---

--- a/documentation/pdb_client_tools.markdown
+++ b/documentation/pdb_client_tools.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: PuppetDB CLI"
+title: "PuppetDB: PuppetDB CLI"
 layout: default
 ---
 

--- a/documentation/pdb_support_guide.markdown
+++ b/documentation/pdb_support_guide.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Support and Troubleshooting Guide"
+title: "PuppetDB: Support and Troubleshooting Guide"
 layout: default
 ---
 

--- a/documentation/postgres_ssl.markdown
+++ b/documentation/postgres_ssl.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Setting up SSL for PostgreSQL"
+title: "PuppetDB: Setting up SSL for PostgreSQL"
 layout: default
 canonical: "/puppetdb/latest/postgres_ssl.html"
 ---

--- a/documentation/puppetdb-faq.markdown
+++ b/documentation/puppetdb-faq.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2 » FAQ"
+title: "PuppetDB: FAQ"
 layout: default
 subtitle: "Frequently asked questions"
 ---

--- a/documentation/puppetdb_connection.markdown
+++ b/documentation/puppetdb_connection.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Configuring a Puppet/PuppetDB connection"
+title: "PuppetDB: Configuring a Puppet/PuppetDB connection"
 layout: default
 canonical: "/puppetdb/latest/puppetdb_connection.html"
 ---

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Release notes"
+title: "PuppetDB 6.0: Release notes"
 layout: default
 canonical: "/puppetdb/latest/release_notes.html"
 ---
@@ -17,9 +17,20 @@ canonical: "/puppetdb/latest/release_notes.html"
 [queue_support_guide]: ./pdb_support_guide.html#message-queue
 [upgrade_policy]: ./versioning_policy.html#upgrades
 
-## 6.0.0
+## PuppetDB 6.0.0
 
-## Upgrading
+### New features
+
+- Puppet 6 supports 
+[rich_data](https://github.com/puppetlabs/puppet-specifications/blob/master/language/types_values_variables.md#richdata) 
+types like Timestamp and SemVer, and enables rich data by default. 
+When rich data is enabled, readable string representations of rich 
+data values may appear in the report resource event `old_value` and 
+`new_value` fields, and in catalog parameter values. ([PDB-4082](https://tickets.puppetlabs.com/browse/PDB-4082))
+- A `help` subcommand has been added to display usage information to standard output. If an invalid command is specified, usage information will now be printed to standard error, not standard output. ([PDB-3993](https://tickets.puppetlabs.com/browse/PDB-3993))
+- PuppetDB has migrated to Clojure 1.9. ([PDB-3953])(https://tickets.puppetlabs.com/browse/PDB-3953))
+
+### Upgrading
 
 -  Support for ActiveMQ has been completely removed, meaning that
    PuppetDB can no longer convert an existing queue to the new format
@@ -30,13 +41,45 @@ canonical: "/puppetdb/latest/release_notes.html"
 
    As a result of the removal, these ActiveMQ specific configuration
    options have been retired: `store-usage`, `temp-usage`,
-   `memory-usage`, and `max-frame-size`,
+   `memory-usage`, and `max-frame-size`
+
+### Bug fixes
+
+- Prior to this fix, the HTTP submission with `command_broadcast` enabled 
+always returned the last response. As a result, a failure was shown if 
+the last connection produced a 503 response even though there was 
+previously a successful PuppetDB response and the minimum successful 
+responses had been met. This issue does not occur with responses that 
+raised an exception. Since the puppet `http_pool` does not raise 503 
+as an exception, this issue can be seen when PuppetDB is in 
+maintenance mode. This fix changes the behavior to send the last successful response 
+when the minimum successful submissions have been met. ([PDB-4020](https://tickets.puppetlabs.com/browse/PDB-4020))
+- A problem that could cause harmless but noisy database connection errors during shutdown has been fixed. ([PDB-3952](https://tickets.puppetlabs.com/browse/PDB-3952))
+- If using the default logback.xml configuration, PuppetDB should notice log config file changes every 60 seconds. Recent versions of PuppetDB had stopped noticing as a result of changes to Trapperkeeper (TK-426). This is fixed. ([PDB-3884](https://tickets.puppetlabs.com/browse/PDB-3884))
+- PuppetDB now no longer attempts database migrations at startup under inappropriate conditions, for example when the relevant migrations table is unreadable. ([PDB-3268](https://tickets.puppetlabs.com/browse/PDB-3268))
+
+### Deprecations
+
+- PuppetDB no longer officially supports JDK 7. PuppetDB 6.0.0 officially supports JDK 8, and has been tested against JDK 10. Please see the [FAQ](./puppetdb-faq.html#which-versions-of-java-are-supported) for further, or more current information. ([PDB-4069](https://tickets.puppetlabs.com/browse/PDB-4069))
+- Support for these database configuration options has been completely retired: `classname`, `subprotocol`, `log-slow-statements`, and `conn-keep-alive`. Aside from warning at startup, PuppetDB will completely ignore them, and references to them have been removed from the documentation. ([PDB-3935](https://tickets.puppetlabs.com/browse/PDB-3935))
+
+### Contributors
+
+Austin Blatt, Britt Gresham, Charlie Sharpsteen, Garrett Guillotte, Jarret Lavallee
+Molly Waggett, Morgan Rhodes, Rob Browning, and Zachary Kent
 
 ## 5.2.4
 
 PuppetDB 5.2.4 is a minor bug-fix release.
 
 -   [All issues resolved in PuppetDB 5.2.4](https://tickets.puppetlabs.com/issues/?jql=fixVersion%20%3D%20%27PDB%205.2.4%27)
+
+### New feature
+
+- - An `upgrade` subcommand has been added that should be useful for cases where you want to upgrade across multiple major versions without skipping major versions (as per the [versioning policy][versioning]). See [these notes [multiple-major-upgrades] for additional information. 
+([PDB-3993](https://tickets.puppetlabs.com/browse/PDB-3993)) 
+
+
 
 ### Bug fixes
 

--- a/documentation/repl.markdown
+++ b/documentation/repl.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Debugging with remote REPL"
+title: "PuppetDB: Debugging with remote REPL"
 layout: default
 canonical: "/puppetdb/latest/repl.html"
 ---

--- a/documentation/scaling_recommendations.markdown
+++ b/documentation/scaling_recommendations.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Scaling recommendations"
+title: "PuppetDB: Scaling recommendations"
 layout: default
 canonical: "/puppetdb/latest/scaling_recommendations.html"
 ---

--- a/documentation/trouble_session_logging.markdown
+++ b/documentation/trouble_session_logging.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2 » Troubleshooting » Session Logging"
+title: "PuppetDB: Troubleshooting » Session Logging"
 layout: default
 canonical: "/puppetdb/latest/trouble_session_logging.html"
 ---

--- a/documentation/upgrade.markdown
+++ b/documentation/upgrade.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Upgrading PuppetDB"
+title: "PuppetDB: Upgrading PuppetDB"
 layout: default
 ---
 

--- a/documentation/using.markdown
+++ b/documentation/using.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2 » Using PuppetDB"
+title: "PuppetDB: Using PuppetDB"
 layout: default
 canonical: "/puppetdb/latest/using.html"
 ---

--- a/documentation/versioning_policy.markdown
+++ b/documentation/versioning_policy.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Versioning policy"
+title: "PuppetDB: Versioning policy"
 layout: default
 canonical: "/puppetdb/latest/versioning_policy.html"
 ---


### PR DESCRIPTION
@rbrw / @Zak-Kent we've merged these changes up through 6.0.x... and this is the final PR up to master to get some of the changes necessary to build Docker containers on Windows.

There was one merge conflict in `project.clj`, but I took what was on master - `(def pdb-version "6.1.0-SNAPSHOT")` from https://github.com/puppetlabs/puppetdb/blob/master/project.clj#L1