### PR TITLE
Updated the name on page to take out the version number.

### DIFF
--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Contributing to PuppetDB"
+title: "PuppetDB: Contributing to PuppetDB"
 layout: default
 ---
 

--- a/documentation/anonymization.markdown
+++ b/documentation/anonymization.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Export, import and anonymization"
+title: "PuppetDB: Export, import and anonymization"
 layout: default
 ---
 

--- a/documentation/api/admin/v1/archive.markdown
+++ b/documentation/api/admin/v1/archive.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Archive endpoint"
+title: "PuppetDB: Archive endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/admin/v1/archive.html"
 ---

--- a/documentation/api/admin/v1/cmd.markdown
+++ b/documentation/api/admin/v1/cmd.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Admin commands (cmd) endpoint"
+title: "PuppetDB: Admin commands (cmd) endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/admin/v1/cmd.html"
 ---

--- a/documentation/api/admin/v1/summary-stats.markdown
+++ b/documentation/api/admin/v1/summary-stats.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Summary-stats endpoint"
+title: "PuppetDB: Summary-stats endpoint"
 layout: default
 ---
 

--- a/documentation/api/command/v1/commands.markdown
+++ b/documentation/api/command/v1/commands.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Commands endpoint"
+title: "PuppetDB: Commands endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/command/v1/commands.html"
 ---

--- a/documentation/api/ext/v1/managed-packages.markdown
+++ b/documentation/api/ext/v1/managed-packages.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PE PuppetDB 5.0 » Managed Packages endpoints"
+title: "PE PuppetDB» Managed Packages endpoints"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/managed-packages.html"
 ---

--- a/documentation/api/ext/v1/resource-graphs.markdown
+++ b/documentation/api/ext/v1/resource-graphs.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2 » Extensions API (PE only)"
+title: "PuppetDB» Extensions API (PE only)"
 layout: default
 canonical: "/puppetdb/latest/api/ext/v1/resource-graphs.html"
 ---

--- a/documentation/api/ext/v1/state-overview.markdown
+++ b/documentation/api/ext/v1/state-overview.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: State overview endpoint"
+title: "PuppetDB: State overview endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/state-overview.html"
 ---

--- a/documentation/api/index.markdown
+++ b/documentation/api/index.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: API overview"
+title: "PuppetDB: API overview"
 layout: default
 canonical: "/puppetdb/latest/api/index.html"
 ---

--- a/documentation/api/meta/v1/server-time.markdown
+++ b/documentation/api/meta/v1/server-time.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Server time endpoint"
+title: "PuppetDB: Server time endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/meta/v1/server-time.html"
 ---

--- a/documentation/api/meta/v1/version.markdown
+++ b/documentation/api/meta/v1/version.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Version endpoint"
+title: "PuppetDB: Version endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/meta/v1/version.html"
 ---

--- a/documentation/api/metrics/v1/mbeans.markdown
+++ b/documentation/api/metrics/v1/mbeans.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Metrics endpoint"
+title: "PuppetDB: Metrics endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/metrics/v1/index.html"
 ---

--- a/documentation/api/query/curl.markdown
+++ b/documentation/api/query/curl.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "PuppetDB 5.2: API curl tips"
+title: "PuppetDB: API curl tips"
 canonical: "/puppetdb/latest/api/query/curl.html"
 ---
 

--- a/documentation/api/query/tutorial.markdown
+++ b/documentation/api/query/tutorial.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: API query tutorial"
+title: "PuppetDB: API query tutorial"
 layout: default
 canonical: "/puppetdb/latest/api/query/tutorial.html"
 ---

--- a/documentation/api/query/v4/aggregate-event-counts.markdown
+++ b/documentation/api/query/v4/aggregate-event-counts.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Aggregate event counts endpoint"
+title: "PuppetDB: Aggregate event counts endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/aggregate-event-counts.html"
 ---

--- a/documentation/api/query/v4/ast.markdown
+++ b/documentation/api/query/v4/ast.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: AST query language"
+title: "PuppetDB: AST query language"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/ast.html"
 ---

--- a/documentation/api/query/v4/catalogs.markdown
+++ b/documentation/api/query/v4/catalogs.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Catalogs endpoint"
+title: "PuppetDB: Catalogs endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/catalogs.html"
 ---

--- a/documentation/api/query/v4/edges.markdown
+++ b/documentation/api/query/v4/edges.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Edges endpoint"
+title: "PuppetDB: Edges endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/edges.html"
 ---

--- a/documentation/api/query/v4/entities.markdown
+++ b/documentation/api/query/v4/entities.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Entities"
+title: "PuppetDB: Entities"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/entities.html"
 ---

--- a/documentation/api/query/v4/environments.markdown
+++ b/documentation/api/query/v4/environments.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Environments endpoint"
+title: "PuppetDB: Environments endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/environments.html"
 ---

--- a/documentation/api/query/v4/event-counts.markdown
+++ b/documentation/api/query/v4/event-counts.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Event counts endpoint"
+title: "PuppetDB: Event counts endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/event-counts.html"
 ---

--- a/documentation/api/query/v4/events.markdown
+++ b/documentation/api/query/v4/events.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Events endpoint"
+title: "PuppetDB: Events endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/events.html"
 ---

--- a/documentation/api/query/v4/fact-contents.markdown
+++ b/documentation/api/query/v4/fact-contents.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Fact-contents endpoint"
+title: "PuppetDB: Fact-contents endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/fact-contents.html"
 ---

--- a/documentation/api/query/v4/fact-names.markdown
+++ b/documentation/api/query/v4/fact-names.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Fact-names endpoint"
+title: "PuppetDB: Fact-names endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/fact-names.html"
 ---

--- a/documentation/api/query/v4/fact-paths.markdown
+++ b/documentation/api/query/v4/fact-paths.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Fact-paths endpoint"
+title: "PuppetDB: Fact-paths endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/fact-paths.html"
 ---

--- a/documentation/api/query/v4/facts.markdown
+++ b/documentation/api/query/v4/facts.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Facts endpoint"
+title: "PuppetDB: Facts endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/facts.html"
 ---

--- a/documentation/api/query/v4/factsets.markdown
+++ b/documentation/api/query/v4/factsets.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Factsets endpoint"
+title: "PuppetDB: Factsets endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/factsets.html"
 ---

--- a/documentation/api/query/v4/index.markdown
+++ b/documentation/api/query/v4/index.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Root endpoint"
+title: "PuppetDB: Root endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/index.html"
 ---

--- a/documentation/api/query/v4/inventory.markdown
+++ b/documentation/api/query/v4/inventory.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Inventory endpoint"
+title: "PuppetDB: Inventory endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/inventory.html"
 ---

--- a/documentation/api/query/v4/nodes.markdown
+++ b/documentation/api/query/v4/nodes.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Nodes endpoint"
+title: "PuppetDB: Nodes endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/nodes.html"
 ---

--- a/documentation/api/query/v4/packages.markdown
+++ b/documentation/api/query/v4/packages.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Package endpoints"
+title: "PuppetDB: Package endpoints"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/packages.html"
 ---

--- a/documentation/api/query/v4/paging.markdown
+++ b/documentation/api/query/v4/paging.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Query paging"
+title: "PuppetDB: Query paging"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/paging.html"
 ---

--- a/documentation/api/query/v4/producers.markdown
+++ b/documentation/api/query/v4/producers.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Producers endpoint"
+title: "PuppetDB: Producers endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/producers.html"
 ---

--- a/documentation/api/query/v4/query.markdown
+++ b/documentation/api/query/v4/query.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Query structure"
+title: "PuppetDB: Query structure"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/query.html"
 ---

--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Reports endpoint"
+title: "PuppetDB: Reports endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/reports.html"
 ---

--- a/documentation/api/query/v4/resources.markdown
+++ b/documentation/api/query/v4/resources.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Resources endpoint"
+title: "PuppetDB: Resources endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/resources.html"
 ---

--- a/documentation/api/query/v4/upgrading-from-v3.markdown
+++ b/documentation/api/query/v4/upgrading-from-v3.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Upgrading from version 3"
+title: "PuppetDB: Upgrading from version 3"
 layout: default
 canonical: "/puppetdb/latest/api/query/v4/upgrading-from-v3.html"
 ---

--- a/documentation/api/status/v1/status.markdown
+++ b/documentation/api/status/v1/status.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Status endpoint"
+title: "PuppetDB: Status endpoint"
 layout: default
 canonical: "/puppetdb/latest/api/status/v1/status.html"
 ---

--- a/documentation/api/wire_format/catalog_format_v6.markdown
+++ b/documentation/api/wire_format/catalog_format_v6.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Catalog wire format, version 6"
+title: "PuppetDB: Catalog wire format, version 6"
 layout: default
 canonical: "/puppetdb/latest/api/wire_format/catalog_format_v6.html"
 ---

--- a/documentation/api/wire_format/catalog_format_v7.markdown
+++ b/documentation/api/wire_format/catalog_format_v7.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Catalog wire format, version 7"
+title: "PuppetDB: Catalog wire format, version 7"
 layout: default
 canonical: "/puppetdb/latest/api/wire_format/catalog_format_v7.html"
 ---

--- a/documentation/api/wire_format/catalog_format_v8.markdown
+++ b/documentation/api/wire_format/catalog_format_v8.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Catalog wire format, version 8"
+title: "PuppetDB: Catalog wire format, version 8"
 layout: default
 canonical: "/puppetdb/latest/api/wire_format/catalog_format_v8.html"
 ---

--- a/documentation/api/wire_format/catalog_format_v9.markdown
+++ b/documentation/api/wire_format/catalog_format_v9.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Catalog wire format, version 9"
+title: "PuppetDB: Catalog wire format, version 9"
 layout: default
 canonical: "/puppetdb/latest/api/wire_format/catalog_format_v9.html"
 ---

--- a/documentation/api/wire_format/deactivate_node_format_v3.markdown
+++ b/documentation/api/wire_format/deactivate_node_format_v3.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Deactivate node wire format, version 3"
+title: "PuppetDB: Deactivate node wire format, version 3"
 layout: default
 canonical: "/puppetdb/latest/api/wire_format/deactivate_node_format_v3.html"
 ---

--- a/documentation/api/wire_format/facts_format_v4.markdown
+++ b/documentation/api/wire_format/facts_format_v4.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Facts wire format, version 4"
+title: "PuppetDB: Facts wire format, version 4"
 layout: default
 canonical: "/puppetdb/latest/api/wire_format/facts_format_v4.html"
 ---

--- a/documentation/api/wire_format/facts_format_v5.markdown
+++ b/documentation/api/wire_format/facts_format_v5.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Facts wire format, version 5"
+title: "PuppetDB: Facts wire format, version 5"
 layout: default
 canonical: "/puppetdb/latest/api/wire_format/facts_format_v5.html"
 ---

--- a/documentation/api/wire_format/report_format_v5.markdown
+++ b/documentation/api/wire_format/report_format_v5.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Report wire format, version 5"
+title: "PuppetDB: Report wire format, version 5"
 layout: default
 canonical: "/puppetdb/latest/api/wire_format/report_format_v5.html"
 ---

--- a/documentation/api/wire_format/report_format_v6.markdown
+++ b/documentation/api/wire_format/report_format_v6.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Report wire format, version 6"
+title: "PuppetDB: Report wire format, version 6"
 layout: default
 canonical: "/puppetdb/latest/api/wire_format/report_format_v6.html"
 ---

--- a/documentation/api/wire_format/report_format_v7.markdown
+++ b/documentation/api/wire_format/report_format_v7.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Report wire format, version 7"
+title: "PuppetDB: Report wire format, version 7"
 layout: default
 canonical: "/puppetdb/latest/api/wire_format/report_format_v6.html"
 ---

--- a/documentation/api/wire_format/report_format_v8.markdown
+++ b/documentation/api/wire_format/report_format_v8.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Report wire format, version 8"
+title: "PuppetDB: Report wire format, version 8"
 layout: default
 canonical: "/puppetdb/latest/api/wire_format/report_format_v8.html"
 ---

--- a/documentation/community_add_ons.markdown
+++ b/documentation/community_add_ons.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Community projects and add-ons"
+title: "PuppetDB: Community projects and add-ons"
 layout: default
 canonical: "/puppetdb/latest/community_add_ons.html"
 ---

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Configuring PuppetDB"
+title: "PuppetDB: Configuring PuppetDB"
 layout: default
 canonical: "/puppetdb/latest/configure.html"
 ---

--- a/documentation/connect_puppet_apply.markdown
+++ b/documentation/connect_puppet_apply.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Connecting standalone Puppet nodes to PuppetDB"
+title: "PuppetDB: Connecting standalone Puppet nodes to PuppetDB"
 layout: default
 canonical: "/puppetdb/latest/connect_puppet_apply.html"
 ---

--- a/documentation/connect_puppet_master.markdown
+++ b/documentation/connect_puppet_master.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Connecting Puppet masters to PuppetDB"
+title: "PuppetDB: Connecting Puppet masters to PuppetDB"
 layout: default
 canonical: "/puppetdb/latest/connect_puppet_master.html"
 ---

--- a/documentation/ha.markdown
+++ b/documentation/ha.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: PuppetDB HA"
+title: "PuppetDB: PuppetDB HA"
 layout: default
 ---
 

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Installing PuppetDB from packages"
+title: "PuppetDB: Installing PuppetDB from packages"
 layout: default
 ---
 

--- a/documentation/install_from_source.markdown
+++ b/documentation/install_from_source.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Installing PuppetDB from source"
+title: "PuppetDB: Installing PuppetDB from source"
 layout: default
 ---
 

--- a/documentation/install_via_module.markdown
+++ b/documentation/install_via_module.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Installing PuppetDB via Puppet module"
+title: "PuppetDB: Installing PuppetDB via Puppet module"
 layout: default
 ---
 

--- a/documentation/known_issues.markdown
+++ b/documentation/known_issues.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Known issues"
+title: "PuppetDB: Known issues"
 layout: default
 canonical: "/puppetdb/latest/known_issues.html"
 ---

--- a/documentation/load_testing_tool.markdown
+++ b/documentation/load_testing_tool.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Load testing"
+title: "PuppetDB: Load testing"
 layout: default
 ---
 

--- a/documentation/pdb_client_tools.markdown
+++ b/documentation/pdb_client_tools.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: PuppetDB CLI"
+title: "PuppetDB: PuppetDB CLI"
 layout: default
 ---
 

--- a/documentation/pdb_support_guide.markdown
+++ b/documentation/pdb_support_guide.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Support and Troubleshooting Guide"
+title: "PuppetDB: Support and Troubleshooting Guide"
 layout: default
 ---
 

--- a/documentation/postgres_ssl.markdown
+++ b/documentation/postgres_ssl.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Setting up SSL for PostgreSQL"
+title: "PuppetDB: Setting up SSL for PostgreSQL"
 layout: default
 canonical: "/puppetdb/latest/postgres_ssl.html"
 ---

--- a/documentation/puppetdb_connection.markdown
+++ b/documentation/puppetdb_connection.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Configuring a Puppet/PuppetDB connection"
+title: "PuppetDB: Configuring a Puppet/PuppetDB connection"
 layout: default
 canonical: "/puppetdb/latest/puppetdb_connection.html"
 ---

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Release notes"
+title: "PuppetDB: Release notes"
 layout: default
 canonical: "/puppetdb/latest/release_notes.html"
 ---

--- a/documentation/repl.markdown
+++ b/documentation/repl.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Debugging with remote REPL"
+title: "PuppetDB: Debugging with remote REPL"
 layout: default
 canonical: "/puppetdb/latest/repl.html"
 ---

--- a/documentation/scaling_recommendations.markdown
+++ b/documentation/scaling_recommendations.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Scaling recommendations"
+title: "PuppetDB: Scaling recommendations"
 layout: default
 canonical: "/puppetdb/latest/scaling_recommendations.html"
 ---

--- a/documentation/upgrade.markdown
+++ b/documentation/upgrade.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Upgrading PuppetDB"
+title: "PuppetDB: Upgrading PuppetDB"
 layout: default
 ---
 

--- a/documentation/versioning_policy.markdown
+++ b/documentation/versioning_policy.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PuppetDB 5.2: Versioning policy"
+title: "PuppetDB: Versioning policy"
 layout: default
 canonical: "/puppetdb/latest/versioning_policy.html"
 ---


### PR DESCRIPTION
There were some instances of 5.2 still in the docs page titles.