### PR TITLE
(DOCUMENT-918) Remove comment of supporting postgresql 10 for now

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -269,11 +269,7 @@ server. Note that users installing PuppetDB via [the module][module]
 will already have PostgreSQL configured properly and these steps
 should not be necessary.
 
-At a minimum, you will need to ensure that you have PostgreSQL 9.6 or
-later running that will accept incoming connections, a user and
-an empty database for PuppetDB. Information on
-connection/authentication configuration in PostgreSQL and be found
-[here](https://www.postgresql.org/docs/9.6/static/auth-pg-hba-conf.html). Docs
+Ensure that you have PostgreSQL 9.6 running that will accept incoming connections, a user and an empty database for PuppetDB. Information on connection/authentication configuration in PostgreSQL and be found [here](https://www.postgresql.org/docs/9.6/static/auth-pg-hba-conf.html). Docs
 on setting up users and databases can be found in the [Getting
 Started](https://www.postgresql.org/docs/9.6/static/tutorial-start.html)
 section of the [PostgreSQL

--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -269,7 +269,7 @@ server. Note that users installing PuppetDB via [the module][module]
 will already have PostgreSQL configured properly and these steps
 should not be necessary.
 
-Ensure that you have PostgreSQL 9.6 running that will accept incoming connections, a user and an empty database for PuppetDB. Information on connection/authentication configuration in PostgreSQL and be found [here](https://www.postgresql.org/docs/9.6/static/auth-pg-hba-conf.html). Docs
+Ensure that you have configured a PostgreSQL 9.6 server to include a user and empty database for PuppetDB, and to accept connections to that database as that user. Information on connection/authentication configuration in PostgreSQL and be found [here](https://www.postgresql.org/docs/9.6/static/auth-pg-hba-conf.html). Docs
 on setting up users and databases can be found in the [Getting
 Started](https://www.postgresql.org/docs/9.6/static/tutorial-start.html)
 section of the [PostgreSQL


### PR DESCRIPTION
This commit removes mention of supporting PostgreSQL 10, based on DOCUMENT-918.