### PR TITLE
Add configuration options to the terminus to filter facts out

### DIFF
--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -31,6 +31,18 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
         package_inventory = inventory['packages'] if inventory.respond_to?(:keys)
         facts.values.delete('_puppet_inventory_1')
 
+        fact_names_blacklist = Puppet::Util::Puppetdb.config.fact_names_blacklist
+
+        fact_names_blacklist.each{|blacklisted_fact_name|
+          facts.values.delete(blacklisted_fact_name)
+        }
+
+        fact_names_blacklist_regexps = Puppet::Util::Puppetdb.config.fact_names_blacklist_regex
+
+        fact_names_blacklist_regexps.each{|blacklisted_fact_name_regexp_str|
+          facts.values.reject!{|k,v| k =~ Regexp.new(blacklisted_fact_name_regexp_str)}
+        }
+
         payload_value = {
           "certname" => facts.name,
           "values" => facts.values,

--- a/puppet/lib/puppet/util/puppetdb/config.rb
+++ b/puppet/lib/puppet/util/puppetdb/config.rb
@@ -14,9 +14,11 @@ module Puppet::Util::Puppetdb
         :server_url_timeout          => 30,
         :include_unchanged_resources => false,
         :min_successful_submissions => 1,
-        :submit_only_server_urls   => "",
-        :command_broadcast         => false,
-        :sticky_read_failover      => false
+        :submit_only_server_urls    => "",
+        :command_broadcast          => false,
+        :sticky_read_failover       => false,
+        :fact_names_blacklist       => "",
+        :fact_names_blacklist_regex => ""
       }
 
       config_file ||= File.join(Puppet[:confdir], "puppetdb.conf")
@@ -67,7 +69,9 @@ module Puppet::Util::Puppetdb
            :min_successful_submissions,
            :submit_only_server_urls,
            :command_broadcast,
-           :sticky_read_failover].include?(k))
+           :sticky_read_failover,
+           :fact_names_blacklist,
+           :fact_names_blacklist_regex].include?(k))
       end
 
       parsed_urls = config_hash[:server_urls].split(",").map {|s| s.strip}
@@ -101,6 +105,10 @@ module Puppet::Util::Puppetdb
         raise "min_successful_submissions (#{config_hash[:min_successful_submissions]}) must be less than "\
           "or equal to the number of server_urls (#{config_hash[:server_urls].length})"
       end
+
+      config_hash[:fact_names_blacklist] = config_hash[:fact_names_blacklist].split(",").map {|s| s.strip}
+
+      config_hash[:fact_names_blacklist_regex] = config_hash[:fact_names_blacklist_regex].split(",").map {|s| s.strip}
 
       self.new(config_hash)
     rescue => detail
@@ -145,6 +153,14 @@ module Puppet::Util::Puppetdb
 
     def sticky_read_failover
       config[:sticky_read_failover]
+    end
+
+    def fact_names_blacklist
+      config[:fact_names_blacklist]
+    end
+
+    def fact_names_blacklist_regex
+      config[:fact_names_blacklist_regex]
     end
 
     # @!group Private instance methods


### PR DESCRIPTION
This changeset adds two configuration options to be consumed by the facts PuppetDB indirector:

  * fact_names_blacklist
  * fact_names_blacklist_regex

They can be used to configure a list of fact names that will never be sent to PuppetDB, based on exact fact names or regular expressions. I'm aware that PuppetDB [supports black listing facts](https://puppet.com/docs/puppetdb/5.1/configure.html#facts-blacklist) but over here we do prefer to filter them in the origin to avoid sending bits over the wire that will be discarded by the other end.

I'm happy to further develop the change request adding tests and documentation if you're interested.