### PR TITLE
(PDB-4135) Support PUPPET_SUPPRESS_INTERNAL_LEIN_REPOS

### DIFF
--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -55,6 +55,12 @@ top of things.
 
 ### Testing
 
+Before you do anything else, you may want to consider setting
+`PUPPET_SUPPRESS_INTERNAL_LEIN_REPOS=1` in your environment.  We'll
+eventually make that the default, but for now that setting may help
+avoid delays incurred if lein tries to reach unreachable internal
+repositories.
+
 The easiest way to run the tests until you need to do it often is to
 use the built-in sandbox harness.  If you just want to check some
 changes against "all the normal tests", this should work (assuming

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,9 @@
 (def pdb-version "5.1.6-SNAPSHOT")
 (def clj-parent-version "1.4.3")
 
+(defn true-in-env? [x]
+  (#{"true" "yes" "1"} (System/getenv x)))
+
 (defn pdb-run-sh [& args]
   (apply vector
          ["run" "-m" "puppetlabs.puppetdb.dev.lein/run-sh" (pr-str args)]))
@@ -21,6 +24,12 @@
 
 (def need-permgen?
   (= "1.7" (System/getProperty "java.specification.version")))
+
+(def pdb-repositories
+  (if (true-in-env? "PUPPET_SUPPRESS_INTERNAL_LEIN_REPOS")
+    []
+    [["releases" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-releases__local/"]
+     ["snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-snapshots__local/"]]))
 
 ;; See the integration tests section in documentation/CONTRIBUTING.md.
 (def puppetserver-test-dep-ver
@@ -191,8 +200,7 @@
               ["-XX:MaxPermSize=200M"]
               [])
 
-  :repositories [["releases" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-releases__local/"]
-                 ["snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-snapshots__local/"]]
+  :repositories ~pdb-repositories
 
   :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]
             [lein-cloverage "1.0.6" :exclusions [org.clojure/clojure]]


### PR DESCRIPTION
Until we're able to remove the internal :repositories from the default
repository list, allow them to be removed by setting
PUPPET_SUPPRESS_INTERNAL_LEIN_REPOS to true, yes, or 1 in the
environment.