### PR TITLE
(PDB-2001) Raise an error when an invalid date is sent on a command

### DIFF
--- a/src/puppetlabs/puppetdb/time.clj
+++ b/src/puppetlabs/puppetdb/time.clj
@@ -226,7 +226,9 @@
   more likely formatters first"
   [s :- (s/maybe String)]
   (when s
-    (some #(attempt-date-time-parse % s) ordered-formatters)))
+    (or (some #(attempt-date-time-parse % s) ordered-formatters)
+        (when (re-matches (re-pattern "\\d+") s)
+          (tc/from-long (Long/parseLong s))))))
 
 (s/defn ^:always-validate to-timestamp :- (s/maybe java.sql.Timestamp)
   "Delegates to clj-time.core/to-timestamp, except when `ts` is a


### PR DESCRIPTION
This adds validation of the producer_timestamp value inside a command body.
    
This supports all the common date-time formats, and adds support for UNIX
timestamps as strings (as is used in a lot of tests)
    
When validation fails, the server returns an HTTP 500, matching the other
behavior of failures for missing required parameters and such.