### PR TITLE
(PDB-4141) Fix jdk-support-status regexes

### DIFF
--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -41,10 +41,10 @@
 (defn jdk-support-status [version]
   "Returns :official, :tested, or :unknown, or :no."
   (cond
-    (re-matches #"1.[123456]($|(\..*))" version) :no
-    (re-matches #"1.7($|(\..*))" version) :unknown
-    (re-matches #"1.8($|(\..*))*" version) :official
-    (re-matches #"1.10($|(\..*))*" version) :tested
+    (re-matches #"1\.[123456]($|(\..*))" version) :no
+    (re-matches #"1\.7($|(\..*))" version) :unknown
+    (re-matches #"1\.8($|(\..*))" version) :official
+    (re-matches #"10($|(\..*))" version) :tested
     :else :unknown))
 
 (defn describe-and-return-jdk-status [version]

--- a/test/puppetlabs/puppetdb/utils_test.clj
+++ b/test/puppetlabs/puppetdb/utils_test.clj
@@ -32,8 +32,8 @@
   (is (= :unknown (jdk-support-status "huh?")))
   (is (= :official (jdk-support-status "1.8")))
   (is (= :official (jdk-support-status "1.8.0")))
-  (is (= :tested (jdk-support-status "1.10")))
-  (is (= :tested (jdk-support-status "1.10.0"))))
+  (is (= :tested (jdk-support-status "10")))
+  (is (= :tested (jdk-support-status "10.0"))))
 
 (deftest describe-and-return-jdk-status-behavior
   (letfn [(check [version invalid?]


### PR DESCRIPTION
Both to account for the version change for newer jdks (e.g. 10 instead
of 1.10), and to fix bugs.