### PR TITLE
(maint) Add basic Azure Pipelines definition

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,48 @@
+pool:
+  # self-hosted agent on Windows 10 1709 environment
+  # includes newer Docker engine with LCOW enabled, new build of LCOW image
+  # includes Ruby 2.5, Go 1.10, Node.js 10.10, hadolint
+  name: Default
+
+variables:
+  PUPPET_DOCKER_LOCATION: git://github.com/underscorgan/puppet_docker_tools#maint/master/run-better
+
+steps:
+- checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+  clean: true  # whether to fetch clean each time
+- powershell: |
+    $line = '=' * 80
+    Write-Host "$line`nWindows`n$line`n"
+    Get-ComputerInfo |
+      select WindowsProductName, WindowsVersion, OsHardwareAbstractionLayer |
+      Out-String |
+      Write-Host
+    #
+    # Azure
+    #
+    Write-Host "`n`n$line`nAzure`n$line`n"
+    Invoke-RestMethod -Headers @{'Metadata'='true'} -URI http://169.254.169.254/metadata/instance?api-version=2017-12-01 -Method Get |
+      ConvertTo-Json -Depth 10 |
+      Write-Host
+    #
+    # Docker
+    #
+    Write-Host "`n`n$line`nDocker`n$line`n"
+    docker version
+    docker images
+    docker info
+    sc.exe qc docker
+    #
+    # Ruby
+    #
+    Write-Host "`n`n$line`nRuby`n$line`n"
+    ruby --version
+    gem --version
+    bundle --version
+    #
+    # Environment
+    #
+    Write-Host "`n`n$line`nEnvironment`n$line`n"
+    Get-ChildItem Env: | % { Write-Host "$($_.Key): $($_.Value)"  }
+  displayName: Diagnostic Host Information
+  name: hostinfo

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -1,8 +1,8 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-def location_for(place)
-  if place =~ /^((?:git|https?)[:@][^#]*)#(.*)/
-    [{ :git => $1, :branch => $2, :require => false }]
+def location_for(place, fake_version = nil)
+  if place =~ /^(git[:@][^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
   elsif place =~ /^file:\/\/(.*)/
     ['>= 0', { :path => File.expand_path($1), :require => false }]
   else


### PR DESCRIPTION
- This definition doesn't do anything other than query system information.

It must be first merged against the 5.1.x branch to enable Azure Pipelines authorization to run custom agent builds against this branch.