### PR TITLE
(PDB-2001) Validate producer-timestamp in query string

### DIFF
--- a/src/puppetlabs/puppetdb/client.clj
+++ b/src/puppetlabs/puppetdb/client.clj
@@ -9,7 +9,8 @@
             [puppetlabs.puppetdb.schema :refer [defn-validated]]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.kitchensink.core :as kitchensink]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [puppetlabs.puppetdb.time :as t]))
 
 (defn get-metric [base-url metric-name]
   (let [url (str (utils/base-url->str base-url)
@@ -42,7 +43,7 @@
    (let [body (json/generate-string payload)
          url (str (utils/base-url->str base-url)
                   (format "?command=%s&version=%s&certname=%s&producer-timestamp=%s"
-                          (str/replace command #" " "_") version certname (System/currentTimeMillis))
+                          (str/replace command #" " "_") version certname (t/now-to-string))
                   (when timeout (format "&secondsToWaitForCompletion=%s" timeout)))]
      (http-client/post url {:body body
                             :throw-exceptions false

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -114,6 +114,13 @@
                                        :timed_out false)
                                 http/status-ok)))))))
 
+(defn valid-optional-timestamp
+  "Validates a timestamp if the parameter is not nil"
+  [ts]
+  (if ts
+    (pdbtime/from-string ts) ;; handle unix timestamps as strings
+    true))
+
 (def new-request-schema
   {:params {(s/required-key "command") s/Str
             (s/required-key "version") s/Str
@@ -121,7 +128,7 @@
             (s/required-key "received") s/Str
             (s/optional-key "secondsToWaitForCompletion") s/Str
             (s/optional-key "checksum") s/Str
-            (s/optional-key "producer-timestamp") s/Str}
+            (s/optional-key "producer-timestamp") (s/pred valid-optional-timestamp)}
    :body java.io.InputStream
    s/Any s/Any})
 

--- a/src/puppetlabs/puppetdb/time.clj
+++ b/src/puppetlabs/puppetdb/time.clj
@@ -8,7 +8,8 @@
            (org.joda.time Period ReadablePeriod PeriodType DateTime))
   (:require [clj-time.coerce :as tc]
             [clj-time.format :as tf]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [clj-time.core :as t]))
 
 ;; Functions for parsing Periods from Strings
 
@@ -238,3 +239,13 @@
    (if (string? ts)
      (from-string ts)
      ts)))
+
+(defn to-string
+  "Converts a DateTime object to a 'Z' format ISO-8601 string"
+  [ts]
+  (tf/unparse (:date-time tf/formatters) ts))
+
+(defn now-to-string
+  "Gets the current time and returns it as a 'Z' format ISO-8601 string"
+  []
+  (to-string (t/now)))

--- a/test/puppetlabs/puppetdb/acceptance/node_ttl.clj
+++ b/test/puppetlabs/puppetdb/acceptance/node_ttl.clj
@@ -5,9 +5,9 @@
             [puppetlabs.puppetdb.testutils.db :refer [*db* with-test-db]]
             [puppetlabs.puppetdb.testutils.http :as tuhttp]
             [puppetlabs.puppetdb.examples :refer [wire-catalogs]]
-            [clj-time.core :refer [now]]
             [puppetlabs.puppetdb.testutils :as tu]
-            [puppetlabs.puppetdb.test-protocols :refer [called?]]))
+            [puppetlabs.puppetdb.test-protocols :refer [called?]]
+            [puppetlabs.puppetdb.time :as t]))
 
 (deftest test-node-ttl
   (tu/with-coordinated-fn run-purge-nodes puppetlabs.puppetdb.cli.services/purge-nodes!
@@ -22,7 +22,7 @@
            (let [certname "foo.com"
                  catalog (-> (get-in wire-catalogs [8 :empty])
                              (assoc :certname certname
-                                    :producer_timestamp (now)))]
+                                    :producer_timestamp (t/now-to-string)))]
              (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) certname
                                           "replace catalog" 8 catalog)
 

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -89,7 +89,7 @@
                          :values {:foo "the foo"
                                   :bar "the bar"
                                   :baz "the baz"}
-                         :producer_timestamp (to-string (now))})
+                         :producer_timestamp (pdbtime/now-to-string)})
                        "")
 
       @(block-until-results 200 (first (get-factsets "foo.local")))
@@ -125,7 +125,7 @@
                         {:certname "foo.local"
                          :environment "DEV"
                          :values {:a "a" :b "b" :c "c"}
-                         :producer_timestamp (to-string (now))})
+                         :producer_timestamp (pdbtime/now-to-string)})
                        "")
 
       @(block-until-results 200 (first (get-factsets "foo.local")))

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -22,7 +22,8 @@
                      query-result]]
             [clojure.walk :refer [stringify-keys]]
             [clojure.test :refer :all]
-            [puppetlabs.puppetdb.examples.reports :refer :all]))
+            [puppetlabs.puppetdb.examples.reports :refer :all]
+            [puppetlabs.puppetdb.time :as t]))
 
 (def endpoints [[:v4 "/v4/events"]
                 [:v4 "/v4/environments/DEV/events"]])
@@ -464,7 +465,7 @@
                            :values {"ipaddress" "1.1.1.1"}
                            :timestamp (now)
                            :environment nil
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"}))
 
   (doseq [[query results] (get versioned-subqueries endpoint)]

--- a/test/puppetlabs/puppetdb/http/explore_test.clj
+++ b/test/puppetlabs/puppetdb/http/explore_test.clj
@@ -8,7 +8,8 @@
             [puppetlabs.puppetdb.testutils :refer [assert-success! get-request]]
             [puppetlabs.puppetdb.testutils.db :refer [with-test-db]]
             [puppetlabs.puppetdb.testutils.http :refer [*app* deftest-http-app]]
-            [puppetlabs.puppetdb.examples :refer :all]))
+            [puppetlabs.puppetdb.examples :refer :all]
+            [puppetlabs.puppetdb.time :as t]))
 
 (defn get-versioned-response
   [version route]
@@ -56,19 +57,19 @@
                            :values facts1
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo1"})
     (scf-store/add-facts! {:certname "host2"
                            :values facts2
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo2"})
     (scf-store/add-facts! {:certname "host3"
                            :values facts3
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo3"})
     (scf-store/deactivate-node! "host3")
 

--- a/test/puppetlabs/puppetdb/http/fact_names_test.clj
+++ b/test/puppetlabs/puppetdb/http/fact_names_test.clj
@@ -12,7 +12,8 @@
                      query-response
                      query-result
                      vector-param]]
-            [puppetlabs.puppetdb.jdbc :refer [with-transacted-connection]]))
+            [puppetlabs.puppetdb.jdbc :refer [with-transacted-connection]]
+            [puppetlabs.puppetdb.time :as t]))
 
 (def fact-name-endpoints [[:v4 "/v4/fact-names"]])
 
@@ -51,20 +52,20 @@
                              :values facts2
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp (now)
+                             :producer_timestamp (t/now-to-string)
                              :producer "bar2"})
       (scf-store/add-facts! {:certname "foo3"
                              :values facts3
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp (now)
+                             :producer_timestamp (t/now-to-string)
                              :producer "bar3"})
       (scf-store/deactivate-node! "foo1")
       (scf-store/add-facts! {:certname "foo1"
                              :values  facts1
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp (now)
+                             :producer_timestamp (t/now-to-string)
                              :producer "bar1"}))
 
     (let [expected-result ["domain" "hostname" "kernel" "memorysize" "operatingsystem" "uptime_seconds"]]
@@ -151,20 +152,20 @@
                              :values facts2
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp (now)
+                             :producer_timestamp (t/now-to-string)
                              :producer "bar2"})
       (scf-store/add-facts! {:certname "foo3"
                              :values facts3
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp (now)
+                             :producer_timestamp (t/now-to-string)
                              :producer "bar3"})
       (scf-store/deactivate-node! "foo1")
       (scf-store/add-facts! {:certname "foo1"
                              :values  facts1
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp (now)
+                             :producer_timestamp (t/now-to-string)
                              :producer "bar1"}))
 
     (testing "query should return appropriate results"

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -39,7 +39,8 @@
              :refer [call-with-puppetdb-instance]]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.trapperkeeper.app :refer [get-service]]
-            [puppetlabs.puppetdb.middleware :as mid]))
+            [puppetlabs.puppetdb.middleware :as mid]
+            [puppetlabs.puppetdb.time :as t]))
 
 (def v4-facts-endpoint "/v4/facts")
 (def v4-facts-environment "/v4/environments/DEV/facts")
@@ -543,25 +544,25 @@
                              :values facts1
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp (now)
+                             :producer_timestamp (t/now-to-string)
                              :producer "bar1"})
       (scf-store/add-facts! {:certname  "foo2"
                              :values facts2
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp (now)
+                             :producer_timestamp (t/now-to-string)
                              :producer "bar2"})
       (scf-store/add-facts! {:certname "foo3"
                              :values facts3
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp (now)
+                             :producer_timestamp (t/now-to-string)
                              :producer nil})
       (scf-store/add-facts! {:certname "foo4"
                              :values facts4
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp (now)
+                             :producer_timestamp (t/now-to-string)
                              :producer "bar4"})
       (scf-store/deactivate-node! "foo4"))
 
@@ -608,19 +609,19 @@
                          :values {"ipaddress" "192.168.1.100" "operatingsystem" "Debian" "osfamily" "Debian" "uptime_seconds" 11000}
                          :timestamp (now)
                          :environment "DEV"
-                         :producer_timestamp (now)
+                         :producer_timestamp (t/now-to-string)
                          :producer "mom"})
   (scf-store/add-facts! {:certname "bar"
                          :values {"ipaddress" "192.168.1.101" "operatingsystem" "Ubuntu" "osfamily" "Debian" "uptime_seconds" 12}
                          :timestamp (now)
                          :environment "DEV"
-                         :producer_timestamp (now)
+                         :producer_timestamp (t/now-to-string)
                          :producer "mom"})
   (scf-store/add-facts! {:certname "baz"
                          :values {"ipaddress" "192.168.1.102" "operatingsystem" "CentOS" "osfamily" "RedHat" "uptime_seconds" 50000}
                          :timestamp (now)
                          :environment "DEV"
-                         :producer_timestamp (now)
+                         :producer_timestamp (t/now-to-string)
                          :producer "mom"})
 
   (let [catalog (:empty catalogs)
@@ -681,7 +682,7 @@
                                      :values facts1
                                      :timestamp (now)
                                      :environment "DEV"
-                                     :producer_timestamp (now)
+                                     :producer_timestamp (t/now-to-string)
                                      :producer "bar1"}))
 
             (testing "queries only use the read database"
@@ -750,13 +751,13 @@
                              :values facts1
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp (now)
+                             :producer_timestamp (t/now-to-string)
                              :producer "bar1"})
       (scf-store/add-facts! {:certname "foo2"
                              :values facts2
                              :timestamp (now)
                              :environment "DEV"
-                             :producer_timestamp (now)
+                             :producer_timestamp (t/now-to-string)
                              :producer "bar2"}))
 
     (testing "should support fact paging"
@@ -829,35 +830,35 @@
                            :values {"hostname" "c-host"}
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
     (scf-store/add-certname! "a.local")
     (scf-store/add-facts! {:certname "a.local"
                            :values {"hostname" "a-host"}
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
     (scf-store/add-certname! "d.local")
     (scf-store/add-facts! {:certname "d.local"
                            :values {"uptime_days" "2"}
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
     (scf-store/add-certname! "b.local")
     (scf-store/add-facts! {:certname "b.local"
                            :values {"uptime_days" "4"}
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
     (scf-store/add-certname! "e.local")
     (scf-store/add-facts! {:certname "e.local"
                            :values {"my_structured_fact" (:value f5)}
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
 
     (testing "include total results count"
@@ -968,35 +969,35 @@
                            :values {"my_structured_fact" (:value f3)}
                            :timestamp (now)
                            :environment "C"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
     (scf-store/add-certname! "a.local")
     (scf-store/add-facts! {:certname "a.local"
                            :values {"hostname" "a-host"}
                            :timestamp (now)
                            :environment "A"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
     (scf-store/add-certname! "b.local")
     (scf-store/add-facts! {:certname "b.local"
                            :values {"uptime_days" "4"}
                            :timestamp (now)
                            :environment "B"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
     (scf-store/add-certname! "b2.local")
     (scf-store/add-facts! {:certname "b2.local"
                            :values {"max" "4"}
                            :timestamp (now)
                            :environment "B"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
     (scf-store/add-certname! "d.local")
     (scf-store/add-facts! {:certname "d.local"
                            :values {"min" "-4"}
                            :timestamp (now)
                            :environment "D"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
 
     (testing "ordering by environment should work"
@@ -1051,22 +1052,22 @@
                                :values facts1
                                :timestamp (now)
                                :environment "DEV"
-                               :producer_timestamp (now)})
+                               :producer_timestamp (t/now-to-string)})
         (scf-store/add-facts! {:certname "foo2"
                                :values facts2
                                :timestamp (now)
                                :environment "DEV"
-                               :producer_timestamp (now)})
+                               :producer_timestamp (t/now-to-string)})
         (scf-store/add-facts! {:certname "foo3"
                                :values facts3
                                :timestamp (now)
                                :environment "PROD"
-                               :producer_timestamp (now)})
+                               :producer_timestamp (t/now-to-string)})
         (scf-store/add-facts! {:certname "foo4"
                                :values facts4
                                :timestamp (now)
                                :environment "PROD"
-                               :producer_timestamp (now)}))
+                               :producer_timestamp (t/now-to-string)}))
 
       (doseq [query '[[= environment PROD]
                       [not [= environment DEV]]
@@ -1962,7 +1963,7 @@
                           (let [facts {:certname "foo"
                                        :timestamp (now)
                                        :environment "DEV"
-                                       :producer_timestamp (now)
+                                       :producer_timestamp (t/now-to-string)
                                        :producer "bar"
                                        :values{"foo" "bar"
                                                "baz" "bax"}}]

--- a/test/puppetlabs/puppetdb/http/index_test.clj
+++ b/test/puppetlabs/puppetdb/http/index_test.clj
@@ -14,7 +14,8 @@
                      query-response
                      query-result
                      vector-param
-                     with-http-app]]))
+                     with-http-app]]
+            [puppetlabs.puppetdb.time :as t]))
 
 ;; Queries issued at the root query endpoint
 (def endpoints [[:v4 "/v4"]])
@@ -45,25 +46,25 @@
                            :values facts1
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo1"})
     (scf-store/add-facts! {:certname "host2"
                            :values facts2
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo2"})
     (scf-store/add-facts! {:certname "host3"
                            :values facts3
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo3"})
     (scf-store/add-facts! {:certname "host4"
                            :values facts4
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo4"})
     (scf-store/deactivate-node! "host4")
 
@@ -335,7 +336,7 @@
                         "baz" 3
                         "match" "match"}
                :timestamp right-now
-               :producer_timestamp right-now
+               :producer_timestamp (t/to-string right-now)
                :producer "bar.com"}]
     (with-test-db
       (scf-store/add-certname! "foo.local")
@@ -408,7 +409,7 @@
                           "bar" 2
                           "baz" 3}
                  :timestamp right-now
-                 :producer_timestamp right-now}
+                 :producer_timestamp (t/to-string right-now)}
           resource {:type "File"
                     :title "/etc/apache/apache2.conf"
                     :exported false

--- a/test/puppetlabs/puppetdb/pdb_routing_test.clj
+++ b/test/puppetlabs/puppetdb/pdb_routing_test.clj
@@ -4,9 +4,7 @@
             [puppetlabs.puppetdb.testutils :as tu]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.time :as time]
-            [puppetlabs.puppetdb.client :as pdb-client]
-            [clj-time.coerce :refer [to-string]]
-            [clj-time.core :refer [now]]
+            [puppetlabs.puppetdb.client :as pdb-client] 
             [puppetlabs.puppetdb.testutils.dashboard :as dtu]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.cli.services :as clisvc]
@@ -28,7 +26,7 @@
 
 (def test-facts {:certname "foo.com"
                  :environment "DEV"
-                 :producer_timestamp (to-string (now))
+                 :producer_timestamp (time/now-to-string)
                  :values {:foo 1
                           :bar "2"
                           :baz 3}})

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -9,7 +9,8 @@
             [puppetlabs.puppetdb.testutils.db :refer [*db* with-test-db]]
             [puppetlabs.puppetdb.testutils.http :refer [*app* deftest-http-app]]
             [puppetlabs.puppetdb.http :as http]
-            [puppetlabs.puppetdb.scf.storage-utils :as su]))
+            [puppetlabs.puppetdb.scf.storage-utils :as su]
+            [puppetlabs.puppetdb.time :as t]))
 
 (deftest test-plan-sql
   (let [col1 {:type :string :field :foo}
@@ -197,20 +198,20 @@
                            :values facts2
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "bar2"})
     (scf-store/add-facts! {:certname "foo3"
                            :values facts3
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "bar3"})
     (scf-store/deactivate-node! "foo1")
     (scf-store/add-facts! {:certname "foo1"
                            :values  facts1
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "bar1"}))
 
   (let [expected-result ["domain" "hostname" "kernel" "memorysize"

--- a/test/puppetlabs/puppetdb/testutils/cli.clj
+++ b/test/puppetlabs/puppetdb/testutils/cli.clj
@@ -1,7 +1,5 @@
 (ns puppetlabs.puppetdb.testutils.cli
-  (:require [clj-time.coerce :as time-coerce]
-            [clj-time.core :as time]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [clojure.walk :refer [keywordize-keys stringify-keys]]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.utils :as utils]
@@ -14,7 +12,8 @@
             [puppetlabs.puppetdb.testutils.catalogs :as tuc]
             [puppetlabs.puppetdb.testutils.facts :as tuf]
             [puppetlabs.puppetdb.testutils.services :as svc-utils]
-            [clojure.walk :as walk]))
+            [clojure.walk :as walk]
+            [puppetlabs.puppetdb.time :as t]))
 
 (defn get-nodes []
   (-> (svc-utils/query-url-str "/nodes")
@@ -51,14 +50,14 @@
             :bar "the bar"
             :baz "the baz"
             :biz {:a [3.14 2.71] :b "the b" :c [1 2 3] :d {:e nil}}}
-   :producer_timestamp (time-coerce/to-string (time/now))
+   :producer_timestamp (t/now-to-string)
    :producer example-producer})
 
 (def example-catalog
   (-> examples/wire-catalogs
       (get-in [9 :empty])
       (assoc :certname example-certname
-             :producer_timestamp (time/now))))
+             :producer_timestamp (t/now-to-string))))
 
 (def example-report
   (-> examples-reports/reports

--- a/test/puppetlabs/puppetdb/testutils/nodes.clj
+++ b/test/puppetlabs/puppetdb/testutils/nodes.clj
@@ -4,7 +4,8 @@
             [puppetlabs.puppetdb.examples :refer :all]
             [puppetlabs.puppetdb.zip :as zip]
             [puppetlabs.puppetdb.reports :as report]
-            [clj-time.core :refer [now plus seconds]]))
+            [clj-time.core :refer [now plus seconds]]
+            [puppetlabs.puppetdb.time :as t]))
 
 (defn change-certname
   "Changes [:certname certname] anywhere in `data` to `new-certname`"
@@ -51,7 +52,7 @@
                                     "uptime_seconds" 10000}
                            :timestamp (now)
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
     (scf-store/add-facts! {:certname web2
                            :values {"ipaddress" "192.168.1.101"
@@ -60,7 +61,7 @@
                                     "uptime_seconds" 13000}
                            :timestamp (plus (now) (seconds 1))
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
     (scf-store/add-facts! {:certname puppet
                            :values {"ipaddress" "192.168.1.110"
@@ -68,7 +69,7 @@
                                     "RedHat" "uptime_seconds" 15000}
                            :timestamp (plus (now) (seconds 2))
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
     (scf-store/add-facts! {:certname db
                            :values {"ipaddress" "192.168.1.111"
@@ -76,7 +77,7 @@
                                     "operatingsystem" "Debian"}
                            :timestamp (plus (now) (seconds 3))
                            :environment "DEV"
-                           :producer_timestamp (now)
+                           :producer_timestamp (t/now-to-string)
                            :producer "foo.com"})
     (scf-store/replace-catalog! (assoc web1-catalog :certname web1) (now))
     (scf-store/replace-catalog! (assoc puppet-catalog :certname puppet) (plus (now) (seconds 1)))


### PR DESCRIPTION
Adds validation to the producer-timestamp in the query string of a command. This
ignores the producer_timestamp in the body, as we do not do validation of
command bodies until the command is popped off the queue.

Also modifies tests that submit producer_timestamp to reflect the proper 'Z'
format of ISO-8601. The command processors fail when this value is a UNIX
timestamp instead of an ISO-8601 string, so updating the tests improves our
"example" code for this field to match the wire format.