### PR TITLE
(PDB-4165) Duplicate dependency pins in :ezbake profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,6 @@
 (def pdb-version "5.1.6-SNAPSHOT")
 (def clj-parent-version "1.4.3")
+(def tk-jetty9-ver "2.2.0")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))
@@ -58,10 +59,10 @@
 
 (def pdb-dev-deps
   (concat
+   `[[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-ver :classifier "test"]]
    '[[ring-mock]
      [puppetlabs/trapperkeeper :classifier "test"]
      [puppetlabs/kitchensink :classifier "test"]
-     [puppetlabs/trapperkeeper-webserver-jetty9 "2.2.0" :classifier "test"]
      [org.flatland/ordered "1.5.3"]
      [org.clojure/test.check "0.9.0"]
      [com.gfredericks/test.chuck "0.2.7" :exclusions
@@ -74,6 +75,18 @@
      [puppetlabs/trapperkeeper-authorization nil]
      [puppetlabs/trapperkeeper-filesystem-watcher nil]]
    puppetserver-test-deps))
+
+;; Until we resolve the issue with :dependencies ^:replace in the
+;; ezbake profile below ignoring all the pins in :dependencies, repeat
+;; them in both places via this list.  For now, only include the pins
+;; that we added after we recognized the problem (when fixing CVEs),
+;; so we don't change unrelated deps that have been deployed for a
+;; long time.
+(def pdb-dep-pins
+  `[;; Use jetty 9.4.11.v20180605 to fix CVE-2017-7656 (PDB-4160)
+    [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-ver]
+    ;; Fix CVE-2018-5968 (PDB-4161)
+    [com.fasterxml.jackson.core/jackson-databind "2.9.7"]])
 
 ;; Don't use lein :clean-targets so that we don't have to repeat
 ;; ourselves, given that we need to remove some protected files, and
@@ -127,74 +140,71 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :dependencies [;; Clojure org
-                 [org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.async]
-                 [org.clojure/core.match "0.3.0-alpha4" :exclusions [org.clojure/tools.analyzer.jvm]]
-                 [org.clojure/core.memoize "0.5.9"]
-                 [org.clojure/java.jdbc "0.6.1"]
-                 [org.clojure/tools.macro]
-                 [org.clojure/math.combinatorics "0.1.1"]
-                 [org.clojure/math.numeric-tower "0.0.4"]
-                 [org.clojure/tools.logging]
+  :dependencies ~(concat
+                  pdb-dep-pins
+                  '[[org.clojure/clojure "1.8.0"]
+                    [org.clojure/core.async]
+                    [org.clojure/core.match "0.3.0-alpha4" :exclusions [org.clojure/tools.analyzer.jvm]]
+                    [org.clojure/core.memoize "0.5.9"]
+                    [org.clojure/java.jdbc]
+                    [org.clojure/tools.macro]
+                    [org.clojure/math.combinatorics "0.1.1"]
+                    [org.clojure/math.numeric-tower "0.0.4"]
+                    [org.clojure/tools.logging]
 
-                 ;; Puppet specific
-                 [puppetlabs/comidi]
-                 [puppetlabs/dujour-version-check]
-                 [puppetlabs/http-client]
-                 [puppetlabs/i18n]
-                 [puppetlabs/kitchensink]
-                 [puppetlabs/stockpile "0.0.4"]
-                 [puppetlabs/tools.namespace "0.2.4.1"]
-                 [puppetlabs/trapperkeeper]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "2.2.0"]
-                 [puppetlabs/trapperkeeper-metrics :exclusions [ring/ring-defaults org.slf4j/slf4j-api]]
-                 [puppetlabs/trapperkeeper-status]
+                    ;; Puppet specific
+                    [puppetlabs/comidi]
+                    [puppetlabs/dujour-version-check]
+                    [puppetlabs/http-client]
+                    [puppetlabs/i18n]
+                    [puppetlabs/kitchensink]
+                    [puppetlabs/stockpile "0.0.4"]
+                    [puppetlabs/tools.namespace "0.2.4.1"]
+                    [puppetlabs/trapperkeeper]
+                    [puppetlabs/trapperkeeper-metrics :exclusions [ring/ring-defaults org.slf4j/slf4j-api]]
+                    [puppetlabs/trapperkeeper-status]
 
-                 ;; Various
-                 [cheshire]
-                 [clj-stacktrace]
-                 [clj-time]
-                 [com.rpl/specter "0.5.7"]
-                 [com.taoensso/nippy "2.10.0" :exclusions [org.clojure/tools.reader]]
-                 [digest "1.4.3"]
-                 [fast-zip-visit "1.0.2"]
-                 [instaparse "1.4.1"]
-                 [me.raynes/fs]
-                 [metrics-clojure "2.6.1" :exclusions [org.clojure/clojure org.slf4j/slf4j-api]]
-                 [prismatic/schema "1.1.2"]
-                 [robert/hooke "1.3.0"]
-                 [slingshot]
-                 [trptcolin/versioneer]
+                    ;; Various
+                    [cheshire]
+                    [clj-stacktrace]
+                    [clj-time]
+                    [com.rpl/specter "0.5.7"]
+                    [com.taoensso/nippy "2.10.0" :exclusions [org.clojure/tools.reader]]
+                    [digest "1.4.3"]
+                    [fast-zip-visit "1.0.2"]
+                    [instaparse "1.4.1"]
+                    [me.raynes/fs]
+                    [metrics-clojure "2.6.1" :exclusions [org.clojure/clojure org.slf4j/slf4j-api]]
+                    [prismatic/schema "1.1.2"]
+                    [robert/hooke "1.3.0"]
+                    [slingshot]
+                    [trptcolin/versioneer]
 
-                 ;; Filesystem utilities
-                 [org.apache.commons/commons-lang3 "3.4"]
-                 ;; Version information
-                 ;; Job scheduling
-                 [overtone/at-at "1.2.0"]
+                    ;; Filesystem utilities
+                    [org.apache.commons/commons-lang3 "3.4"]
+                    ;; Version information
+                    ;; Job scheduling
+                    [overtone/at-at "1.2.0"]
 
-                 ;; Database connectivity
-                 [com.zaxxer/HikariCP "2.4.3" :exclusions [org.slf4j/slf4j-api]]
-                 [honeysql "0.6.3"]
-                 [org.postgresql/postgresql "9.4.1208.jre7"]
+                    ;; Database connectivity
+                    [com.zaxxer/HikariCP]
+                    [honeysql "0.6.3"]
+                    [org.postgresql/postgresql "9.4.1208.jre7"]
 
-                 ;; MQ connectivity
-                 [org.apache.activemq/activemq-broker "5.13.2" :exclusions [org.slf4j/slf4j-api]]
-                 [org.apache.activemq/activemq-kahadb-store "5.13.2" :exclusions [org.slf4j/slf4j-api]]
-                 [org.apache.activemq/activemq-pool "5.13.2" :exclusions [org.slf4j/slf4j-api]]
-                 ;; bridge to allow some spring/activemq stuff to log over slf4j
-                 [org.slf4j/jcl-over-slf4j "1.7.14" :exclusions [org.slf4j/slf4j-api]]
+                    ;; MQ connectivity
+                    [org.apache.activemq/activemq-broker "5.13.2" :exclusions [org.slf4j/slf4j-api]]
+                    [org.apache.activemq/activemq-kahadb-store "5.13.2" :exclusions [org.slf4j/slf4j-api]]
+                    [org.apache.activemq/activemq-pool "5.13.2" :exclusions [org.slf4j/slf4j-api]]
+                    ;; bridge to allow some spring/activemq stuff to log over slf4j
+                    [org.slf4j/jcl-over-slf4j "1.7.14" :exclusions [org.slf4j/slf4j-api]]
 
-                 ;; WebAPI support libraries.
-                 [bidi "2.0.12" :exclusions [org.clojure/clojurescript]]
-                 [clj-http "2.0.1" :exclusions [org.apache.httpcomponents/httpcore org.apache.httpcomponents/httpclient]]
-                 [com.novemberain/pantomime "2.1.0"]
-                 [compojure]
-                 [org.apache.commons/commons-compress "1.10"]
-                 [ring/ring-core :exclusions [javax.servlet/servlet-api org.clojure/tools.reader]]
-
-                 ;; Pin version for PDB-3809
-                 [com.fasterxml.jackson.core/jackson-databind "2.9.7"]]
+                    ;; WebAPI support libraries.
+                    [bidi "2.0.12" :exclusions [org.clojure/clojurescript]]
+                    [clj-http "2.0.1" :exclusions [org.apache.httpcomponents/httpcore org.apache.httpcomponents/httpclient]]
+                    [com.novemberain/pantomime "2.1.0"]
+                    [compojure]
+                    [org.apache.commons/commons-compress "1.10"]
+                    [ring/ring-core :exclusions [javax.servlet/servlet-api org.clojure/tools.reader]]])
 
   :jvm-opts ~(if need-permgen?
               ["-XX:MaxPermSize=200M"]
@@ -236,28 +246,30 @@
                    :injections [(do
                                   (require 'schema.core)
                                   (schema.core/set-fn-validation! true))]}
-             :ezbake {:dependencies ^:replace [;; NOTE: we need to explicitly pass in `nil` values
-                                               ;; for the version numbers here in order to correctly
-                                               ;; inherit the versions from our parent project.
-                                               ;; This is because of a bug in lein 2.7.1 that
-                                               ;; prevents the deps from being processed properly
-                                               ;; with `:managed-dependencies` when you specify
-                                               ;; dependencies in a profile.  See:
-                                               ;; https://github.com/technomancy/leiningen/issues/2216
-                                               ;; Hopefully we can remove those `nil`s (if we care)
-                                               ;; and this comment when lein 2.7.2 is available.
+             :ezbake {:dependencies ^:replace ~(concat
+                                                pdb-dep-pins
+                                                `[;; NOTE: we need to explicitly pass in `nil` values
+                                                  ;; for the version numbers here in order to correctly
+                                                  ;; inherit the versions from our parent project.
+                                                  ;; This is because of a bug in lein 2.7.1 that
+                                                  ;; prevents the deps from being processed properly
+                                                  ;; with `:managed-dependencies` when you specify
+                                                  ;; dependencies in a profile.  See:
+                                                  ;; https://github.com/technomancy/leiningen/issues/2216
+                                                  ;; Hopefully we can remove those `nil`s (if we care)
+                                                  ;; and this comment when lein 2.7.2 is available.
 
-                                               ;; we need to explicitly pull in our parent project's
-                                               ;; clojure version here, because without it, lein
-                                               ;; brings in its own version, and older versions of
-                                               ;; lein depend on clojure 1.6.
-                                               [org.clojure/clojure nil]
+                                                  ;; we need to explicitly pull in our parent project's
+                                                  ;; clojure version here, because without it, lein
+                                                  ;; brings in its own version, and older versions of
+                                                  ;; lein depend on clojure 1.6.
+                                                  [org.clojure/clojure nil]
 
-                                               ;; This circular dependency is required because of a bug in
-                                               ;; ezbake (EZ-35); without it, bootstrap.cfg will not be included
-                                               ;; in the final package.
-                                               [puppetlabs/puppetdb ~pdb-version]
-                                               [org.clojure/tools.nrepl nil]]
+                                                  ;; This circular dependency is required because of a bug in
+                                                  ;; ezbake (EZ-35); without it, bootstrap.cfg will not be included
+                                                  ;; in the final package.
+                                                  [puppetlabs/puppetdb ~pdb-version]
+                                                  [org.clojure/tools.nrepl nil]])
                       :name "puppetdb"
                       :plugins [[puppetlabs/lein-ezbake "1.8.5"]]}
              :testutils {:source-paths ^:replace ["test"]}


### PR DESCRIPTION
It looks like the use of ^:replace :dependencies in the ezbake profile
causes all pins in the normal :dependencies section to be ignored.  So
for now, just repeat the pins for the recent CVEs in the :ezbake
profile, which does cause them to show up here:

  lein with-profiles ezbake deps :tree

In addition, stop pinning hikaricp and clojure/jdbc so that we won't
fall afoul of :pedantic, *and* so that we'll actually be testing the
versions that we ship (verified by spot-checking the relevant
META-INF/maven/ pom.xml versions in the 5.1.5 debian/stretch jar).