### PR TITLE
(PDB-2276) Replace robert.hooke with explicit config map

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -161,7 +161,7 @@
                  [puppetlabs/kitchensink]
                  [puppetlabs/stockpile "0.0.4"]
                  [puppetlabs/tools.namespace "0.2.4.1"]
-                 [puppetlabs/trapperkeeper]
+                 [puppetlabs/trapperkeeper "1.5.7-SNAPSHOT"]
                  [puppetlabs/trapperkeeper-webserver-jetty9]
                  [puppetlabs/trapperkeeper-metrics]
                  [puppetlabs/trapperkeeper-status]
@@ -177,7 +177,6 @@
                  [instaparse]
                  [me.raynes/fs]
                  [metrics-clojure]
-                 [robert/hooke "1.3.0"]
                  [slingshot]
                  [trptcolin/versioneer]
 

--- a/resources/puppetlabs/puppetdb/bootstrap.cfg
+++ b/resources/puppetlabs/puppetdb/bootstrap.cfg
@@ -19,7 +19,6 @@ puppetlabs.puppetdb.cli.services/puppetdb-service
 puppetlabs.puppetdb.command/command-service
 puppetlabs.puppetdb.pdb-routing/maint-mode-service
 puppetlabs.puppetdb.pdb-routing/pdb-routing-service
-puppetlabs.puppetdb.config/config-service
 
 # NREPL
 puppetlabs.trapperkeeper.services.nrepl.nrepl-service/nrepl-service

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -622,7 +622,7 @@
 
 (defservice command-service
   PuppetDBCommandDispatcher
-  [[:DefaultedConfig get-config]
+  [[:ConfigService get-config]
    [:PuppetDBServer shared-globals]]
   (init [this context]
     (let [response-chan (async/chan 1000)

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -97,7 +97,7 @@
    [:PuppetDBServer clean shared-globals query set-url-prefix]
    [:PuppetDBCommandDispatcher enqueue-command]
    [:MaintenanceMode enable-maint-mode maint-mode? disable-maint-mode]
-   [:DefaultedConfig get-config]
+   [:ConfigService get-config]
    [:StatusService register-status]]
   (init [this context]
         (let [context-root (get-route this)

--- a/test-resources/integration-bootstrap.cfg
+++ b/test-resources/integration-bootstrap.cfg
@@ -7,5 +7,4 @@ puppetlabs.puppetdb.cli.services/puppetdb-service
 puppetlabs.puppetdb.command/command-service
 puppetlabs.puppetdb.pdb-routing/maint-mode-service
 puppetlabs.puppetdb.pdb-routing/pdb-routing-service
-puppetlabs.puppetdb.config/config-service
 puppetlabs.puppetdb.dashboard/dashboard-redirect-service

--- a/test/puppetlabs/puppetdb/admin_clean_test.clj
+++ b/test/puppetlabs/puppetdb/admin_clean_test.clj
@@ -6,7 +6,7 @@
             [metrics.gauges :as gauges]
             [metrics.timers :as timers]
             [puppetlabs.puppetdb.admin :as admin]
-            [puppetlabs.puppetdb.config :as conf]
+            [puppetlabs.trapperkeeper.config :as conf]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.cli.services :as cli-svc]
             [puppetlabs.puppetdb.http :as http]
@@ -135,7 +135,7 @@
 
 (deftest node-purge-batch-limits
   (with-pdb-with-no-gc
-    (let [config (-> *server* (get-service :DefaultedConfig) conf/get-config)
+    (let [config (-> *server* (get-service :ConfigService) conf/get-config)
           orig-clean @#'cli-svc/clean-puppetdb
           after-clean (CyclicBarrier. 2)
           node-purge-ttl (get-in config [:database :node-purge-ttl])

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -60,7 +60,8 @@
             [puppetlabs.trapperkeeper.services
              :refer [service-context]]
             [overtone.at-at :refer [mk-pool scheduled-jobs]]
-            [puppetlabs.puppetdb.testutils :as tu])
+            [puppetlabs.puppetdb.testutils :as tu]
+            [puppetlabs.trapperkeeper.config :as tkconfig])
   (:import [java.nio.file Files]
            [java.util.concurrent TimeUnit]
            [org.joda.time DateTime DateTimeZone]))
@@ -1360,7 +1361,7 @@
       (is (empty? (fs/list-dir (:path dlo)))))))
 
 (defn- get-config []
-  (conf/get-config (get-service svc-utils/*server* :DefaultedConfig)))
+  (tkconfig/get-config (get-service svc-utils/*server* :ConfigService)))
 
 (deftest command-service-stats
   (svc-utils/with-puppetdb-instance

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -33,7 +33,6 @@
             [puppetlabs.puppetdb.dashboard :refer [dashboard-redirect-service]]
             [puppetlabs.puppetdb.pdb-routing :refer [pdb-routing-service
                                                      maint-mode-service]]
-            [puppetlabs.puppetdb.config :refer [config-service]]
             [puppetlabs.http.client.sync :as http]
             [puppetlabs.puppetdb.schema :as pls]
             [ring.util.response :as rr]))
@@ -75,8 +74,7 @@
    #'metrics-webservice
    #'dashboard-redirect-service
    #'pdb-routing-service
-   #'maint-mode-service
-   #'config-service])
+   #'maint-mode-service])
 
 (defn clear-counters!
   [metrics]


### PR DESCRIPTION
This removes the use of the robert.hooke library to interrupt normal
trapperkeeper config processing flow. Now we allow tk to parse the config, then
we manipulate it with our defaults and conversion and retirement warnings, then
call a new function in tk to boot with that modified config.

Depends on puppetlabs/trapperkeeper#278