### PR TITLE
(PDB-4178) Expose TTL config options with ENV variables

### DIFF
--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -10,6 +10,9 @@ ENV UBUNTU_CODENAME="xenial"
 ENV PUPPETDB_DATABASE_CONNECTION="//postgres:5432/puppetdb"
 ENV PUPPETDB_USER=puppetdb
 ENV PUPPETDB_PASSWORD=puppetdb
+ENV PUPPETDB_NODE_TTL=7d
+ENV PUPPETDB_NODE_PURGE_TTL=14d
+ENV PUPPETDB_REPORT_TTL=14d
 ENV PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m"
 ENV PATH="/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH"
 

--- a/docker/puppetdb/conf.d/database.conf
+++ b/docker/puppetdb/conf.d/database.conf
@@ -2,4 +2,7 @@ database: {
   subname: ${PUPPETDB_DATABASE_CONNECTION}
   username: ${PUPPETDB_USER}
   password: ${PUPPETDB_PASSWORD}
+  node-ttl: ${PUPPETDB_NODE_TTL}
+  node-purge-ttl: ${PUPPETDB_NODE_PURGE_TTL}
+  report-ttl: ${PUPPETDB_REPORT_TTL}
 }


### PR DESCRIPTION
This makes it easier to use PuppetDB in a dev setup where you might want to disable purging.