### PR TITLE
(PDB-4179) Travis: fix master test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,23 @@ jobs:
       env: PDB_TEST=core+ext/openjdk10/pg-9.6
       script: *run-core-and-ext-tests
 
+    # === integration with master branches
+    - stage: ❧ pdb tests
+      env: PDB_TEST=int/openjdk10/pup-master/srv-master/pg-9.6
+      script: *run-integration-tests
+
+    - stage: ❧ pdb tests
+      env: PDB_TEST=int/openjdk10/pup-master/srv-master/pg-9.6/rich
+      script: *run-integration-tests
+
+    - stage: ❧ pdb tests
+      env: PDB_TEST=int/openjdk8/pup-master/srv-master/pg-9.6/rich
+      script: *run-integration-tests
+
+    - stage: ❧ pdb tests
+      env: PDB_TEST=int/oraclejdk8/pup-master/srv-master/pg-9.6/rich
+      script: *run-integration-tests
+
     # === integration with current platform
     - stage: ❧ pdb tests
       env: PDB_TEST=int/openjdk10/pup-6.0.x/srv-6.0.x/pg-9.6
@@ -128,15 +145,6 @@ jobs:
 
     - stage: ❧ pdb tests
       env: PDB_TEST=int/oraclejdk8/pup-6.0.x/srv-6.0.x/pg-9.6/rich
-      script: *run-integration-tests
-
-    # === integration with previous platform (no support for jdk > 8)
-    - stage: ❧ pdb tests
-      env: PDB_TEST=int/openjdk8/pup-5.5.x/srv-5.3.x/pg-9.6
-      script: *run-integration-tests
-
-    - stage: ❧ pdb tests
-      env: PDB_TEST=int/oraclejdk8/pup-5.5.x/srv-5.3.x/pg-9.6
       script: *run-integration-tests
 
     # === rspec tests
@@ -163,12 +171,12 @@ jobs:
 
     # === integration tests
     - stage: ❧ pdb tests
-      env: PDB_TEST=int/openjdk8/pup-6.0.x/srv-6.0.x/pg-9.6/rich
+      env: PDB_TEST=int/openjdk8/pup-master/srv-master/pg-9.6/rich
       script: *run-integration-tests
       os: osx
 
     - stage: ❧ pdb tests
-      env: PDB_TEST=int/openjdk10/pup-6.0.x/srv-6.0.x/pg-9.6/rich
+      env: PDB_TEST=int/openjdk10/pup-master/srv-master/pg-9.6/rich
       script: *run-integration-tests
       os: osx
 


### PR DESCRIPTION
Master should be running integration tests against puppet and
puppetserver's master branches as well as the latest release branches
(the 6.0.x branch for each).