### PR TITLE
(maint) Make check in container whether puppetmaster is up more robust

### DIFF
--- a/docker/puppetdb/docker-entrypoint.sh
+++ b/docker/puppetdb/docker-entrypoint.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
+master_running() {
+    curl -sf "http://${PUPPETSERVER_HOSTNAME}:8140/production/status/test" \
+        | grep -q '"is_alive":true'
+}
+
 PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"
 if [ ! -d "/etc/puppetlabs/puppetdb/ssl" ]; then
-  while ! nc -z "$PUPPETSERVER_HOSTNAME" 8140; do
+  while ! master_running; do
     sleep 1
   done
   set -e


### PR DESCRIPTION
Previously, docker-entrypoint.sh checked whether the puppetmaster is up and
running by using 'nc -z'. That only checks that something is listening on
the given port, but not whether that service is actually ready. This is a
problem when the puppetmaster is behind a load balancer since it only
checks that the loadbalancer is listening, even though the puppetmaster
might take quite a while longer to become ready; in such a scenario, the
PuppetDB startup fails.

This change replaces the 'nc -z' check with a check for the puppetmaster's
status, and only proceeds when the master is fully up and ready to handle
requests.