### PR TITLE
(PDB-4177) Fix bash in place

### DIFF
--- a/puppet/lib/puppet/util/puppetdb/command.rb
+++ b/puppet/lib/puppet/util/puppetdb/command.rb
@@ -58,7 +58,7 @@ class Puppet::Util::Puppetdb::Command
     checksum = Digest::SHA1.hexdigest(checksum_payload)
 
     for_whom = " for #{certname}" if certname
-    params = "checksum=#{checksum}&version=#{version}&certname=#{certname}&command=#{command}&producer-timestamp=#{producer_timestamp_utc.to_i}"
+    params = "checksum=#{checksum}&version=#{version}&certname=#{certname}&command=#{command}&producer-timestamp=#{producer_timestamp_utc.iso8601(3)}"
     begin
       response = profile("Submit command HTTP post", [:puppetdb, :command, :submit]) do
         Http.action("#{CommandsUrl}?#{params}", :command) do |http_instance, path|

--- a/puppet/spec/spec_helper.rb
+++ b/puppet/spec/spec_helper.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift File.join(dir, "../lib")
 # don't fail any worse than we already would.
 $LOAD_PATH.push File.join(dir, "../../../puppetlabs_spec_helper")
 
+require 'cgi'
 require 'rspec'
 require 'rspec/expectations'
 require 'puppetlabs_spec_helper/puppet_spec_helper'
@@ -31,6 +32,13 @@ def assert_command_req(expected_payload, actual_payload)
   req.delete("producer_timestamp")
   req == expected_payload &&
     actual_producer_timestamp <= Time.now.to_i
+end
+
+def assert_valid_producer_ts(path)
+  _, param_str = path.split "?"
+  params = CGI::parse(param_str)
+  return false if params["producer-timestamp"].size != 1
+  Time.iso8601(params["producer-timestamp"].first)
 end
 
 RSpec.configure do |config|

--- a/puppet/spec/unit/util/puppetdb/command_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/command_spec.rb
@@ -26,11 +26,12 @@ describe Puppet::Util::Puppetdb::Command do
         httpok.stubs(:body).returns '{"uuid": "a UUID"}'
         http.expects(:post).with() do | path, payload, headers, options |
           param_map = CGI::parse(URI(path).query)
-          param_map['certname'].first.should == 'foo.localdomain' &&
+          assert_valid_producer_ts(path) &&
+            param_map['certname'].first.should == 'foo.localdomain' &&
             param_map['version'].first.should == '1' &&
-            param_map['command'].first.should == 'OPEN_SESAME'
-          options[:compress].should == :gzip
-          options[:metric_id].should == [:puppetdb, :command, 'OPEN_SESAME']
+            param_map['command'].first.should == 'OPEN_SESAME' &&
+            options[:compress] == :gzip &&
+            options[:metric_id] == [:puppetdb, :command, 'OPEN_SESAME']
         end.returns(httpok)
 
         subject.submit

--- a/src/puppetlabs/puppetdb/client.clj
+++ b/src/puppetlabs/puppetdb/client.clj
@@ -9,7 +9,8 @@
             [puppetlabs.puppetdb.schema :refer [defn-validated]]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.kitchensink.core :as kitchensink]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [clj-time.coerce :as c]))
 
 (defn get-metric [base-url metric-name]
   (let [url (str (utils/base-url->str base-url)
@@ -42,7 +43,8 @@
    (let [body (json/generate-string payload)
          url (str (utils/base-url->str base-url)
                   (format "?command=%s&version=%s&certname=%s&producer-timestamp=%s"
-                          (str/replace command #" " "_") version certname (System/currentTimeMillis))
+                          (str/replace command #" " "_") version certname
+                          (c/from-long (System/currentTimeMillis)))
                   (when timeout (format "&secondsToWaitForCompletion=%s" timeout)))]
      (http-client/post url {:body body
                             :throw-exceptions false

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -65,7 +65,7 @@
             [puppetlabs.puppetdb.utils :as utils]
             [slingshot.slingshot :refer [try+ throw+]]
             [puppetlabs.puppetdb.command.constants
-             :refer [command-names supported-command-versions]]
+             :refer [command-names command-keys supported-command-versions]]
             [puppetlabs.trapperkeeper.services
              :refer [defservice service-context]]
             [schema.core :as s]
@@ -503,7 +503,8 @@
   [{:keys [command version certname id received] :as cmdref}
    q scf-write-db response-chan stats blacklist-config]
   (process-command-and-respond! cmdref scf-write-db response-chan stats blacklist-config)
-  (log-command-processed-messsage id received (now) :command-obsolete certname {:obsolete-cmd? true})
+  (log-command-processed-messsage id received (now) (command-keys command)
+                                  certname {:obsolete-cmd? true})
   (queue/ack-command q {:entry (queue/cmdref->entry cmdref)})
   (update-counter! :depth command version dec!)
   (update-counter! :invalidated command version dec!))

--- a/src/puppetlabs/puppetdb/command/constants.clj
+++ b/src/puppetlabs/puppetdb/command/constants.clj
@@ -1,10 +1,13 @@
-(ns puppetlabs.puppetdb.command.constants)
+(ns puppetlabs.puppetdb.command.constants
+  (:require [clojure.set :as set]))
 
 (def command-names
   {:replace-catalog "replace catalog"
    :replace-facts   "replace facts"
    :deactivate-node "deactivate node"
    :store-report    "store report"})
+
+(def command-keys (set/map-invert command-names))
 
 (defn- version-range [min-version max-version]
   (set (range min-version (inc max-version))))

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -214,7 +214,7 @@
                                          (get "secondsToWaitForCompletion")
                                          Double/parseDouble
                                          (* 1000))
-           submit-params (select-keys params ["certname" "command" "version"])
+           submit-params (select-keys params ["certname" "command" "version" "producer-timestamp"])
            submit-params (if-let [v (submit-params "version")]
                            (update submit-params "version" str)
                            submit-params)
@@ -226,7 +226,7 @@
                         (get submit-params "command")
                         (Integer/parseInt (get submit-params "version"))
                         (get submit-params "certname")
-                        (pdbtime/from-string (get submit-params "producer-ts"))
+                        (get submit-params "producer-timestamp")
                         (stream-with-max-check body max-command-size)
                         compression
                         command-callback))]


### PR DESCRIPTION
Prior to these commits the producer-timestamp wasn't sent in the correct format from the terminus or pulled out of the query parameters. This caused all cmdrefs to have nil values for producer-ts. 