### PR TITLE
(MAINT) Revert back to nc for Docker entrypoint

### DIFF
--- a/docker/puppetdb/docker-entrypoint.sh
+++ b/docker/puppetdb/docker-entrypoint.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
 master_running() {
-    curl -sf "http://${PUPPETSERVER_HOSTNAME}:8140/production/status/test" \
-        | grep -q '"is_alive":true'
+    # TODO Figure out a different way to detect when puppetserver is up.
+    # This netcat call doesn't work when a load balancer is in place as it just
+    # detects that the LB is up.
+    # curl -sf "http://${PUPPETSERVER_HOSTNAME}:8140/production/status/test" \
+    #     | grep -q '"is_alive":true'
+    nc -z "$PUPPETSERVER_HOSTNAME" 8140
 }
 
 PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"


### PR DESCRIPTION
The current curl call doesn't seem to work and thus PuppetDB will never
start as this check never succeeds.

We do need the orthogonal USE_PUPPETSERVER change though, so we can't
just revert the commit that changed the netcat call to curl.

For now, revert back to using netcat while we figure out how to better
detect when Puppet Server is up.

The netcat call doesn't work when a load balancer is in place as it
just detects that the LB is up, but we don't actually need this
functionality yet.