### PR TITLE
(maint) Update puppetdb entrypoint for less dependence on puppetserver

### DIFF
--- a/docker/puppetdb/docker-entrypoint.sh
+++ b/docker/puppetdb/docker-entrypoint.sh
@@ -6,14 +6,18 @@ master_running() {
 }
 
 PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"
-if [ ! -d "/etc/puppetlabs/puppetdb/ssl" ] && [ "$USE_PUPPETSERVER" = true ]; then
+/opt/puppetlabs/bin/puppet config set certname "$HOSTNAME"
+/opt/puppetlabs/bin/puppet config set server "$PUPPETSERVER_HOSTNAME"
+
+if [ ! -f "/etc/puppetlabs/puppet/ssl/certs/${HOSTNAME}.pem" ] && [ "$USE_PUPPETSERVER" = true ]; then
+  # if this is our first run, run puppet agent to get certs in place
   while ! master_running; do
     sleep 1
   done
   set -e
-  /opt/puppetlabs/bin/puppet config set certname "$HOSTNAME"
-  /opt/puppetlabs/bin/puppet config set server "$PUPPETSERVER_HOSTNAME"
   /opt/puppetlabs/bin/puppet agent --verbose --onetime --no-daemonize --waitforcert 120
+fi
+if [ ! -d "/etc/puppetlabs/puppetdb/ssl" ] && [ "$USE_PUPPETSERVER" = true ]; then
   /opt/puppetlabs/server/bin/puppetdb ssl-setup -f
 fi
 


### PR DESCRIPTION
Previously, on anything but the initial run, if the puppetdb container
started up before puppetserver, the container would fail and exit since
the directory that is checked for existence never exists on startup. By
updating the checks in the entrypoint, there is now no hard dependency
between puppetserver and puppetdb.