### PR TITLE
(RE-11578) Bump to ezbake 1.8.10

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -271,7 +271,7 @@
                                                   [puppetlabs/puppetdb ~pdb-version]
                                                   [org.clojure/tools.nrepl nil]])
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "1.8.5"]]}
+                      :plugins [[puppetlabs/lein-ezbake "1.8.10"]]}
              :testutils {:source-paths ^:replace ["test"]}
              :install-gems {:source-paths ^:replace ["src-gems"]
                             :target-path "target-gems"


### PR DESCRIPTION
This commit bumps to the latest ezbake version. This version adds a Gemfile to
the resulting package build and makes use of the packaging gem, rather than
cloning the packaging repo.