### PR TITLE
(PDB-4192) Curl Puppet Server status endpoint

### DIFF
--- a/docker/puppetdb/docker-entrypoint.sh
+++ b/docker/puppetdb/docker-entrypoint.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 master_running() {
-    # This netcat call doesn't work when a load balancer is in place as it just
-    # detects that the LB is up (see PDB-4192)
-    nc -z "$PUPPETSERVER_HOSTNAME" 8140
+    status=$(curl --silent --fail --insecure "https://${PUPPETSERVER_HOSTNAME}:8140/status/v1/simple")
+    test "$status" = "running"
 }
 
 PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"


### PR DESCRIPTION
Hitting an endpoint instead of using netcat will work when Puppet Server
is behind a load balancer.

We tried this approach earlier but weren't specifying HTTPS and the
-k flag when curling.