### PR TITLE
(PDB-2487) adding the ability to gc the resource-events table

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -387,6 +387,18 @@ runs every `gc-interval` minutes.
 
 If unset, the default value is 14 days.
 
+### `resource-events-ttl`
+
+Automatically delete report events older than the specified time. The reports
+will still be available, but the contained events will not be present.
+
+This allows for more fine-grained control of the expiration of reports. If this
+value is set higher than `report-ttl`, it will have no effect.
+
+If unset, the default value is 14 days.
+
+See `node-ttl` above for the format of this value.
+
 ### `subname`
 
 This describes where to find the database. It should be something like

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -85,7 +85,7 @@
 (def database-metrics-registry (get-in metrics/metrics-registries [:database :registry]))
 
 (def clean-options
-  #{"expire_nodes" "purge_nodes" "purge_reports" "gc_packages" "other"})
+  #{"expire_nodes" "purge_nodes" "purge_reports" "gc_packages" "purge_resource_events" "other"})
 
 (def purge-nodes-opts-schema {:batch_limit s/Int})
 
@@ -114,6 +114,7 @@
        (map {"expire_nodes" "expiring-nodes"
              "purge_nodes" "purging-nodes"
              "purge_reports" "purging-reports"
+             "purge_resource_events" "purging-resource-events"
              "gc_packages" "package-gc"
              "other" "other"})
        (str/join " ")))
@@ -177,8 +178,18 @@
       (log/error e (trs "Error while running package gc")))))
 
 (defn gc-resource-events!
-  []
-  (trs "Error while sweeping resource events"))
+  "Delete resource-events entries which are older than than `resource-events-ttl`."
+  [resource-events-ttl db]
+  {:pre [(map? db)
+         (period? resource-events-ttl)]}
+  (try
+    (kitchensink/demarcate
+     (format "sweep of stale resource events (threshold: %s)"
+             (format-period resource-events-ttl))
+     (jdbc/with-transacted-connection db
+       (scf-store/delete-resource-events-older-than! (ago resource-events-ttl))))
+    (catch Exception e
+      (log/error e (trs "Error while sweeping resource events")))))
 
 (defn garbage-collect!
   "Perform garbage collection on `db`, which means deleting any orphaned data.
@@ -206,12 +217,14 @@
    :node-expirations (counter admin-metrics-registry "node-expirations")
    :node-purges (counter admin-metrics-registry "node-purges")
    :report-purges (counter admin-metrics-registry "report-purges")
+   :resource-events-purges (counter admin-metrics-registry "resource-event-purges")
    :package-gcs (counter admin-metrics-registry "package-gcs")
    :other-cleans (counter admin-metrics-registry "other-cleans")
 
    :node-expiration-time (timer admin-metrics-registry ["node-expiration-time"])
    :node-purge-time (timer admin-metrics-registry ["node-purge-time"])
    :report-purge-time (timer admin-metrics-registry ["report-purge-time"])
+   :resource-events-purge-time (timer admin-metrics-registry ["resource-events-purge-time"])
    :package-gc-time (timer admin-metrics-registry "package-gc-time")
    :other-clean-time (timer admin-metrics-registry ["other-clean-time"])})
 
@@ -225,10 +238,12 @@
   request is empty?."
   [db
    lock :- ReentrantLock
-   {:keys [node-ttl node-purge-ttl report-ttl]} :- {:node-ttl Period
-                                                    :node-purge-ttl Period
-                                                    :report-ttl Period
-                                                    s/Keyword s/Any}
+   {:keys [node-ttl node-purge-ttl
+           report-ttl resource-events-ttl]} :- {:node-ttl Period
+                                                :node-purge-ttl Period
+                                                :report-ttl Period
+                                                :resource-events-ttl Period
+                                                s/Keyword s/Any}
    ;; Later, the values might be maps, i.e. {:limit 1000}
    request :- clean-request-schema]
   (when-not (.isHeldByCurrentThread lock)
@@ -255,6 +270,10 @@
         (time! (:package-gc-time admin-metrics)
                (gc-packages! db))
         (counters/inc! (:package-gcs admin-metrics)))
+      (when (request "purge_resource_events")
+        (time! (:resource-events-purge-time admin-metrics)
+               (gc-resource-events! resource-events-ttl db))
+        (counters/inc! (:resource-events-purges admin-metrics)))
       ;; It's important that this go last to ensure anything referencing
       ;; an env or resource param is purged first.
       (when (request "other")
@@ -368,10 +387,12 @@
              (when (some-> (:node-purge-ttl config) seconds-pos?)
                (let [limit (:node-purge-gc-batch-limit config)]
                  (if (zero? limit)
-                            "purge_nodes"
-                            ["purge_nodes" {:batch_limit limit}])))
+                   "purge_nodes"
+                   ["purge_nodes" {:batch_limit limit}])))
              (when (some-> (:report-ttl config) seconds-pos?)
                "purge_reports")
+             (when (some-> (:resource-events-ttl config) seconds-pos?)
+               "purge_resource_events")
              "gc_packages"
              "other"])))
 

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -84,7 +84,8 @@
             :report-ttl (pls/defaulted-maybe String "14d")
             :node-purge-ttl (pls/defaulted-maybe String "14d")
             :node-purge-gc-batch-limit (pls/defaulted-maybe s/Int 25)
-            :node-ttl (pls/defaulted-maybe String "7d")})))
+            :node-ttl (pls/defaulted-maybe String "7d")
+            :resource-events-ttl (pls/defaulted-maybe String "14d")})))
 
 (def database-config-out
   "Schema for parsed/processed database config"
@@ -118,7 +119,8 @@
           :report-ttl Period
           :node-purge-ttl Period
           :node-purge-gc-batch-limit (s/constrained s/Int (complement neg?))
-          :node-ttl Period}))
+          :node-ttl Period
+          :resource-events-ttl Period}))
 
 (defn half-the-cores*
   "Function for computing half the cores of the system, useful

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1312,6 +1312,12 @@
   {:pre [(kitchensink/datetime? time)]}
   (jdbc/delete! :reports ["producer_timestamp < ?" (to-timestamp time)]))
 
+(defn delete-resource-events-older-than!
+  "Delete all resource events in the database which have an `timestamp` that is prior to
+   the specified date/time."
+  [time]
+  {:pre [(kitchensink/datetime? time)]}
+  (jdbc/delete! :resource_events ["timestamp < ?" (to-timestamp time)]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -230,7 +230,18 @@
       (testing "should default to 14 days"
         (let [report-ttl (get-in (config-with {}) [:database :report-ttl])]
           (is (pl-time/period? report-ttl))
-          (is (= (time/days 14) (time/days (pl-time/to-days report-ttl)))))))))
+          (is (= (time/days 14) (time/days (pl-time/to-days report-ttl)))))))
+
+    (testing "resource-events-ttl"
+      (testing "should parse resource-events-ttl and produce resource-events-ttl"
+        (let [resource-events-ttl (get-in (config-with {:database {:resource-events-ttl "10d"}})
+                                          [:database :resource-events-ttl])]
+          (is (pl-time/period? resource-events-ttl))
+          (is (= (time/days 10) (time/days (pl-time/to-days resource-events-ttl))))))
+      (testing "should default to 14 days"
+        (let [resource-events-ttl (get-in (config-with {}) [:database :resource-events-ttl])]
+          (is (pl-time/period? resource-events-ttl))
+          (is (= (time/days 14) (time/days (pl-time/to-days resource-events-ttl)))))))))
 
 (defn vardir [path]
   {:global {:vardir (str path)}})

--- a/test/puppetlabs/puppetdb/integration/resource_events.clj
+++ b/test/puppetlabs/puppetdb/integration/resource_events.clj
@@ -1,0 +1,46 @@
+(ns puppetlabs.puppetdb.integration.resource-events
+  (:require [clojure.test :refer :all]
+            [me.raynes.fs :as fs]
+            [puppetlabs.puppetdb.integration.fixtures :as int]
+            [puppetlabs.puppetdb.testutils.services :as svc-utils]
+            [clj-time.core :refer [now]]
+            [clj-time.core :refer [now days plus]]
+            [metrics.counters :as counters]
+            [puppetlabs.puppetdb.cli.services :as pdb-services]
+            [puppetlabs.puppetdb.testutils :as tu]))
+
+(defn read-gc-count-metric []
+  ;; metrics are global, so...
+  (counters/value (:resource-events-purges pdb-services/admin-metrics)))
+
+(deftest ^:integration resource-events-ttl
+  (with-open [pg (int/setup-postgres)]
+    (with-open [pdb (int/run-puppetdb pg {})
+                ps (int/run-puppet-server [pdb] {})]
+      (testing "Run agent once to populate database"
+        (int/run-puppet-as "ttl-agent" ps pdb "notify { 'irrelevant manifest': }"))
+
+      (testing "Verify we have resource events"
+        (is (= 1 (count (int/pql-query pdb "events { timestamp > 0 }"))))))
+
+    (testing "Sleep for one second to make sure we have a ttl to exceed"
+      (Thread/sleep 1000))
+
+    (let [initial-gc-count (counters/value (:resource-events-purges pdb-services/admin-metrics))]
+      (with-open [pdb (int/run-puppetdb pg {:database {:resource-events-ttl "1s"}})]
+        (let [start-time (System/currentTimeMillis)]
+          (loop []
+            (cond
+              (> (- (System/currentTimeMillis) start-time) tu/default-timeout-ms)
+              (throw (ex-info "Timeout waiting for pdb gc to happen" {}))
+
+              (> (read-gc-count-metric) initial-gc-count)
+              true ;; gc happened
+
+              :default
+              (do
+                (Thread/sleep 250)
+                (recur)))))
+
+        (testing "Verify that the resource events have been deleted"
+          (is (= 0 (count (int/pql-query pdb "events { timestamp > 0 }")))))))))


### PR DESCRIPTION
* Adds a config parameter: database.resource-events-ttl with a default of 14d
* Adds two admin metrics: resource-events-purges and resource-events-purge-time
* Adds documentation for this new feature

This will allow the resource_events table to be cleaned up at a different interval
than the reports table.