### PR TITLE
(PDB-4164) update lein-parent to support snapshots

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -214,7 +214,7 @@
 
   :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]
             [lein-cloverage "1.0.6" :exclusions [org.clojure/clojure]]
-            [lein-parent "0.3.1"]
+            [lein-parent "0.3.5"]
             [puppetlabs/i18n ~i18n-version]]
 
   :lein-release {:scm        :git


### PR DESCRIPTION
lein-parent 0.3.1 doesn't work properly with -SNAPSHOT builds of
dependencies.