### PR TITLE
Update tk-webserver-jetty9 to 2.3.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def pdb-version "5.2.7-SNAPSHOT")
 (def clj-parent-version "1.4.3")
-(def tk-jetty9-ver "2.2.0")
+(def tk-jetty9-ver "2.3.1")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
Update is in order to pull in a change to our Jetty configuration that 
prevents Jetty from sending the server version in the HTTP response and
error pages.