### PR TITLE
(MAINT) Fix cacert for adoptopenjdk10

### DIFF
--- a/ext/travisci/prep-os-essentials-for
+++ b/ext/travisci/prep-os-essentials-for
@@ -24,7 +24,8 @@ case "$OSTYPE" in
         brew install postgresql@"$pgver"
 
         case "$jdkver" in
-          8)
+          8|10)
+
             # Install AdoptOpenJDK 11, we will use this for its cacert
             brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask/636d8f0d1afce664f47620b46571e42b01c93d8c/Casks/adoptopenjdk.rb
             cacert_path=/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/lib/security/cacerts
@@ -35,15 +36,14 @@ case "$OSTYPE" in
             fi
 
             brew tap AdoptOpenJDK/openjdk
-            # brew cask install adoptopenjdk8
             brew cask install "adopt$jdk"
-            old_cacert_path="/Library/Java/JavaVirtualMachines/adoptopenjdk-$jdkver.jdk/Contents/Home/jre/lib/security/cacerts"
-            rm "$old_cacert_path"
+
+            if test "$jdkver" -eq 8; then
+              rm "/Library/Java/JavaVirtualMachines/adoptopenjdk-$jdkver.jdk/Contents/Home/jre/lib/security/cacerts"
+            else
+              rm "/Library/Java/JavaVirtualMachines/adoptopenjdk-$jdkver.jdk/Contents/Home/lib/security/cacerts"
+            fi
             ln -s $cacert_path "$old_cacert_path"
-            ;;
-          10)
-            brew tap AdoptOpenJDK/openjdk
-            brew cask install "adopt$jdk"
             ;;
           *)
             echo "JDK version '$jdk' is not supported on Mac OSX"


### PR DESCRIPTION
The previous commit fixed the ability to download adoptopenjdk10 but the
cacert was still not compatible with clojars, so when a dependency
changed, it could not be downloaded.

This commit fixed adoptopen10's cacert in the same way we fixed it for
adoptopenjdk8, by downloading 11 and using its fixed cacert.