### PR TITLE
(maint) change install method for puppet agent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ end
 gem 'facter'
 gem 'rake'
 gem 'packaging', *location_for(ENV['PACKAGING_VERSION'] || '~> 0.99')
-gem 'beaker-puppet', '~> 1.0'
 
 group :test do
   # Add test-unit for ruby 2.2+ support (has been removed from stdlib)

--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -868,7 +868,7 @@ EOS
 
   def install_puppet_from_package
     hosts.each do |host|
-      install_puppet_on(host, {})
+      install_puppet_agent_on(host, {:puppet_collection => "puppet5"})
       on( host, puppet('resource', 'host', 'updates.puppetlabs.com', 'ensure=present', "ip=127.0.0.1") )
       install_package(host, 'puppetserver')
     end


### PR DESCRIPTION
Prior to this commit the puppet agent install would fail on some but not all
platforms due to a repo url mismatch. We need to specify the :puppet_collection
in order to get the correct behavior on all platforms.