### PR TITLE
(maint) Change install puppet-agent call to use more general method

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -868,7 +868,7 @@ EOS
 
   def install_puppet_from_package
     hosts.each do |host|
-      install_puppet_agent_on(host, {:puppet_collection => "puppet5"})
+      install_puppet_on(host, {:puppet_collection => "puppet5"})
       on( host, puppet('resource', 'host', 'updates.puppetlabs.com', 'ensure=present', "ip=127.0.0.1") )
       install_package(host, 'puppetserver')
     end


### PR DESCRIPTION
Prior to this commit we were using a more specific method to install the agent
which lacked beaker path munging on the host when doing a non aio install.