### PR TITLE
Revert "(maint) Change install puppet-agent call to use more general …

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -868,7 +868,7 @@ EOS
 
   def install_puppet_from_package
     hosts.each do |host|
-      install_puppet_on(host, {:puppet_collection => "puppet5"})
+      install_puppet_agent_on(host, {:puppet_collection => "puppet5"})
       on( host, puppet('resource', 'host', 'updates.puppetlabs.com', 'ensure=present', "ip=127.0.0.1") )
       install_package(host, 'puppetserver')
     end


### PR DESCRIPTION
…method"

This reverts commit a2b284422e27198899fb54a13f5f5612bcf52ebd.

In some of our periodic builds the more generic call hits a path which doesn't allow us to pass :puppet_collection through the opts hash. This causes beaker to default to older repo urls which breaks acceptance tests on certain platforms. 