### PR TITLE
(maint) dep-diff: actually respect --ignore-exclusions

### DIFF
--- a/ext/bin/dep-diff
+++ b/ext/bin/dep-diff
@@ -152,7 +152,7 @@ Usage:
     (if (:help? opts)
       (do (usage *out*) 0)
       (apply dispatch-diff
-             (merge {:out *out*} (select-keys opts [:mismatches-only?]))
+             (merge {:out *out*} (select-keys opts [:mismatches-only? :ignore-exclusions?]))
              (:positional opts)))))
 
 (defn main [args]


### PR DESCRIPTION
This makes ignore-exclusions work, so global exclusions won't cause a build to fail