### PR TITLE
(PDB-4244) travis: brew update ruby to fix brew failures

### DIFF
--- a/ext/travisci/prep-os-essentials-for
+++ b/ext/travisci/prep-os-essentials-for
@@ -28,18 +28,18 @@ case "$OSTYPE" in
         brew install bash
         brew install postgresql@"$pgver"
 
+        brew tap AdoptOpenJDK/openjdk
         case "$jdkver" in
           8)
             # Install AdoptOpenJDK 11, we will use this for its cacert
-            brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask/636d8f0d1afce664f47620b46571e42b01c93d8c/Casks/adoptopenjdk.rb
-            cacert_path=/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/lib/security/cacerts
+            brew cask install adoptopenjdk11
+            cacert_path=/Library/Java/JavaVirtualMachines/adoptopenjdk-11.0.1.jdk/Contents/Home/lib/security/cacerts
 
             if test ! -f "$cacert_path"; then
               echo "The cacerts file did not exist at '$cacert_path'" 1>&2
               exit 3
             fi
 
-            brew tap AdoptOpenJDK/openjdk
             # brew cask install adoptopenjdk8
             brew cask install "adopt$jdk"
             old_cacert_path="/Library/Java/JavaVirtualMachines/adoptopenjdk-$jdkver.jdk/Contents/Home/jre/lib/security/cacerts"

--- a/ext/travisci/prep-os-essentials-for
+++ b/ext/travisci/prep-os-essentials-for
@@ -20,6 +20,11 @@ pgver="$(ext/travisci/prefixed-ref-from-spec "$spec" pg-)"
 
 case "$OSTYPE" in
     darwin*)
+        # brew produced some HOMEBREW_LOGS related error on the first
+        # run but said that "everything should be fine" if you try
+        # again, so we do that...
+        brew install ruby || true
+        brew install ruby
         brew install bash
         brew install postgresql@"$pgver"
 


### PR DESCRIPTION
Recently osx tests started failing like this during "brew install
bash":

  /usr/local/Homebrew/Library/Homebrew/config.rb:39:in `initialize': no implicit conversion of nil into String (TypeError)
  from /usr/local/Homebrew/Library/Homebrew/config.rb:39:in `new'
  from /usr/local/Homebrew/Library/Homebrew/config.rb:39:in `<top (required)>'
  from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /usr/local/Homebrew/Library/Homebrew/global.rb:25:in `<top (required)>'
  from /usr/local/Homebrew/Library/Homebrew/brew.rb:13:in `require_relative'
  from /usr/local/Homebrew/Library/Homebrew/brew.rb:13:in `<main>'

Some evidence suggested it might be resolved by updating ruby, but
an initial "brew install ruby" fails like this:

  error: HOMEBREW_LOGS was not exported!
  Please don't worry, you likely hit a bug auto-updating from an old version.
  Rerun your command, everything is up-to-date and fine now.

And indeed, running the command twice does seem to get the tests
working again.