### PR TITLE
(PDB-3911) adding pk to resource_events table

### DIFF
--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -61,9 +61,13 @@ test ! -e "$PDBBOX"/var/mq-migrated
 psql -U puppetdb puppetdb -c '\dt' >"$tmpdir/out" 2>"$tmpdir/err"
 cat "$tmpdir/out"
 cat "$tmpdir/err"
+
 # Output moved to err and changed as of at least pg 11
 grep 'No relations found' "$tmpdir/out" \
     || grep 'Did not find any relations' "$tmpdir/err"
+
+psql -U $PDB_TEST_DB_ADMIN puppetdb -c 'create extension if not exists pg_trgm'
+psql -U $PDB_TEST_DB_ADMIN puppetdb -c 'create extension if not exists pgcrypto'
 
 ./pdb upgrade -c "$PDBBOX/pdb.ini"
 
@@ -71,7 +75,7 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 66$' "$tmpdir/out"
+grep -qE ' 67$' "$tmpdir/out"
 
 test -e "$PDBBOX"/var/mq-migrated
 (cd "$PDBBOX"/var/stockpile/cmd/q

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -194,6 +194,16 @@
     :resource_events (sort (map resource-event-identity-string resource_events))
     :transaction_uuid transaction_uuid}))
 
+(defn resource-event-identity-hash
+  "Compute a hash for a resource-event's content, used as a primary key
+
+  This is different than resource-event-identity-string in that it does not
+  include every field - it only uses the fields that make up a unique constraint
+  in the database"
+  [{:keys [report_id resource_type resource_title property] :as event}]
+  (kitchensink/utf8-string->sha1
+   (str report_id resource_type resource_title (or property ""))))
+
 (defn fact-identity-hash
   "Compute a hash for a fact's content
 

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1496,6 +1496,17 @@
 
   {::vacuum-analyze #{"factsets"}})
 
+(defn resource-events-pk []
+  (jdbc/do-commands
+   "alter table resource_events add column event_hash bytea"
+
+   "update resource_events re
+    set event_hash = digest(concat(re.report_id, re.resource_type, re.resource_title, coalesce(re.property, ''))::text, 'sha1'::text)"
+
+   "alter table resource_events add primary key (event_hash)")
+
+  {::vaccum-analyze #{"resource_events"}})
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1539,7 +1550,8 @@
    63 add-job-id
    64 rededuplicate-facts
    65 varchar-columns-to-text
-   66 jsonb-facts})
+   66 jsonb-facts
+   67 resource-events-pk})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1294,11 +1294,15 @@
                        adjust-event-metadata #(-> %
                                                   (assoc :report_id report-id
                                                          :certname_id certname-id)
-                                                  maybe-corrective-change)]
+                                                  maybe-corrective-change)
+                       add-hash #(-> %
+                                     (assoc :event_hash (sutils/munge-hash-for-storage
+                                                         (shash/resource-event-identity-hash %))))]
                    (when-not (empty? resource_events)
                      (->> resource_events
                           (sp/transform [sp/ALL :containment_path] #(some-> % sutils/to-jdbc-varchar-array))
                           (map adjust-event-metadata)
+                          (map add-hash)
                           (jdbc/insert-multi! :resource_events)
                           dorun))
                    (when update-latest-report?


### PR DESCRIPTION
This will allow this table to be cleaned with pg_repack instead of relying
on a VACUUM FULL, which avoids locks on the table.