### PR TITLE
(MAINT) Introduce docker-entrypoint.d/

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 docker/puppetdb/*                                        text  eol=lf
 docker/puppetdb/conf.d/*                                 text  eol=lf
 docker/puppetdb/logging/*                                text  eol=lf
+docker/puppetdb/docker-entrypoint.d/*                    text  eol=lf

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -70,6 +70,7 @@ VOLUME /etc/puppetlabs/puppet/ssl/
 
 COPY docker/puppetdb/docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
+COPY docker/puppetdb/docker-entrypoint.d /docker-entrypoint.d
 
 EXPOSE 8080 8081
 

--- a/docker/puppetdb/docker-entrypoint.d/10-configure-ssl.sh
+++ b/docker/puppetdb/docker-entrypoint.d/10-configure-ssl.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+master_running() {
+    status=$(curl --silent --fail --insecure "https://${PUPPETSERVER_HOSTNAME}:8140/status/v1/simple")
+    test "$status" = "running"
+}
+
+PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"
+
+if [ ! -f "/etc/puppetlabs/puppet/ssl/certs/${HOSTNAME}.pem" ] && [ "$USE_PUPPETSERVER" = true ]; then
+  # if this is our first run, run puppet agent to get certs in place
+  while ! master_running; do
+    sleep 1
+  done
+  set -e
+  /ssl.sh
+fi
+if [ ! -d "/etc/puppetlabs/puppetdb/ssl" ] && [ "$USE_PUPPETSERVER" = true ]; then
+  /ssl-setup.sh -f
+fi

--- a/docker/puppetdb/docker-entrypoint.sh
+++ b/docker/puppetdb/docker-entrypoint.sh
@@ -1,23 +1,12 @@
 #!/bin/sh
 
-master_running() {
-    status=$(curl --silent --fail --insecure "https://${PUPPETSERVER_HOSTNAME}:8140/status/v1/simple")
-    test "$status" = "running"
-}
+set -e
 
-PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"
-
-if [ ! -f "/etc/puppetlabs/puppet/ssl/certs/${HOSTNAME}.pem" ] && [ "$USE_PUPPETSERVER" = true ]; then
-  # if this is our first run, run puppet agent to get certs in place
-  while ! master_running; do
-    sleep 1
-  done
-  set -e
-  /ssl.sh
-fi
-if [ ! -d "/etc/puppetlabs/puppetdb/ssl" ] && [ "$USE_PUPPETSERVER" = true ]; then
-  /ssl-setup.sh -f
-fi
+for f in /docker-entrypoint.d/*.sh; do
+    echo "Running $f"
+    chmod +x "$f"
+    "$f"
+done
 
 exec java $PUPPETDB_JAVA_ARGS -cp /puppetdb.jar \
     clojure.main -m puppetlabs.puppetdb.core "$@" \


### PR DESCRIPTION
Decompose the single docker-entrypoint.sh script into a directory of
ordered scripts.

This follows the same pattern that was introduced recently in the
puppetserver container.