### PR TITLE
(MAINT) Don't tag as latest in Azure

### DIFF
--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -38,8 +38,7 @@ function Build-Container(
     '--build-arg', "build_date=$build_date",
     '--build-arg', "version=$Version",
     '--file', "puppetdb/Dockerfile",
-    '--tag', "$Namespace/puppetdb:$Version",
-    '--tag', "$Namespace/puppetdb:latest"
+    '--tag', "$Namespace/puppetdb:$Version"
   )
 
   docker build $docker_args ..


### PR DESCRIPTION
Tagging as latest was accidentally added during a recent refactor.

We don't need to deal with "latest" in Azure for PuppetDB because the
latest tagging will happen during "make publish" after the tests pass,
which is currently only called by the Distelli/Pipelines CI.

----

I accidentally added this line here: https://github.com/puppetlabs/puppetdb/commit/00a73a8426bb9da24c5d1841945ad28ec78493aa#diff-170dc9c792e45a1be2328aa2dbf41483L35