### PR TITLE
(PDB-4199) Allow multi-value array in 'in' queries

### DIFF
--- a/documentation/api/query/v4/ast.markdown
+++ b/documentation/api/query/v4/ast.markdown
@@ -493,7 +493,7 @@ For example, the following query on the `/nodes` endpoint is valid:
      ["array",
       [20000.0,
        150.0,
-       300000]]]
+       30000.0]]]
 
 #### `from`
 

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -1498,7 +1498,7 @@
                   [op "value" fact-value]]]]]
 
               [["in" ["fact" fact-name] ["array" fact-values]]]
-              (if-not (= (count (map type fact-values)) 1)
+              (if-not (= (count (set (map type fact-values))) 1)
                 (throw (IllegalArgumentException.
                          (tru "All values in 'array' must be the same type.")))
                 ["in" "certname"

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -129,13 +129,13 @@
       (is-query-result' ["=" ["fact" "uptime_seconds"] "10000"] [])
       (is-query-result' ["=" ["fact" "uptime_seconds"] 10000.0] [web1])
       (is-query-result' ["in" ["fact" "uptime_seconds"] ["array" [10000.0]]] [web1])
-      (is-query-result' ["in" ["fact" "uptime_seconds"] ["array" [10000]]] [web1])
+      (is-query-result' ["in" ["fact" "uptime_seconds"] ["array" [10000 50000]]] [web1])
       (is-query-result' ["=" ["fact" "uptime_seconds"] true] [])
       (is-query-result' ["=" ["fact" "uptime_seconds"] 0] []))
 
     (testing "missing facts are not equal to anything"
       (is-query-result' ["=" ["fact" "fake_fact"] "something"] [])
-      (is-query-result' ["in" ["fact" "fake_fact"] ["array" ["something"]]] [])
+      (is-query-result' ["in" ["fact" "fake_fact"] ["array" ["something" "something else" "a whole other thing entirely"]]] [])
       (is-query-result' ["not" ["=" ["fact" "fake_fact"] "something"]] [db puppet web1 web2]))
 
     (testing "arithmetic works on facts"

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -149,7 +149,14 @@
 (deftest test-valid-query-fields
   (is (thrown-with-msg? IllegalArgumentException
                         #"'foo' is not a queryable object for resources. Known queryable objects are.*"
-                        (compile-user-query->sql resources-query ["=" "foo" "bar"]))))
+                        (compile-user-query->sql resources-query ["=" "foo" "bar"])))
+  (let [err #"All values in array must be the same type\."]
+    (is (thrown-with-msg? IllegalArgumentException
+                          err
+                          (compile-user-query->sql nodes-query ["in" ["fact" "uptime_seconds"] ["array" [500 100.0]]])))
+    (is (thrown-with-msg? IllegalArgumentException
+                          err
+                          (compile-user-query->sql nodes-query ["in" ["fact" "uptime_seconds"] ["array" ["500" 100.0]]])))))
 
 (deftest test-valid-subqueries
   (is (thrown-with-msg? IllegalArgumentException


### PR DESCRIPTION
Previously this array type check would fail for any array greater than
one element. This solves the type check bug by using a set to
de-depulicate the array of fact-value types.

This also updates a documentation example that is no longer valid due to
a stricter type-checking.