### PR TITLE
(PDB-3742) Add atom to track enqueued commands

### DIFF
--- a/src/puppetlabs/puppetdb/client.clj
+++ b/src/puppetlabs/puppetdb/client.clj
@@ -9,8 +9,7 @@
             [puppetlabs.puppetdb.schema :refer [defn-validated]]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.kitchensink.core :as kitchensink]
-            [schema.core :as s]
-            [clj-time.coerce :as c]))
+            [schema.core :as s]))
 
 (defn get-metric [base-url metric-name]
   (let [url (str (utils/base-url->str base-url)
@@ -41,10 +40,13 @@
     payload :- {s/Any s/Any}
     timeout]
    (let [body (json/generate-string payload)
+         url-params (str
+                     (format "?command=%s&version=%s&certname=%s"
+                             (str/replace command #" " "_") version certname)
+                     (when-let [producer_timestamp (-> payload :producer_timestamp str)]
+                       (format "&producer-timestamp=%s" producer_timestamp)))
          url (str (utils/base-url->str base-url)
-                  (format "?command=%s&version=%s&certname=%s&producer-timestamp=%s"
-                          (str/replace command #" " "_") version certname
-                          (c/from-long (System/currentTimeMillis)))
+                  url-params
                   (when timeout (format "&secondsToWaitForCompletion=%s" timeout)))]
      (http-client/post url {:body body
                             :throw-exceptions false

--- a/src/puppetlabs/puppetdb/queue.clj
+++ b/src/puppetlabs/puppetdb/queue.clj
@@ -427,6 +427,17 @@
    ;; to get rid of it somehow when we refactor mq-listener and command.clj.
    (SortedCommandBuffer. (TreeMap.) (HashMap.) n delete-update-fn)))
 
+(defn make-cmd-event
+  "Given a cmdref and kind return a cmd-event-map which is suitable to be put
+   on the cmd-event-chan.
+   Valid :kind values are: ::command/ingested and ::command/processed."
+  [cmdref kind]
+  (let [{:keys [command certname producer-ts]} cmdref]
+    {:kind kind
+     :command (command-constants/command-keys command)
+     :certname certname
+     :producer-ts producer-ts}))
+
 (defn message-loader
   "Returns a function that will enqueue existing stockpile messages to
   `command-chan`. Messages with ids less than `message-id-ceiling`
@@ -434,29 +445,32 @@
   when new commands are enqueued before all existing commands have
   been enqueued. Note that there is no guarantee on the enqueuing
   order of commands read from stockpile's reduce function"
-  [q message-id-ceiling]
+  [q message-id-ceiling maybe-send-cmd-event! cmd-event-ch]
   (fn [command-chan update-metrics]
-    (stock/reduce q
-                  (fn [chan entry]
-                    ;;This conditional guards against a new command
-                    ;;enqueued in the same directory before we've
-                    ;;read all existing files
-                    (when (< (stock/entry-id entry) message-id-ceiling)
-                      (let [{:keys [command version] :as cmdref} (entry->cmdref entry)]
-                        (async/>!! chan cmdref)
-                        (update-metrics command version)))
-                    chan)
-                  command-chan)))
+    (let [output (stock/reduce q
+                               (fn [chan entry]
+                                 ;;This conditional guards against a new command
+                                 ;;enqueued in the same directory before we've
+                                 ;;read all existing files
+                                 (when (< (stock/entry-id entry) message-id-ceiling)
+                                   (let [{:keys [command version] :as cmdref} (entry->cmdref entry)]
+                                     (async/>!! chan cmdref)
+                                     (maybe-send-cmd-event! cmdref :puppetlabs.puppetdb.command/ingested)
+                                     (update-metrics command version)))
+                                 chan)
+                               command-chan)]
+      (async/>!! cmd-event-ch {:kind ::queue-loaded})
+      output)))
 
 (defn create-or-open-stockpile
   "Opens an existing stockpile queue if one is present otherwise
   creates a new stockpile queue at `queue-dir`"
-  [queue-dir]
+  [queue-dir maybe-send-cmd-event! cmd-event-ch]
   (let [stockpile-root (kitchensink/absolute-path queue-dir)
         queue-path (get-path stockpile-root "cmd")]
     (if-let [q (and (Files/exists queue-path (make-array LinkOption 0))
                     (stock/open queue-path))]
-      [q (message-loader q (stock/next-likely-id q))]
+      [q (message-loader q (stock/next-likely-id q) maybe-send-cmd-event! cmd-event-ch)]
       (do
         (Files/createDirectories (get-path stockpile-root)
                                  (make-array FileAttribute 0))

--- a/test/puppetlabs/puppetdb/http/command_test.clj
+++ b/test/puppetlabs/puppetdb/http/command_test.clj
@@ -287,11 +287,13 @@
 (defn handler-with-max [q command-chan max-command-size]
   (#'tgt/enqueue-command-handler
    (fn [command version certname producer-ts stream compression callback]
-     (cmd/do-enqueue-command
-              q
-              command-chan
-              (Semaphore. 100)
-              (queue/create-command-req command version certname producer-ts compression callback stream)))
+     (let [maybe-send-cmd-event! (constantly true)]
+       (cmd/do-enqueue-command
+        q
+        command-chan
+        (Semaphore. 100)
+        (queue/create-command-req command version certname producer-ts compression callback stream)
+        maybe-send-cmd-event!)))
    max-command-size))
 
 (deftest enqueue-max-command-size

--- a/test/puppetlabs/puppetdb/queue_test.clj
+++ b/test/puppetlabs/puppetdb/queue_test.clj
@@ -334,7 +334,9 @@
      (get-path "target")
      (str *ns*)
      (fn [temp-path]
-       (let [[q load-messages] (create-or-open-stockpile temp-path)]
+       (let [maybe-send-cmd-event! (constantly true)
+             cmd-event-ch (async/chan 10)
+             [q load-messages] (create-or-open-stockpile temp-path maybe-send-cmd-event! cmd-event-ch)]
 
          (is (nil? load-messages))
          (store-command q (catalog->command-req 1 {:message "payload 1"
@@ -346,7 +348,9 @@
          (store-command q (catalog->command-req 1 {:message "payload 4"
                                                          :certname "foo4"})))
 
-       (let [[q load-messages] (create-or-open-stockpile temp-path)
+       (let [maybe-send-cmd-event! (constantly true)
+             cmd-event-ch (async/chan 10)
+             [q load-messages] (create-or-open-stockpile temp-path maybe-send-cmd-event! cmd-event-ch)
              command-chan (async/chan 4)
              cc (tu/call-counter)]
 
@@ -366,7 +370,9 @@
      (get-path "target")
      (str *ns*)
      (fn [temp-path]
-       (let [[q load-messages] (create-or-open-stockpile temp-path)]
+       (let [maybe-send-cmd-event! (constantly true)
+             cmd-event-ch (async/chan 10)
+             [q load-messages] (create-or-open-stockpile temp-path maybe-send-cmd-event! cmd-event-ch)]
 
          (is (nil? load-messages))
          (store-command q (catalog->command-req 1 {:message "payload 1"
@@ -374,7 +380,9 @@
          (store-command q (catalog->command-req 1 {:message "payload 2"
                                                    :certname "foo2"})))
 
-       (let [[q load-messages] (create-or-open-stockpile temp-path)
+       (let [maybe-send-cmd-event! (constantly true)
+             cmd-event-ch (async/chan 10)
+             [q load-messages] (create-or-open-stockpile temp-path maybe-send-cmd-event! cmd-event-ch)
              command-chan (async/chan 4)
              cc (tu/call-counter)]
 

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -448,11 +448,13 @@
    (command-app
     (fn [] {})
     (fn [command version certname producer-ts stream compression callback]
-      (dispatch/do-enqueue-command
-       q
-       command-chan
-       (Semaphore. 100)
-       (queue/create-command-req command version certname producer-ts compression callback stream)))
+      (let [maybe-send-cmd-event! (constantly true)]
+        (dispatch/do-enqueue-command
+         q
+         command-chan
+         (Semaphore. 100)
+         (queue/create-command-req command version certname producer-ts compression callback stream)
+         maybe-send-cmd-event!)))
 
     false
     nil)))


### PR DESCRIPTION
This commit adds an atom which tracks commands that are enqueued but not
yet processed. The pdbext HA-sync code uses this atom to avoid enqueuing
duplicate commands when performing a sync.