### PR TITLE
(PDB-4256) Pin puppetlabs-apt to 6.2.1 in acceptance tests

### DIFF
--- a/acceptance/setup/pre_suite/50_install_modules.rb
+++ b/acceptance/setup/pre_suite/50_install_modules.rb
@@ -4,6 +4,7 @@ extend Beaker::DSL::InstallUtils
 
 unless (test_config[:skip_presuite_provisioning])
   step "Install the puppetdb module and dependencies" do
+    on databases, "puppet module install puppetlabs-apt --version 6.2.1"
     on databases, "puppet module install puppetlabs/puppetdb"
   end
 end


### PR DESCRIPTION
This commit pins the version of puppetlabs-apt in our acceptances tests
in order to work around a dependency cycle issue which was introduced in
the 6.3.0 release. We plan to drop this pin when the issue is resolved.