### PR TITLE
(maint) Allow configuration of certname in ssl-setup.sh

### DIFF
--- a/docker/puppetdb/ssl-setup.sh
+++ b/docker/puppetdb/ssl-setup.sh
@@ -2,6 +2,9 @@
 
 ssl_command="puppetdb ssl-setup"
 
+# If CERTNAME environment variable is set use that, otherwise use HOSTNAME
+mycertname="${CERTNAME:-$HOSTNAME}"
+
 #############
 # FUNCTIONS #
 #############
@@ -249,7 +252,6 @@ fi
 set -e
 
 # mycertname=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint  certname`
-mycertname="${HOSTNAME}"
 
 # orig_public_file=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint  hostcert`
 orig_public_file="/etc/puppetlabs/puppet/ssl/certs/${mycertname}.pem"


### PR DESCRIPTION
Previously the `ssl-setup.sh` script would use the `HOSTNAME` environment when dealing with `{certname}.*.pem` ssl cert paths. In the case where a hard coded cert name is copied in to place in a Dockerfile that derives from the puppetdb image allow the configuration of the certname with an environment variable called `CERTNAME`. The default of `HOSTNAME` will still be respected in the case that `CERTNAME` is unset.