### PR TITLE
(maint) travis: Use path expansion to find jdk11

### DIFF
--- a/ext/travisci/prep-os-essentials-for
+++ b/ext/travisci/prep-os-essentials-for
@@ -20,13 +20,12 @@ pgver="$(ext/travisci/prefixed-ref-from-spec "$spec" pg-)"
 
 case "$OSTYPE" in
     darwin*)
+        rm -rf "$(brew --cache)"
         # brew produced some HOMEBREW_LOGS related error on the first
         # run but said that "everything should be fine" if you try
         # again, so we do that...
         brew install ruby || true
         brew install ruby
-
-        brew update
         brew install bash
         brew install postgresql@"$pgver"
 


### PR DESCRIPTION
Previously this was a hardcoded value, but the path can change if they
change the formula we are using from the adoptopenjdk tap. This uses
path expansion to find the path regardless of changes upstream of us.