### PR TITLE
(PDB-3284) Make PQL !~<=> not need leading ws

### DIFF
--- a/resources/puppetlabs/puppetdb/pql/pql-grammar.ebnf
+++ b/resources/puppetlabs/puppetdb/pql/pql-grammar.ebnf
@@ -88,9 +88,9 @@ groupedarglist = <lparens>, [<whitespace>], [arglist], [<whitespace>], <rparens>
 (* Represents a field from an entity *)
 field = #'[a-zA-Z0-9_]+\??' | (dottedfield, fieldpath);
 <fieldpath> = <'.'>, (quotedfield | standardfield | matchfield) , [fieldpath];
-<quotedfield> = #'\".*?\"(?=\.|\s)';
+<quotedfield> = #'\".*?\"';
 <matchfield> = #'match\(.*?\)';
-<standardfield> = #'[^\s\.\"]+';
+<standardfield> = #'[^\s\.\"!<=>~]+';
 <dottedfield> = 'facts' | 'trusted' | 'parameters';
 
 <condregexp>      = '~';

--- a/test/puppetlabs/puppetdb/pql/parser_test.clj
+++ b/test/puppetlabs/puppetdb/pql/parser_test.clj
@@ -34,6 +34,15 @@
        [:expr-not
         [:condexpression [:field "a"] "=" [:integer "1"]]]]]]
 
+    ;; Test that whitespace is optional
+    "nodes{a=1}"
+    [:from
+     "nodes"
+     [:expr-or
+      [:expr-and
+       [:expr-not
+        [:condexpression [:field "a"] "=" [:integer "1"]]]]]]
+
     "nodes [a, b, c] {}"
     [:from
      "nodes"
@@ -100,6 +109,26 @@
                             "="
                             [:integer "100"]]]]]]
 
+    ;; whitespace optional
+    "inventory[certname]{facts.foo.bar=100}"
+    [:from
+     "inventory"
+     [:extract [:field "certname"]]
+     [:expr-or [:expr-and [:expr-not
+                           [:condexpression
+                            [:field "facts" "foo" "bar"] "=" [:integer "100"]]]]]]
+
+    ;; whitespace optional
+    "inventory[certname]{facts.foo.\"quoted string\"=100}"
+    [:from
+     "inventory"
+     [:extract [:field "certname"]]
+     [:expr-or [:expr-and [:expr-not
+                           [:condexpression
+                            [:field "facts" "foo" "\"quoted string\""]
+                            "="
+                            [:integer "100"]]]]]]
+
     "inventory [certname] {facts.foo.\"dotted.string\" = 100}"
     [:from
      "inventory"
@@ -119,6 +148,25 @@
                             [:field "parameters" "foo" "bar"] "=" [:integer "100"]]]]]]
 
     "facts [value] { [certname,name] in fact_contents [certname, name] { value < 100 }}"
+    [:from
+     "facts"
+     [:extract [:field "value"]]
+     [:expr-or
+      [:expr-and
+       [:expr-not
+        [:condexpression
+         [:groupedfieldlist [:field "certname"] [:field "name"]]
+         "in"
+         [:from
+          "fact_contents"
+          [:extract [:field "certname"] [:field "name"]]
+          [:expr-or
+           [:expr-and
+            [:expr-not
+             [:condexpression [:field "value"] "<" [:integer "100"]]]]]]]]]]]
+
+    ;; whitespace optional
+    "facts[value]{[certname,name]in fact_contents[certname, name]{value<100}}"
     [:from
      "facts"
      [:extract [:field "value"]]


### PR DESCRIPTION
Previously, due to greedy Java regexes, the special character operators
such as =, >, >=, ~, etc all required a leading space. This makes the
leading space optional. The goal is that only spaces required are around
the word operators such as 'in', 'and', and 'or'.