### PR TITLE
(PDB-4256) Remove pin to puppetlabs-apt 6.2.1

### DIFF
--- a/acceptance/setup/pre_suite/50_install_modules.rb
+++ b/acceptance/setup/pre_suite/50_install_modules.rb
@@ -4,7 +4,6 @@ extend Beaker::DSL::InstallUtils
 
 unless (test_config[:skip_presuite_provisioning])
   step "Install the puppetdb module and dependencies" do
-    on databases, "puppet module install puppetlabs-apt --version 6.2.1"
     on databases, "puppet module install puppetlabs/puppetdb"
   end
 end


### PR DESCRIPTION
With the fix to puppetlabs-postgresql for MODULES-8553 we no longer need
to pin to the last release of apt.