### PR TITLE
(MAINT) Add container shutdown hooks

### DIFF
--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -12,7 +12,7 @@ RUN lein with-profile uberjar uberjar
 
 
 FROM openjdk:8-jre-alpine
-RUN apk add --no-cache tini curl openssl
+RUN apk add --no-cache tini curl openssl su-exec
 COPY --from=builder /app/target/puppetdb.jar /
 
 ARG vcs_ref
@@ -69,12 +69,15 @@ ADD https://raw.githubusercontent.com/puppetlabs/pupperware/b651119f16a1c18d5e91
 RUN chmod +x /ssl.sh
 COPY docker/puppetdb/ssl-setup.sh /
 RUN chmod +x /ssl-setup.sh
+COPY docker/puppetdb/analytics.sh /
+RUN chmod +x /analytics.sh
 
 VOLUME /etc/puppetlabs/puppet/ssl/
 
 COPY docker/puppetdb/docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
 COPY docker/puppetdb/docker-entrypoint.d /docker-entrypoint.d
+COPY docker/puppetdb/docker-exit.d /docker-exit.d
 
 EXPOSE 8080 8081
 

--- a/docker/puppetdb/analytics.sh
+++ b/docker/puppetdb/analytics.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+EVENT=${1:-start}
+
+if [ "${PUPPERWARE_DISABLE_ANALYTICS}" = "true" ]; then
+    echo "($0) Pupperware analytics disabled; skipping metric submission"
+    exit 0
+fi
+
+# See: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
+# Tracking ID
+tid=UA-132486246-1
+# Application Name
+an=puppetdb
+# Application Version
+av=$PUPPETDB_VERSION
+# Anonymous Client ID
+_file=/var/tmp/pwclientid
+cid=$(cat $_file 2>/dev/null || (cat /proc/sys/kernel/random/uuid | tee $_file))
+# Event Category
+ec=${PUPPERWARE_ANALYTICS_STREAM:-dev}
+# Event Action
+ea=${EVENT}
+
+_params="v=1&t=event&tid=${tid}&an=${an}&av=${av}&cid=${cid}&ec=${ec}&ea=${ea}"
+_url="http://www.google-analytics.com/collect?${_params}"
+
+echo "($0) Sending metrics ${_url}"
+curl --fail --silent --show-error --output /dev/null \
+    -X POST -H "Content-Length: 0" $_url

--- a/docker/puppetdb/docker-entrypoint.d/10-analytics.sh
+++ b/docker/puppetdb/docker-entrypoint.d/10-analytics.sh
@@ -1,28 +1,3 @@
 #!/bin/sh
 
-if [ "${PUPPERWARE_DISABLE_ANALYTICS}" = "true" ]; then
-    echo "($0) Pupperware analytics disabled; skipping metric submission"
-    exit 0
-fi
-
-# See: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
-# Tracking ID
-tid=UA-132486246-1
-# Application Name
-an=puppetdb
-# Application Version
-av=$PUPPETDB_VERSION
-# Anonymous Client ID
-_file=/var/tmp/pwclientid
-cid=$(cat $_file 2>/dev/null || (cat /proc/sys/kernel/random/uuid | tee $_file))
-# Event Category
-ec=${PUPPERWARE_ANALYTICS_STREAM:-dev}
-# Event Action
-ea=start
-
-_params="v=1&t=event&tid=${tid}&an=${an}&av=${av}&cid=${cid}&ec=${ec}&ea=${ea}"
-_url="http://www.google-analytics.com/collect?${_params}"
-
-echo "($0) Sending metrics ${_url}"
-curl --fail --silent --show-error --output /dev/null \
-    -X POST -H "Content-Length: 0" $_url
+/analytics.sh start

--- a/docker/puppetdb/docker-entrypoint.sh
+++ b/docker/puppetdb/docker-entrypoint.sh
@@ -8,6 +8,21 @@ for f in /docker-entrypoint.d/*.sh; do
     "$f"
 done
 
-exec java $PUPPETDB_JAVA_ARGS -cp /puppetdb.jar \
+on_exit() {
+    status=$?
+    for f in /docker-exit.d/*.sh; do
+        echo "Running $f"
+        chmod +x "$f"
+        "$f"
+    done
+    # Don't call ourselves when we exit below
+    trap '' EXIT
+    exit $status
+}
+
+# Shutdown hook
+trap on_exit EXIT SIGINT SIGTERM
+
+/sbin/su-exec root java $PUPPETDB_JAVA_ARGS -cp /puppetdb.jar \
     clojure.main -m puppetlabs.puppetdb.core "$@" \
     -c /etc/puppetlabs/puppetdb/conf.d/

--- a/docker/puppetdb/docker-exit.d/10-analytics.sh
+++ b/docker/puppetdb/docker-exit.d/10-analytics.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/analytics.sh stop


### PR DESCRIPTION
Add a directory of scripts to be executed when the container shuts down,
for things like Google Analytics metrics and Consul deregistration.