### PR TITLE
(MAINT) Fixing errors that make CI fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,11 +157,11 @@ jobs:
 
     # === integration with current platform
     - stage: ❧ pdb tests
-      env: PDB_TEST=int/openjdk10/pup-6.0.x/srv-6.0.x/pg-9.6
+      env: PDB_TEST=int/openjdk11/pup-6.0.x/srv-6.0.x/pg-9.6
       script: *run-integration-tests
 
     - stage: ❧ pdb tests
-      env: PDB_TEST=int/openjdk10/pup-6.0.x/srv-6.0.x/pg-9.6/rich
+      env: PDB_TEST=int/openjdk11/pup-6.0.x/srv-6.0.x/pg-9.6/rich
       script: *run-integration-tests
 
     - stage: ❧ pdb tests

--- a/ext/test/top-level-cli
+++ b/ext/test/top-level-cli
@@ -14,9 +14,7 @@ expected_version_warnings=0
 case "$jdkver" in
     8)
         ;;
-    10|11)
-        expected_help_warnings=0
-        expected_version_warnings=535
+    11)
         ;;
     *)
         echo "JDK version '$jdkver' is not supported" 1>&2
@@ -41,8 +39,6 @@ cat "$tmpdir/out" "$tmpdir/err"
 test "$rc" -eq 0
 grep -F 'Available subcommands:' "$tmpdir/out"
 grep -E 'Display version information' "$tmpdir/out"
-# FIXME: this should and will be 0 once we fix the pos-int?, dynapath,
-# etc. replacement warnings.
 test $(wc -c < "$tmpdir/err") -eq $expected_help_warnings
 
 rc=0
@@ -51,6 +47,4 @@ cat "$tmpdir/out" "$tmpdir/err"
 test "$rc" -eq 0
 grep -E '^version=' "$tmpdir/out"
 grep -E '^target_schema_version=' "$tmpdir/out"
-# FIXME: this should and will be 0 once we fix the pos-int?, dynapath,
-# etc. replacement warnings.
 test $(wc -c < "$tmpdir/err") -eq $expected_version_warnings

--- a/project.clj
+++ b/project.clj
@@ -196,7 +196,10 @@
                  [ring/ring-core]
 
                  ;; conflict resolution
-                 [org.clojure/tools.nrepl "0.2.13"]]
+                 [org.clojure/tools.nrepl "0.2.13"]
+
+                 ;; fixing a illegal reflective access
+                 [org.tcrawley/dynapath "1.0.0"]]
 
   ; permanently exclude jackson-databind, as it is a source of CVE's and we don't use it
   :exclusions [[com.fasterxml.jackson.core/jackson-databind]]


### PR DESCRIPTION
Update dynapath to 1.0.0 to fix an illegal reflective access error

Remove openjdk10 from build matrix as it EOL'ed in September 2018