### PR TITLE
(PDB-4270) Support "configure expiration" command

### DIFF
--- a/documentation/api/command/v1/commands.markdown
+++ b/documentation/api/command/v1/commands.markdown
@@ -15,6 +15,7 @@ canonical: "/puppetdb/latest/api/command/v1/commands.html"
 [reportv7]: ../../wire_format/report_format_v7.html
 [reportv8]: ../../wire_format/report_format_v8.html
 [deactivatev3]: ../../wire_format/deactivate_node_format_v3.html
+[expirev1]: ../../wire_format/configure_expiration_format_v1.html
 
 Commands are used to change PuppetDB's model of a population. Commands are represented by `command objects`,
 which have the following JSON wire format:
@@ -45,6 +46,9 @@ containing the given command's wire format. This mechanism allows PuppetDB to
 provide better validation and feedback at time of POSTing without inspecting the
 command payload itself, and should be preferred over the alternative due to
 lower memory consumption.
+
+> *Note*: every command that requires an accurate certname *must*
+> include (duplicate) the certname in the wire format (the payload).
 
 * Payload only (deprecated): This method entails POSTing a single JSON body
 containing the certname, command name, and command version along side a
@@ -204,6 +208,16 @@ The payload is expected to be a report, containing events that occurred on
 Puppet resources. It is structured as a JSON object, conforming to the
 [report wire format v5][reportv5].
 
+### "configure expiration", version 1 (experimental)
+
+The payload should be a JSON format command, conforming to the
+[configure_expiration wire format v1][expirev1], indicating whether or
+not facts should be expired for a given `certname`.
+
+> *Note*: this is an experimental command, which might be altered or
+> removed in a future release, and for the time being, PuppetDB
+> exports will not include this information.
+
 ## Examples using `curl`
 
 To post a `replace facts` command you can use the following curl command:
@@ -237,3 +251,11 @@ or equivalently:
       -H "Content-Type: application/json" \
       -d '{"command":"deactivate node","version":3,"payload":{"certname":"test1","producer_timestamp":"2015-01-01"}}' \
       http://localhost:8080/pdb/cmd/v1
+
+To `configure expiration` for facts:
+
+    curl -X POST \
+      -H 'Content-Type:application/json' \
+      -H 'Accept:application/json' \
+      -d '{"certname":"test1","producer_timestamp":"2019-01-01","expire":{"facts":false}}' \
+      "http://localhost:8080/pdb/cmd/v1?certname=test1&command=configure_expiration&version=1"

--- a/documentation/api/wire_format/configure_expiration_format_v1.markdown
+++ b/documentation/api/wire_format/configure_expiration_format_v1.markdown
@@ -1,0 +1,77 @@
+---
+title: "PuppetDB: Configure expiration wire format, version 1 (experimental)"
+layout: default
+canonical: "/puppetdb/latest/api/wire_format/configure_expiration_v1.html"
+---
+
+The v1 `configure expiration` command tells PuppetDB whether or not
+factsets for a given certname should ever be expired (and by
+extension, the node itself).  By default, unless expiration has been
+explicitly set to false by this command, factsets are deleted when the
+node itself is purged.
+
+Changing the value of this setting for a certname has the same effect
+as receipt of a new factset with respect to extending the lifetime of
+the node.
+
+> *Note*: this is an experimental command, which might be altered or
+> removed in a future release, and for the time being, PuppetDB
+> exports will not include this information.
+
+Configure expiration command format
+-----
+
+### Version
+
+This is **version 1** of the configure expiration command.
+
+### Encoding
+
+The command is serialized as JSON, which requires strict UTF-8 encoding.
+
+### Main data type: Deactivate node
+
+     {
+      "certname": <string>,
+      "expire": {"facts": <boolean>},
+      "producer_timestamp": <datetime>
+     }
+
+#### `certname`
+
+String. The name of the node for which the expiration behavior should
+be configured.
+
+#### `expire`
+
+JSON.  A map containing a single boolean `facts` value indicating
+whether or not factsets should ever expire for the certname.
+
+#### `producer_timestamp`
+
+DateTime. The time of command submission from the Puppet master to PuppetDB,
+according to the clock on the Puppet master.
+
+`producer_timestamp` is optional but *highly* recommended. When provided, it is
+used to determine the precedence between this command and other commands that
+modify the same node. This field is provided by, and should thus reflect the
+clock of, the Puppet master.
+
+When `producer_timestamp` is not provided, the PuppetDB server's local time is
+used. If another command is received for a node while a non-timestamped
+"deactivate node" command is pending processing, the results are *undefined*.
+
+### Data type: `<string>`
+
+A JSON string. Because the command is UTF-8, these must also be UTF-8.
+
+### Data type: `<boolean>`
+
+A JSON Boolean.
+
+### Data type: `<datetime>`
+
+A JSON string representing a date and time (with time zone), formatted based on
+the recommendations in ISO 8601. For example, for a UTC time, the string would be
+formatted as `YYYY-MM-DDThh:mm:ss.sssZ`. For non-UTC time, the `Z` may be replaced
+with `±hh:mm` to represent the specific timezone.

--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -69,6 +69,6 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 67$' "$tmpdir/out"
+grep -qE ' 68$' "$tmpdir/out"
 
 test ! -e "$PDBBOX"/var/mq-migrated

--- a/src/puppetlabs/puppetdb/command/constants.clj
+++ b/src/puppetlabs/puppetdb/command/constants.clj
@@ -2,7 +2,8 @@
   (:require [clojure.set :as set]))
 
 (def command-names
-  {:replace-catalog "replace catalog"
+  {:configure-expiration "configure expiration"
+   :replace-catalog "replace catalog"
    :replace-facts   "replace facts"
    :deactivate-node "deactivate node"
    :store-report    "store report"})
@@ -13,7 +14,8 @@
   (set (range min-version (inc max-version))))
 
 (def supported-command-versions
-  {"replace facts" (version-range 2 5)
+  {"configure expiration" (version-range 1 1)
+   "replace facts" (version-range 2 5)
    "replace catalog" (version-range 4 9)
    "store report" (version-range 3 8)
    "deactivate node" (version-range 1 3)})

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -25,7 +25,8 @@
            [org.apache.commons.fileupload.util LimitedInputStream]))
 
 (def min-supported-commands
-  {"replace catalog" 6
+  {"configure expiration" 1
+   "replace catalog" 6
    "replace facts" 4
    "store report" 5
    "deactivate node" 3})

--- a/src/puppetlabs/puppetdb/queue.clj
+++ b/src/puppetlabs/puppetdb/queue.clj
@@ -37,7 +37,8 @@
   {"catalog" "replace catalog"
    "facts" "replace facts"
    "rm-node" "deactivate node"
-   "report" "store report"})
+   "report" "store report"
+   "set-expire" "configure expiration"})
 
 (def puppetdb-command->metadata-command
   (into {} (for [[md pdb] metadata-command->puppetdb-command] [pdb md])))

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1561,6 +1561,20 @@
 
   {::vaccum-analyze #{"resource_events"}})
 
+(defn support-fact-expiration-configuration []
+  ;; Note that a missing row implies "true", i.e. expiration should
+  ;; behave as it always had, and as it does for agent managed nodes.
+  (jdbc/do-commands
+   ["create table certname_fact_expiration"
+    "  (certid bigint not null primary key,"
+    "   expire bool not null,"
+    "   updated timestamp with time zone not null,"
+    "   constraint certname_fact_expiration_certid_fkey"
+    "     foreign key (certid) references certnames(id) on delete cascade,"
+    "   constraint certname_fact_expiration_expire_updated_vals_match"
+    "     check ((expire is not null and updated is not null)"
+    "             or (expire is null and updated is null)))"]))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1605,7 +1619,8 @@
    64 rededuplicate-facts
    65 varchar-columns-to-text
    66 jsonb-facts
-   67 add-resource-events-pk})
+   67 add-resource-events-pk
+   68 support-fact-expiration-configuration})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/test/puppetlabs/puppetdb/http/command_test.clj
+++ b/test/puppetlabs/puppetdb/http/command_test.clj
@@ -128,7 +128,7 @@
            (is (= ["Content-Type"] (keys headers)))
            (is (http/json-utf8-ctype? (headers "Content-Type")))
            (is (= (:error (json/parse-string body true))
-                  "Supported commands are deactivate node, replace catalog, replace facts, store report. Received 'null'.")))))
+                  "Supported commands are configure expiration, deactivate node, replace catalog, replace facts, store report. Received 'null'.")))))
 
      (testing "should not do checksum verification if no checksum is provided"
        (tqueue/with-stockpile q


### PR DESCRIPTION
Add a new "configure expiration" command which can be used to disable
factset expiration for a given certname.  This is intended to support
nodes that are managed more directly, and/or are more ephemeral than
nodes that are managed by the agent.