### PR TITLE
(PDB-3911) adding pk to resource_events table

### DIFF
--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -69,6 +69,6 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 66$' "$tmpdir/out"
+grep -qE ' 67$' "$tmpdir/out"
 
 test ! -e "$PDBBOX"/var/mq-migrated

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
             (slurp (str "ext/test-conf/puppetserver-dep"))
             (catch java.io.FileNotFoundException ex
               (binding [*out* *err*]
-                (println "puppetserver test depdency unconfigured (ignoring)"))
+                (println "puppetserver test dependency unconfigured (ignoring)"))
               nil))
           clojure.string/trim))
 

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -194,6 +194,20 @@
     :resource_events (sort (map resource-event-identity-string resource_events))
     :transaction_uuid transaction_uuid}))
 
+(defn resource-event-identity-pkey
+  "Compute a hash for a resource-event's content, used as a primary key
+
+  This is different than resource-event-identity-string in that it does not
+  include every field - it only uses the fields that make up a unique constraint
+  in the database"
+  [{:keys [report_id resource_type resource_title property] :as event}]
+  (assert report_id "report_id must not be nil")
+  (generic-identity-hash
+   {:report_id report_id
+    :resource_type resource_type
+    :resource_title resource_title
+    :property property}))
+
 (defn fact-identity-hash
   "Compute a hash for a fact's content
 
@@ -203,5 +217,5 @@
   "
   [fact-data]
   (-> fact-data
-    (dissoc :timestamp :producer_timestamp :producer)
-    generic-identity-hash))
+      (dissoc :timestamp :producer_timestamp :producer)
+      generic-identity-hash))

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -903,6 +903,7 @@
    "CREATE INDEX catalogs_certname_idx ON catalogs (certname)"))
 
 (defn add-indexes-for-reports-summary-query
+  "This aggregate and function is used by PE, not puppetdb"
   []
   (jdbc/do-commands
    "CREATE FUNCTION dual_md5(BYTEA, BYTEA) RETURNS bytea AS $$
@@ -1496,6 +1497,68 @@
 
   {::vacuum-analyze #{"factsets"}})
 
+(defn add-resource-events-pk []
+  (jdbc/do-commands
+   "CREATE TABLE resource_events_transform (
+      event_hash bytea NOT NULL PRIMARY KEY,
+      report_id bigint NOT NULL,
+      certname_id bigint NOT NULL,
+      status text NOT NULL,
+      \"timestamp\" timestamp with time zone NOT NULL,
+      resource_type text NOT NULL,
+      resource_title text NOT NULL,
+      property text,
+      new_value text,
+      old_value text,
+      message text,
+      file text DEFAULT NULL::character varying,
+      line integer,
+      containment_path text[],
+      containing_class text,
+      corrective_change boolean)")
+
+  (migrate-through-app
+   :resource_events
+   :resource_events_transform
+   ["report_id" "certname_id" "status" "\"timestamp\"" "resource_type" "resource_title"
+    "property" "new_value" "old_value" "message" "file" "line" "containment_path"
+    "containing_class" "corrective_change"]
+   #(-> %
+        (update :containment_path sutils/to-jdbc-varchar-array)
+        (assoc :event_hash (->> (hash/resource-event-identity-pkey %)
+                                (sutils/munge-hash-for-storage)))))
+
+  (jdbc/do-commands
+   "DROP TABLE resource_events"
+
+   "ALTER TABLE resource_events_transform RENAME TO resource_events"
+
+   "ALTER INDEX resource_events_transform_pkey RENAME TO resource_events_pkey"
+
+   "ALTER TABLE ONLY resource_events
+      ADD CONSTRAINT resource_events_unique UNIQUE (report_id, resource_type, resource_title, property)"
+
+   "CREATE INDEX resource_events_containing_class_idx ON resource_events USING btree (containing_class)"
+
+   "CREATE INDEX resource_events_property_idx ON resource_events USING btree (property)"
+
+   "CREATE INDEX resource_events_reports_id_idx ON resource_events USING btree (report_id)"
+
+   "CREATE INDEX resource_events_resource_timestamp ON resource_events USING btree (resource_type, resource_title, \"timestamp\")"
+
+   "CREATE INDEX resource_events_resource_title_idx ON resource_events USING btree (resource_title)"
+
+   "CREATE INDEX resource_events_status_for_corrective_change_idx ON resource_events USING btree (status) WHERE corrective_change"
+
+   "CREATE INDEX resource_events_status_idx ON resource_events USING btree (status)"
+
+   "CREATE INDEX resource_events_timestamp_idx ON resource_events USING btree (\"timestamp\")"
+
+   "ALTER TABLE ONLY resource_events
+      ADD CONSTRAINT resource_events_report_id_fkey FOREIGN KEY (report_id) REFERENCES reports(id) ON DELETE CASCADE")
+
+  {::vaccum-analyze #{"resource_events"}})
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1539,7 +1602,8 @@
    63 add-job-id
    64 rededuplicate-facts
    65 varchar-columns-to-text
-   66 jsonb-facts})
+   66 jsonb-facts
+   67 add-resource-events-pk})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -41,11 +41,11 @@
 (defn db-admin-config
   ([] (db-admin-config "postgres"))
   ([database]
-    {:classname "org.postgresql.Driver"
-     :subprotocol "postgresql"
-     :subname (format "//%s:%s/%s" (:host test-env) (:port test-env) database)
-     :user (get-in test-env [:admin :name])
-     :password (get-in test-env [:admin :password])}))
+   {:classname "org.postgresql.Driver"
+    :subprotocol "postgresql"
+    :subname (format "//%s:%s/%s" (:host test-env) (:port test-env) database)
+    :user (get-in test-env [:admin :name])
+    :password (get-in test-env [:admin :password])}))
 
 (defn db-user-config
   [database]
@@ -98,7 +98,7 @@
    (doseq [sequence-name (cons "test" (sutils/sql-current-connection-sequence-names))]
      (drop-sequence! sequence-name))
    (doseq [function-name (sutils/sql-current-connection-function-names)]
-          (drop-function! function-name))))
+     (drop-function! function-name))))
 
 (def ^:private pdb-test-id (env :pdb-test-id))
 


### PR DESCRIPTION
This will allow this table to be cleaned with pg_repack instead of relying
on a VACUUM FULL, which avoids locks on the table.