### PR TITLE
(PDB-2487) remove events from reports hash

### DIFF
--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -69,6 +69,6 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 66$' "$tmpdir/out"
+grep -qE ' 68$' "$tmpdir/out"
 
 test ! -e "$PDBBOX"/var/mq-migrated

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -180,9 +180,9 @@
 
   This hash is useful for situations where you'd like to determine
   whether or not two reports contain the same things (certname,
-  configuration version, timestamps, events)."
+  configuration version, timestamps)."
   [{:keys [certname puppet_version report_format configuration_version
-           start_time end_time producer_timestamp resource_events transaction_uuid] :as report}]
+           start_time end_time producer_timestamp transaction_uuid] :as report}]
   (generic-identity-hash
    {:certname certname
     :puppet_version puppet_version
@@ -191,7 +191,6 @@
     :start_time start_time
     :end_time end_time
     :producer_timestamp producer_timestamp
-    :resource_events (sort (map resource-event-identity-string resource_events))
     :transaction_uuid transaction_uuid}))
 
 (defn fact-identity-hash

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1496,6 +1496,138 @@
 
   {::vacuum-analyze #{"factsets"}})
 
+(defn change-reports-hash-to-summary-hash
+  "Changes the reports table primary key hash to remove the events from
+  the hash calculation. This allows events to be garbage collected separately
+  from reports"
+  []
+  (jdbc/do-commands
+   "CREATE TABLE reports_transform (
+      id bigint not null,
+      hash bytea not null,
+      transaction_uuid uuid,
+      certname text not null,
+      puppet_version text not null,
+      report_format smallint not null,
+      configuration_version text not null,
+      start_time timestamp with time zone not null,
+      end_time timestamp with time zone not null,
+      receive_time timestamp with time zone not null,
+      noop boolean,
+      environment_id bigint,
+      status_id bigint,
+      metrics_json json,
+      logs_json json,
+      producer_timestamp timestamp with time zone not null,
+      metrics jsonb,
+      logs jsonb,
+      resources jsonb,
+      catalog_uuid uuid,
+      cached_catalog_status text,
+      code_id text,
+      producer_id bigint,
+      noop_pending boolean,
+      corrective_change boolean,
+      job_id text)")
+
+  (migrate-through-app
+   :reports
+   :reports_transform
+   ["id" "transaction_uuid" "certname" "puppet_version" "report_format" "configuration_version"
+    "start_time" "end_time" "receive_time" "noop" "environment_id" "status_id" "metrics_json"
+    "logs_json" "producer_timestamp" "metrics" "logs" "resources" "catalog_uuid" "cached_catalog_status"
+    "code_id" "producer_id" "noop_pending" "corrective_change" "job_id"]
+   #(-> %
+        ;; add a new hash field that does not include include events
+        (assoc :hash (->> (hash/report-identity-hash %)
+                          (sutils/munge-hash-for-storage)))))
+
+  (jdbc/do-commands
+   ;; drop the existing constraints on the reports table. many of these constraints
+   ;; have cascades on delete, and we don't want that to actually happen during the
+   ;; migration
+   "DROP INDEX idx_reports_noop_pending"
+   "DROP INDEX idx_reports_prod"
+   "DROP INDEX idx_reports_producer_timestamp"
+   "DROP INDEX idx_reports_producer_timestamp_by_hour_certname"
+   "DROP INDEX reports_cached_catalog_status_on_fail"
+   "DROP INDEX reports_catalog_uuid_idx"
+   "DROP INDEX reports_certname_idx"
+   "DROP INDEX reports_end_time_idx"
+   "DROP INDEX reports_environment_id_idx"
+   "DROP INDEX reports_hash_expr_idx"
+   "DROP INDEX reports_job_id_idx"
+   "DROP INDEX reports_noop_idx"
+   "DROP INDEX reports_status_id_idx"
+   "DROP INDEX reports_tx_uuid_expr_idx"
+   "ALTER TABLE reports DROP CONSTRAINT reports_certname_fkey"
+   "ALTER TABLE reports DROP CONSTRAINT reports_env_fkey"
+   "ALTER TABLE reports DROP CONSTRAINT reports_prod_fkey"
+   "ALTER TABLE reports DROP CONSTRAINT reports_status_fkey"
+
+   "ALTER TABLE resource_events DROP CONSTRAINT resource_events_report_id_fkey"
+
+   "ALTER TABLE certnames DROP CONSTRAINT certnames_reports_id_fkey"
+
+   "ALTER SEQUENCE reports_id_seq OWNED BY NONE"
+
+   "DROP TABLE reports"
+   "ALTER TABLE reports_transform RENAME TO reports"
+
+   "ALTER TABLE ONLY reports
+      ALTER COLUMN id SET DEFAULT nextval('reports_id_seq'::regclass)"
+
+   "ALTER SEQUENCE reports_id_seq OWNED BY reports.id"
+
+   "ALTER TABLE ONLY reports
+      ADD CONSTRAINT reports_pkey PRIMARY KEY (id)"
+
+   "CREATE INDEX idx_reports_noop_pending ON reports USING btree (noop_pending) WHERE (noop_pending = true)"
+
+   "CREATE INDEX idx_reports_prod ON reports USING btree (producer_id)"
+
+   "CREATE INDEX idx_reports_producer_timestamp ON reports USING btree (producer_timestamp)"
+
+   "CREATE INDEX idx_reports_producer_timestamp_by_hour_certname ON reports USING btree (date_trunc('hour'::text, timezone('UTC'::text, producer_timestamp)), producer_timestamp, certname)"
+
+   "CREATE INDEX reports_cached_catalog_status_on_fail ON reports USING btree (cached_catalog_status) WHERE (cached_catalog_status = 'on_failure'::text)"
+
+   "CREATE INDEX reports_catalog_uuid_idx ON reports USING btree (catalog_uuid)"
+
+   "CREATE INDEX reports_certname_idx ON reports USING btree (certname)"
+
+   "CREATE INDEX reports_end_time_idx ON reports USING btree (end_time)"
+
+   "CREATE INDEX reports_environment_id_idx ON reports USING btree (environment_id)"
+
+   "CREATE UNIQUE INDEX reports_hash_expr_idx ON reports USING btree (encode(hash, 'hex'::text))"
+
+   "CREATE INDEX reports_job_id_idx ON reports USING btree (job_id) WHERE (job_id IS NOT NULL)"
+
+   "CREATE INDEX reports_noop_idx ON reports USING btree (noop) WHERE (noop = true)"
+
+   "CREATE INDEX reports_status_id_idx ON reports USING btree (status_id)"
+
+   "CREATE INDEX reports_tx_uuid_expr_idx ON reports USING btree (((transaction_uuid)::text))"
+
+   "ALTER TABLE ONLY reports
+      ADD CONSTRAINT reports_certname_fkey FOREIGN KEY (certname) REFERENCES certnames(certname) ON DELETE CASCADE"
+
+   "ALTER TABLE ONLY reports
+      ADD CONSTRAINT reports_env_fkey FOREIGN KEY (environment_id) REFERENCES environments(id) ON DELETE CASCADE"
+
+   "ALTER TABLE ONLY reports
+      ADD CONSTRAINT reports_prod_fkey FOREIGN KEY (producer_id) REFERENCES producers(id)"
+
+   "ALTER TABLE ONLY reports
+      ADD CONSTRAINT reports_status_fkey FOREIGN KEY (status_id) REFERENCES report_statuses(id) ON DELETE CASCADE"
+
+   "ALTER TABLE ONLY resource_events
+      ADD CONSTRAINT resource_events_report_id_fkey FOREIGN KEY (report_id) REFERENCES reports(id) ON DELETE CASCADE"
+
+   "ALTER TABLE ONLY certnames
+      ADD CONSTRAINT certnames_reports_id_fkey FOREIGN KEY (latest_report_id) REFERENCES reports(id) ON DELETE SET NULL"))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1539,7 +1671,10 @@
    63 add-job-id
    64 rededuplicate-facts
    65 varchar-columns-to-text
-   66 jsonb-facts})
+   66 jsonb-facts
+   ;; this is a placeholder for the resource-events pk PR
+   67 (fn [] true)
+   68 change-reports-hash-to-summary-hash})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/test/puppetlabs/puppetdb/examples/reports.clj
+++ b/test/puppetlabs/puppetdb/examples/reports.clj
@@ -293,7 +293,7 @@
    {:certname "foo.local"
     :puppet_version "3.0.1"
     :report_format 4
-    :transaction_uuid "e1e561ba-212f-11e3-9d58-60a44c233a9d"
+    :transaction_uuid "e1e561ba-212f-11e3-9d58-60a44c233a9e"
     :catalog_uuid "5ea3a70b-84c8-426c-813c-dd6492fb829b"
     :code_id nil
     :job_id nil

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -379,7 +379,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "7d0cfa08901e1e1d80cf2f2f814d356d0e457e09"
+       :report "8bd4d65f561a73caf8022d1d654bde76a3b417ad"
        :resource_title "hi"
        :property nil
        :file "bar"
@@ -405,7 +405,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "7d0cfa08901e1e1d80cf2f2f814d356d0e457e09"
+       :report "8bd4d65f561a73caf8022d1d654bde76a3b417ad"
        :resource_title "hi"
        :property nil
        :file "bar"
@@ -433,7 +433,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "7d0cfa08901e1e1d80cf2f2f814d356d0e457e09"
+       :report "8bd4d65f561a73caf8022d1d654bde76a3b417ad"
        :resource_title "hi"
        :property nil
        :file "bar"

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -147,12 +147,12 @@
                                             ["group_by" "status" "certname"]])
              #{{:certname "bar.local" :status "unchanged" :count 1}
                {:certname "foo.local" :status "unchanged" :count 1}}))
-      (is (= (query-result method endpoint ["extract" ["hash"]
+      (is (= #{{:hash "5bc5d561c7912570a7c7f525b815477cdaed70a2"}
+               {:hash "5067c5ac56f39501e504c0b76186d31ec1b5ca94"}}
+             (query-result method endpoint ["extract" ["hash"]
                                             ["in" "hash"
-                                             ["array" ["572d1e89a4075170938f4e960b26d8f63ad705f8"
-                                                       "b437558374bf9d6e21cb880c22409f42f743de9b"]]]])
-             #{{:hash "572d1e89a4075170938f4e960b26d8f63ad705f8"}
-               {:hash "b437558374bf9d6e21cb880c22409f42f743de9b"}}))
+                                             ["array" ["5bc5d561c7912570a7c7f525b815477cdaed70a2"
+                                                       "5067c5ac56f39501e504c0b76186d31ec1b5ca94"]]]])))
       (is (= (query-result method endpoint ["extract" [["function" "count"] "status" "certname"]
                                             ["or"
                                              ["in" "status" ["array" ["unchanged"]]]
@@ -426,7 +426,7 @@
         basic4 (assoc (:basic4 reports) :status "failed")
         _ (store-example-report! basic4 (now))]
 
-    (testing "should return all reports for a certname"
+    (testing "should return all reports based on their status"
       (let [unchanged-reports (query-result method endpoint ["=" "status" "unchanged"]
                                             {} munge-reports-for-comparison)
             changed-reports (query-result method endpoint ["=" "status" "changed"]
@@ -437,16 +437,16 @@
         (is (= 2 (count unchanged-reports)))
         (is (every? #(= "unchanged" (:status %)) unchanged-reports))
 
-        (is (= unchanged-reports
-               (munge-reports-for-comparison [basic basic2])))
+        (is (= (munge-reports-for-comparison [basic basic2])
+               unchanged-reports))
 
         (is (= 1 (count changed-reports)))
-        (is (= changed-reports
-               (munge-reports-for-comparison [basic3])))
+        (is (= (munge-reports-for-comparison [basic3])
+               changed-reports))
 
         (is (= 1 (count failed-reports)))
-        (is (= failed-reports
-               (munge-reports-for-comparison [basic4])))))))
+        (is (= (munge-reports-for-comparison [basic4])
+               failed-reports))))))
 
 (deftest-http-app query-by-certname-with-environment
   [[version endpoint] endpoints

--- a/test/puppetlabs/puppetdb/scf/hash_test.clj
+++ b/test/puppetlabs/puppetdb/scf/hash_test.clj
@@ -146,16 +146,10 @@
                   :configuration_version "asdffdsa"
                   :start_time "2012-03-01-12:31:11.123"
                   :end_time   "2012-03-01-12:31:31.123"
-                  :producer_timestamp "2012-03-01-1:31:51.123"
-                  :resource_events [
-                                    {:type "Type"
-                                     :title "title"
-                                     :parameters {:d {:b 2 :c [:a :b :c]} :c 3 :a 1}
-                                     :exported false :file "/tmp/zzz"
-                                     :line 15}]}]
+                  :producer_timestamp "2012-03-01-1:31:51.123"}]
 
       (testing "should return sorted predictable string output"
-        (is (= "3016159f704726b486f8b42309773ec625e2f3b7"
+        (is (= "f0dc33b54c9eea0a83444fa1fecfe6a2b2b6db39"
                (report-identity-hash sample))))
 
       (testing "should return the same value twice"
@@ -232,13 +226,7 @@
         report (:basic reports)
         report2-events (get-in reports [:basic4 :resource_events :data])
         report2 (assoc-in report [:resource_events :data] report2-events)
-        report-hash (report-query->hash report)
-        report2-hash (report-query->hash report2)
-        report3-hash (report-query->hash
-                      (update-in report [:resource_events :data] rest))]
-    (testing "Reports with the same metadata but different events should have different hashes"
-      (is (not= report-hash report2-hash))
-      (is (not= report-hash report3-hash)))
+        report-hash (report-query->hash report)]
 
     (testing "Reports with different metadata but the same events should have different hashes"
       (let [mod-report-fns [#(assoc % :certname (str (:certname %) "foo"))


### PR DESCRIPTION
Removes the report events from the calculation of a report's hash. This
will allow garbage collection of resource events. During a sync between
puppetdb instances, the report's hash will change if the events are
missing, which will lead to duplicate reports in the database.