### PR TITLE
(PDB-2488) remove events from reports hash

### DIFF
--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -69,6 +69,6 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 68$' "$tmpdir/out"
+grep -qE ' 69$' "$tmpdir/out"
 
 test ! -e "$PDBBOX"/var/mq-migrated

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -180,9 +180,9 @@
 
   This hash is useful for situations where you'd like to determine
   whether or not two reports contain the same things (certname,
-  configuration version, timestamps, events)."
+  configuration version, timestamps)."
   [{:keys [certname puppet_version report_format configuration_version
-           start_time end_time producer_timestamp resource_events transaction_uuid] :as report}]
+           start_time end_time producer_timestamp transaction_uuid] :as report}]
   (generic-identity-hash
    {:certname certname
     :puppet_version puppet_version
@@ -191,7 +191,6 @@
     :start_time start_time
     :end_time end_time
     :producer_timestamp producer_timestamp
-    :resource_events (sort (map resource-event-identity-string resource_events))
     :transaction_uuid transaction_uuid}))
 
 (defn resource-event-identity-pkey

--- a/test/puppetlabs/puppetdb/examples/reports.clj
+++ b/test/puppetlabs/puppetdb/examples/reports.clj
@@ -293,7 +293,7 @@
    {:certname "foo.local"
     :puppet_version "3.0.1"
     :report_format 4
-    :transaction_uuid "e1e561ba-212f-11e3-9d58-60a44c233a9d"
+    :transaction_uuid "e1e561ba-212f-11e3-9d58-60a44c233a9e"
     :catalog_uuid "5ea3a70b-84c8-426c-813c-dd6492fb829b"
     :code_id nil
     :job_id nil

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -379,7 +379,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "7d0cfa08901e1e1d80cf2f2f814d356d0e457e09"
+       :report "8bd4d65f561a73caf8022d1d654bde76a3b417ad"
        :resource_title "hi"
        :property nil
        :file "bar"
@@ -405,7 +405,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "7d0cfa08901e1e1d80cf2f2f814d356d0e457e09"
+       :report "8bd4d65f561a73caf8022d1d654bde76a3b417ad"
        :resource_title "hi"
        :property nil
        :file "bar"
@@ -433,7 +433,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "7d0cfa08901e1e1d80cf2f2f814d356d0e457e09"
+       :report "8bd4d65f561a73caf8022d1d654bde76a3b417ad"
        :resource_title "hi"
        :property nil
        :file "bar"

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -147,12 +147,12 @@
                                             ["group_by" "status" "certname"]])
              #{{:certname "bar.local" :status "unchanged" :count 1}
                {:certname "foo.local" :status "unchanged" :count 1}}))
-      (is (= (query-result method endpoint ["extract" ["hash"]
+      (is (= #{{:hash "5bc5d561c7912570a7c7f525b815477cdaed70a2"}
+               {:hash "5067c5ac56f39501e504c0b76186d31ec1b5ca94"}}
+             (query-result method endpoint ["extract" ["hash"]
                                             ["in" "hash"
-                                             ["array" ["572d1e89a4075170938f4e960b26d8f63ad705f8"
-                                                       "b437558374bf9d6e21cb880c22409f42f743de9b"]]]])
-             #{{:hash "572d1e89a4075170938f4e960b26d8f63ad705f8"}
-               {:hash "b437558374bf9d6e21cb880c22409f42f743de9b"}}))
+                                             ["array" ["5bc5d561c7912570a7c7f525b815477cdaed70a2"
+                                                       "5067c5ac56f39501e504c0b76186d31ec1b5ca94"]]]])))
       (is (= (query-result method endpoint ["extract" [["function" "count"] "status" "certname"]
                                             ["or"
                                              ["in" "status" ["array" ["unchanged"]]]
@@ -426,7 +426,7 @@
         basic4 (assoc (:basic4 reports) :status "failed")
         _ (store-example-report! basic4 (now))]
 
-    (testing "should return all reports for a certname"
+    (testing "should return all reports based on their status"
       (let [unchanged-reports (query-result method endpoint ["=" "status" "unchanged"]
                                             {} munge-reports-for-comparison)
             changed-reports (query-result method endpoint ["=" "status" "changed"]
@@ -437,16 +437,16 @@
         (is (= 2 (count unchanged-reports)))
         (is (every? #(= "unchanged" (:status %)) unchanged-reports))
 
-        (is (= unchanged-reports
-               (munge-reports-for-comparison [basic basic2])))
+        (is (= (munge-reports-for-comparison [basic basic2])
+               unchanged-reports))
 
         (is (= 1 (count changed-reports)))
-        (is (= changed-reports
-               (munge-reports-for-comparison [basic3])))
+        (is (= (munge-reports-for-comparison [basic3])
+               changed-reports))
 
         (is (= 1 (count failed-reports)))
-        (is (= failed-reports
-               (munge-reports-for-comparison [basic4])))))))
+        (is (= (munge-reports-for-comparison [basic4])
+               failed-reports))))))
 
 (deftest-http-app query-by-certname-with-environment
   [[version endpoint] endpoints

--- a/test/puppetlabs/puppetdb/scf/hash_test.clj
+++ b/test/puppetlabs/puppetdb/scf/hash_test.clj
@@ -146,16 +146,10 @@
                   :configuration_version "asdffdsa"
                   :start_time "2012-03-01-12:31:11.123"
                   :end_time   "2012-03-01-12:31:31.123"
-                  :producer_timestamp "2012-03-01-1:31:51.123"
-                  :resource_events [
-                                    {:type "Type"
-                                     :title "title"
-                                     :parameters {:d {:b 2 :c [:a :b :c]} :c 3 :a 1}
-                                     :exported false :file "/tmp/zzz"
-                                     :line 15}]}]
+                  :producer_timestamp "2012-03-01-1:31:51.123"}]
 
       (testing "should return sorted predictable string output"
-        (is (= "3016159f704726b486f8b42309773ec625e2f3b7"
+        (is (= "f0dc33b54c9eea0a83444fa1fecfe6a2b2b6db39"
                (report-identity-hash sample))))
 
       (testing "should return the same value twice"
@@ -232,13 +226,7 @@
         report (:basic reports)
         report2-events (get-in reports [:basic4 :resource_events :data])
         report2 (assoc-in report [:resource_events :data] report2-events)
-        report-hash (report-query->hash report)
-        report2-hash (report-query->hash report2)
-        report3-hash (report-query->hash
-                      (update-in report [:resource_events :data] rest))]
-    (testing "Reports with the same metadata but different events should have different hashes"
-      (is (not= report-hash report2-hash))
-      (is (not= report-hash report3-hash)))
+        report-hash (report-query->hash report)]
 
     (testing "Reports with different metadata but the same events should have different hashes"
       (let [mod-report-fns [#(assoc % :certname (str (:certname %) "foo"))


### PR DESCRIPTION
Removes the report events from the calculation of a report's hash. This
will allow garbage collection of resource events. During a sync between
puppetdb instances, the report's hash will change if the events are
missing, which will lead to duplicate reports in the database.