### PR TITLE
(PDB-3911) adding pk to resource_events table

### DIFF
--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -69,6 +69,6 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 66$' "$tmpdir/out"
+grep -qE ' 67$' "$tmpdir/out"
 
 test ! -e "$PDBBOX"/var/mq-migrated

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
             (slurp (str "ext/test-conf/puppetserver-dep"))
             (catch java.io.FileNotFoundException ex
               (binding [*out* *err*]
-                (println "puppetserver test depdency unconfigured (ignoring)"))
+                (println "puppetserver test dependency unconfigured (ignoring)"))
               nil))
           clojure.string/trim))
 

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -194,6 +194,20 @@
     :resource_events (sort (map resource-event-identity-string resource_events))
     :transaction_uuid transaction_uuid}))
 
+(defn resource-event-identity-pkey
+  "Compute a hash for a resource-event's content, used as a primary key
+
+  This is different than resource-event-identity-string in that it does not
+  include every field - it only uses the fields that make up a unique constraint
+  in the database"
+  [{:keys [report_id resource_type resource_title property] :as event}]
+  (assert report_id "report_id must not be nil")
+  (generic-identity-hash
+   {:report_id report_id
+    :resource_type resource_type
+    :resource_title resource_title
+    :property property}))
+
 (defn fact-identity-hash
   "Compute a hash for a fact's content
 


### PR DESCRIPTION
This will allow this table to be cleaned with pg_repack instead of relying
on a VACUUM FULL, which avoids locks on the table.