### PR TITLE
(PDB-4277) Add logback logstash encoder

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -177,6 +177,10 @@
                  [robert/hooke "1.3.0"]
                  [slingshot]
                  [trptcolin/versioneer]
+                 ;; We do not currently use this dependency directly, but
+                 ;; we have documentation that shows how users can use it to
+                 ;; send their logs to logstash, so we include it in the jar.
+                 [net.logstash.logback/logstash-logback-encoder]
 
                  ;; Filesystem utilities
                  [org.apache.commons/commons-lang3]


### PR DESCRIPTION
This commit adds a dependency on net.logstash.logback/logstash-logback-encoder
which is described in the PuppetDB documentation as a tool for transforming
log messages into JSON format:

  https://puppet.com/docs/puppetdb/6.2/logging.html#json-text

Prior to this commit, the required library was missing from the uberjar. The
library is managed by clj-parent as Puppet Server includes it.