### PR TITLE
Revert "(RE-12078) Bump to ezbake 1.9.6"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -272,7 +272,7 @@
                                                   [puppetlabs/puppetdb ~pdb-version]
                                                   [org.clojure/tools.nrepl nil]])
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "1.9.6"]]}
+                      :plugins [[puppetlabs/lein-ezbake "1.8.10"]]}
              :testutils {:source-paths ^:replace ["test"]}
              :install-gems {:source-paths ^:replace ["src-gems"]
                             :target-path "target-gems"


### PR DESCRIPTION
This reverts commit d0712d72d5760330059a075413072648769ed785.
Puppetserver tests started to fail after this bump, so reverting until we sort
it out.