### PR TITLE
(PDB-4271) query for fact expiration

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1273,7 +1273,7 @@
                        status noop metrics logs resources resource_events catalog_uuid
                        code_id job_id cached_catalog_status noop_pending corrective_change]
                 :as report} (normalize-report orig-report)
-               report-hash (shash/report-identity-hash report)]
+                report-hash (shash/report-identity-hash report)]
            (jdbc/with-db-transaction []
              (let [shash (sutils/munge-hash-for-storage report-hash)]
                (when-not (-> "select 1 from reports where encode(hash, 'hex'::text) = ? limit 1"

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -47,8 +47,11 @@
                :catalog_environment :facts_environment :report_environment
                :latest_report_status :latest_report_hash :latest_report_noop
                :latest_report_noop_pending :cached_catalog_status
-               :latest_report_corrective_change :latest_report_job_id} (keyset res))
+               :latest_report_corrective_change :latest_report_job_id :expires} (keyset res))
           (str "Query was: " query))
+      (is (= #{:facts :facts_updated} (keyset (:expires res)))
+          (str "Query was: " query))
+
       (is (= (set expected) (set (mapv :certname result)))
           (str "Query was: " query)))
 


### PR DESCRIPTION
Adds an "expires" field to the node response, that contains two embedded
fields: "facts" and "facts_updated"

If "facts" is true (the default), the node is subject to garbage
collection and expiration. If the value is set to false, the node is
excluded from the garbage collection procedure. If this value has been
explicitly set via a command, the facts_updated field will be a
timestamp representing when the field was set.
