### PR TITLE
(RE-12078) Bump to ezbake 1.9.7

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -272,7 +272,7 @@
                                                   [puppetlabs/puppetdb ~pdb-version]
                                                   [org.clojure/tools.nrepl nil]])
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "1.8.10"]]}
+                      :plugins [[puppetlabs/lein-ezbake "1.9.7"]]}
              :testutils {:source-paths ^:replace ["test"]}
              :install-gems {:source-paths ^:replace ["src-gems"]
                             :target-path "target-gems"


### PR DESCRIPTION
This commit bumps the ezbake version to 1.9.7, which includes support for el 8.