### PR TITLE
(maint) Adjust travis osx cacert paths as admin

### DIFF
--- a/ext/travisci/prep-os-essentials-for
+++ b/ext/travisci/prep-os-essentials-for
@@ -44,8 +44,8 @@ case "$OSTYPE" in
             # brew cask install adoptopenjdk8
             brew cask install "adopt$jdk"
             old_cacert_path="/Library/Java/JavaVirtualMachines/adoptopenjdk-$jdkver.jdk/Contents/Home/jre/lib/security/cacerts"
-            rm "$old_cacert_path"
-            ln -s $cacert_path "$old_cacert_path"
+            sudo -i rm "$old_cacert_path"
+            sudo -i ln -s $cacert_path "$old_cacert_path"
             ;;
           *)
             echo "JDK version '$jdk' is not supported on Mac OSX"


### PR DESCRIPTION
Attempt to fix recently appearing failures like this by manipulating
the cert file as root:

  +old_cacert_path=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/security/cacerts
  +rm /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/security/cacerts
  override rw-r--r--  root/wheel for /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/security/cacerts?
  No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
  Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
  The build has been terminated