### PR TITLE
(SERVER-2497) Extract `job_id` from request metadata

### DIFF
--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -23,6 +23,7 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
   def extract_extra_request_data(request)
     {
       :transaction_uuid => request.options[:transaction_uuid],
+      :job_id => request.options[:job_id],
       :environment => request.environment.to_s
     }
   end


### PR DESCRIPTION
Previously, the `save` method of the catalog terminus would only save
`job_id` if it came in as part of the catalog. This commit ensures that
we also extract `job_id` from the extra request data if it is present,
and use that if `job_id` is not present in the catalog.