### PR TITLE
(maint) If consul is enabled, run the http healthcheck every 10 seconds

### DIFF
--- a/docker/puppetdb/docker-entrypoint.d/40-consul.sh
+++ b/docker/puppetdb/docker-entrypoint.d/40-consul.sh
@@ -14,7 +14,7 @@ if [ "$CONSUL_ENABLED" = "true" ]; then
   "checks": [
     {
       "http": "http://$HOSTNAME:8080/status/v1/services/puppetdb-status",
-      "interval": "30s",
+      "interval": "10s",
       "deregister_critical_service_after": "10m"
     }
   ]


### PR DESCRIPTION
We should run this check every 10 seconds to decrease latency with consul knowing what services/hosts are available
