### PR TITLE
(maint) Disable Azure Docker builds on 6.x branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,10 @@ pool:
 variables:
   NAMESPACE: puppet
 
+# completely disables the pipeline
+trigger: none
+pr: none
+
 steps:
 - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
   clean: true  # whether to fetch clean each time


### PR DESCRIPTION
 - When merging this up, do not carry the change forward to master
 - Note that changes had to be made in the Azure UI so as not override
   the values set in the YAML