### PR TITLE
(PDB-4271) query for fact expiration

### DIFF
--- a/documentation/api/query/v4/nodes.markdown
+++ b/documentation/api/query/v4/nodes.markdown
@@ -21,6 +21,7 @@ canonical: "/puppetdb/latest/api/query/v4/nodes.html"
 [edges]: ./edges.html
 [resources]: ./resources.html
 [inventory]: ./inventory.html
+[expirev1]: ../../wire_format/configure_expiration_format_v1.html
 
 Nodes can be queried by making an HTTP request to the `/nodes` endpoint.
 
@@ -84,6 +85,21 @@ The below fields are allowed as filter criteria and are returned in all response
 
     Note that nodes which are missing a fact referenced by a `not` query will match
     the query.
+
+* `expires_facts` (boolean): indicates whether or not factsets for the
+  node will be a candidate for expiration.  This field will only be
+  visible if the `include_facts_expiration` query parameter is set to
+  `true`.
+
+> *Note*: configuration of fact expiration is an experimental feature
+> which might be altered or removed in a future release, and for the
+> time being, PuppetDB exports will not include this information.
+
+* `expires_facts_updated` (timestamp or null): indicates when the
+  value of `expires_facts` was last changed.  This will be `null` if
+  the value has never been explicitly set by a [configure expiration][expirev1]
+  command.  This field will only be visible if the
+  `include_facts_expiration` query parameter is set to true.
 
 ### Response format
 

--- a/src/puppetlabs/puppetdb/http/handlers.clj
+++ b/src/puppetlabs/puppetdb/http/handlers.clj
@@ -311,7 +311,8 @@
     (cmdi/context ["/" (route-param :node)]
                   (cmdi/ANY "" []
                             (-> (node-status version)
-                                (validate-query-params {:optional ["pretty"]})))
+                                (validate-query-params {:optional ["pretty"
+                                                                   "include_facts_expiration"]})))
 
                   (cmdi/context "/facts"
                                 (-> (facts-routes version)

--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -34,6 +34,7 @@
    (s/optional-key :ast_only) (s/maybe s/Bool)
    (s/optional-key :include_total) (s/maybe s/Bool)
    (s/optional-key :pretty) (s/maybe s/Bool)
+   (s/optional-key :include_facts_expiration) (s/maybe s/Bool)
    (s/optional-key :order_by) (s/maybe [[(s/one s/Keyword "field")
                                          (s/one (s/enum :ascending :descending) "order")]])
    (s/optional-key :distinct_resources) (s/maybe s/Bool)
@@ -267,6 +268,7 @@
       (update-when [:offset] parse-offset)
       (update-when [:include_total] coerce-to-boolean)
       (update-when [:pretty] coerce-to-boolean)
+      (update-when [:include_facts_expiration] coerce-to-boolean)
       (update-when [:distinct_resources] coerce-to-boolean)))
 
 (defn get-req->query
@@ -278,6 +280,7 @@
       (update-when ["order_by"] parse-order-by-json)
       (update-when ["counts_filter"] json/parse-strict-string true)
       (update-when ["pretty"] coerce-to-boolean)
+      (update-when ["include_facts_expiration"] coerce-to-boolean)
       keywordize-keys))
 
 (defn post-req->query
@@ -312,7 +315,9 @@
      (handler
       (if puppetdb-query
         req
-        (let [param-spec (update param-spec :optional conj "pretty")
+        (let [param-spec (-> param-spec
+                             (update :optional conj "pretty")
+                             (update :optional conj "include_facts_expiration"))
               query-map (create-query-map req param-spec parse-fn)
               pretty-print (:pretty query-map
                                     (get-in req [:globals :pretty-print]))]

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -48,7 +48,8 @@
    "fact_contents" {:columns ["certname"]}
    "events" {:columns ["certname"]}
    "edges" {:columns ["certname"]}
-   "resources" {:columns ["certname"]}})
+   "resources" {:columns ["certname"]}
+   "certname_fact_expiration" {:columns ["certid"]}})
 
 (def type-coercion-matrix
   {:string {:numeric (su/sql-cast "int")
@@ -271,7 +272,13 @@
                                                     :field :catalog_environment.environment}
                              "report_environment" {:type :string
                                                    :queryable? true
-                                                   :field :reports_environment.environment}}
+                                                   :field :reports_environment.environment}
+                             "expires_facts" {:type :boolean
+                                              :queryable? true
+                                              :field (hcore/raw "coalesce(certname_fact_expiration.expire, true)")}
+                             "expires_facts_updated" {:type :timestamp
+                                                      :queryable? true
+                                                      :field :certname_fact_expiration.updated}}
 
                :relationships certname-relations
 
@@ -297,7 +304,10 @@
                                        [:= :facts_environment.id :fs.environment_id]
 
                                        [:environments :reports_environment]
-                                       [:= :reports_environment.id :reports.environment_id]]}
+                                       [:= :reports_environment.id :reports.environment_id]
+
+                                       :certname_fact_expiration
+                                       [:= :certnames.id :certname_fact_expiration.certid]]}
 
                :source-table "certnames"
                :alias "nodes"

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -222,96 +222,106 @@
                :entity :inventory
                :subquery? false}))
 
+(def nodes-query-base
+  {:projections {"certname" {:type :string
+                             :queryable? true
+                             :field :certnames.certname}
+                 "deactivated" {:type :string
+                                :queryable? true
+                                :field :certnames.deactivated}
+                 "expired" {:type :timestamp
+                            :queryable? true
+                            :field :certnames.expired}
+                 "facts_environment" {:type :string
+                                      :queryable? true
+                                      :field :facts_environment.environment}
+                 "catalog_timestamp" {:type :timestamp
+                                      :queryable? true
+                                      :field :catalogs.timestamp}
+                 "facts_timestamp" {:type :timestamp
+                                    :queryable? true
+                                    :field :fs.timestamp}
+                 "report_timestamp" {:type :timestamp
+                                     :queryable? true
+                                     :field :reports.end_time}
+                 "latest_report_hash" {:type :string
+                                       :queryable? true
+                                       :field (hsql-hash-as-str
+                                               :reports.hash)}
+                 "latest_report_noop" {:type :boolean
+                                       :queryable? true
+                                       :field :reports.noop}
+                 "latest_report_noop_pending" {:type :boolean
+                                               :queryable? true
+                                               :field :reports.noop_pending}
+                 "latest_report_status" {:type :string
+                                         :queryable? true
+                                         :field :report_statuses.status}
+                 "latest_report_corrective_change" {:type :boolean
+                                                    :queryable? true
+                                                    :field :reports.corrective_change}
+                 "latest_report_job_id" {:type :string
+                                         :queryable? true
+                                         :field :reports.job_id}
+                 "cached_catalog_status" {:type :string
+                                          :queryable? true
+                                          :field :reports.cached_catalog_status}
+                 "catalog_environment" {:type :string
+                                        :queryable? true
+                                        :field :catalog_environment.environment}
+                 "report_environment" {:type :string
+                                       :queryable? true
+                                       :field :reports_environment.environment}}
+
+   :relationships certname-relations
+
+   :selection {:from [:certnames]
+               :left-join [:catalogs
+                           [:= :catalogs.certname :certnames.certname]
+
+                           [:factsets :fs]
+                           [:= :certnames.certname :fs.certname]
+
+                           :reports
+                           [:and
+                            [:= :certnames.certname :reports.certname]
+                            [:= :certnames.latest_report_id :reports.id]]
+
+                           [:environments :catalog_environment]
+                           [:= :catalog_environment.id :catalogs.environment_id]
+
+                           :report_statuses
+                           [:= :reports.status_id :report_statuses.id]
+
+                           [:environments :facts_environment]
+                           [:= :facts_environment.id :fs.environment_id]
+
+                           [:environments :reports_environment]
+                           [:= :reports_environment.id :reports.environment_id]]}
+
+   :source-table "certnames"
+   :alias "nodes"
+   :subquery? false})
+
 (def nodes-query
   "Query for nodes entities, mostly used currently for subqueries"
-  (map->Query {:projections {"certname" {:type :string
-                                         :queryable? true
-                                         :field :certnames.certname}
-                             "deactivated" {:type :string
-                                            :queryable? true
-                                            :field :certnames.deactivated}
-                             "expired" {:type :timestamp
-                                        :queryable? true
-                                        :field :certnames.expired}
-                             "facts_environment" {:type :string
-                                                  :queryable? true
-                                                  :field :facts_environment.environment}
-                             "catalog_timestamp" {:type :timestamp
-                                                  :queryable? true
-                                                  :field :catalogs.timestamp}
-                             "facts_timestamp" {:type :timestamp
-                                                :queryable? true
-                                                :field :fs.timestamp}
-                             "report_timestamp" {:type :timestamp
-                                                 :queryable? true
-                                                 :field :reports.end_time}
-                             "latest_report_hash" {:type :string
-                                                   :queryable? true
-                                                   :field (hsql-hash-as-str
-                                                            :reports.hash)}
-                             "latest_report_noop" {:type :boolean
-                                                   :queryable? true
-                                                   :field :reports.noop}
-                             "latest_report_noop_pending" {:type :boolean
-                                                           :queryable? true
-                                                           :field :reports.noop_pending}
-                             "latest_report_status" {:type :string
-                                                     :queryable? true
-                                                     :field :report_statuses.status}
-                             "latest_report_corrective_change" {:type :boolean
-                                                                :queryable? true
-                                                                :field :reports.corrective_change}
-                             "latest_report_job_id" {:type :string
-                                                     :queryable? true
-                                                     :field :reports.job_id}
-                             "cached_catalog_status" {:type :string
-                                                      :queryable? true
-                                                      :field :reports.cached_catalog_status}
-                             "catalog_environment" {:type :string
-                                                    :queryable? true
-                                                    :field :catalog_environment.environment}
-                             "report_environment" {:type :string
-                                                   :queryable? true
-                                                   :field :reports_environment.environment}
-                             "expires_facts" {:type :boolean
-                                              :queryable? true
-                                              :field (hcore/raw "coalesce(certname_fact_expiration.expire, true)")}
-                             "expires_facts_updated" {:type :timestamp
-                                                      :queryable? true
-                                                      :field :certname_fact_expiration.updated}}
+  (map->Query nodes-query-base))
 
-               :relationships certname-relations
-
-               :selection {:from [:certnames]
-                           :left-join [:catalogs
-                                       [:= :catalogs.certname :certnames.certname]
-
-                                       [:factsets :fs]
-                                       [:= :certnames.certname :fs.certname]
-
-                                       :reports
-                                       [:and
-                                        [:= :certnames.certname :reports.certname]
-                                        [:= :certnames.latest_report_id :reports.id]]
-
-                                       [:environments :catalog_environment]
-                                       [:= :catalog_environment.id :catalogs.environment_id]
-
-                                       :report_statuses
-                                       [:= :reports.status_id :report_statuses.id]
-
-                                       [:environments :facts_environment]
-                                       [:= :facts_environment.id :fs.environment_id]
-
-                                       [:environments :reports_environment]
-                                       [:= :reports_environment.id :reports.environment_id]
-
-                                       :certname_fact_expiration
-                                       [:= :certnames.id :certname_fact_expiration.certid]]}
-
-               :source-table "certnames"
-               :alias "nodes"
-               :subquery? false}))
+(def nodes-query-with-fact-expiration
+  "Query for nodes entities, mostly used currently for subqueries"
+  (map->Query (-> nodes-query-base
+                  (assoc-in [:projections "expires_facts"]
+                            {:type :boolean
+                             :queryable? true
+                             :field (hcore/raw "coalesce(certname_fact_expiration.expire, true)")})
+                  (assoc-in [:projections "expires_facts_updated"]
+                            {:type :timestamp
+                             :queryable? true
+                             :field :certname_fact_expiration.updated})
+                  (update-in [:selection :left-join]
+                             #(conj %
+                                    :certname_fact_expiration
+                                    [:= :certnames.id :certname_fact_expiration.certid])))))
 
 (def resource-params-query
   "Query for the resource-params query, mostly used as a subquery"

--- a/src/puppetlabs/puppetdb/time.clj
+++ b/src/puppetlabs/puppetdb/time.clj
@@ -10,6 +10,9 @@
             [clj-time.format :as tf]
             [schema.core :as s]))
 
+(defn date-time? [x]
+  (instance? DateTime x))
+
 ;; Functions for parsing Periods from Strings
 
 (defn period?

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -47,7 +47,8 @@
                :catalog_environment :facts_environment :report_environment
                :latest_report_status :latest_report_hash :latest_report_noop
                :latest_report_noop_pending :cached_catalog_status
-               :latest_report_corrective_change :latest_report_job_id} (keyset res))
+               :latest_report_corrective_change :latest_report_job_id
+               :expires_facts :expires_facts_updated} (keyset res))
           (str "Query was: " query))
       (is (= (set expected) (set (mapv :certname result)))
           (str "Query was: " query)))

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -47,8 +47,7 @@
                :catalog_environment :facts_environment :report_environment
                :latest_report_status :latest_report_hash :latest_report_noop
                :latest_report_noop_pending :cached_catalog_status
-               :latest_report_corrective_change :latest_report_job_id
-               :expires_facts :expires_facts_updated} (keyset res))
+               :latest_report_corrective_change :latest_report_job_id} (keyset res))
           (str "Query was: " query))
       (is (= (set expected) (set (mapv :certname result)))
           (str "Query was: " query)))

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -319,7 +319,9 @@
     (scf-store/set-certname-facts-expiration "foo2" true (now)))
 
   (testing "test facts expiring for nodes set to false"
-    (let [request (get-request endpoint (json/generate-string ["=" "expires_facts" false]))
+    (let [request (get-request endpoint
+                               (json/generate-string ["=" "expires_facts" false])
+                               {:include_facts_expiration true})
           {:keys [status body]} (*app* request)
           result (vec (parse-result body))]
 
@@ -331,7 +333,9 @@
         (is (-> node :expires_facts_updated time/from-string time/date-time?)))))
 
   (testing "test facts expiring for nodes set to true (default)"
-    (let [request (get-request endpoint (json/generate-string ["=" "expires_facts" true]))
+    (let [request (get-request endpoint
+                               (json/generate-string ["=" "expires_facts" true])
+                               {:include_facts_expiration true})
           {:keys [status body]} (*app* request)
           result (vec (parse-result body))]
 

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.puppetdb.query-eng-test
-  (:require [clojure.test :refer :all]
+  (:require [cheshire.core :as json]
+            [clojure.test :refer :all]
             [puppetlabs.puppetdb.scf.storage :as scf-store]
             [puppetlabs.puppetdb.query-eng.engine :refer :all]
             [puppetlabs.puppetdb.query-eng :refer [entity-fn-idx]]
@@ -8,6 +9,7 @@
             [puppetlabs.puppetdb.testutils :refer [get-request parse-result]]
             [puppetlabs.puppetdb.testutils.db :refer [*db* with-test-db]]
             [puppetlabs.puppetdb.testutils.http :refer [*app* deftest-http-app]]
+            [puppetlabs.puppetdb.time :as time]
             [puppetlabs.puppetdb.http :as http]
             [puppetlabs.puppetdb.scf.storage-utils :as su]))
 
@@ -303,3 +305,44 @@
             result (vec (parse-result body))]
         (is (= status http/status-ok))
         (is (= result expected-result))))))
+
+(deftest-http-app fact-expiration-queries
+  [version [:v4]
+   endpoint ["/v4/nodes"]]
+
+  (with-transacted-connection *db*
+    (scf-store/add-certname! "foo1")
+    (scf-store/add-certname! "foo2")
+    (scf-store/add-certname! "foo3")
+
+    (scf-store/set-certname-facts-expiration "foo1" false (now))
+    (scf-store/set-certname-facts-expiration "foo2" true (now)))
+
+  (testing "test facts expiring for nodes set to false"
+    (let [request (get-request endpoint (json/generate-string ["=" "expires_facts" false]))
+          {:keys [status body]} (*app* request)
+          result (vec (parse-result body))]
+
+      (is (= status http/status-ok))
+      (is (= 1 (count result)))
+      (let [node (first result)]
+        (is (= false (:expires_facts node)))
+        (is (= "foo1" (:certname node)))
+        (is (-> node :expires_facts_updated time/from-string time/date-time?)))))
+
+  (testing "test facts expiring for nodes set to true (default)"
+    (let [request (get-request endpoint (json/generate-string ["=" "expires_facts" true]))
+          {:keys [status body]} (*app* request)
+          result (vec (parse-result body))]
+
+      (is (= status http/status-ok))
+      (is (= 2 (count result)))
+      (let [nodes (sort-by :certname result)]
+        (is (= true (:expires_facts (first nodes))))
+        (is (= "foo2" (:certname (first nodes))))
+        (is (-> nodes first :expires_facts_updated time/from-string
+                time/date-time?))
+
+        (is (= true (:expires_facts (second nodes))))
+        (is (= "foo3" (:certname (second nodes))))
+        (is (nil? (:expires_facts_updated (second nodes))))))))

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -349,4 +349,16 @@
 
         (is (= true (:expires_facts (second nodes))))
         (is (= "foo3" (:certname (second nodes))))
-        (is (nil? (:expires_facts_updated (second nodes))))))))
+        (is (nil? (:expires_facts_updated (second nodes)))))))
+
+  (testing "/nodes/foo also respects include_facts_expiration=true"
+    (let [request (get-request (str endpoint "/foo1")
+                               nil
+                               {:include_facts_expiration true})
+          {:keys [status body]} (*app* request)
+          result (parse-result body)]
+      (is (= status http/status-ok))
+      (is (= "foo1" (:certname result)))
+      (is (= false (:expires_facts result)))
+      (is (-> result :expires_facts_updated time/from-string
+              time/date-time?)))))


### PR DESCRIPTION
Adds an "expires" field to the node response, that contains two embedded
fields: "facts" and "facts_updated"

If "facts" is true (the default), the node is subject to garbage
collection and expiration. If the value is set to false, the node is
excluded from the garbage collection procedure. If this value has been
explicitly set via a command, the facts_updated field will be a
timestamp representing when the field was set.