### PR TITLE
(PDB-4315) ignore duplicates in resource_events

### DIFF
--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -69,6 +69,6 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 68$' "$tmpdir/out"
+grep -qE ' 69$' "$tmpdir/out"
 
 test ! -e "$PDBBOX"/var/mq-migrated

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -197,16 +197,23 @@
 (defn resource-event-identity-pkey
   "Compute a hash for a resource-event's content, used as a primary key
 
-  This is different than resource-event-identity-string in that it does not
-  include every field - it only uses the fields that make up a unique constraint
-  in the database"
-  [{:keys [report_id resource_type resource_title property] :as event}]
+  This is similar to resource-event-identity-string but it also includes the report id."
+  [{:keys [report_id resource_type resource_title property timestamp
+           status old_value new_value message file line] :as event}]
   (assert report_id "report_id must not be nil")
   (generic-identity-hash
    {:report_id report_id
     :resource_type resource_type
     :resource_title resource_title
-    :property property}))
+    :property property
+    :timestamp timestamp
+    :status status
+    :old_value old_value
+    :new_value new_value
+    :message message
+    :name nil ;TODO: fill this field
+    :file file
+    :line line}))
 
 (defn fact-identity-hash
   "Compute a hash for a fact's content

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1513,6 +1513,7 @@
       message text,
       file text DEFAULT NULL::character varying,
       line integer,
+      name text,
       containment_path text[],
       containing_class text,
       corrective_change boolean)")
@@ -1631,8 +1632,12 @@
    64 rededuplicate-facts
    65 varchar-columns-to-text
    66 jsonb-facts
-   67 add-resource-events-pk
-   68 support-fact-expiration-configuration})
+   ;; migration 69 replaces migration 67 - we do not need to apply both
+   ;; 67 exposed an agent bug where we would get duplicate resource events
+   ;; from a failed exec call. The updated migration adds additional columns
+   ;; to the hash to avoid these sorts of collisions
+   68 support-fact-expiration-configuration
+   69 add-resource-events-pk})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/test/puppetlabs/puppetdb/admin_test.clj
+++ b/test/puppetlabs/puppetdb/admin_test.clj
@@ -38,8 +38,13 @@
 
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
                                     "replace catalog" cmd-consts/latest-catalog-version example-catalog)
-       (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
-                                    "store report" cmd-consts/latest-report-version example-report)
+       (let [report-with-duplicate-events (update-in example-report
+                                                     [:resources 0 :events]
+                                                     (fn [events] (conj events (first events))))]
+         ;; this will add a duplicate event into a report, which will then be dropped at the database
+         ;; side
+         (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
+                                      "store report" cmd-consts/latest-report-version report-with-duplicate-events))
        (svc-utils/sync-command-post (svc-utils/pdb-cmd-url) example-certname
                                     "replace facts" cmd-consts/latest-facts-version example-facts)
 


### PR DESCRIPTION
Add a name column to the resource_events table that will be put to use
in a future PR. This column is needed to further guarantee uniqueness of
events.

Add more columns to the resource_events hash: timestamp, status,
old_value, new_value, message, file, line, name

Replace existing migration with a new migration that will rehash
the resource_events table again

Add an ON CONFLICT DO NOTHING to do the resource_events insert-multi to
ignore any duplicate hashes found. This can happen due to an agent bug
where the exec module can send duplicate events.
