### PR TITLE
(PDB-4326) Allow unicode in resource tags

### DIFF
--- a/test/puppetlabs/puppetdb/catalogs_test.clj
+++ b/test/puppetlabs/puppetdb/catalogs_test.clj
@@ -59,8 +59,20 @@
           (is (thrown-with-msg? IllegalArgumentException #"invalid tag 'b@r'"
                                 (validate-resources catalog)))))
 
+      (testing "should fail when a resource has tags with extra whitespace characters at end"
+        (let [resources {{:type "Type" :title "foo"} {:tags ["foo" "bar\n"]}}
+              catalog {:resources resources}]
+          (is (thrown-with-msg? IllegalArgumentException #"invalid tag 'bar\n'"
+                                (validate-resources catalog)))))
+
       (testing "should not fail when a resource has only lower-case tags"
         (let [resources {{:type "Type" :title "foo"} {:tags ["foo" "bar"]}}
+              catalog {:resources resources}]
+          (is (= catalog (validate-resources catalog)))))
+
+      (testing "should not fail when a resource has lower-case unicode tags"
+        (let [resources {{:type "Type" :title "foo"}
+                         {:tags ["foo٤" "a\u06FF\u16A0\ud841\udf0e" "norwegian_characters_æøå"]}} ; tags foo<arabic 4> aۿᚠ𠜎
               catalog {:resources resources}]
           (is (= catalog (validate-resources catalog))))))
 

--- a/test/puppetlabs/puppetdb/http/resources_test.clj
+++ b/test/puppetlabs/puppetdb/http/resources_test.clj
@@ -52,6 +52,7 @@ to the result of the form supplied to this method."
       (doseq [[query result] [[["=" "type" "File"] #{foo1 bar1}]
                               [["=" "tag" "one"] #{foo1 bar1}]
                               [["=" "tag" "two"] #{foo1 bar1}]
+                              [["=" "tag" "æøåۿᚠ𠜎٤"] #{foo1}]
                               [["~" "tag" "tw"] #{foo1 bar1}]
 
                               [["and"

--- a/test/puppetlabs/puppetdb/testutils/resources.clj
+++ b/test/puppetlabs/puppetdb/testutils/resources.clj
@@ -94,7 +94,7 @@
         :catalog_resources
          [{:certname_id 1 :resource (sutils/munge-hash-for-storage "01")
            :type "File" :title "/etc/passwd" :exported false
-           :tags (to-jdbc-varchar-array ["one" "two"])}
+           :tags (to-jdbc-varchar-array ["one" "two" "æøåۿᚠ𠜎٤"])}
           {:certname_id 1 :resource (sutils/munge-hash-for-storage "02")
            :type "Notify" :title "hello" :exported false
            :tags (to-jdbc-varchar-array [])}
@@ -109,7 +109,7 @@
              :resource   "01"
              :type       "File"
              :title      "/etc/passwd"
-             :tags       ["one" "two"]
+             :tags       ["one" "two" "æøåۿᚠ𠜎٤"]
              :exported   false
              :file nil
              :line nil


### PR DESCRIPTION
In PUP-7579, Puppet added support for Unicode letters in resource tags,
but the supported tags regex was never changed in PuppetDB so any
catalogs using unicode resource tags would not be stored in PuppetDB.

This changes the tag regex in PuppetDB to allow all lower case unicode
letters as tags.