### PR TITLE
(maint) Properly perform health checks

### DIFF
--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -72,7 +72,7 @@ RUN chmod +x /ssl-setup.sh
 
 VOLUME /etc/puppetlabs/puppet/ssl/
 
-ADD https://raw.githubusercontent.com/puppetlabs/wtfc/4dbbc91eb0d89c48e3494c1fab37c74c6b13178c/wtfc.sh /wtfc.sh
+ADD https://raw.githubusercontent.com/puppetlabs/wtfc/6aa5eef89728cc2903490a618430cc3e59216fa8/wtfc.sh /wtfc.sh
 RUN chmod +x /wtfc.sh
 COPY docker/puppetdb/docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh

--- a/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
+++ b/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
@@ -34,13 +34,13 @@ wait_for_host "postgres"
 
 if [ "$USE_PUPPETSERVER" = true ]; then
   wait_for_host $PUPPETSERVER_HOSTNAME
-  HEALTH_COMMAND="curl --silent --fail --insecure "\""https://${PUPPETSERVER_HOSTNAME}:8140/status/v1/simple"\"" | grep -q '^running$'"
+  HEALTH_COMMAND="curl --silent --fail --insecure 'https://${PUPPETSERVER_HOSTNAME}:8140/status/v1/simple' | grep -q '^running$'"
 fi
 
 if [ "$CONSUL_ENABLED" = "true" ]; then
   wait_for_host $CONSUL_HOSTNAME
   # with Consul enabled, wait on Consul instead of Puppetserver
-  HEALTH_COMMAND="curl --silent --fail "\""http://${CONSUL_HOSTNAME}:${CONSUL_PORT}/v1/health/checks/puppet"\"" | grep -q '"\""Status"\"": "\""passing"\""'"
+  HEALTH_COMMAND="curl --silent --fail 'http://${CONSUL_HOSTNAME}:${CONSUL_PORT}/v1/health/checks/puppet' | grep -q '\\"\""state"\\\"":\\"\""running\\"\""'"
 fi
 
 if [ -n "$HEALTH_COMMAND" ]; then


### PR DESCRIPTION
 - After some fumbling around with @underscorgan, we determined that the
   wtfc code doesn't properly handle command strings that include pipes.

   Even if situations where the command is successful, it will exit with
   a non-0 failing exit status.

   The fix for that is in https://github.com/puppetlabs/wtfc/pull/1

 - With this script updated in the container, nested quotes have to be
   handled differently as well (in the case where the Consul JSON is
   being grepped for "state":"running"). " must first become \", which
   is then escaped as \\"\"".

 - Simplify how quoting is done around hostnames, replacing " with '

 - This fixes code originally introduced in #2883 that was presumed
   fixed in #2884 (but wasn't actually fixed)