### PR TITLE
Add sync to prevent a 'Text file busy' error

### DIFF
--- a/docker/puppetdb/docker-entrypoint.sh
+++ b/docker/puppetdb/docker-entrypoint.sh
@@ -2,9 +2,11 @@
 
 set -e
 
+chmod +x /docker-entrypoint.d/*.sh
+# sync prevents aufs from sometimes returning EBUSY if you exec right after a chmod
+sync
 for f in /docker-entrypoint.d/*.sh; do
     echo "Running $f"
-    chmod +x "$f"
     "$f"
 done
 


### PR DESCRIPTION
In rare situations running chmod and the script directly afterwards causes a 'Text file busy' error. 

Looks like this:
```
Running /docker-entrypoint.d/10-analytics.sh
/docker-entrypoint.sh: line 8: /docker-entrypoint.d/10-analytics.sh: Text file busy

Running /docker-entrypoint.d/10-analytics.sh
(/docker-entrypoint.d/10-analytics.sh) Sending metrics http://www.google-analytics.com/collect?v=1&t=event&tid=UA-132486246-1&an=puppetdb&av=6.3.0&cid=a81b1abe-6e61-463e-980d-57cbddd8bcd3&ec=production&ea=start
Running /docker-entrypoint.d/20-wait-for-hosts.sh
wtfc.sh: waiting 30 seconds for ping -c1 -W1 postgres
wtfc.sh: ping -c1 -W1 postgres finished with expected status 0 after 0 seconds
Running /docker-entrypoint.d/30-configure-ssl.sh
Running /docker-entrypoint.d/40-consul.sh
/docker-entrypoint.sh: line 8: /docker-entrypoint.d/40-consul.sh: Text file busy
```

The small change here will prevent that. See https://github.com/moby/moby/issues/13594 for details