### PR TITLE
(maint) Rework tests for Linux Postgres container / Docker Compose

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@ docker/puppetdb/*                                        text  eol=lf
 docker/puppetdb/conf.d/*                                 text  eol=lf
 docker/puppetdb/logging/*                                text  eol=lf
 docker/puppetdb/docker-entrypoint.d/*                    text  eol=lf
+docker/puppetdb/postgres-custom/*                        text  eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,10 @@ aliases:
 
   - &run-docker-tests |
     set -ex
+    sudo rm /usr/local/bin/docker-compose
+    curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
+    chmod +x docker-compose
+    sudo mv docker-compose /usr/local/bin
     cd docker
     make lint
     make build
@@ -212,6 +216,7 @@ jobs:
       os: osx
 
     - stage: ❧ pdb container tests
+      env: DOCKER_COMPOSE_VERSION=1.24.0
       script: *run-docker-tests
 
 on_success: ext/travisci/on-success

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,12 @@ steps:
   displayName: Build PuppetDB Container
   name: build_puppetdb_container
 - powershell: |
+    # set an Azure variable for temp volumes root
+    $tempVolumeRoot = Join-Path -Path $ENV:TEMP -ChildPath ([System.IO.Path]::GetRandomFileName())
+    Write-Host "##vso[task.setvariable variable=VOLUME_ROOT]$tempVolumeRoot"
+  displayName: Prepare Test Environment
+  name: test_prepare
+- powershell: |
     . ./docker/ci/build.ps1
     Invoke-ContainerTest -Name puppetdb -Namespace $ENV:NAMESPACE
   displayName: Test PuppetDB
@@ -78,5 +84,7 @@ steps:
 - powershell: |
     . ./docker/ci/build.ps1
     Clear-ContainerBuilds -Name puppetdb
+    Write-Host "Cleaning up temporary volume: $ENV:VOLUME_ROOT"
+    Remove-Item $ENV:VOLUME_ROOT -Force -Recurse -ErrorAction Continue
   displayName: Container Cleanup
   condition: always()

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -109,4 +109,10 @@ $($output | Out-String)
 
   Write-Output "`nPruning Dangling Images"
   docker image prune --filter "dangling=true" --force
+
+  Write-Output "`nPruning Volumes"
+  docker volume prune
+
+  Write-Output "`nPruning Networks"
+  docker network prune
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  postgres:
+    image: postgres:9.6
+    environment:
+      - POSTGRES_PASSWORD=puppetdb
+      - POSTGRES_USER=puppetdb
+      - POSTGRES_DB=puppetdb
+    expose:
+      - 5432
+    volumes:
+      - ./puppetdb/postgres-custom:/docker-entrypoint-initdb.d
+      - ${VOLUME_ROOT:-.}/pgdata:/var/lib/postgresql/data
+
+  puppetdb:
+    image: ${PUPPET_TEST_DOCKER_IMAGE:-puppet/puppetdb}
+    environment:
+      - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-false}
+      - PUPPETDB_PASSWORD=puppetdb
+      - PUPPETDB_USER=puppetdb
+      - USE_PUPPETSERVER=false
+    ports:
+      - 8080
+      - 8081
+    depends_on:
+      - postgres

--- a/docker/puppetdb/spec/puppetdb_spec.rb
+++ b/docker/puppetdb/spec/puppetdb_spec.rb
@@ -1,6 +1,5 @@
 require 'timeout'
 require 'json'
-require 'open3'
 require 'rspec'
 require 'net/http'
 
@@ -11,68 +10,23 @@ describe 'puppetdb container specs' do
     'pgdata'
   ]
 
-  def count_database(container, database)
-    cmd = "docker exec #{container} psql -t --username=puppetdb --command=\"SELECT count(datname) FROM pg_database where datname = '#{database}'\""
+  def count_postgres_database(database)
+    cmd = "docker-compose --no-ansi exec -T postgres psql -t --username=puppetdb --command=\"SELECT count(datname) FROM pg_database where datname = '#{database}'\""
     run_command(cmd)[:stdout].strip
   end
 
-  def wait_on_postgres_db(container, database)
-    Timeout::timeout(120) do
-      while count_database(container, database) != '1'
-        sleep(1)
-      end
+  def wait_on_postgres_db(database, seconds = 240)
+    return retry_block_up_to_timeout(seconds) do
+      count_postgres_database('puppetdb') == '1' ? '1' :
+        raise("database #{database} never created")
     end
-  rescue Timeout::Error
-    STDOUT.puts("database #{database} never created")
-    raise
-  end
-
-  def run_postgres_container
-    image_name = 'postgres:9.6'
-    run_command("docker pull #{image_name}")
-
-    data_mount = ''
-    if !!File::ALT_SEPARATOR
-      data_mount = "--volume #{ENV['VOLUME_ROOT']}/pgdata:/var/lib/postgresql/data"
-    end
-
-    postgres_custom_source = File.join(File.expand_path(__dir__), '..', 'postgres-custom')
-    result = run_command("docker run --detach \
-          --env POSTGRES_PASSWORD=puppetdb \
-          --env POSTGRES_USER=puppetdb \
-          --env POSTGRES_DB=puppetdb \
-          --name postgres \
-          --network #{@network} \
-          --hostname postgres \
-          --publish-all \
-          --volume #{postgres_custom_source}:/docker-entrypoint-initdb.d \
-          #{data_mount} \
-          #{image_name}")
-    fail 'Failed to create postgres container' unless result[:status].exitstatus == 0
-    id = result[:stdout].chomp
-
-    # this is necessary to add a wait for database creation
-    wait_on_postgres_db(id, 'puppetdb')
-
-    return id
-  end
-
-  def run_puppetdb_container
-    # skip Postgres SSL initialization for tests with USE_PUPPETSERVER
-    result = run_command("docker run --detach \
-          --env USE_PUPPETSERVER=false \
-          --env PUPPERWARE_ANALYTICS_ENABLED=false \
-          --name puppetdb \
-          --hostname puppetdb \
-          --publish-all \
-          --network #{@network} \
-          #{@pdb_image}")
-    fail 'Failed to create puppetdb container' unless result[:status].exitstatus == 0
-    result[:stdout].chomp
   end
 
   def get_puppetdb_state
-    pdb_uri = URI::join(get_container_port(@pdb_container, 8080), '/status/v1/services/puppetdb-status')
+    # make sure PDB container hasn't stopped
+    get_service_container('puppetdb', 5)
+    # now query its status endpoint
+    pdb_uri = URI::join(get_service_base_uri('puppetdb', 8080), '/status/v1/services/puppetdb-status')
     response = Net::HTTP.get_response(pdb_uri)
     STDOUT.puts "retrieved raw puppetdb status: #{response.body}"
     case response
@@ -93,7 +47,7 @@ describe 'puppetdb container specs' do
   end
 
   def get_postgres_extensions
-    result = run_command("docker exec #{@postgres_container} psql --username=puppetdb --command=\"SELECT * FROM pg_extension\"")
+    result = run_command('docker-compose --no-ansi exec -T postgres psql --username=puppetdb --command="SELECT * FROM pg_extension"')
     extensions = result[:stdout].chomp
     STDOUT.puts("retrieved extensions: #{extensions}")
     extensions
@@ -119,38 +73,29 @@ describe 'puppetdb container specs' do
       MSG
       fail error_message
     end
+    status = run_command('docker-compose --no-ansi version')[:status]
+    if status.exitstatus != 0
+      fail "`docker-compose` must be installed and available in your PATH"
+    end
 
     @mapped_ports = {}
 
+    teardown_cluster()
     # LCOW requires directories to exist
     create_host_volume_targets(ENV['VOLUME_ROOT'], VOLUMES)
 
-    # Windows doesn't have the default 'bridge network driver
-    network_opt = File::ALT_SEPARATOR.nil? ? '' : '--driver=nat'
-
-    result = run_command("docker network create #{network_opt} puppetdb_test_network_#{Random.rand(1000)}")
-    fail 'Failed to create network' unless result[:status].exitstatus == 0
-    @network = result[:stdout].chomp
-
-    @postgres_container = run_postgres_container
-
-    @pdb_container = run_puppetdb_container
+    # fire up the cluster and wait for puppetdb creation in postgres
+    run_command('docker-compose --no-ansi up --detach')
+    wait_on_postgres_db('puppetdb')
   end
 
   after(:all) do
-    [
-      @postgres_container,
-      @pdb_container,
-    ].each do |id|
-      emit_log(id)
-      STDOUT.puts("Killing container #{id}")
-      run_command("docker container kill #{id}")
-    end
-    run_command("docker network rm #{@network}") unless @network.nil?
+    emit_logs()
+    teardown_cluster()
   end
 
   it 'should have started postgres' do
-    expect(@postgres_container).to_not be_empty
+    expect(get_service_container('postgres', 30)).to_not be_empty
   end
 
   it 'should have installed postgres extensions' do
@@ -160,7 +105,7 @@ describe 'puppetdb container specs' do
   end
 
   it 'should have started puppetdb' do
-    expect(@pdb_container).to_not be_empty
+    expect(get_service_container('puppetdb', 60)).to_not be_empty
   end
 
   it 'should have a "running" puppetdb container' do

--- a/docker/puppetdb/spec/puppetdb_spec.rb
+++ b/docker/puppetdb/spec/puppetdb_spec.rb
@@ -66,22 +66,19 @@ describe 'puppetdb container specs' do
   end
 
   before(:all) do
-    @pdb_image = ENV['PUPPET_TEST_DOCKER_IMAGE']
-    if @pdb_image.nil?
+    if ENV['PUPPET_TEST_DOCKER_IMAGE'].nil?
+      fail <<-MSG
       error_message = <<-MSG
   * * * * *
   PUPPET_TEST_DOCKER_IMAGE environment variable must be set so we
   know which image to test against!
   * * * * *
       MSG
-      fail error_message
     end
     status = run_command('docker-compose --no-ansi version')[:status]
     if status.exitstatus != 0
       fail "`docker-compose` must be installed and available in your PATH"
     end
-
-    @mapped_ports = {}
 
     teardown_cluster()
     # LCOW requires directories to exist

--- a/docker/puppetdb/spec/puppetdb_spec.rb
+++ b/docker/puppetdb/spec/puppetdb_spec.rb
@@ -119,7 +119,7 @@ describe 'puppetdb container specs' do
     # Windows doesn't have the default 'bridge network driver
     network_opt = File::ALT_SEPARATOR.nil? ? '' : '--driver=nat'
 
-    result = run_command("docker network create #{network_opt} puppetdb_test_network")
+    result = run_command("docker network create #{network_opt} puppetdb_test_network_#{Random.rand(1000)}")
     fail 'Failed to create network' unless result[:status].exitstatus == 0
     @network = result[:stdout].chomp
 

--- a/docker/puppetdb/spec/spec_helper.rb
+++ b/docker/puppetdb/spec/spec_helper.rb
@@ -2,11 +2,11 @@ require 'open3'
 require 'timeout'
 
 module Helpers
-  def run_command(command)
+  def run_command(env = ENV.to_h, command)
     stdout_string = ''
     status = nil
 
-    Open3.popen3(command) do |stdin, stdout, stderr, wait_thread|
+    Open3.popen3(env, command) do |stdin, stdout, stderr, wait_thread|
       Thread.new do
         Thread.current.report_on_exception = false
         stdout.each { |l| stdout_string << l and STDOUT.puts l }

--- a/docker/puppetdb/spec/spec_helper.rb
+++ b/docker/puppetdb/spec/spec_helper.rb
@@ -8,9 +8,11 @@ module Helpers
 
     Open3.popen3(command) do |stdin, stdout, stderr, wait_thread|
       Thread.new do
+        Thread.current.report_on_exception = false
         stdout.each { |l| stdout_string << l and STDOUT.puts l }
       end
       Thread.new do
+        Thread.current.report_on_exception = false
         stderr.each { |l| STDOUT.puts l }
       end
 
@@ -50,6 +52,7 @@ module Helpers
   end
 
   def get_service_base_uri(service, port)
+    @mapped_ports ||= {}
     @mapped_ports["#{service}:#{port}"] ||= begin
       result = run_command("docker-compose --no-ansi port #{service} #{port}")
       service_ip_port = result[:stdout].chomp

--- a/docker/puppetdb/spec/spec_helper.rb
+++ b/docker/puppetdb/spec/spec_helper.rb
@@ -20,6 +20,16 @@ module Helpers
     { status: status, stdout: stdout_string }
   end
 
+  # Windows requires directories to exist prior, whereas Linux will create them
+  def create_host_volume_targets(root, volumes)
+    return unless !!File::ALT_SEPARATOR
+
+    STDOUT.puts("Creating volumes directory structure in #{root}")
+    volumes.each { |subdir| FileUtils.mkdir_p(File.join(root, subdir)) }
+    # Hack: grant all users access to this temp dir for the sake of Docker daemon
+    run_command("icacls \"#{root}\" /grant Users:\"(OI)(CI)F\" /T")
+  end
+
   def get_container_port(container, port)
     @mapped_ports["#{container}:#{port}"] ||= begin
       service_ip_port = run_command("docker port #{container} #{port}/tcp")[:stdout].chomp

--- a/docker/puppetdb/spec/spec_helper.rb
+++ b/docker/puppetdb/spec/spec_helper.rb
@@ -49,15 +49,46 @@ module Helpers
     run_command("icacls \"#{root}\" /grant Users:\"(OI)(CI)F\" /T")
   end
 
-  def get_container_port(container, port)
-    @mapped_ports["#{container}:#{port}"] ||= begin
-      service_ip_port = run_command("docker port #{container} #{port}/tcp")[:stdout].chomp
+  def get_service_base_uri(service, port)
+    @mapped_ports["#{service}:#{port}"] ||= begin
+      result = run_command("docker-compose --no-ansi port #{service} #{port}")
+      service_ip_port = result[:stdout].chomp
+      raise "Could not retrieve service endpoint for #{service}:#{port}" if service_ip_port == ''
       uri = URI("http://#{service_ip_port}")
       uri.host = 'localhost' if uri.host == '0.0.0.0'
-      STDOUT.puts "determined #{container} endpoint for port #{port}: #{uri}"
+      STDOUT.puts "determined #{service} endpoint for port #{port}: #{uri}"
       uri
     end
-    @mapped_ports["#{container}:#{port}"]
+    @mapped_ports["#{service}:#{port}"]
+  end
+
+  def get_service_container(service, timeout = 120)
+    return retry_block_up_to_timeout(timeout) do
+      container = run_command("docker-compose --no-ansi ps --quiet #{service}")[:stdout].chomp
+      if container.empty?
+        raise "docker-compose never started a service named '#{service}' in #{timeout} seconds"
+      end
+
+      STDOUT.puts("service named '#{service}' is hosted in container: '#{container}'")
+      container
+    end
+  end
+
+  def teardown_cluster
+    STDOUT.puts("Tearing down test cluster")
+    get_containers.each do |id|
+      STDOUT.puts("Killing container #{id}")
+      run_command("docker container kill #{id}")
+    end
+    # still needed to remove network / provide failsafe
+    run_command('docker-compose --no-ansi down --volumes')
+  end
+
+  def get_containers
+    result = run_command('docker-compose --no-ansi --log-level INFO ps -q')
+    ids = result[:stdout].chomp
+    STDOUT.puts("Retrieved running container ids:\n#{ids}")
+    ids.lines.map(&:chomp)
   end
 
   def inspect_container(container, query)
@@ -78,4 +109,8 @@ module Helpers
     STDOUT.puts(logs)
   end
 
+  def emit_logs
+    STDOUT.puts("Emitting container logs")
+    get_containers.each { |id| emit_log(id) }
+  end
 end


### PR DESCRIPTION
 - Wait on Postgres port to be listening

 - In Pupperware tests, waiting on the puppetserver to be listening
   introduces additional wait time that appears to allow Postgres to
   fully startup (preventing cluster start failures), which we don't
   get the benefit of here

 - This test suite isn't using puppetserver, so should instead rely on
   waiting for Postgres

 - Use docker-compose 1.24.0 in Travis

 - Prune volumes / networks in Azure cleanup step

 - Switch to using Linux Postgres container instead of unmaintained Windows Postgres container given our CI builders are now RS5

 - Randomize the location on disk for Postgres data (to be outside of git checked out area)

 - Refactor test failures modes in PuppetDB to catch all errors properly

 - Remove usage of `Timeout` class for retrying operations and replace with custom timer based solution that doesn't cause weird test suite failure modes

 - Refactor the suite to use `docker- compose` instead of `docker run` (adds additional code to spec_helper)

 - Remove unnecessary tests / move required startup checks to pre-suite `before(:all)`

 - Improve error handling inside `run_command` so that terminating threads reading from stdout / stderr don't tank the suite

 - Support ENV vars in `run_command`

 - Most of the spec_helper code is now generically refactored enough to be extracted to a shared testing library, which is the next step!