### PR TITLE
(maint) allow osx build stages to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,6 +145,10 @@ jobs:
       script: *run-spec-tests
       os: osx
 
+matrix:
+  allow_failures:
+  - os: osx
+
 on_success: ext/travisci/on-success
 
 notifications:


### PR DESCRIPTION
Ignore build failures on osx, treat them as advisory