### PR TITLE
(PDB-4338) Re-add migration 67

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1636,6 +1636,7 @@
    ;; 67 exposed an agent bug where we would get duplicate resource events
    ;; from a failed exec call. The updated migration adds additional columns
    ;; to the hash to avoid these sorts of collisions
+   67 (fn [])
    68 support-fact-expiration-configuration
    69 add-resource-events-pk})
 


### PR DESCRIPTION
Removing an existing migration causes puppetdb to throw a state
exception when it doesn't recognize the migration version number.