### PR TITLE
(maint) PDB wait on Puppetserver port

### DIFF
--- a/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
+++ b/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
@@ -43,7 +43,7 @@ CONSUL_PORT="${CONSUL_PORT:-8500}"
 wait_for_host_port "postgres" "5432" $PUPPETDB_WAITFORPOSTGRES_SECONDS
 
 if [ "$USE_PUPPETSERVER" = true ]; then
-  wait_for_host $PUPPETSERVER_HOSTNAME
+  wait_for_host_port $PUPPETSERVER_HOSTNAME "8140"
   HEALTH_COMMAND="curl --silent --fail --insecure 'https://${PUPPETSERVER_HOSTNAME}:8140/status/v1/simple' | grep -q '^running$'"
 fi
 


### PR DESCRIPTION
Prior to this PR, PDB waited for Puppetserver by pinging it. In some
environments, the puppserver may not be pingable even if it is online.
This commit changes the wait for puppetserver to start by checking that
the service is listening on port 8140.