### PR TITLE
(maint) Increase default PDB Postgres wait time

### DIFF
--- a/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
+++ b/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
@@ -5,7 +5,7 @@
 #
 # Optional environment variables:
 #   PUPPETDB_WAITFORHOST_SECONDS     Number of seconds to wait for host, defaults to 30
-#   PUPPETDB_WAITFORPOSTGRES_SECONDS Number of seconds to wait on Postgres, defaults to 90
+#   PUPPETDB_WAITFORPOSTGRES_SECONDS Number of seconds to wait on Postgres, defaults to 150
 #   PUPPETDB_WAITFORHEALTH_SECONDS   Number of seconds to wait for health
 #                                    checks of Consul / Puppetserver to succeed, defaults to 600
 
@@ -34,7 +34,7 @@ wait_for_host_port() {
 }
 
 PUPPETDB_WAITFORHOST_SECONDS=${PUPPETDB_WAITFORHOST_SECONDS:-30}
-PUPPETDB_WAITFORPOSTGRES_SECONDS=${PUPPETDB_WAITFORPOSTGRES_SECONDS:-90}
+PUPPETDB_WAITFORPOSTGRES_SECONDS=${PUPPETDB_WAITFORPOSTGRES_SECONDS:-150}
 PUPPETDB_WAITFORHEALTH_SECONDS=${PUPPETDB_WAITFORHEALTH_SECONDS:-600}
 PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"
 CONSUL_HOSTNAME="${CONSUL_HOSTNAME:-consul}"


### PR DESCRIPTION
 - When firing up the PDB container, it was waiting 90 seconds by
   default for Postgres to become available.

   In CI environments like Azure, this appears to not be long
   enough.

 - Increase the timeout by a minute to 2:30