### PR TITLE
(PDB-4345) populate name column in resource_events

### DIFF
--- a/documentation/api/query/v4/events.markdown
+++ b/documentation/api/query/v4/events.markdown
@@ -87,6 +87,8 @@ See [the AST query language page][ast] for the full list of available operators.
   `Package` resource, this field might have a value of `ensure`. **Note:** this field
   may contain `NULL` values; see notes above.
 
+* `name` (string or null): the name of the resource on which the event occurred.
+
 * `new_value` (string or null): the new value that Puppet was attempting to set for the specified resource property.  Any [rich data][rich_data] values will appear as readable strings.  **Note:** this field may contain `NULL` values; see notes above.
 
 * `old_value` (string or null): the previous value of the resource property, which Puppet was attempting to change.  Any [rich data][rich_data] values will appear as readable strings.  **Note:** this field may contain `NULL` values; see notes above.
@@ -127,6 +129,7 @@ The response is a JSON array of events that match the input parameters. The arra
         "certname": "foo.localdomain",
         "old_value": "absent",
         "property": "ensure",
+        "name": "reporting file",
         "timestamp": "2012-10-30T19:01:05.000Z",
         "resource_type": "File",
         "resource_title": "/tmp/reportingfoo",
@@ -147,6 +150,7 @@ The response is a JSON array of events that match the input parameters. The arra
         "certname": "foo.localdomain",
         "old_value": "absent",
         "property": "message",
+        "name": null,
         "timestamp": "2012-10-30T19:01:05.000Z",
         "resource_type": "Notify",
         "resource_title": "notify, yo",

--- a/documentation/api/query/v4/reports.markdown
+++ b/documentation/api/query/v4/reports.markdown
@@ -182,6 +182,7 @@ The `<expanded resource events>` object is of the following form:
         "resource_type": <type of resource event occurred on>,
         "resource_title": <title of resource event occurred on>,
         "property": <property/parameter of resource on which event occurred>,
+        "name": <name of the resource on which event occurred>,
         "new_value": <new value for resource property>,
         "old_value": <old value of resource property>,
         "message": <description of what happened during event>,
@@ -210,6 +211,7 @@ Where an `<event>` object is of the form:
     {
             "timestamp": <timestamp (from agent) at which event occurred>,
             "property": <property/parameter of resource on which event occurred>,
+            "name": <name of resource on which event occurred>,
             "new_value": <new value for resource property>,
             "old_value": <old value of resource property>,
             "status": <status of event (`success`, `failure`, or `noop`)>,
@@ -282,6 +284,7 @@ Query for all reports:
         "data": [ {
           "new_value" : "hi world",
           "property" : "message",
+          "name": "define message",
           "file" : "/home/wyatt/.puppet/manifests/site.pp",
           "old_value" : "absent",
           "line" : 7,
@@ -294,6 +297,7 @@ Query for all reports:
         }, {
           "new_value" : "hi world",
           "property" : "message",
+          "name": "define message",
           "file" : "/home/wyatt/.puppet/manifests/site.pp",
           "old_value" : "absent",
           "line" : 3,
@@ -381,6 +385,7 @@ for a report with hash `32c821673e647b0650717db467abc51d9949fd9a`:
           "events":[
              {
                 "property":"message",
+                "name": null,
                 "old_value":"absent",
                 "new_value":"hi world",
                 "status":"success",

--- a/documentation/api/wire_format/report_format_v8.markdown
+++ b/documentation/api/wire_format/report_format_v8.markdown
@@ -145,6 +145,7 @@ In each `<resource>` object `"events"` is an array of objects of the following f
       "status": <status of event (`success`, `failure`, `noop`)>,
       "timestamp": <timestamp (from agent) at which event occurred>,
       "property": <property/parameter of resource on which event occurred>,
+      "name": <name of resource on which event occurred>,
       "new_value": <new value for resource property>,
       "old_value": <old value of resource property>,
       "message": <description of what happened during event>,
@@ -245,6 +246,7 @@ A JSONObject of the following form:
 
     {
      "property": <string>,
+     "name": <string>,
      "timestamp": <datetime>,
      "status": <string>,
      "old_value": <string>,
@@ -257,6 +259,8 @@ All keys are required.
 `"timestamp"` is the date/time at which the event occurred.
 
 `"property"` is the name of the property of the resource for which the event occurred.
+
+`"name"` is the name of the resource for which the event occurred.
 
 `"old_value"` is the value that Puppet determined the property to have held prior
 to the event.

--- a/puppet/lib/puppet/reports/puppetdb.rb
+++ b/puppet/lib/puppet/reports/puppetdb.rb
@@ -166,6 +166,7 @@ Puppet::Reports.register_report(:puppetdb) do
     {
       "status"            => event.status,
       "timestamp"         => Puppet::Util::Puppetdb.to_wire_time(event.time),
+      "name"              => event.name,
       "property"          => event.property,
       "new_value"         => event.desired_value.to_s,
       "old_value"         => event.previous_value.to_s,

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -230,6 +230,7 @@ describe processor do
           event.desired_value = "fooval"
           event.previous_value = "oldfooval"
           event.message = "foomessage"
+          event.name = "foobar"
           if defined?(event.corrective_change) then
             event.corrective_change = true
           end
@@ -256,6 +257,7 @@ describe processor do
           res_event["new_value"].should == "fooval"
           res_event["old_value"].should == "oldfooval"
           res_event["message"].should == "foomessage"
+          res_event["name"].should == "foobar"
           if defined?(event.corrective_change) then
             res_event["corrective_change"].should == true
           else

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -260,6 +260,7 @@
    "line"                   ["resource_events"]
    "containment_path"       ["resource_events"]
    "containing_class"       ["resource_events"]
+   "name"                   ["resource_events"]
    "environment"            ["environments"]})
 
 (def resource-event-columns
@@ -275,6 +276,7 @@
    "resource_type"          ["latest_events"]
    "resource_title"         ["latest_events"]
    "property"               ["latest_events"]
+   "name"                   ["latest_events"]
    "new_value"              ["latest_events"]
    "old_value"              ["latest_events"]
    "message"                ["latest_events"]
@@ -303,6 +305,7 @@
    "line"                   ["resource_events"]
    "containment_path"       ["resource_events"]
    "containing_class"       ["resource_events"]
+   "name"                   ["resource_events"]
    "environment"            ["environments"]})
 
 (def report-columns

--- a/src/puppetlabs/puppetdb/query/events.clj
+++ b/src/puppetlabs/puppetdb/query/events.clj
@@ -71,6 +71,7 @@
                             distinct_events.resource_type AS resource_type,
                             distinct_events.resource_title AS resource_title,
                             distinct_events.property as property,
+                            distinct_events.name as name,
                             new_value,
                             old_value,
                             message,
@@ -84,6 +85,7 @@
                         resource_type COLLATE \"C\" AS resource_type,
                         resource_title COLLATE \"C\" AS resource_title,
                         property COLLATE \"C\" AS property,
+                        name COLLATE \"C\" AS name,
                         MAX(resource_events.timestamp) AS latest_timestamp
                 FROM resource_events
                 WHERE resource_events.timestamp >= ?
@@ -92,15 +94,19 @@
                 GROUP BY certname_id,
                          resource_type COLLATE \"C\",
                          resource_title COLLATE \"C\",
-                         property COLLATE \"C\") distinct_events
+                         property COLLATE \"C\",
+                         name COLLATE \"C\") distinct_events
                 INNER JOIN resource_events
                 ON resource_events.resource_type = distinct_events.resource_type
                    AND resource_events.resource_title = distinct_events.resource_title
                    AND ((resource_events.property = distinct_events.property) OR
                         (resource_events.property IS NULL
                          AND distinct_events.property IS NULL))
-                AND resource_events.timestamp = distinct_events.latest_timestamp
-                AND resource_events.certname_id = distinct_events.certname_id
+                   AND ((resource_events.name = distinct_events.name) OR
+                        (resource_events.name IS NULL
+                         AND distinct_events.name IS NULL))
+                   AND resource_events.timestamp = distinct_events.latest_timestamp
+                   AND resource_events.certname_id = distinct_events.certname_id
                 INNER JOIN reports ON resource_events.report_id = reports.id
                 LEFT OUTER JOIN environments
                   ON reports.environment_id = environments.id

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -596,7 +596,8 @@
                                                     :re.file
                                                     :re.line
                                                     :re.containment_path
-                                                    :re.containing_class]
+                                                    :re.containing_class
+                                                    :re.name]
                                                    :from [[:resource_events :re]]
                                                    :where [:= :reports.id :re.report_id]} :t]]}
                                          :event_data]]}}}
@@ -883,7 +884,10 @@
                              "report_id" {:type :numeric
                                           :queryable? false
                                           :query-only? true
-                                          :field :events.report_id}}
+                                          :field :events.report_id}
+                             "name" {:type :string
+                                     :queryable? true
+                                     :field :name}}
                :selection {:from [[:resource_events :events]]
                            :join [:reports
                                   [:= :events.report_id :reports.id]]

--- a/src/puppetlabs/puppetdb/reports.clj
+++ b/src/puppetlabs/puppetdb/reports.clj
@@ -18,7 +18,8 @@
    :property (s/maybe s/Str)
    :new_value (s/maybe pls/JSONable)
    :old_value (s/maybe pls/JSONable)
-   :message (s/maybe s/Str)})
+   :message (s/maybe s/Str)
+   (s/optional-key :name) (s/maybe s/Str)})
 
 (def resource-wireformat-schema
   {:skipped s/Bool
@@ -76,7 +77,7 @@
         (update :events #(mapv update-fn %)))))
 
 (def report-v7-wireformat-schema
-  (let [update-fn #(dissoc % :corrective_change)]
+  (let [update-fn #(dissoc % :corrective_change :name)]
     (-> report-wireformat-schema
         (dissoc :producer :noop_pending :corrective_change :job_id)
         (update :resources #(mapv (update-resource-events update-fn) %)))))
@@ -128,7 +129,8 @@
    :file (s/maybe s/Str)
    :line (s/maybe s/Int)
    :status (s/maybe s/Str)
-   :message (s/maybe s/Str)})
+   :message (s/maybe s/Str)
+   (s/optional-key :name) (s/maybe s/Str)})
 
 (def resource-events-expanded-query-schema
   {:href s/Str
@@ -291,7 +293,7 @@
   [resource]
   (-> resource
       ;; We also need to grab the timestamp when the resource is `skipped'
-      (select-keys [:resource_type :resource_title :file :line :containment_path :timestamp])
+      (select-keys [:resource_type :resource_title :file :line :containment_path :timestamp :name])
       (merge {:status "skipped" :property nil :old_value nil :new_value nil :message nil :corrective_change false})
       vector))
 

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -199,7 +199,7 @@
 
   This is similar to resource-event-identity-string but it also includes the report id."
   [{:keys [report_id resource_type resource_title property timestamp
-           status old_value new_value message file line] :as event}]
+           status old_value new_value message file line name] :as event}]
   (assert report_id "report_id must not be nil")
   (generic-identity-hash
    {:report_id report_id
@@ -211,7 +211,7 @@
     :old_value old_value
     :new_value new_value
     :message message
-    :name nil ;TODO: fill this field
+    :name name
     :file file
     :line line}))
 

--- a/test/puppetlabs/puppetdb/examples/reports.clj
+++ b/test/puppetlabs/puppetdb/examples/reports.clj
@@ -62,6 +62,7 @@
        :resource_title "notify, yo"
        :environment "DEV"
        :property "message"
+       :name "foo"
        :new_value "notify, yo"
        :old_value ["what" "the" "woah"]
        :corrective_change true
@@ -78,6 +79,7 @@
        :corrective_change false
        :resource_title "notify, yar"
        :property "message"
+       :name "bar"
        :new_value {"absent" 5}
        :old_value {"absent" true}
        :message "defined 'message' as 'notify, yo'"
@@ -93,6 +95,7 @@
        :resource_title "hi"
        :corrective_change false
        :property nil
+       :name nil
        :new_value nil
        :old_value nil
        :message nil
@@ -158,6 +161,7 @@
        :resource_type "Notify"
        :resource_title "Creating tmp directory at /Users/foo/tmp"
        :property "message"
+       :name "foo"
        :new_value "Creating tmp directory at /Users/foo/tmp"
        :old_value "absent"
        :corrective_change false
@@ -172,6 +176,7 @@
        :resource_type "File"
        :resource_title "puppet-managed-file"
        :property "ensure"
+       :name "bar"
        :new_value "present"
        :old_value "absent"
        :corrective_change false
@@ -186,6 +191,7 @@
        :resource_type "File"
        :resource_title "tmp-directory"
        :property "ensure"
+       :name nil
        :new_value "directory"
        :old_value "absent"
        :corrective_change false
@@ -252,6 +258,7 @@
        :resource_type "Notify"
        :resource_title "notify, yo"
        :property "message"
+       :name "foo"
        :new_value "notify, yo"
        :old_value ["what" "the" "woah"]
        :corrective_change false
@@ -266,6 +273,7 @@
        :resource_type "Notify"
        :resource_title "notify, yar"
        :property "message"
+       :name "bar"
        :corrective_change false
        :new_value {"absent" 5}
        :old_value {"absent" true}
@@ -280,6 +288,7 @@
        :resource_type "Notify"
        :resource_title "hi"
        :property nil
+       :name nil
        :new_value nil
        :old_value nil
        :corrective_change false
@@ -346,6 +355,7 @@
        :resource_type "Notify"
        :resource_title "notify, yo"
        :property "message"
+       :name "foo"
        :new_value "notify, yo"
        :corrective_change false
        :old_value ["what" "the" "woah"]
@@ -360,6 +370,7 @@
        :resource_type "Notify"
        :resource_title "notify, yar"
        :property "message"
+       :name "bar"
        :corrective_change false
        :new_value {"absent" 5}
        :old_value {"absent" true}
@@ -375,6 +386,7 @@
        :resource_title "hi"
        :corrective_change false
        :property nil
+       :name nil
        :new_value nil
        :old_value nil
        :message nil

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -383,6 +383,7 @@
        :report "7d0cfa08901e1e1d80cf2f2f814d356d0e457e09"
        :resource_title "hi"
        :property nil
+       :name nil
        :file "bar"
        :old_value nil
        :run_start_time "2011-01-01T15:00:00.000Z"
@@ -409,6 +410,7 @@
        :report "7d0cfa08901e1e1d80cf2f2f814d356d0e457e09"
        :resource_title "hi"
        :property nil
+       :name nil
        :file "bar"
        :old_value nil
        :run_start_time "2011-01-01T15:00:00.000Z"
@@ -437,6 +439,7 @@
        :report "7d0cfa08901e1e1d80cf2f2f814d356d0e457e09"
        :resource_title "hi"
        :property nil
+       :name nil
        :file "bar"
        :old_value nil
        :run_start_time "2011-01-01T15:00:00.000Z"

--- a/test/puppetlabs/puppetdb/testutils/reports.clj
+++ b/test/puppetlabs/puppetdb/testutils/reports.clj
@@ -83,7 +83,7 @@
 
 (defn munge-resources-for-comparison [resources]
   (let [resources-sort-fn (partial sort-by (juxt :resource_type :resource_title))
-        events-sort-fn (partial sort-by :property)]
+        events-sort-fn (partial sort-by (juxt :name :property))]
     (->> resources
          (map (fn [resource]
                 (-> resource
@@ -145,7 +145,7 @@
 (defn munge-resource-events [resource-events]
   (->> resource-events
        (map #(update % :timestamp time-coerce/to-string))
-       (sort-by #(mapv % [:timestamp :resource_type :resource_title :property]))))
+       (sort-by #(mapv % [:timestamp :resource_type :resource_title :name :property]))))
 
 (defn munge-report
   [report]


### PR DESCRIPTION
Add the name column to the terminus so it's sent to puppetdb

Populate the name column that was previously added to the database in
PDB-4315