### PR TITLE
(maint) handle apt-get update failures

### DIFF
--- a/ext/travisci/prep-os-essentials-for
+++ b/ext/travisci/prep-os-essentials-for
@@ -11,6 +11,24 @@ misuse() {
     exit 2
 }
 
+# this handles the issue where apt-get update fails but has an exit code of zero
+# because there's a mirror sync going on. This failure is retryable, but you have
+# to look for it in the output from the command. This is a common failure on AWS
+# and GCP because they inject their own mirrors into /etc/apt/sources.list at VM
+# start time, and there's a delay in getting all their mirrors in sync.
+apt_get_update() {
+    local tmpdir
+    tmpdir=$(mktemp)
+    set +e
+    for i in $(seq 1 20); do
+        sudo apt-get update 2>&1 | tee $tmpdir
+        grep -x "[WE]:.*" $tmpdir || break
+        sleep 1
+    done;
+    set -e
+    echo Executed apt-get update $i times;
+}
+
 test $# -eq 1 || misuse
 spec="$1"
 
@@ -65,7 +83,12 @@ case "$OSTYPE" in
         sudo apt-get purge \
              postgresql{,-client}-{9.2,9.3,9.4,9.5,9.6} \
              postgresql-client-common postgresql-client postgresql-common
-        sudo apt-get update
+        # workaround for mongodb, CouchDB and git-lfs having invalid keys
+        # see: https://github.com/travis-ci/travis-ci/issues/9037 (which is still broken)
+        sudo rm -f /etc/apt/sources.list.d/mongodb*
+        sudo rm -f /etc/apt/sources.list.d/couchdb*
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157
+        apt_get_update
         sudo -i apt-get -y install postgresql-9.6 postgresql-11
         ;;
 esac


### PR DESCRIPTION
Remove mongodb and CouchDB repositories from /etc/apt/sources.list.d/

Update git-lfs repo key

Add a retry to apt-get update when the mirror is out of sync.

When this happens, the failure similar to:

    W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 Release: The following signatures were invalid: KEYEXPIRED 1515625755
    W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://packagecloud.io/github/git-lfs/ubuntu trusty InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 6B05F25D762E3157
    W: http://ppa.launchpad.net/couchdb/stable/ubuntu/dists/trusty/Release.gpg: Signature by key 15866BAFD9BCC4F3C1E0DFC7D69548E1C17EAB57 uses weak digest algorithm (SHA1)
    W: Failed to fetch https://packagecloud.io/github/git-lfs/ubuntu/dists/trusty/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 6B05F25D762E3157
    W: Failed to fetch http://repo.mongodb.org/apt/ubuntu/dists/trusty/mongodb-org/3.4/Release.gpg  The following signatures were invalid: KEYEXPIRED 1515625755
    W: Some index files failed to download. They have been ignored, or old ones used instead.

In this specific case, it's bad repo keys which will be fixed by another
portion of this PR, but out of date mirrors will cause package catalog
mismatches during a mirror sync. This retry loop will handle that
condition gracefully.