### PR TITLE
(maint) travis: osx: Remove jdk8 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,18 +127,6 @@ jobs:
 
     # ==== osx
 
-    # === core+ext tests
-    - stage: ❧ pdb tests
-      env: PDB_TEST=core+ext/openjdk8/pg-9.6
-      script: *run-core-and-ext-tests
-      os: osx
-
-    # === integration tests
-    - stage: ❧ pdb tests
-      env: PDB_TEST=int/openjdk8/pup-5.5.x/srv-5.3.x/pg-9.6
-      script: *run-integration-tests
-      os: osx
-
     # === rspec tests
     - stage: ❧ pdb tests
       env: PDB_TEST=rspec/pup-5.5.x


### PR DESCRIPTION
Our AdoptOpenJDK packages on MacOS are a nightmare to manage due to
their unmodified cacert. This problem is resolved in JDK 11 so we will
only be running OSX tests on JDK 11 for increase PuppetDB team sanity.