### PR TITLE
(MAINT) Use new ssl.sh that gets the CRL

### DIFF
--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -66,7 +66,7 @@ RUN mkdir -p /opt/puppetlabs/server/data/puppetdb
 
 RUN addgroup $GROUP && adduser -S $USER -G $GROUP
 
-ADD https://raw.githubusercontent.com/puppetlabs/pupperware/2630075434af829489b5fb3e01039701ed6fe752/shared/ssl.sh /ssl.sh
+ADD https://raw.githubusercontent.com/puppetlabs/pupperware/2f621aab9242a7845dc1d5af71eb1d29d09219e4/shared/ssl.sh /ssl.sh
 RUN chmod +x /ssl.sh
 COPY docker/puppetdb/ssl-setup.sh /
 RUN chmod +x /ssl-setup.sh


### PR DESCRIPTION
The CRL isn't necessary here in PuppetDB but update to the latest
version of this script anyway for consistency across the containers.