### PR TITLE
(maint) Update the check when consul is enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -216,6 +216,8 @@ jobs:
       os: osx
 
     - stage: ❧ pdb container tests
+      language:ruby
+      rvm: 2.5.0
       env: DOCKER_COMPOSE_VERSION=1.24.0
       script: *run-docker-tests
 

--- a/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
+++ b/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
@@ -50,7 +50,7 @@ fi
 if [ "$CONSUL_ENABLED" = "true" ]; then
   wait_for_host $CONSUL_HOSTNAME
   # with Consul enabled, wait on Consul instead of Puppetserver
-  HEALTH_COMMAND="curl --silent --fail 'http://${CONSUL_HOSTNAME}:${CONSUL_PORT}/v1/health/checks/puppet' | grep -q '\\"\""state"\\\"":\\"\""running\\"\""'"
+  HEALTH_COMMAND="curl --silent --fail 'http://${CONSUL_HOSTNAME}:${CONSUL_PORT}/v1/health/checks/puppet' | grep -q '\\"\""Status"\\\"": \\"\""passing\\"\""'"
 fi
 
 if [ -n "$HEALTH_COMMAND" ]; then


### PR DESCRIPTION
We were checking for an incorrect string to tell when puppetserver is up
and running, causing PDB to loop forever then fail.