### PR TITLE
(maint) Refactor PDB Docker HEALTHCHECK

### DIFF
--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -84,15 +84,13 @@ EXPOSE 8080 8081
 ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["services"]
 
+COPY docker/puppetdb/healthcheck.sh /
+RUN chmod +x /healthcheck.sh
 # The start-period is just a wild guess how long it takes PuppetDB to come
 # up in the worst case. The other timing parameters are set so that it
 # takes at most a minute to realize that PuppetDB has failed.
-HEALTHCHECK --interval=10s --timeout=10s --retries=6 \
-  --start-period=5m CMD \
-  curl --fail --silent \
-  --resolve 'puppetdb:8080:127.0.0.1' \
-  http://puppetdb:8080/status/v1/services/puppetdb-status \
-  | grep -q '"state":"running"' \
-  || exit 1
+# Probe failure during --start-period will not be counted towards the maximum number of retries
+HEALTHCHECK --start-period=5m --interval=10s --timeout=10s --retries=6 CMD ["/healthcheck.sh"]
+
 
 COPY docker/puppetdb/Dockerfile /

--- a/docker/puppetdb/healthcheck.sh
+++ b/docker/puppetdb/healthcheck.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+set -x
+set -e
+
+curl --fail \
+--resolve "puppetdb:8080:127.0.0.1" \
+"http://puppetdb:8080/status/v1/services/puppetdb-status" \
+|  grep -q '"state":"running"' \
+|| exit 1


### PR DESCRIPTION
 - The previous format can confuse LCOW and result in errors like:

   CreateProcess: failure in a Windows system call: Unspecified error (0x80004005)
   [Event Detail: failed to run runc create/exec call for container

 - Puppetserver is using this style with success