### PR TITLE
(PDB-4362) Always uninstall puppet5-nightly-release during upgrade_ol…

### DIFF
--- a/acceptance/setup/pre_suite/75_clean_out_puppet5_repos.rb
+++ b/acceptance/setup/pre_suite/75_clean_out_puppet5_repos.rb
@@ -7,11 +7,7 @@ if (test_config[:install_mode] == :upgrade_oldest) \
 
         # need to remove puppet5 repos to avoid conflicts when upgrading
         uninstall_package(database, "puppet5-release")
-
-        case test_config[:os_families][database.name]
-        when :debian
-          uninstall_package(database, "puppet5-nightly-release")
-        end
+        uninstall_package(database, "puppet5-nightly-release")
 
         # init the puppet6 repos to allow it to find the puppet6 collection
         initialize_repo_on_host(database, test_config[:os_families][database.name], test_config[:nightly])


### PR DESCRIPTION
…dest

Prior to this commit the puppet5-nightly-release repos were only uninstalled on
debian platforms during the upgrade_oldest tests. This caused conflicts on
RHEL8, but not Centos. Now uninstall the repo on all platforms when testing
upgrade_oldest.