### PR TITLE
(maint) Docker DNS reliability improvements

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -83,6 +83,10 @@ The following environment variables are supported:
 
   The hostname for the puppetserver instance. This determines where to request certificates from. Defaults to 'puppet'.
 
+- `PUPPETSERVER_PORT`
+
+  The port for the puppetserver instance. This determines where to request certificates from. Defaults to '8140'.
+
 ## Analytics Data Collection
 
  The puppetdb container collects usage data. This is disabled by default. You can enable it by passing `--env PUPPERWARE_ANALYTICS_ENABLED=true`

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -12,7 +12,7 @@ RUN lein with-profile uberjar uberjar
 
 
 FROM openjdk:8-jre-alpine
-RUN apk add --no-cache tini curl openssl
+RUN apk add --no-cache tini curl openssl bind-tools
 COPY --from=builder /app/target/puppetdb.jar /
 
 ARG vcs_ref

--- a/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
+++ b/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
@@ -18,6 +18,8 @@ error() {
     exit 1
 }
 
+# Alpine as high as 3.9 seems to have failures reaching addresses sporadically
+# In local repro scenarios, performing a DNS lookup with dig increases reliability
 wait_for_host_name_resolution() {
   # host and dig are in the bind-tools Alpine package
   # k8s nodes may not be reachable with a ping
@@ -40,11 +42,13 @@ wait_for_host_port() {
 PUPPETDB_WAITFORHOST_SECONDS=${PUPPETDB_WAITFORHOST_SECONDS:-30}
 PUPPETDB_WAITFORPOSTGRES_SECONDS=${PUPPETDB_WAITFORPOSTGRES_SECONDS:-150}
 PUPPETDB_WAITFORHEALTH_SECONDS=${PUPPETDB_WAITFORHEALTH_SECONDS:-600}
+PUPPETDB_POSTGRES_HOSTNAME="${PUPPETDB_POSTGRES_HOSTNAME:-postgres}"
 PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"
 CONSUL_HOSTNAME="${CONSUL_HOSTNAME:-consul}"
 CONSUL_PORT="${CONSUL_PORT:-8500}"
 
-wait_for_host_port "${PUPPETDB_POSTGRES_HOSTNAME:-postgres}" "${PUPPETDB_POSTGRES_PORT:-5432}" $PUPPETDB_WAITFORPOSTGRES_SECONDS
+wait_for_host_name_resolution $PUPPETDB_POSTGRES_HOSTNAME
+wait_for_host_port $PUPPETDB_POSTGRES_HOSTNAME "${PUPPETDB_POSTGRES_PORT:-5432}" $PUPPETDB_WAITFORPOSTGRES_SECONDS
 
 if [ "$USE_PUPPETSERVER" = true ]; then
   wait_for_host_name_resolution $PUPPETSERVER_HOSTNAME

--- a/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
+++ b/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
@@ -18,8 +18,12 @@ error() {
     exit 1
 }
 
-wait_for_host() {
-  /wtfc.sh --timeout=$PUPPETDB_WAITFORHOST_SECONDS --interval=1 --progress ping -c1 -W1 $1
+wait_for_host_name_resolution() {
+  # host and dig are in the bind-tools Alpine package
+  # k8s nodes may not be reachable with a ping
+  /wtfc.sh --timeout=$PUPPETDB_WAITFORHOST_SECONDS --interval=1 --progress host $1
+  # additionally log the DNS lookup information for diagnostic purposes
+  dig $1
   if [ $? -ne 0 ]; then
     error "dependent service at $1 cannot be resolved or contacted"
   fi
@@ -43,12 +47,12 @@ CONSUL_PORT="${CONSUL_PORT:-8500}"
 wait_for_host_port "${PUPPETDB_POSTGRES_HOSTNAME:-postgres}" "${PUPPETDB_POSTGRES_PORT:-5432}" $PUPPETDB_WAITFORPOSTGRES_SECONDS
 
 if [ "$USE_PUPPETSERVER" = true ]; then
-  wait_for_host $PUPPETSERVER_HOSTNAME
+  wait_for_host_name_resolution $PUPPETSERVER_HOSTNAME
   HEALTH_COMMAND="curl --silent --fail --insecure 'https://${PUPPETSERVER_HOSTNAME}:"${PUPPETSERVER_PORT:-8140}"/status/v1/simple' | grep -q '^running$'"
 fi
 
 if [ "$CONSUL_ENABLED" = "true" ]; then
-  wait_for_host $CONSUL_HOSTNAME
+  wait_for_host_name_resolution $CONSUL_HOSTNAME
   # with Consul enabled, wait on Consul instead of Puppetserver
   HEALTH_COMMAND="curl --silent --fail 'http://${CONSUL_HOSTNAME}:${CONSUL_PORT}/v1/health/checks/puppet' | grep -q '\\"\""Status"\\\"": \\"\""passing\\"\""'"
 fi

--- a/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
+++ b/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
@@ -44,7 +44,7 @@ wait_for_host_port "${PUPPETDB_POSTGRES_HOSTNAME:-postgres}" "${PUPPETDB_POSTGRE
 
 if [ "$USE_PUPPETSERVER" = true ]; then
   wait_for_host $PUPPETSERVER_HOSTNAME
-  HEALTH_COMMAND="curl --silent --fail --insecure 'https://${PUPPETSERVER_HOSTNAME}:8140/status/v1/simple' | grep -q '^running$'"
+  HEALTH_COMMAND="curl --silent --fail --insecure 'https://${PUPPETSERVER_HOSTNAME}:"${PUPPETSERVER_PORT:-8140}"/status/v1/simple' | grep -q '^running$'"
 fi
 
 if [ "$CONSUL_ENABLED" = "true" ]; then


### PR DESCRIPTION
-  New variable `PUPPETSERVER_PORT` is added that defaults to 8140
- Rename wait_for_host to wait_for_host_name_resolution to better
   reflect its purpose.

   Change it's behavior to use the host command (which returns proper
   exit codes) instead of using ping. ping will not work in a k8s
   environment where hosts are not reachable by ping

 - After succeeding or failing DNS lookup with the host command,
   emit the dig output for that lookup for the sake of logs

- There appear to be many reported issues against Alpine DNS. This
   is an attempt to work around the ones we're experiencing.

 - In local testing (specifically under LCOW), DNS resolution under
   Alpine seems to be very problematic.

   `nslookup` may repeatedly fail to perform a DNS resolution against
   another container name like `puppet.local` repeatedly.

   Lookup failures will resemble something like:

     / # nslookup puppet.local
     nslookup: can't resolve '(null)': Name does not resolve

     nslookup: can't resolve 'puppet.local': Name does not resolve

   Even successes have problems with the DNS server

     / # nslookup puppet.local
     nslookup: can't resolve '(null)': Name does not resolve

     Name:      puppet.local
     Address 1: 172.17.212.25

 - Supposedly the "can't resolve '(null)'" part is innocuous, but it's
   unclear if that is the case.  More info at:

   nicolaka/netshoot#6
   gliderlabs/docker-alpine#476

 - It seems that just having the `bind-tools` package installed will
   increase the reliability, but after running dig once against the
   given host, intermittnet DNS resolution problems seem to go away

     / # nslookup puppet.local
     Server:         172.17.208.1
     Address:        172.17.208.1#53

     Non-authoritative answer:
     Name:   puppet.local
     Address: 172.17.212.25

   So the script is changed to query for the postgres hostname

 - We don't use curl here because we're mostly interested in making
   sure a host with a given name *should* exist.

   There are scenarios where host / dig will succeed, but latter
   checks with curl may not - and we want to differentiate those
   failure modes as much as possible

   serverfault.com/questions/335359/how-is-it-possible-that-i-can-do-a-host-lookup-but-not-a-curl