### PR TITLE
(maint) Improve Docker wait script dig output

### DIFF
--- a/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
+++ b/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
@@ -25,7 +25,7 @@ wait_for_host_name_resolution() {
   # k8s nodes may not be reachable with a ping
   /wtfc.sh --timeout=$PUPPETDB_WAITFORHOST_SECONDS --interval=1 --progress host $1
   # additionally log the DNS lookup information for diagnostic purposes
-  dig $1
+  dig +search $1
   if [ $? -ne 0 ]; then
     error "dependent service at $1 cannot be resolved or contacted"
   fi


### PR DESCRIPTION
 - By default, dig will not use the search list provided by
   etc/resolv.conf.

   "
    +[no]search
    Use [do not use] the search list defined by the searchlist or domain directive in resolv.conf (if any). The search list is not used by default.
   "

 - In k8s, this will prevent dig from showing the actual hostname
   resolutions like (note no answer in DNS response):

   ; <<>> DiG 9.12.4-P1 <<>> puppet
   ;; global options: +cmd
   ;; Got answer:
   ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 49995
   ;; flags: qr rd ra ad; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

   ;; OPT PSEUDOSECTION:
   ; EDNS: version: 0, flags:; udp: 4096
   ; COOKIE: e1ed0b866217fc15 (echoed)
   ;; QUESTION SECTION:
   ;puppet.				IN	A

   ;; Query time: 1 msec
   ;; SERVER: 10.96.0.10#53(10.96.0.10)
   ;; WHEN: Thu May 02 23:48:52 UTC 2019
   ;; MSG SIZE  rcvd: 47

 - With +search added, the response is instead something like:

   ; <<>> DiG 9.12.4-P1 <<>> +search puppet
   ;; global options: +cmd
   ;; Got answer:
   ;; WARNING: .local is reserved for Multicast DNS
   ;; You are currently testing what happens when an mDNS query is leaked to DNS
   ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 1594
   ;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
   ;; WARNING: recursion requested but not available

   ;; OPT PSEUDOSECTION:
   ; EDNS: version: 0, flags:; udp: 4096
   ; COOKIE: 19a36cb038b7f56f (echoed)
   ;; QUESTION SECTION:
   ;puppet.default.svc.cluster.local. IN	A

   ;; ANSWER SECTION:
   puppet.default.svc.cluster.local. 5 IN	A	10.103.58.54

   ;; Query time: 0 msec
   ;; SERVER: 10.96.0.10#53(10.96.0.10)
   ;; WHEN: Fri May 03 15:36:37 UTC 2019
   ;; MSG SIZE  rcvd: 121