### PR TITLE
(maint) Exit Docker wait script properly

### DIFF
--- a/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
+++ b/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
@@ -25,8 +25,9 @@ wait_for_host_name_resolution() {
   # k8s nodes may not be reachable with a ping
   /wtfc.sh --timeout=$PUPPETDB_WAITFORHOST_SECONDS --interval=1 --progress host $1
   # additionally log the DNS lookup information for diagnostic purposes
+  NAME_RESOLVED=$?
   dig $1
-  if [ $? -ne 0 ]; then
+  if [ $NAME_RESOLVED -ne 0 ]; then
     error "dependent service at $1 cannot be resolved or contacted"
   fi
 }


### PR DESCRIPTION
 - Running `dig` always yields a non-zero exit code. Capture the exit
   status of the wtfc.sh helper script when querying the name with host
   which yields a non-zero exit code on failure.

   This ensures that initial lookups fail the entrypoint script as
   desired, rather than continuing on