### PR TITLE
(maint) Only query host A records in Docker waiter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -216,7 +216,7 @@ jobs:
       os: osx
 
     - stage: ❧ pdb container tests
-      language:ruby
+      language: ruby
       rvm: 2.5.0
       env: DOCKER_COMPOSE_VERSION=1.24.0
       script: *run-docker-tests

--- a/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
+++ b/docker/puppetdb/docker-entrypoint.d/20-wait-for-hosts.sh
@@ -25,7 +25,7 @@ wait_for_host_name_resolution() {
   # k8s nodes may not be reachable with a ping
   # performing a dig prior to a host may help prime the cache in Alpine
   # https://github.com/Microsoft/opengcs/issues/303
-  /wtfc.sh --timeout=$PUPPETDB_WAITFORHOST_SECONDS --interval=1 --progress "dig $1 && host $1"
+  /wtfc.sh --timeout=$PUPPETDB_WAITFORHOST_SECONDS --interval=1 --progress "dig $1 && host -t A $1"
   # additionally log the DNS lookup information for diagnostic purposes
   NAME_RESOLVED=$?
   dig $1


### PR DESCRIPTION
 - The host command may return non-zero exit codes when the given host
   is missing certain record types. For instance:

   / # host www.google.com
   www.google.com has address 172.217.3.196
   www.google.com has IPv6 address 2607:f8b0:400a:803::2004
   Host www.google.com not found: 3(NXDOMAIN)

   / # echo $?
   1

 - If the record type is limited to A records for IPv4, the same query
   returns the expected 0 exit status

   / # host -t A www.google.com
   www.google.com has address 172.217.3.196

   / # echo $?
   0

 - In TravisCI, failures are cropping up when puppetdb looks up the
   postgres container via the network alias postgres.internal and
   this should help to alleviate that problem