### PR TITLE
(maint) Update Makefile / .travis.yml to use rvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,7 @@ aliases:
     make lint
     make build
     make test
+    set +x
 
 jobs:
   include:
@@ -217,7 +218,7 @@ jobs:
 
     - stage: ❧ pdb container tests
       language: ruby
-      rvm: 2.5.0
+      rvm: 2.5.5
       env: DOCKER_COMPOSE_VERSION=1.24.0
       script: *run-docker-tests
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,7 +8,10 @@ hadolint_command := hadolint --ignore DL3008 --ignore DL3018 --ignore DL4000 --i
 hadolint_container := hadolint/hadolint:latest
 version = $(shell echo $(git_describe) | sed 's/-.*//')
 dockerfile := Dockerfile
-
+pwd := $(shell pwd)
+export BUNDLE_PATH = $(pwd)/.bundle/gems
+export BUNDLE_BIN = $(pwd)/.bundle/bin
+export GEMFILE = $(pwd)/Gemfile
 
 prep:
 	@git fetch --unshallow ||:
@@ -38,9 +41,9 @@ ifeq ($(IS_LATEST),true)
 endif
 
 test: prep
-	@bundle install --path .bundle/gems
+	@bundle install --path $$BUNDLE_PATH --gemfile $$GEMFILE
 	@PUPPET_TEST_DOCKER_IMAGE=$(NAMESPACE)/puppetdb:$(version) \
-		bundle exec rspec puppetdb/spec
+		bundle exec --gemfile $$GEMFILE rspec puppetdb/spec
 
 push-image: prep
 	@docker push puppet/puppetdb:$(version)


### PR DESCRIPTION
Bundle installing / bundle execing with an RVM project in travis gets
complicated when there's a Gemfile at the root of your repo and you're
trying to use a gemfile from a different directory.

This makes sure we're setting the BUNDLE_PATH and BUNDLE_BIN environment
variables, and explicitly passes the path for the Gemfile for all bundle
commands.