### PR TITLE
(PDB-3840) Fix rededuplicate migration crash; rm values with no path

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1314,7 +1314,8 @@
 (defn rededuplicate-facts []
   (log/info (trs "[1/8] Cleaning up unreferenced facts..."))
   (jdbc/do-commands
-   "DELETE FROM facts WHERE factset_id NOT IN (SELECT id FROM factsets)")
+   "DELETE FROM facts WHERE factset_id NOT IN (SELECT id FROM factsets)"
+   "DELETE FROM facts WHERE fact_path_id NOT IN (SELECT id FROM fact_paths)")
 
   (log/info (trs "[2/8] Creating new fact storage tables..."))
   (jdbc/do-commands


### PR DESCRIPTION
Prevent rededuplicate-facts migration failures caused by orphaned
facts that have no path in fact_paths.  For example:

  ERROR [p.p.s.migrate] Caught SQLException during migration
  java.sql.BatchUpdateException: Batch entry 3 ALTER TABLE facts ADD CONSTRAINT fact_path_id_fk
  FOREIGN KEY (fact_path_id)
  REFERENCES fact_paths(id) was aborted. Call getNextException to see the cause.
  at org.postgresql.jdbc.BatchResultHandler.handleError(BatchResultHandler.java:133)
  at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2004)
  at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:360)
  at org.postgresql.jdbc.PgStatement.executeBatch(PgStatement.java:1019)
  at com.zaxxer.hikari.pool.ProxyStatement.executeBatch(ProxyStatement.java:125)
  at com.zaxxer.hikari.pool.HikariProxyStatement.executeBatch(HikariProxyStatement.java)
  at clojure.java.jdbc$execute_batch.invokeStatic(jdbc.clj:439)
  at clojure.java.jdbc$execute_batch.invoke(jdbc.clj:432)
  at clojure.java.jdbc$db_do_commands$fn__21859.invoke(jdbc.clj:748)
  at clojure.java.jdbc$db_transaction_STAR_.invokeStatic(jdbc.clj:662)
  at clojure.java.jdbc$db_transaction_STAR_.invoke(jdbc.clj:598)
  at clojure.java.jdbc$db_transaction_STAR_.invokeStatic(jdbc.clj:611)
  at clojure.java.jdbc$db_transaction_STAR_.invoke(jdbc.clj:598)
  at clojure.java.jdbc$db_do_commands.invokeStatic(jdbc.clj:747)
  at clojure.java.jdbc$db_do_commands.invoke(jdbc.clj:732)
  at puppetlabs.puppetdb.jdbc$do_commands.invokeStatic(jdbc.clj:38)
  at puppetlabs.puppetdb.jdbc$do_commands.doInvoke(jdbc.clj:33)
  at clojure.lang.RestFn.invoke(RestFn.java:512)
  at puppetlabs.puppetdb.scf.migrate$rededuplicate_facts.invokeStatic(migrate.clj:1433)
  at puppetlabs.puppetdb.scf.migrate$rededuplicate_facts.invoke(migrate.clj:1315)
  at puppetlabs.puppetdb.scf.migrate$migrate_BANG_$fn__36253$fn__36255$fn__36257.invoke(migrate.clj:1616)

[rlb@puppet.com: rebase onto current 5.2.x; remove deletion based on
 fact_values since that table doesn't exist during this particular
 migration; adjust commit message and add sample error message]