### PR TITLE
(PDB-4347) Make fact path gc table temp, not unlogged

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1144,7 +1144,7 @@
     "                     union (select generate_series(0, jsonb_array_length(value - 1))::text as key,"
     "                                   jsonb_array_elements(value) as value"
     "                              where jsonb_typeof(value) = 'array')) as sub_level)"
-    "   select path into unlogged tmp_live_paths from live_paths"]
+    "   select path into temp tmp_live_paths from live_paths"]
 
    "analyze tmp_live_paths"
 


### PR DESCRIPTION
Temp tables *are* unlogged tables[1], not vice versa (as had been
assumed), so change the gc table to a temp table.

Since unlogged tables aren't temp tables, you could see a table name
conflict if, for example, multiple gc attempts ran simultaneously:

  WITH recursive live_paths(path, value) AS
  ...
  SELECT path
  INTO   unlogged tmp_live_paths
  FROM   live_paths

  was aborted: ERROR: relation "tmp_live_paths" already exists
  ...

[1] https://rhaas.blogspot.com/2010/05/global-temporary-and-unlogged-tables.html