### PR TITLE
(PDB-4390) Store the uncoerced catalog certname

### DIFF
--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -290,8 +290,8 @@
 ;; Catalog replacement
 
 (defn replace-catalog*
-  [{:keys [certname version id received payload]} start-time db]
-  (let [{producer-timestamp :producer_timestamp :as catalog} payload]
+  [{:keys [version id received payload]} start-time db]
+  (let [{producer-timestamp :producer_timestamp certname :certname :as catalog} payload]
     (jdbc/with-transacted-connection' db :repeatable-read
       (scf-storage/maybe-activate-node! certname producer-timestamp)
       (scf-storage/replace-catalog! catalog received))


### PR DESCRIPTION
If a certname contain invalid characters for the queue metadata, such as
an underscore, or if it is too long it will be coerced and a hash of the
original will be appended to the end. For replace-catalogs, this
certname would end up getting stored in the database (only after PDB-4257).

Now the certname is correctly read out of the command payload (the
uncoerced value) and stored properly.