### PR TITLE
(PDB-4360) add IPv6 support to pdbbox

### DIFF
--- a/ext/bin/pdbbox-env
+++ b/ext/bin/pdbbox-env
@@ -10,9 +10,10 @@ if test "$#" -lt 1 -o -z "$PDBBOX"; then
 fi
 
 pgport="$(cat "$PDBBOX/pg/port")"
+pghost="$(cat "$PDBBOX/pg/bind-addrs" | tail -1)"
 
 export PGBOX="$PDBBOX/pg"
-export PDB_TEST_DB_HOST=localhost
+export PDB_TEST_DB_HOST="$pghost"
 export PDB_TEST_DB_PORT="$pgport"
 export PDB_TEST_DB_USER=pdb_test
 export PDB_TEST_DB_USER_PASSWORD="$(cat "$PDBBOX/test-pass")"

--- a/ext/bin/pdbbox-env
+++ b/ext/bin/pdbbox-env
@@ -10,7 +10,7 @@ if test "$#" -lt 1 -o -z "$PDBBOX"; then
 fi
 
 pgport="$(cat "$PDBBOX/pg/port")"
-pghost="$(cat "$PDBBOX/pg/bind-addrs" | tail -1)"
+pghost="$(tail -1 "$PDBBOX/pg/bind-addrs")"
 
 export PGBOX="$PDBBOX/pg"
 export PDB_TEST_DB_HOST="$pghost"

--- a/ext/bin/pdbbox-init
+++ b/ext/bin/pdbbox-init
@@ -39,8 +39,8 @@ while test $# -gt 0; do
             ;;
         --bind-addr)
             shift
-            test ! -z $# || misuse
-            bind_addr[${#bind_addr[@]}]="$1"
+            test $# -gt 0 || misuse
+            bind_addr+=("$1")
             shift
             ;;
         *)
@@ -52,12 +52,17 @@ test "$pgbin" || misuse
 test "$pgport" || misuse
 test "$bind_addr" || misuse
 
+bind_args=()
+for addr in "${bind_addr[@]}"; do
+    bind_args+=(--bind-addr "$addr")
+done
+
 export PGBOX="$pdbbox/pg"
 export PGUSER=postgres
 
 mkdir "$pdbbox"
 
-pgbox init --pgbin "$pgbin" --port "$pgport" --bind-addr "${bind_addr[@]/#/}" -- -E UTF8 --locale=C
+pgbox init --pgbin "$pgbin" --port "$pgport" "${bind_args[@]}" -- -E UTF8 --locale=C
 
 mkdir "$pdbbox/var"
 

--- a/ext/bin/pdbbox-init
+++ b/ext/bin/pdbbox-init
@@ -4,7 +4,7 @@ set -ueo pipefail
 
 usage()
 {
-    echo "Usage: $(basename $0) <-s|--sandbox> DIR --pgbin DIR --pgport PORT"
+    echo "Usage: $(basename $0) <-s|--sandbox> DIR --pgbin DIR --pgport PORT --bind-addr ADDR1 [--bind-addr ADDR2 ...]"
 }
 
 misuse()
@@ -16,6 +16,7 @@ misuse()
 pdbbox=''
 pgbin=''
 pgport=''
+bind_addr=()
 while test $# -gt 0; do
     case "$1" in
         -s|--sandbox)
@@ -36,6 +37,12 @@ while test $# -gt 0; do
             pgport="$1"
             shift
             ;;
+        --bind-addr)
+            shift
+            test ! -z $# || misuse
+            bind_addr[${#bind_addr[@]}]="$1"
+            shift
+            ;;
         *)
             misuse
     esac
@@ -43,13 +50,14 @@ done
 test "$pdbbox" || misuse
 test "$pgbin" || misuse
 test "$pgport" || misuse
+test "$bind_addr" || misuse
 
 export PGBOX="$pdbbox/pg"
 export PGUSER=postgres
 
 mkdir "$pdbbox"
 
-pgbox init --pgbin "$pgbin" --port "$pgport" -- -E UTF8 --locale=C
+pgbox init --pgbin "$pgbin" --port "$pgport" --bind-addr "${bind_addr[@]/#/}" -- -E UTF8 --locale=C
 
 mkdir "$pdbbox/var"
 
@@ -151,6 +159,8 @@ cat > "$pdbbox/logback.xml" <<EOF
 </configuration>
 EOF
 
+host=${bind_addr[${#bind_addr[@]}-1]}
+
 cat > "$pdbbox/pdb.ini" <<EOF
 
 [global]
@@ -158,7 +168,7 @@ vardir = $abs_pdbbox/var
 logging-config = $abs_pdbbox/logback.xml
 
 [database]
-subname = //localhost:$pgport/puppetdb
+subname = //$host:$pgport/puppetdb
 username = puppetdb
 password = $passwd
 

--- a/ext/bin/require-pgbox
+++ b/ext/bin/require-pgbox
@@ -13,7 +13,7 @@ usage() { echo "Usage: $cmdname VERSION INSTALLDIR_IF_NEEDED"; }
 misuse() { usage 1>&2; exit 2; }
 
 declare -A known_hash
-known_hash[0.0.0]=b5840a59f5437677e22a33dd27b27282c5186d1ecd89b23d8d2ef4c62d3511ce
+known_hash[0.0.0]=c4dd424ddbcaf33cb0d3ef51255943cbdd87446ea7bf220528441849de35cfef
 
 test "$#" -eq 2 || misuse
 
@@ -42,7 +42,7 @@ tmpdir="$(cd "$tmpdir" && pwd)"
 trap "$(printf 'rm -rf %q' "$tmpdir")" EXIT
 
 cd "$tmpdir"
-curl -O "https://gitlab.com/pgbox-org/pgbox/raw/8ba9c69e061c89ef6f06cb40f5d60e85c1e2e336/pgbox"
+curl -O "https://gitlab.com/pgbox-org/pgbox/raw/82e512d37a7c6c2ae72d1293ea98945eaaae51f4/pgbox"
 obshash="$("$script_home/sha256sum" < pgbox | cut -d' ' -f1)"
 cd ..
 

--- a/ext/bin/with-pdbbox
+++ b/ext/bin/with-pdbbox
@@ -61,7 +61,9 @@ set -x
 
 trap "$(printf 'rm -rf %q' "$box")" EXIT
 export PDBBOX="$box"
-"$script_home"/pdbbox-init --sandbox "$box" --pgbin "$pgbin" --pgport "$pgport" --bind-addr ip6-localhost localhost
+"$script_home"/pdbbox-init --sandbox "$box" --pgbin "$pgbin" \
+              --pgport "$pgport" \
+              --bind-addr ip6-localhost --bind-addr localhost
 
 # Use a subshell for a nested EXIT trap
 (trap '"$script_home"/pdbbox-env pg_ctl stop' EXIT

--- a/ext/bin/with-pdbbox
+++ b/ext/bin/with-pdbbox
@@ -61,7 +61,7 @@ set -x
 
 trap "$(printf 'rm -rf %q' "$box")" EXIT
 export PDBBOX="$box"
-"$script_home"/pdbbox-init --sandbox "$box" --pgbin "$pgbin" --pgport "$pgport"
+"$script_home"/pdbbox-init --sandbox "$box" --pgbin "$pgbin" --pgport "$pgport" --bind-addr ip6-localhost localhost
 
 # Use a subshell for a nested EXIT trap
 (trap '"$script_home"/pdbbox-env pg_ctl stop' EXIT


### PR DESCRIPTION
Add IPv6 support to pdbbox. Allows a pdbbox sandbox to initialize with
IPv6 support, IPv4 support, or both. IPv4 defaults to on, IPv6 defaults
to off.