### PR TITLE
(PDB-4266) Add include_package_inventory flag to factsets query

### DIFF
--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -34,6 +34,7 @@
    (s/optional-key :ast_only) (s/maybe s/Bool)
    (s/optional-key :include_total) (s/maybe s/Bool)
    (s/optional-key :pretty) (s/maybe s/Bool)
+   (s/optional-key :include_package_inventory) (s/maybe s/Bool)
    (s/optional-key :order_by) (s/maybe [[(s/one s/Keyword "field")
                                          (s/one (s/enum :ascending :descending) "order")]])
    (s/optional-key :distinct_resources) (s/maybe s/Bool)
@@ -267,6 +268,7 @@
       (update-when [:offset] parse-offset)
       (update-when [:include_total] coerce-to-boolean)
       (update-when [:pretty] coerce-to-boolean)
+      (update-when [:include_package_inventory] coerce-to-boolean)
       (update-when [:distinct_resources] coerce-to-boolean)))
 
 (defn get-req->query
@@ -278,6 +280,7 @@
       (update-when ["order_by"] parse-order-by-json)
       (update-when ["counts_filter"] json/parse-strict-string true)
       (update-when ["pretty"] coerce-to-boolean)
+      (update-when ["include_package_inventory"] coerce-to-boolean)
       keywordize-keys))
 
 (defn post-req->query
@@ -312,7 +315,9 @@
      (handler
       (if puppetdb-query
         req
-        (let [param-spec (update param-spec :optional conj "pretty")
+        (let [param-spec (-> param-spec
+                             (update :optional conj "pretty")
+                             (update :optional conj "include_package_inventory"))
               query-map (create-query-map req param-spec parse-fn)
               pretty-print (:pretty query-map
                                     (get-in req [:globals :pretty-print]))]

--- a/src/puppetlabs/puppetdb/query/facts.clj
+++ b/src/puppetlabs/puppetdb/query/facts.clj
@@ -49,3 +49,8 @@
   [_ _]
   (fn [rows]
     (map :name rows)))
+
+(defn munge-package-inventory
+  [_ _]
+  (fn [rows]
+    (map #(utils/update-when % [:package_inventory] (partial map vec)) rows)))

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -1009,56 +1009,81 @@
                :subquery? false
                :source-table packages"}))
 
+(def factsets-query-base
+  {:projections
+   {"timestamp" {:type :timestamp
+                 :queryable? true
+                 :field :timestamp}
+    "facts" {:type :queryable-json
+             :queryable? true
+             :field {:select [(h/row-to-json :facts_data)]
+                     :from [[{:select [[(hcore/raw "json_agg(json_build_object('name', t.name, 'value', t.value))")
+                                        :data]
+                                       [(hsql-hash-as-href "fs.certname" :factsets :facts)
+                                        :href]]
+                              :from [[{:select [[:key :name] :value :fs.certname]
+                                       :from [(hcore/raw "jsonb_each(fs.volatile || fs.stable)")]}
+                                      :t]]}
+                             :facts_data]]}}
+    "certname" {:type :string
+                :queryable? true
+                :field :fs.certname}
+    "hash" {:type :string
+            :queryable? true
+            :field (hsql-hash-as-str :fs.hash)}
+    "producer_timestamp" {:type :timestamp
+                          :queryable? true
+                          :field :fs.producer_timestamp}
+    "producer" {:type :string
+                :queryable? true
+                :field :producers.name}
+    "environment" {:type :string
+                   :queryable? true
+                   :field :environments.environment}}
+
+   :selection {:from [[:factsets :fs]]
+               :left-join [:environments
+                           [:= :fs.environment_id :environments.id]
+                           :producers
+                           [:= :producers.id :fs.producer_id]]}
+
+   :relationships (merge certname-relations
+                         {"environments" {:local-columns ["environment"]
+                                          :foreign-columns ["name"]}
+                          "producers" {:local-columns ["producer"]
+                                       :foreign-columns ["name"]}})
+
+   :alias "factsets"
+   :entity :factsets
+   :source-table "factsets"
+   :subquery? false})
+
 (def factsets-query
   "Query for the top level facts query"
+  (map->Query factsets-query-base))
+
+(def factsets-with-packages-query
+  "Query for factsets with the package_inventory reconstructed (used for sync)"
   (map->Query
-    {:projections
-     {"timestamp" {:type :timestamp
-                   :queryable? true
-                   :field :timestamp}
-      "facts" {:type :queryable-json
-               :queryable? true
-               :field {:select [(h/row-to-json :facts_data)]
-                       :from [[{:select [[(hcore/raw "json_agg(json_build_object('name', t.name, 'value', t.value))")
-                                          :data]
-                                         [(hsql-hash-as-href "fs.certname" :factsets :facts)
-                                          :href]]
-                                :from [[{:select [[:key :name] :value :certname]
-                                         :from [(hcore/raw "jsonb_each(fs.volatile || fs.stable)")]}
-                                        :t]]}
-                               :facts_data]]}}
-      "certname" {:type :string
-                  :queryable? true
-                  :field :fs.certname}
-      "hash" {:type :string
-              :queryable? true
-              :field (hsql-hash-as-str :fs.hash)}
-      "producer_timestamp" {:type :timestamp
-                            :queryable? true
-                            :field :fs.producer_timestamp}
-      "producer" {:type :string
-                  :queryable? true
-                  :field :producers.name}
-      "environment" {:type :string
-                     :queryable? true
-                     :field :environments.environment}}
-
-     :selection {:from [[:factsets :fs]]
-                 :left-join [:environments
-                             [:= :fs.environment_id :environments.id]
-                             :producers
-                             [:= :producers.id :fs.producer_id]]}
-
-     :relationships (merge certname-relations
-                           {"environments" {:local-columns ["environment"]
-                                            :foreign-columns ["name"]}
-                            "producers" {:local-columns ["producer"]
-                                         :foreign-columns ["name"]}})
-
-     :alias "factsets"
-     :entity :factsets
-     :source-table "factsets"
-     :subquery? false}))
+    (-> factsets-query-base
+        (assoc-in [:projections "package_inventory"]
+                  {:type :array
+                   :queryable? false
+                   :field :package_inventory.packages})
+        (update-in
+          [:selection :left-join]
+          conj
+          :certnames
+          [:= :certnames.certname :fs.certname]
+          [{:select [[:certname_packages.certname_id :certname_id]
+                     [:%array_agg.p.triple :packages]]
+            :from [:certname_packages]
+            :left-join [[{:select [:id
+                                  [(htypes/array [:name :version :provider]) :triple]]
+                         :from [:packages]} :p]
+                        [:= :p.id :certname_packages.package_id]]
+            :group-by [:certname_id]} :package_inventory]
+          [:= :package_inventory.certname_id :certnames.id]))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Conversion from plan to SQL

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -202,6 +202,13 @@
   and producer.
   "
   [fact-data]
-  (-> fact-data
-    (dissoc :timestamp :producer_timestamp :producer)
-    generic-identity-hash))
+  (-> ;; If the :package_inventory is not a seq (ie. empty) in fact-data
+      ;; we remove package-inventory key entirely because an absent
+      ;; and empty package inventory are stored identically so there's no
+      ;; way to tell them apart during sync, and we need the the hashing
+      ;; to be consistent.
+      (if (seq (:package_inventory fact-data))
+        fact-data
+        (dissoc fact-data :package_inventory))
+      (dissoc :timestamp :producer_timestamp :producer)
+      generic-identity-hash))

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -1121,7 +1121,10 @@
                                       "e" "1"}
                 "domain" "testing.com"
                 "hostname" "foo4"
-                "uptime_seconds" "6000"}]
+                "uptime_seconds" "6000"}
+        package-inventory [["package1" "1.2.3" "provider1"]
+                           ["package2" "3.2.1" "provider1"]
+                           ["package3" "5" "provider2"]]]
     (jdbc/with-transacted-connection *db*
       (scf-store/add-certname! "foo1")
       (scf-store/add-certname! "foo2")
@@ -1131,24 +1134,28 @@
                              :values facts1
                              :timestamp test-time
                              :environment "DEV"
+                             :package_inventory package-inventory
                              :producer_timestamp test-time
                              :producer "bar1"})
       (scf-store/add-facts! {:certname  "foo2"
                              :values facts2
                              :timestamp (to-timestamp "2013-01-01")
                              :environment "DEV"
+                             :package_inventory package-inventory
                              :producer_timestamp (to-timestamp "2013-01-01")
                              :producer "bar2"})
       (scf-store/add-facts! {:certname "foo3"
                              :values facts3
                              :timestamp test-time
                              :environment "PROD"
+                             :package_inventory package-inventory
                              :producer_timestamp test-time
                              :producer "bar3"})
       (scf-store/add-facts! {:certname "foo4"
                              :values facts4
                              :timestamp test-time
                              :environment "PROD"
+                             :package_inventory package-inventory
                              :producer_timestamp test-time
                              :producer "bar4"})
       (scf-store/deactivate-node! "foo4"))))
@@ -1183,7 +1190,7 @@
          "environment" "DEV"
          "certname" "foo1"
          "producer" "bar1"
-         "hash" "b966980c39a141ab3c82b51951bb51a2e3787ac7"}
+         "hash" "e9e19bca48ab42c44687822415df77b47fa41e64"}
 
         {"facts" {"href" (str "/pdb/query/" (name version) "/factsets/foo2/facts")
                   "data" [{"name" "uptime_seconds"
@@ -1198,7 +1205,7 @@
          "certname" "foo2"
          "producer_timestamp" "2013-01-01T00:00:00.000Z"
          "producer" "bar2"
-         "hash" "28ea981ebb992fa97a1ba509790fd213d0f98411"}
+         "hash" "39ad058afe565c797e925a862394d1bf457cf592"}
 
         {"facts" {"href" (str "/pdb/query/" (name version) "/factsets/foo3/facts")
                   "data" [{"name" "domain"
@@ -1211,7 +1218,7 @@
          "environment" "PROD"
          "certname" "foo3"
          "producer" "bar3"
-         "hash" "f1122885dd4393bd1b786751384728bd1ca97bab"}]))
+         "hash" "f78da40ed4ad5f8009bf1e9e2963e44a86cfef00"}]))
 
 (deftest-http-app factset-paging-results
   [[version endpoint] factsets-endpoints
@@ -1361,7 +1368,7 @@
                "producer" "bar1"
                "environment" "DEV"
                "certname" "foo1"
-               "hash" "b966980c39a141ab3c82b51951bb51a2e3787ac7"})))
+               "hash" "e9e19bca48ab42c44687822415df77b47fa41e64"})))
       (is (= (munge-factsets-response (into [] (second responses)))
              (map munge-factset-response
                   [{"facts" {"href" (str "/pdb/query/" (name version) "/factsets/foo1/facts")
@@ -1384,7 +1391,7 @@
                     "producer" "bar1"
                     "environment" "DEV"
                     "certname" "foo1"
-                    "hash" "b966980c39a141ab3c82b51951bb51a2e3787ac7"}
+                    "hash" "e9e19bca48ab42c44687822415df77b47fa41e64"}
 
                    {"facts" {"href" (str "/pdb/query/" (name version) "/factsets/foo2/facts")
                              "data" [{"name" "my_structured_fact"
@@ -1403,7 +1410,7 @@
                     "producer" "bar2"
                     "environment" "DEV"
                     "certname" "foo2"
-                    "hash" "28ea981ebb992fa97a1ba509790fd213d0f98411"}])))
+                    "hash" "39ad058afe565c797e925a862394d1bf457cf592"}])))
 
       (is (= (munge-factsets-response (into [] (nth responses 2)))
              (map munge-factset-response
@@ -1424,7 +1431,7 @@
                     "producer" "bar2"
                     "environment" "DEV"
                     "certname" "foo2"
-                    "hash" "28ea981ebb992fa97a1ba509790fd213d0f98411"}])))
+                    "hash" "39ad058afe565c797e925a862394d1bf457cf592"}])))
       (is (= (munge-factsets-response (into [] (nth responses 3)))
              (map munge-factset-response
                   [{"facts" {"href" (str "/pdb/query/" (name version) "/factsets/foo2/facts")
@@ -1444,10 +1451,10 @@
                     "producer" "bar2"
                     "environment" "DEV"
                     "certname" "foo2"
-                    "hash" "28ea981ebb992fa97a1ba509790fd213d0f98411"}])))
+                    "hash" "39ad058afe565c797e925a862394d1bf457cf592"}])))
       (is (= (into [] (nth responses 4))
              [{"certname" "foo1"
-               "hash" "b966980c39a141ab3c82b51951bb51a2e3787ac7"}]))
+               "hash" "e9e19bca48ab42c44687822415df77b47fa41e64"}]))
      (is (= (munge-factsets-response (into [] (nth responses 5)))
             (map munge-factset-response
                  [{"facts" {"href" (str "/pdb/query/" (name version) "/factsets/foo2/facts")
@@ -1467,7 +1474,7 @@
                    "producer" "bar2"
                    "environment" "DEV"
                    "certname" "foo2"
-                   "hash" "28ea981ebb992fa97a1ba509790fd213d0f98411"}]))))))
+                   "hash" "39ad058afe565c797e925a862394d1bf457cf592"}]))))))
 
 (deftest-http-app factset-subqueries
   [[version endpoint] factsets-endpoints
@@ -1574,7 +1581,7 @@
                                  {"name" "test#~delimiter" "value" "foo"}
                                  {"name" "uptime_seconds" "value" "4000"}}
                         "href" "/pdb/query/v4/factsets/foo1/facts"}
-               "hash" "b966980c39a141ab3c82b51951bb51a2e3787ac7"
+               "hash" "e9e19bca48ab42c44687822415df77b47fa41e64"
                "producer_timestamp" "2014-10-28T20:26:21.727Z"
                "producer" "bar1"
                "timestamp" "2014-10-28T20:26:21.727Z"}))))))
@@ -1902,6 +1909,184 @@
         :body
         slurp
         json/parse-string)))
+
+(deftest-http-app factset-with-package-inventory-queries
+  [[version endpoint] factsets-endpoints
+   method [:get :post]]
+  (populate-for-structured-tests reference-time)
+
+  (testing "query with only include_package_inventory param should not fail"
+    (let [response (query-response method endpoint nil {:include_package_inventory true})]
+      (assert-success! response)
+      (slurp (:body response))))
+
+  (testing "factsets with package inventory query should ignore deactivated nodes"
+    (let [responses (json/parse-string (slurp (:body (query-response
+                                                       method endpoint))))]
+      (is (not (contains? (into [] (map #(get % "certname") responses)) "foo4")))))
+
+  (testing "factset queries should return appropriate results"
+    (let [queries [["=" "certname" "foo1"]
+                   ["=" "environment" "DEV"]
+                   ["<" "timestamp" "2014-01-01"]
+                   ["<" "producer_timestamp" "2014-01-01"]
+                   ["extract" ["certname" "hash"]
+                   ["=" "certname" "foo1"]]
+                   ["=" "producer" "bar2"]]
+          responses (map (comp json/parse-string
+                               slurp
+                               :body
+                               #(query-response method endpoint % {:include_package_inventory true}))
+                         queries)]
+      (is (= (munge-factset-response (into {} (first responses)))
+             (munge-factset-response
+              {"facts" {"href" (str "/pdb/query/" (name version) "/factsets/foo1/facts")
+                        "data" [{"name" "domain"
+                                 "value" "testing.com"}
+                                {"name" "my_structured_fact"
+                                 "value"
+                                 {"a" 1
+                                  "b" 3.14
+                                  "c" ["a" "b" "c"]
+                                  "d" {"n" ""}
+                                  "e" "1"
+                                  "f" nil}}
+                                {"name" "test#~delimiter"
+                                 "value" "foo"}
+                                {"name" "uptime_seconds"
+                                 "value" "4000"}]}
+               "timestamp" reference-time
+               "producer_timestamp" reference-time
+               "producer" "bar1"
+               "package_inventory" [["package1" "1.2.3" "provider1"]
+                                    ["package2" "3.2.1" "provider1"]
+                                    ["package3" "5" "provider2"]]
+               "environment" "DEV"
+               "certname" "foo1"
+               "hash" "e9e19bca48ab42c44687822415df77b47fa41e64"})))
+      (is (= (munge-factsets-response (into [] (second responses)))
+             (map munge-factset-response
+                  [{"facts" {"href" (str "/pdb/query/" (name version) "/factsets/foo1/facts")
+                             "data" [{"name" "my_structured_fact"
+                                      "value"
+                                      {"a" 1
+                                       "b" 3.14
+                                       "c" ["a" "b" "c"]
+                                       "d" {"n" ""}
+                                       "e" "1"
+                                       "f" nil}}
+                                     {"name" "domain"
+                                      "value" "testing.com"}
+                                     {"name" "uptime_seconds"
+                                      "value" "4000"}
+                                     {"name" "test#~delimiter"
+                                      "value" "foo"}]}
+                    "timestamp" reference-time
+                    "producer_timestamp" reference-time
+                    "producer" "bar1"
+                    "package_inventory" [["package1" "1.2.3" "provider1"]
+                                         ["package2" "3.2.1" "provider1"]
+                                         ["package3" "5" "provider2"]]
+                    "environment" "DEV"
+                    "certname" "foo1"
+                    "hash" "e9e19bca48ab42c44687822415df77b47fa41e64"}
+
+                   {"facts" {"href" (str "/pdb/query/" (name version) "/factsets/foo2/facts")
+                             "data" [{"name" "my_structured_fact"
+                                      "value"
+                                      {"a" 1
+                                       "b" 3.14
+                                       "c" ["a" "b" "c"]
+                                       "d" {"n" ""}
+                                       "e" "1"}}
+                                     {"name" "domain"
+                                      "value" "testing.com"}
+                                     {"name" "uptime_seconds"
+                                      "value" "6000"}]}
+                    "timestamp" (to-string (to-timestamp "2013-01-01"))
+                    "producer_timestamp" (to-string (to-timestamp "2013-01-01"))
+                    "producer" "bar2"
+                    "package_inventory" [["package1" "1.2.3" "provider1"]
+                                         ["package2" "3.2.1" "provider1"]
+                                         ["package3" "5" "provider2"]]
+                    "environment" "DEV"
+                    "certname" "foo2"
+                    "hash" "39ad058afe565c797e925a862394d1bf457cf592"}])))
+
+      (is (= (munge-factsets-response (into [] (nth responses 2)))
+             (map munge-factset-response
+                  [{"facts" {"href" (str "/pdb/query/" (name version) "/factsets/foo2/facts")
+                             "data" [{"name" "my_structured_fact"
+                                      "value"
+                                      {"a" 1
+                                       "b" 3.14
+                                       "c" ["a" "b" "c"]
+                                       "d" {"n" ""}
+                                       "e" "1"}}
+                                     {"name" "domain"
+                                      "value" "testing.com"}
+                                     {"name" "uptime_seconds"
+                                      "value" "6000"}]}
+                    "timestamp" (to-string (to-timestamp "2013-01-01"))
+                    "producer_timestamp" (to-string (to-timestamp "2013-01-01"))
+                    "producer" "bar2"
+                    "package_inventory" [["package1" "1.2.3" "provider1"]
+                                         ["package2" "3.2.1" "provider1"]
+                                         ["package3" "5" "provider2"]]
+                    "environment" "DEV"
+                    "certname" "foo2"
+                    "hash" "39ad058afe565c797e925a862394d1bf457cf592"}])))
+
+      (is (= (munge-factsets-response (into [] (nth responses 3)))
+             (map munge-factset-response
+                  [{"facts" {"href" (str "/pdb/query/" (name version) "/factsets/foo2/facts")
+                             "data" [{"name" "my_structured_fact"
+                                      "value"
+                                      {"a" 1
+                                       "b" 3.14
+                                       "c" ["a" "b" "c"]
+                                       "d" {"n" ""}
+                                       "e" "1"}}
+                                     {"name" "domain"
+                                      "value" "testing.com"}
+                                     {"name" "uptime_seconds"
+                                      "value" "6000"}]}
+                    "timestamp" (to-string (to-timestamp "2013-01-01"))
+                    "producer_timestamp" (to-string (to-timestamp "2013-01-01"))
+                    "producer" "bar2"
+                    "package_inventory" [["package1" "1.2.3" "provider1"]
+                                         ["package2" "3.2.1" "provider1"]
+                                         ["package3" "5" "provider2"]]
+                    "environment" "DEV"
+                    "certname" "foo2"
+                    "hash" "39ad058afe565c797e925a862394d1bf457cf592"}])))
+      (is (= (into [] (nth responses 4))
+             [{"certname" "foo1"
+               "hash" "e9e19bca48ab42c44687822415df77b47fa41e64"}]))
+
+      (is (= (munge-factsets-response (into [] (nth responses 5)))
+             (map munge-factset-response
+                  [{"facts" {"href" (str "/pdb/query/" (name version) "/factsets/foo2/facts")
+                             "data" [{"name" "my_structured_fact"
+                                      "value"
+                                      {"a" 1
+                                       "b" 3.14
+                                       "c" ["a" "b" "c"]
+                                       "d" {"n" ""}
+                                       "e" "1"}}
+                                     {"name" "domain"
+                                      "value" "testing.com"}
+                                     {"name" "uptime_seconds"
+                                      "value" "6000"}]}
+                    "timestamp" (to-string (to-timestamp "2013-01-01"))
+                    "producer_timestamp" (to-string (to-timestamp "2013-01-01"))
+                    "producer" "bar2"
+                    "package_inventory" [["package1" "1.2.3" "provider1"]
+                                         ["package2" "3.2.1" "provider1"]
+                                         ["package3" "5" "provider2"]]
+                    "environment" "DEV"
+                    "certname" "foo2"
+                    "hash" "39ad058afe565c797e925a862394d1bf457cf592"}]))))))
 
 (deftest-http-app fact-contents-queries
   [[version endpoint] fact-contents-endpoints

--- a/test/puppetlabs/puppetdb/testutils/facts.clj
+++ b/test/puppetlabs/puppetdb/testutils/facts.clj
@@ -12,6 +12,11 @@
    "id" "foo"
    "operatingsystem" "Debian"})
 
+(def base-package-inventory
+  [["ntp" "4.2.8" "apt"]
+   ["puppet-agent" "6.6.0" "apt"]
+   ["nokogiri" "4.5.6" "gem"]])
+
 (defn create-host-facts
   "Create a map for `node` suitable for spitting to a tarball
    used by import/export/anonymize"


### PR DESCRIPTION
This adds support for the include_package_inventory query option, which
when provided will re-create the original wire format of
package_inventory.

This is intended to support proper syncing of factsets in PE.