### PR TITLE
(maint) workaround postgresql bug #15865

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1275,9 +1275,12 @@
           "  FROM edges e"
           "  INNER JOIN certnames c ON e.certname = c.certname")
      (str "ALTER TABLE edges_transform"
-          "  ALTER COLUMN certname SET NOT NULL,"
-          "  ALTER COLUMN source SET NOT NULL,"
-          "  ALTER COLUMN target SET NOT NULL,"
+          "  ALTER COLUMN certname SET NOT NULL")
+     (str "ALTER TABLE edges_transform"
+          "  ALTER COLUMN source SET NOT NULL")
+     (str "ALTER TABLE edges_transform"
+          "  ALTER COLUMN target SET NOT NULL")
+     (str "ALTER TABLE edges_transform"
           "  ALTER COLUMN type SET NOT NULL")
      (str "DROP TABLE edges")
      (str "ALTER TABLE edges_transform RENAME TO edges")
@@ -1452,13 +1455,21 @@
 (defn varchar-columns-to-text []
   (jdbc/do-commands
     "alter table reports
-     alter column puppet_version type text,
+     alter column puppet_version type text"
+
+    "alter table reports
      alter column configuration_version type text"
 
     "alter table resource_events
-     alter column status type text,
-     alter column property type text,
-     alter column containing_class type text,
+     alter column status type text"
+
+    "alter table resource_events
+     alter column property type text"
+
+    "alter table resource_events
+     alter column containing_class type text"
+
+    "alter table resource_events
      alter column file type text"))
 
 (def migrations


### PR DESCRIPTION
PostgreSQL 9.6.14 introduced a bug:

BUG #15865: ALTER TABLE statements causing "relation already exists" errors when some indexes exist

See: https://www.postgresql.org/message-id/15865-17940eacc8f8b081%40postgresql.org

This will make any ALTER TABLE statement only affect a single column per
statement.