### PR TITLE
(PUP-9513) Change http_instance to connection

### DIFF
--- a/puppet/lib/puppet/util/puppetdb/http.rb
+++ b/puppet/lib/puppet/util/puppetdb/http.rb
@@ -134,7 +134,8 @@ module Puppet::Util::Puppetdb
         route = concat_url_snippets(server_url.request_uri, path_suffix)
 
         request_exception = with_http_error_logging(server_url, route) {
-          http = Puppet::Network::HttpPool.http_instance(server_url.host, server_url.port)
+          ssl_context = Puppet.lookup(:ssl_context)
+          http = Puppet::Network::HttpPool.connection(server_url.host, server_url.port, ssl_context: ssl_context)
 
           response = Timeout.timeout(config.server_url_timeout) do
             http_callback.call(http, route)
@@ -170,7 +171,8 @@ module Puppet::Util::Puppetdb
         route = concat_url_snippets(server_url.request_uri, path_suffix)
 
         request_exception = with_http_error_logging(server_url, route) {
-          http = Puppet::Network::HttpPool.http_instance(server_url.host, server_url.port)
+          ssl_context = Puppet.lookup(:ssl_context)
+          http = Puppet::Network::HttpPool.connection(server_url.host, server_url.port, ssl_context: ssl_context)
 
           response = Timeout.timeout(config.server_url_timeout) do
             http_callback.call(http, route)

--- a/puppet/spec/unit/face/node/status_spec.rb
+++ b/puppet/spec/unit/face/node/status_spec.rb
@@ -20,7 +20,7 @@ describe "node face: status" do
 
   it "should fetch the status of each node" do
     http = stub 'http'
-    Puppet::Network::HttpPool.stubs(:http_instance).returns(http)
+    Puppet::Network::HttpPool.stubs(:connection).returns(http)
 
     nodes = %w[a b c d e]
     nodes.each do |node|
@@ -32,7 +32,7 @@ describe "node face: status" do
 
   it "should CGI escape the node names" do
     http = stub 'http'
-    Puppet::Network::HttpPool.stubs(:http_instance).returns(http)
+    Puppet::Network::HttpPool.stubs(:connection).returns(http)
 
     node = "foo/+*&bar"
 

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -32,7 +32,7 @@ describe Puppet::Resource::Catalog::Puppetdb do
 
     before :each do
       response.stubs(:body).returns '{"uuid": "a UUID"}'
-      Puppet::Network::HttpPool.expects(:http_instance).returns http
+      Puppet::Network::HttpPool.expects(:connection).returns http
     end
 
     def save

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -18,7 +18,7 @@ describe Puppet::Node::Facts::Puppetdb do
   before :each do
     Puppet::Util::Puppetdb.config.stubs(:server_urls).returns [URI("https://localhost:8282")]
     Puppet::Node::Facts.indirection.stubs(:terminus).returns(subject)
-    Puppet::Network::HttpPool.stubs(:http_instance).returns(http)
+    Puppet::Network::HttpPool.stubs(:connection).returns(http)
     create_environmentdir("my_environment")
   end
 

--- a/puppet/spec/unit/indirector/node/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/node/puppetdb_spec.rb
@@ -27,7 +27,7 @@ describe Puppet::Node::Puppetdb do
     let(:response) { Net::HTTPOK.new('1.1', 200, 'OK') }
     let(:http)     { mock 'http' }
     before :each do
-      Puppet::Network::HttpPool.expects(:http_instance).returns http
+      Puppet::Network::HttpPool.expects(:connection).returns http
     end
 
     it "should POST a '#{CommandDeactivateNode}' command" do

--- a/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/resource/puppetdb_spec.rb
@@ -32,7 +32,7 @@ describe Puppet::Resource::Puppetdb do
       response.stubs(:body).returns '[]'
 
       query = CGI.escape(["and", ["=", "type", "exec"], ["=", "exported", true], ["not", ["=", "certname", "default.local"]]].to_json)
-      Puppet::Network::HttpPool.stubs(:http_instance).returns(http)
+      Puppet::Network::HttpPool.stubs(:connection).returns(http)
       http.stubs(:get).with("/pdb/query/v4/resources?query=#{query}", subject.headers, options).returns response
 
       search("exec").should == []
@@ -45,7 +45,7 @@ describe Puppet::Resource::Puppetdb do
       response.stubs(:body).returns '[]'
 
       query = CGI.escape(["and", ["=", "type", "exec"], ["=", "exported", true], ["not", ["=", "certname", "default.local"]]].to_json)
-      Puppet::Network::HttpPool.stubs(:http_instance).returns(http)
+      Puppet::Network::HttpPool.stubs(:connection).returns(http)
       http.stubs(:get).with("/pdb/query/v4/resources?query=#{query}", subject.headers, options).returns response
 
       Puppet.expects(:deprecation_warning).with do |msg|
@@ -91,7 +91,7 @@ describe Puppet::Resource::Puppetdb do
         response.stubs(:body).returns body
 
         http = stub 'http'
-        Puppet::Network::HttpPool.stubs(:http_instance).returns(http)
+        Puppet::Network::HttpPool.stubs(:connection).returns(http)
         http.stubs(:get).with("/pdb/query/v4/resources?query=#{CGI.escape(query.to_json)}", subject.headers, options).returns response
       end
 

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -36,7 +36,7 @@ describe processor do
 
       expected_body = subject.report_to_hash(Time.now.utc).to_json
 
-      Puppet::Network::HttpPool.expects(:http_instance).returns(http)
+      Puppet::Network::HttpPool.expects(:connection).returns(http)
       http.expects(:post).with {|path, body, headers|
         expect(path).to include(Puppet::Util::Puppetdb::Command::CommandsUrl)
 

--- a/puppet/spec/unit/util/puppetdb/command_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/command_spec.rb
@@ -16,7 +16,7 @@ describe Puppet::Util::Puppetdb::Command do
   describe "#submit" do
     let(:http) { mock 'http' }
     before(:each) do
-      Puppet::Network::HttpPool.expects(:http_instance).returns http
+      Puppet::Network::HttpPool.expects(:connection).returns http
     end
 
     context "when the submission succeeds" do


### PR DESCRIPTION
As part of ongoing work to improve SSL initialization in Puppet,
PUP-9513 is deprecating Puppet::Network::HttpPool.http_instance() that
relied on the old Puppet::SSL::Host in favor of a newer HttpPool.connection()
method that uses the new Puppet::SSL::SSLContext.

This patch updates the Puppet::Util::Puppetdb::Http class to use
Puppet::Network::HttpPool.connection(). The SSLContext object is
obtained from Puppet's base_context via Puppet.lookup.

Specs are updated to match.

This paves the way for these methods to be removed in Puppet 7, and
clears up warnings that were being emitted with Puppet 6.7.1-42-gc60d6aaa88
(and PE 2019.2.x) when Puppet::Util::Puppetdb initializes a connection.