### PR TITLE
(PDB-4372) Log command name for replace catalog inputs

### DIFF
--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -315,7 +315,7 @@
         (scf-storage/maybe-activate-node! certname stamp)
         (scf-storage/replace-catalog-inputs! certname catalog_uuid inputs stamp))
       (log-command-processed-messsage id received start-time
-                                      :catalog-inputs certname))))
+                                      :replace-catalog-inputs certname))))
 
 ;; Fact replacement
 


### PR DESCRIPTION
An incorrect keyword used to look up the command name
for 'replace catalog inputs' commands caused a log message like
`'null' command processed for new-host` to be printed.