### PR TITLE
(maint) Switch PDB container off of Alpine

### DIFF
--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -1,5 +1,6 @@
-FROM clojure:lein-alpine AS builder
-RUN apk add --no-cache make
+FROM clojure:openjdk-8-lein AS builder
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends make
 # Install only dependencies
 WORKDIR /app
 COPY project.clj /app/
@@ -11,8 +12,11 @@ COPY . /app
 RUN lein with-profile uberjar uberjar
 
 
-FROM openjdk:8-jre-alpine
-RUN apk add --no-cache tini curl openssl bind-tools
+FROM openjdk:8-jre-slim-buster
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tini curl openssl dnsutils netcat && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/puppetdb.jar /
 
 ARG vcs_ref
@@ -66,7 +70,7 @@ COPY resources/ext/config/logback.xml /etc/puppetlabs/puppetdb/
 COPY resources/ext/config/request-logging.xml /etc/puppetlabs/puppetdb/
 RUN mkdir -p /opt/puppetlabs/server/data/puppetdb
 
-RUN addgroup $GROUP && adduser -S $USER -G $GROUP
+RUN addgroup $GROUP && adduser --system $USER --ingroup $GROUP
 
 ADD https://raw.githubusercontent.com/puppetlabs/pupperware/8cdc056be09c44ed1ba96f963d71bd074d063b17/shared/ssl.sh /ssl.sh
 RUN chmod +x /ssl.sh
@@ -83,7 +87,7 @@ COPY docker/puppetdb/docker-entrypoint.d /docker-entrypoint.d
 
 EXPOSE 8080 8081
 
-ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["services"]
 
 COPY docker/puppetdb/healthcheck.sh /


### PR DESCRIPTION
 - Alpine seems to still be having issues with DNS resolutions inside
   an LCOW environment. In an effort to reduce these transient
   problems, switch the base container to a non-Alpine platform.

   A ticket has been filed with a repro for Alpine DNS issues under LCOW
   https://github.com/docker/libnetwork/issues/2371

 - While this may increase the image size by about 100MB, the goal here
   is reliability and robustness

   for the builder container:
   clojure:lein-alpine was about 142MB
   clojure:openjdk-8-lein is about 507MB

	 for the target container:
   openjdk:8-jre-alpine was about 85MB
   openjdk:8-buster-slim is about 184MB

 - Ubuntu 18.04 shares a lineage with debian buster, which should
   be a well supported platform for PDB

   All OpenJDK container variants are listed at:
   https://github.com/docker-library/docs/blob/master/openjdk/README.md#supported-tags-and-respective-dockerfile-links