### PR TITLE
(PDB-4482) Suppress duplicate catalog inputs on ingestion

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -834,7 +834,10 @@
   [certid inputs]
     (jdbc/insert-multi! :catalog_inputs
                         [:certname_id :type :name]
-                        (map #(apply vector certid %) inputs)))
+                        (sequence (comp
+                                   (map #(apply vector certid %))
+                                   (distinct))
+                                  inputs)))
 
 (defn update-catalog-input-metadata!
   [certid catalog-uuid last-updated]


### PR DESCRIPTION
I imagine we'll eventually want an index anyway, that'd end up
requiring uniqueness, but for now suppress them so that they won't be
visible to queries, etc.