### PR TITLE
(maint) Add Postgres pg_isready based healthcheck

### DIFF
--- a/docker/.rspec
+++ b/docker/.rspec
@@ -2,3 +2,4 @@
 --format RspecJunitFormatter
 --out TEST-rspec.xml
 --format documentation
+--fail-fast

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,12 @@ services:
       - POSTGRES_PASSWORD=puppetdb
       - POSTGRES_USER=puppetdb
       - POSTGRES_DB=puppetdb
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready --username=puppetdb --dbname=puppetdb"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 90s
     expose:
       - 5432
     volumes:

--- a/docker/spec/puppetdb_spec.rb
+++ b/docker/spec/puppetdb_spec.rb
@@ -31,7 +31,7 @@ describe 'puppetdb container specs' do
 
     # fire up the cluster and wait for puppetdb creation in postgres
     run_command('docker-compose --no-ansi up --detach')
-    wait_on_postgres_db('puppetdb')
+    wait_on_service_health('postgres', 90)
   end
 
   after(:all) do

--- a/docker/spec/puppetdb_spec.rb
+++ b/docker/spec/puppetdb_spec.rb
@@ -11,26 +11,17 @@ describe 'puppetdb container specs' do
   ]
 
   before(:all) do
-    if ENV['PUPPET_TEST_DOCKER_IMAGE'].nil?
-      fail <<-MSG
-      error_message = <<-MSG
-  * * * * *
-  PUPPET_TEST_DOCKER_IMAGE environment variable must be set so we
-  know which image to test against!
-  * * * * *
-      MSG
-    end
-    status = run_command('docker-compose --no-ansi version')[:status]
+    require_test_image()
+    status = docker_compose('version')[:status]
     if status.exitstatus != 0
       fail "`docker-compose` must be installed and available in your PATH"
     end
-
     teardown_cluster()
     # LCOW requires directories to exist
     create_host_volume_targets(ENV['VOLUME_ROOT'], VOLUMES)
 
     # fire up the cluster and wait for puppetdb creation in postgres
-    run_command('docker-compose --no-ansi up --detach')
+    docker_compose_up()
     wait_on_service_health('postgres', 90)
   end
 


### PR DESCRIPTION
 - pupperware stack is using this as a healthcheck, which allows
   replacing any calls to PDB specific waiters with a generic
   health waiter