### PR TITLE
(maint) Update Docker Postgres healthcheck

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       - POSTGRES_USER=puppetdb
       - POSTGRES_DB=puppetdb
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready --username=puppetdb --dbname=puppetdb"]
+      # existence check for puppetdb database
+      test: [ 'CMD-SHELL', "psql --username=puppetdb puppetdb -c ''" ]
       interval: 10s
       timeout: 5s
       retries: 6


### PR DESCRIPTION
 - pg_isready is insufficient for determining that the Postgres database
   is "healthy", since it seems to return a 0 exit code, even for
   invalid user names or invalid databases

 - Instead use a similar check to what spec helpers used to do (i.e.
   establishing that the puppetdb database can be connected to from
   the puppetdb user - this is equivalent to counting databases in the
   postgres system table)

   Adapted from https://stackoverflow.com/questions/14549270

 - Examples of what the script reports to docker when the database is
   not reachable (from `docker inspect`)

```json
"Health": {
    "Status": "healthy",
    "FailingStreak": 0,
    "Log": [
        {
            "Start": "2019-08-20T22:49:19.4322016Z",
            "End": "2019-08-20T22:49:19.7158295Z",
            "ExitCode": 2,
            "Output": "psql: could not connect to server: No such file or directory\n\tIs the server running locally and accepting\n\tconnections on Unix domain socket \"/var/run/postgresql/.s.PGSQL.5432\"?\n"
        },
        {
            "Start": "2019-08-20T22:49:29.6926096Z",
            "End": "2019-08-20T22:49:29.8910214Z",
            "ExitCode": 2,
            "Output": "psql: FATAL:  database \"puppetdb\" does not exist\n"
        },
        {
            "Start": "2019-08-20T22:49:39.9011976Z",
            "End": "2019-08-20T22:49:40.2243735Z",
            "ExitCode": 0,
            "Output": ""
        }
    ]
}
```