### PR TITLE
(maint) disable tests that cannot pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,17 +120,17 @@ jobs:
       script: *run-integration-tests
 
     # === integration with current platform
-    - stage: ❧ pdb tests
-      env: PDB_TEST=int/openjdk11/pup-6.4.x/srv-6.3.x/pg-9.6
-      script: *run-integration-tests
+      #- stage: ❧ pdb tests
+      #  env: PDB_TEST=int/openjdk11/pup-6.4.x/srv-6.3.x/pg-9.6
+      #  script: *run-integration-tests
 
-    - stage: ❧ pdb tests
-      env: PDB_TEST=int/openjdk11/pup-6.4.x/srv-6.3.x/pg-9.6/rich
-      script: *run-integration-tests
+      #- stage: ❧ pdb tests
+      #env: PDB_TEST=int/openjdk11/pup-6.4.x/srv-6.3.x/pg-9.6/rich
+      #script: *run-integration-tests
 
-    - stage: ❧ pdb tests
-      env: PDB_TEST=int/openjdk8/pup-6.4.x/srv-6.3.x/pg-9.6/rich
-      script: *run-integration-tests
+      #- stage: ❧ pdb tests
+      #env: PDB_TEST=int/openjdk8/pup-6.4.x/srv-6.3.x/pg-9.6/rich
+      #script: *run-integration-tests
 
     # === rspec tests
     - stage: ❧ pdb tests


### PR DESCRIPTION
with clj-parent 4.0.4, you cannot run puppetserver 6.4 in the same JVM
as puppetdb. We will address this in a future change to run puppetserver
and puppetdb in separate JVMs.