### PR TITLE
(PDB-4487) Fixing Standalone Nodes using SSLContext

### DIFF
--- a/puppet/lib/puppet/util/puppetdb/config.rb
+++ b/puppet/lib/puppet/util/puppetdb/config.rb
@@ -13,10 +13,11 @@ module Puppet::Util::Puppetdb
         :soft_write_failure          => false,
         :server_url_timeout          => 30,
         :include_unchanged_resources => false,
-        :min_successful_submissions => 1,
-        :submit_only_server_urls   => "",
-        :command_broadcast         => false,
-        :sticky_read_failover      => false
+        :min_successful_submissions  => 1,
+        :submit_only_server_urls     => "",
+        :command_broadcast           => false,
+        :sticky_read_failover        => false,
+        :verify_client_certificate   => true
       }
 
       config_file ||= File.join(Puppet[:confdir], "puppetdb.conf")
@@ -67,7 +68,8 @@ module Puppet::Util::Puppetdb
            :min_successful_submissions,
            :submit_only_server_urls,
            :command_broadcast,
-           :sticky_read_failover].include?(k))
+           :sticky_read_failover,
+           :verify_client_certificate].include?(k))
       end
 
       parsed_urls = config_hash[:server_urls].split(",").map {|s| s.strip}
@@ -81,6 +83,7 @@ module Puppet::Util::Puppetdb
       config_hash[:min_successful_submissions] = config_hash[:min_successful_submissions].to_i
       config_hash[:command_broadcast] = Puppet::Util::Puppetdb.to_bool(config_hash[:command_broadcast])
       config_hash[:sticky_read_failover] = Puppet::Util::Puppetdb.to_bool(config_hash[:sticky_read_failover])
+      config_hash[:verify_client_certificate] = Puppet::Util::Puppetdb.to_bool(config_hash[:verify_client_certificate])
 
       if config_hash[:soft_write_failure] and config_hash[:min_successful_submissions] > 1
         raise "soft_write_failure cannot be enabled when min_successful_submissions is greater than 1"
@@ -145,6 +148,10 @@ module Puppet::Util::Puppetdb
 
     def sticky_read_failover
       config[:sticky_read_failover]
+    end
+
+    def verify_client_certificate
+      config[:verify_client_certificate]
     end
 
     # @!group Private instance methods

--- a/puppet/spec/unit/util/puppetdb/config_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/config_spec.rb
@@ -152,7 +152,7 @@ CONF
           config = described_class.load
         end.to raise_error(/PuppetDB 'server_urls' must be https, found 'http:\/\/foo.something-different.com'/)
       end
-      
+
       it "should fail if given a URL path" do
         uri_string = ""
         write_config <<CONF
@@ -316,6 +316,18 @@ CONF
         config = described_class.load
         config.server_urls.should == [URI("https://foo.com"), URI("https://bar.com")]
         config.sticky_read_failover.should == true
+      end
+
+      it "should read verify_client_certificate" do
+        write_config <<CONF
+[main]
+server_urls = https://foo.com,https://bar.com
+verify_client_certificate = false
+CONF
+
+        config = described_class.load
+        config.server_urls.should == [URI("https://foo.com"), URI("https://bar.com")]
+        config.verify_client_certificate.should == false
       end
 
     end


### PR DESCRIPTION
As part of work to migrate to `Puppet::SSL::SSLContext`, we have unintentionally broken
compatibility with standalone/masterless nodes, who don't have a local CA or cert chain
to validate.

This commit introduces a new configuration variable (name TBC), and uses it to either
inherit from Puppet's SSL context (if we are running with a master and certificates)
or allows simple CA/CRL validation in the event that the PuppetDB server is using
either self-signed or commodity certificates.

Handoff to Puppet for these settings is via the configuration options `localcacert`
and `certificate_revocation` - if using a commodity certificate, `localcacert` should
be pointed to your OS local trust-store, and `certificate_revocation` set to `false`. If
using a self-signed certificate, this needs to be provisioned to each standalone node.