### PR TITLE
(maint) Load OpenSSL library for lein gem commands

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -304,10 +304,10 @@
                                          (if (map? prev) [new prev] (conj prev new)))
                                        #(spit %1 (pr-str %2))]}
 
-  :aliases {"gem" ["with-profie" "install-gems"
+  :aliases {"gem" ["with-profile" "install-gems,dev"
                    "trampoline" "run" "-m" "puppetlabs.puppetserver.cli.gem"
                    "--config" "./test-resources/puppetserver/puppetserver.conf"]
-            "install-gems" ["with-profile" "install-gems"
+            "install-gems" ["with-profile" "install-gems,dev"
                             "trampoline" "run" "-m" "puppetlabs.puppetdb.integration.install-gems"
                             ~puppetserver-test-dep-gem-list
                             "--config" "./test-resources/puppetserver/puppetserver.conf"]


### PR DESCRIPTION
Without the `dev` profile, no OpenSSL library would be loaded, which
causes gem installation to fail with an error such as,

ERROR:  Loading command: install (NameError)
        cannot load (ext) (org.jruby.ext.openssl.OpenSSL)
ERROR:  While executing gem ... (NoMethodError)
    undefined method `invoke_with_build_args' for nil:NilClass