### PR TITLE
(maint) Change HikariCP FailFast to FailTimeout

### DIFF
--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -530,7 +530,7 @@
      (doto config
        (.setJdbcUrl (str "jdbc:" subprotocol ":" subname))
        (.setAutoCommit false)
-       (.setInitializationFailFast false)
+       (.setInitializationFailTimeout -1)
        (.setTransactionIsolation "TRANSACTION_READ_COMMITTED"))
      (some->> pool-name (.setPoolName config))
      (some->> connection-timeout (.setConnectionTimeout config))


### PR DESCRIPTION
The failfast property of HikariCP is deprecated and replaced with a
failtimeout.

Our previous setting of failfast=false would not error when the
minimum number of connections could not be obtained. The new fail
timeout setting of less than zero will mean the pool will start
immediately, and it will not timeout if it can't establish the minimum
number connections.