### PR TITLE
(maint) Change order of left-join for catalog-inputs query

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -765,11 +765,11 @@
       "inputs" {:type :array
                 :queryable? true
                 :field :ci.inputs}}
-     :selection {:from [:certnames]
-                 :left-join [[{:select [:certname_id
-                                        [(hcore/raw "array_agg(array[catalog_inputs.type, name])") :inputs]]
-                              :from [:catalog_inputs]
-                              :group-by [:certname_id]} :ci]
+     :selection {:from [[{:select [:certname_id
+                                   [(hcore/raw "array_agg(array[catalog_inputs.type, name])") :inputs]]
+                          :from [:catalog_inputs]
+                          :group-by [:certname_id]} :ci]]
+                 :left-join [:certnames
                              [:= :certnames.id :ci.certname_id]]}
      :relationships certname-relations
 


### PR DESCRIPTION
Prior to this commit the catalog-inputs-query would return rows for
any entry in the certnames table even if that entry didn't have inputs.
This would cause a validaion error in the row munging function.