### PR TITLE
(maint) Fix install of puppetserver

### DIFF
--- a/acceptance/setup/pre_suite/75_clean_out_puppet5_repos.rb
+++ b/acceptance/setup/pre_suite/75_clean_out_puppet5_repos.rb
@@ -16,7 +16,7 @@ if (test_config[:install_mode] == :upgrade_oldest) \
         # install puppet 6 directly to prepare for upgrade
         install_puppet_agent_on(database, {:puppet_collection => "puppet6"})
         on(database, puppet('resource', 'host', 'updates.puppetlabs.com', 'ensure=present', "ip=127.0.0.1") )
-        install_package(database, 'puppetserver')
+        database.install_package('puppetserver', '-o Dpkg::Options::="--force-confnew"')
       end
     end
   end


### PR DESCRIPTION
During an upgrade_oldest test, the config file of puppetserver
had changed so the install of the new puppetserver was hanging
on confirming what to do with the changed conf file. Now it will
always take the new config file.