### PR TITLE
(maint) Re-add bouncycastle to uberjar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -284,8 +284,14 @@
                                  ;; integration tests cycle jruby a lot, which chews through permgen
                                  ^:replace ["-XX:MaxPermSize=500M"]
                                  [])}
-             :uberjar {:aot ~pdb-aot-namespaces}
-             :provided {:dependencies [[org.bouncycastle/bcpkix-jdk15on]]}}
+             ; We only want to include bouncycastle in the FOSS uberjar.
+             ; PE should be handled by selecting the proper bouncycastle jar
+             ; at runtime (standard/fips)
+             :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk15on]]
+                       :aot ~pdb-aot-namespaces}
+             :fips {:exclusions [org.bouncycastle/bcpkix-jdk15on]
+                    :dependencies [[org.bouncycastle/bcpkix-fips]
+                                   [org.bouncycastle/bc-fips]]}}
 
   :jar-exclusions [#"leiningen/"]
 


### PR DESCRIPTION
Longer term excluding the bouncycastle jar from the uberjar and loading
either the standard or the FIPs version at runtime is likely simpler,
but for now, the infrastructure for that does not exist so we'll revert
to building either a standard uberjar or a FIPs uberjar (with the fips
profile).