### PR TITLE
(maint) Add bouncycastle to ezbake profile

### DIFF
--- a/acceptance/setup/pre_suite/15_setup_repos.rb
+++ b/acceptance/setup/pre_suite/15_setup_repos.rb
@@ -1,6 +1,10 @@
 unless (test_config[:skip_presuite_provisioning])
   step "Install Puppet Labs repositories" do
 
+    if is_rhel8
+      on(hosts, 'update-crypto-policies --set LEGACY')
+    end
+
     hosts.each do |host|
       initialize_repo_on_host(host, test_config[:os_families][host.name], test_config[:nightly], puppet_repo_version)
     end

--- a/project.clj
+++ b/project.clj
@@ -257,6 +257,10 @@
                                                ;; Hopefully we can remove those `nil`s (if we care)
                                                ;; and this comment when lein 2.7.2 is available.
 
+                                               ;; ezbake does not use the uberjar profile so we need
+                                               ;; to duplicate this dependency here
+                                               [org.bouncycastle/bcpkix-jdk15on nil]
+
                                                ;; we need to explicitly pull in our parent project's
                                                ;; clojure version here, because without it, lein
                                                ;; brings in its own version, and older versions of


### PR DESCRIPTION
Ezbake does not use the :uberjar profile, so
it could not find any bouncycastle library.