### PR TITLE
(PDB-4278) Add metric that tracks "bashed" commands

### DIFF
--- a/documentation/api/metrics/v1/mbeans.markdown
+++ b/documentation/api/metrics/v1/mbeans.markdown
@@ -111,6 +111,7 @@ following `<item>`s:
   previously enqueued commands
 * `queue-time`: histogram of the time commands have spent waiting in the queue
 * `depth`: number of currently enqueued commands
+* `ignored`: number of obsolete commands that have been ignored
 * `size`: histogram of submitted command sizes (i.e. HTTP Content-Lengths)
 
 For example: `puppetlabs.puppetdb.mq:name=global.seen`.
@@ -128,6 +129,7 @@ integer command version, and `<item>` must be one of the following:
 * `retried`: meter measuring commands scheduled for retrial
 * `retry-counts`: histogram of retry counts (until success or discard)
 * `discarded`: meter measuring commands discarded as invalid
+* `ignored`: number of obsolete commands that have been ignored
 * `processing-time`: timing statistics for the processing of
   previously enqueued commands
 

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -462,7 +462,8 @@
           command-chan (async/chan
                          (queue/sorted-command-buffer
                           max-enqueued
-                          #(cmd/update-counter! :invalidated %1 %2 inc!)))
+                          #(cmd/update-counter! :invalidated %1 %2 inc!)
+                          #(cmd/update-counter! :ignored %1 %2 inc!)))
           emit-cmd-events? (or (conf/pe? config) emit-cmd-events?)
           maybe-send-cmd-event! (partial maybe-send-cmd-event! emit-cmd-events? cmd-event-ch)
           [q load-messages] (queue/create-or-open-stockpile (conf/stockpile-dir config)

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -462,8 +462,8 @@
           command-chan (async/chan
                          (queue/sorted-command-buffer
                           max-enqueued
-                          #(cmd/update-counter! :invalidated %1 %2 inc!)
-                          #(cmd/update-counter! :ignored %1 %2 inc!)))
+                          (fn [cmd ver] (cmd/update-counter! :invalidated cmd ver inc!))
+                          (fn [cmd ver] (cmd/update-counter! :ignored cmd ver inc!))))
           emit-cmd-events? (or (conf/pe? config) emit-cmd-events?)
           maybe-send-cmd-event! (partial maybe-send-cmd-event! emit-cmd-events? cmd-event-ch)
           [q load-messages] (queue/create-or-open-stockpile (conf/stockpile-dir config)

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -106,6 +106,7 @@
 ;;         :queue-time <histogram>
 ;;         :retry-counts <histogram>
 ;;         :size <histogram>
+;;         :ignored <counter>
 ;;        }
 ;;      "command name"
 ;;        {<version number>
@@ -116,6 +117,7 @@
 ;;            :discarded <meter>
 ;;            :processing-time <timer>
 ;;            :retry-counts <histogram>
+;;            :ignored <counter>
 ;;           }
 ;;        }
 ;;     }
@@ -140,6 +142,7 @@
 ;; * `:invalidated`: commands marked as delete?, caused by a newer command
 ;;                   was enqueued that will overwrite an existing one in the queue
 ;; * `:depth`: number of commands currently enqueued
+;; * `:ignored`: number of obsolete commands that have been ignored.
 ;;
 
 (def mq-metrics-registry (get-in metrics/metrics-registries [:mq :registry]))
@@ -159,7 +162,8 @@
      :fatal (meter mq-metrics-registry (to-metric-name-fn :fatal))
      :retried (meter mq-metrics-registry (to-metric-name-fn :retried))
      :awaiting-retry (counter mq-metrics-registry (to-metric-name-fn :awaiting-retry))
-     :discarded (meter mq-metrics-registry (to-metric-name-fn :discarded))}))
+     :discarded (meter mq-metrics-registry (to-metric-name-fn :discarded))
+     :ignored (counter mq-metrics-registry (to-metric-name-fn :ignored))}))
 
 (def metrics
   (atom {:command-parse-time (timer mq-metrics-registry

--- a/src/puppetlabs/puppetdb/queue.clj
+++ b/src/puppetlabs/puppetdb/queue.clj
@@ -360,7 +360,8 @@
 (deftype SortedCommandBuffer [^TreeMap fifo-queue
                               ^HashMap certnames-map
                               ^long max-entries
-                              ^clojure.lang.IFn delete-update-fn]
+                              ^clojure.lang.IFn delete-update-fn
+                              ^clojure.lang.IFn ignore-update-fn]
   async-protos/Buffer
   (full? [this]
     (>= (.size fifo-queue) max-entries))
@@ -400,6 +401,7 @@
                     (:id maybe-old-command)
                     (assoc maybe-old-command :delete? true))
               (.put fifo-queue (:id cmdref) cmdref)
+              (ignore-update-fn (:command maybe-old-command) (:version maybe-old-command))
               (delete-update-fn (:command maybe-old-command) (:version maybe-old-command)))
 
             :else
@@ -419,12 +421,12 @@
 
 (defn sorted-command-buffer
   ([^long n]
-   (sorted-command-buffer n (constantly nil)))
-  ([^long n ^clojure.lang.IFn delete-update-fn]
+   (sorted-command-buffer n (constantly nil) (constantly nil)))
+  ([^long n ^clojure.lang.IFn delete-update-fn ignore-update-fn]
    ;; accepting a function here is a hack to get around a cyclic dependency
    ;; between this ns, mq-listener.clj, and dlo.clj. My hope is we'll be able
    ;; to get rid of it somehow when we refactor mq-listener and command.clj.
-   (SortedCommandBuffer. (TreeMap.) (HashMap.) n delete-update-fn)))
+   (SortedCommandBuffer. (TreeMap.) (HashMap.) n delete-update-fn ignore-update-fn)))
 
 (defn make-cmd-event
   "Given a cmdref and kind return a cmd-event-map which is suitable to be put


### PR DESCRIPTION
This commit adds a metric that tracks the number of commands which are
"bashed" in the command queue.