### PR TITLE
(MAINT) Remove --fail-fast

### DIFF
--- a/docker/.rspec
+++ b/docker/.rspec
@@ -2,4 +2,3 @@
 --format RspecJunitFormatter
 --out TEST-rspec.xml
 --format documentation
---fail-fast


### PR DESCRIPTION
We already fail fast when the :before block errors, and we'd prefer to
run all tests if we get out of that block.