### PR TITLE
(PDB-4505) Log progress during resource-events-pk migration

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -157,6 +157,7 @@
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]
                  [puppetlabs/stockpile "0.0.4"]
+                 [puppetlabs/structured-logging]
                  [puppetlabs/tools.namespace "0.2.4.1"]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-webserver-jetty9]

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -63,6 +63,7 @@
             [puppetlabs.puppetdb.config :as conf]
             [puppetlabs.i18n.core :refer [trs]]
             [puppetlabs.puppetdb.scf.hash :as hash]
+            [puppetlabs.structured-logging.core :refer [maplog]]
             [clojure.set :as set]
             [clojure.string :as str])
   (:import [org.postgresql.util PGobject]))
@@ -1552,7 +1553,9 @@
        (reduce (fn [hashes-seen [row i]]
                  (let [now (.getTime (java.util.Date.))]
                    (when (> (- now @last-logged) 60000)
-                     (log/info (trs "Migrated {0} of {1} events" i event-count))
+                     (maplog :info
+                             {:migration 69 :at i :of event-count}
+                             #(trs "Migrated {0} of {1} events" (:at %) (:of %)))
                      (reset! last-logged now)))
                  (conj hashes-seen
                        (let [hash-str (hash/resource-event-identity-pkey row)]


### PR DESCRIPTION
Log "Migrated X of Y events" roughly once per minute during the
migration so that you can fairly quickly estimate about how long it
might take, and can see that it's making progress.