### PR TITLE
(docs) Add documentation for 'verify_client_certificate'

### DIFF
--- a/documentation/connect_puppet_apply.markdown
+++ b/documentation/connect_puppet_apply.markdown
@@ -98,7 +98,11 @@ You can specify the contents of [puppetdb.conf][puppetdb_conf] directly in your 
     server = puppetdb.example.com
     port = 8081
 
-PuppetDB's port for secure traffic defaults to 8081. Puppet **requires** use of PuppetDB's secure HTTPS port. You cannot use the unencrypted, plain HTTP port.
+PuppetDB's port for secure traffic defaults to 8081. Puppet **requires** use of PuppetDB's
+secure HTTPS port. You cannot use the unencrypted, plain HTTP port.
+If you are providing SSL via a proxy like nginx (Option A in Step 1) then you need to set
+`verify_client_certificate` to `false`, otherwise Puppet will attempt to verify that
+your certificate was issued by the Puppet Master.
 
 For availability reasons, there is a setting named `soft_write_failure` that will cause the PuppetDB-termini to fail in a soft manner if PuppetDB is not accessible for command submission. This means that users who are either not using storeconfigs or only exporting resources will still have their catalogs compile during a PuppetDB outage.
 

--- a/documentation/release_notes/release_notes_latest.markdown
+++ b/documentation/release_notes/release_notes_latest.markdown
@@ -17,6 +17,7 @@ canonical: "/puppetdb/latest/release_notes.html"
 [queue_support_guide]: ./pdb_support_guide.html#message-queue
 [upgrade_policy]: ./versioning_policy.html#upgrades
 [facts]: ./api/query/v4/facts.html
+[puppet_apply]: ./connect_puppet_apply.html
 
 ## PuppetDB 6.6.0
 
@@ -25,8 +26,8 @@ canonical: "/puppetdb/latest/release_notes.html"
 ### Bug fixes
 
 - A change in the `puppetdb-termini` package for 6.5.0 broke SSL connections that
-  did not use Puppet's CA. This fix adds the `verify_client_connection`. By
-  default, `verify_client_connection` only allows SSL connections authenticated by the
+  did not use Puppet's CA. This fix adds [the `verify_client_connection` configuration option][puppet_apply].
+  By default, `verify_client_connection` only allows SSL connections authenticated by the
   Puppet CA. When set to `false`, it allows the use of other SSL connections. [PDB-4487](https://tickets.puppetlabs.com/browse/PDB-4487)
 
 - Fixed an issue where package upgrades on CentOS 6 would sometimes fail when


### PR DESCRIPTION
This configuration option was added to allow SSL connections to be made
between Puppet and PuppetDB when they are not using the Puppet Server
CA.