### PR TITLE
(maint) Specify Docker volumes explicitly

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       - 5432
     volumes:
       - ./puppetdb/postgres-custom:/docker-entrypoint-initdb.d
-      - ${VOLUME_ROOT:-.}/pgdata:/var/lib/postgresql/data
     dns_search: 'test'
     networks:
       puppetdb_test:

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -66,8 +66,6 @@ ENV SERVICE_STOP_RETRIES=60
 COPY docker/puppetdb/logging /etc/puppetlabs/puppetdb/logging/
 COPY docker/puppetdb/conf.d /etc/puppetlabs/puppetdb/conf.d/
 COPY resources/puppetlabs/puppetdb/bootstrap.cfg /etc/puppetlabs/puppetdb/
-COPY resources/ext/config/logback.xml /etc/puppetlabs/puppetdb/
-COPY resources/ext/config/request-logging.xml /etc/puppetlabs/puppetdb/
 RUN mkdir -p /opt/puppetlabs/server/data/puppetdb
 
 RUN addgroup $GROUP && adduser --system $USER --ingroup $GROUP

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -100,7 +100,5 @@ HEALTHCHECK --start-period=5m --interval=10s --timeout=10s --retries=6 CMD ["/he
 VOLUME /etc/puppetlabs/puppet/ssl
 # puppetdb data
 VOLUME /opt/puppetlabs/server/data/puppetdb
-# log files
-VOLUME /var/log/puppetlabs
 
 COPY docker/puppetdb/Dockerfile /

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -75,8 +75,6 @@ RUN chmod +x /ssl.sh
 COPY docker/puppetdb/ssl-setup.sh /
 RUN chmod +x /ssl-setup.sh
 
-VOLUME /etc/puppetlabs/puppet/ssl/
-
 ADD https://raw.githubusercontent.com/puppetlabs/wtfc/6aa5eef89728cc2903490a618430cc3e59216fa8/wtfc.sh /wtfc.sh
 RUN chmod +x /wtfc.sh
 COPY docker/puppetdb/docker-entrypoint.sh /
@@ -96,5 +94,13 @@ RUN chmod +x /healthcheck.sh
 # Probe failure during --start-period will not be counted towards the maximum number of retries
 HEALTHCHECK --start-period=5m --interval=10s --timeout=10s --retries=6 CMD ["/healthcheck.sh"]
 
+# VOLUME definitions are always at end of Dockerfile to address an LCOW bug
+# https://github.com/moby/moby/issues/39892
+# generated certs
+VOLUME /etc/puppetlabs/puppet/ssl
+# puppetdb data
+VOLUME /opt/puppetlabs/server/data/puppetdb
+# log files
+VOLUME /var/log/puppetlabs
 
 COPY docker/puppetdb/Dockerfile /

--- a/docker/puppetdb/logging/logback.xml
+++ b/docker/puppetdb/logging/logback.xml
@@ -1,11 +1,56 @@
-<configuration scan="true">
+<configuration scan="true" scanPeriod="60 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
+            <!-- default pattern
+              %d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5p [%c{2}] %m%n
+            -->
             <pattern>%d %-5p [%c{2}] %m%n</pattern>
         </encoder>
     </appender>
 
+    <appender name="F1" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/var/log/puppetlabs/puppetdb/puppetdb.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <!-- each file should be at most 200MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>200MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Supress internal Spring Framework logging -->
+    <logger name="org.springframework.jms.connection" level="warn"/>
+
+    <appender name="STATUS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/var/log/puppetlabs/puppetdb/puppetdb-status.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- rollover daily -->
+            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-status-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <!-- each file should be at most 200MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>200MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <!-- note that this will only log the JSON message (%m) and a newline (%n)-->
+            <pattern>%m%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- without additivity="false", the status log messages will be sent to every other appender as well-->
+    <logger name="puppetlabs.trapperkeeper.services.status.status-debug-logging" level="debug" additivity="false">
+        <appender-ref ref="STATUS"/>
+    </logger>
+
     <root level="info">
         <appender-ref ref="STDOUT"/>
+        <appender-ref ref="${logappender:-DUMMY}" />
+        <appender-ref ref="F1" />
     </root>
 </configuration>

--- a/docker/puppetdb/logging/logback.xml
+++ b/docker/puppetdb/logging/logback.xml
@@ -9,10 +9,10 @@
     </appender>
 
     <appender name="F1" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/var/log/puppetlabs/puppetdb/puppetdb.log</file>
+        <file>/opt/puppetlabs/server/data/puppetdb/logs/puppetdb.log</file>
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>/opt/puppetlabs/server/data/puppetdb/logs/puppetdb-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
             <!-- each file should be at most 200MB, keep 90 days worth of history, but at most 1GB total-->
             <maxFileSize>200MB</maxFileSize>
             <maxHistory>90</maxHistory>
@@ -27,11 +27,11 @@
     <logger name="org.springframework.jms.connection" level="warn"/>
 
     <appender name="STATUS" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/var/log/puppetlabs/puppetdb/puppetdb-status.log</file>
+        <file>/opt/puppetlabs/server/data/puppetdb/logs/puppetdb-status.log</file>
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- rollover daily -->
-            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-status-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>/opt/puppetlabs/server/data/puppetdb/logs/puppetdb-status-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
             <!-- each file should be at most 200MB, keep 90 days worth of history, but at most 1GB total-->
             <maxFileSize>200MB</maxFileSize>
             <maxHistory>90</maxHistory>

--- a/docker/puppetdb/logging/request-logging.xml
+++ b/docker/puppetdb/logging/request-logging.xml
@@ -5,10 +5,10 @@
         </encoder>
     </appender>
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/var/log/puppetlabs/puppetdb/puppetdb-access.log</file>
+        <file>/opt/puppetlabs/server/data/puppetdb/logs/puppetdb-access.log</file>
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-access-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>/opt/puppetlabs/server/data/puppetdb/logs/puppetdb-access-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
             <!-- each file should be at most 200MB, keep 90 days worth of history, but at most 1GB total-->
             <maxFileSize>200MB</maxFileSize>
             <maxHistory>90</maxHistory>

--- a/docker/puppetdb/logging/request-logging.xml
+++ b/docker/puppetdb/logging/request-logging.xml
@@ -4,6 +4,20 @@
           <pattern>combined</pattern>
         </encoder>
     </appender>
-
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/var/log/puppetlabs/puppetdb/puppetdb-access.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>/var/log/puppetlabs/puppetdb/puppetdb-access-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <!-- each file should be at most 200MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>200MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D</pattern>
+        </encoder>
+    </appender>
+    <appender-ref ref="FILE" />
     <appender-ref ref="STDOUT"/>
 </configuration>

--- a/docker/spec/puppetdb_spec.rb
+++ b/docker/spec/puppetdb_spec.rb
@@ -6,10 +6,6 @@ require 'net/http'
 describe 'puppetdb container specs' do
   include Pupperware::SpecHelpers
 
-  VOLUMES = [
-    'pgdata'
-  ]
-
   before(:all) do
     require_test_image()
     status = docker_compose('version')[:status]
@@ -17,8 +13,6 @@ describe 'puppetdb container specs' do
       fail "`docker-compose` must be installed and available in your PATH"
     end
     teardown_cluster()
-    # LCOW requires directories to exist
-    create_host_volume_targets(ENV['VOLUME_ROOT'], VOLUMES)
 
     # fire up the cluster and wait for puppetdb creation in postgres
     docker_compose_up()


### PR DESCRIPTION
- Dockerfile was copying 2 files that were unused. Restore the default
       logging configuration files to write to files in addition to STDOUT
  
  Since PDB was already configured to remove timestamps over STDOUT in the logback.xml, keep it configured as such (Docker also emits timestamps, so dupes are not needed)

- It turns out that LCOW has a bug with permissions on Docker VOLUMEs which is why Postgres Linux container won't start by default. This issue is filed as https://github.com/moby/moby#39922

       For now, our hosts have granted permissions to the group that runs
       all containers (NT VIRTUAL MACHINE\Virtual Machines) so that symlinks
       can be created inside NTFS backed VOLUMEs for Linux containers, as
       is required for Postgres container initialization

- Based on the container configuration, there are 3 separate locations
       where persistent data is located, so explicitly specify those:

  * generated certs (when puppetserver is connected)
  * puppetdb data
  * log files

- This data will be updated to consume only a single VOLUME in a future commit to make VOLUME management simpler and align around the same configuration as PE

 - Reconfigure logs for /opt/puppetlabs/server/data/puppetdb/logs rather than /var/logs/puppetlabs/puppetdb so that we can remove one of the defined Docker VOLUME declarations