### PR TITLE
(maint) Use all hostnames for Docker DNS_ALT_NAME

### DIFF
--- a/docker/puppetdb/docker-entrypoint.d/30-configure-ssl.sh
+++ b/docker/puppetdb/docker-entrypoint.d/30-configure-ssl.sh
@@ -4,7 +4,7 @@
 if [ ! -f "${SSLDIR}/certs/${CERTNAME}.pem" ] && [ "$USE_PUPPETSERVER" = true ]; then
   set -e
 
-  DNS_ALT_NAMES="${HOSTNAME},${DNS_ALT_NAMES}" /ssl.sh "$CERTNAME"
+  DNS_ALT_NAMES="${HOSTNAME},$(hostname -s),$(hostname -f),${DNS_ALT_NAMES}" /ssl.sh "$CERTNAME"
 fi
 
 # cert files are present from Puppetserver OR have been user supplied


### PR DESCRIPTION
 - Docker supplies the HOSTNAME value, which may be different from how
   host recognizes its hostname setting (short and fully qualified).

   While these values may be duplicated, that's OK b/c the ssl.sh
   script doesn't care if names are duplicated.

 - NOTE: hostname -s / hostname -f doesn't properly return under LCOW
   like it does on Linux, and always returns the short name