### PR TITLE
(maint) Fix Docker Jetty SSL configuration

### DIFF
--- a/docker/puppetdb/conf.d/jetty.ini
+++ b/docker/puppetdb/conf.d/jetty.ini
@@ -7,26 +7,26 @@ host = 0.0.0.0
 # Port to listen on for clear-text HTTP.
 port = 8080
 
-# The following are SSL specific settings. They can be configured
-# automatically with the tool `puppetdb ssl-setup`, which is normally
-# ran during package installation.
+# The following are SSL specific settings.
+# They are enabled by setting USE_PUPPETSERVER=true (the default) when starting
+# the container by the configure-ssl.sh entrypoint script
 
 # IP address to listen on for HTTPS connections. Hostnames can also be used
 # but are not recommended to avoid DNS resolution issues. To listen on all
 # interfaces, use `0.0.0.0`.
-# ssl-host = <host>
+# ssl-host = 0.0.0.0
 
 # The port to listen on for HTTPS connections
-ssl-port = 8081
+# ssl-port = 8081
 
 # Private key path
-ssl-key = /opt/puppetlabs/server/data/puppetdb/certs/private_keys/private.pem
+# ssl-key = /opt/puppetlabs/server/data/puppetdb/certs/private_keys/private.pem
 
 # Public certificate path
-ssl-cert = /opt/puppetlabs/server/data/puppetdb/certs/certs/public.pem
+# ssl-cert = /opt/puppetlabs/server/data/puppetdb/certs/certs/public.pem
 
 # Certificate authority path
-ssl-ca-cert = /opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem
+# ssl-ca-cert = /opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem
 
 # Access logging configuration path. To turn off access logging
 # comment out the line with `access-log-config=...`

--- a/docker/puppetdb/docker-entrypoint.d/30-configure-ssl.sh
+++ b/docker/puppetdb/docker-entrypoint.d/30-configure-ssl.sh
@@ -10,6 +10,8 @@ if [ ! -f "${SSLDIR}/certs/${CERTNAME}.pem" ] && [ "$USE_PUPPETSERVER" = true ];
   ln -s ${SSLDIR}/private_keys/${CERTNAME}.pem ${SSLDIR}/private_keys/private.pem
   ln -s ${SSLDIR}/certs/${CERTNAME}.pem ${SSLDIR}/certs/public.pem
 
+  sed -i '/^# ssl-/s/^# //g' /etc/puppetlabs/puppetdb/conf.d/jetty.ini
+
   # make sure Java apps running as puppetdb can read these files
   chown -R puppetdb:puppetdb ${SSLDIR}
 


### PR DESCRIPTION
Should have been included in #3082 (specifically as part of https://github.com/puppetlabs/puppetdb/pull/3082/commits/713b736c9721d931774f6250ded57d73ccdcfdb0)

 - Disable all ssl-* settings in jetty.ini initially, and only
   enable them when USE_PUPPETSERVER is on (the default).

   Otherwise, only listen on non-HTTP port 8080 and leave SSL
   unconfigured