### PR TITLE
(maint) Make Docker SSL configuration flexible

### DIFF
--- a/docker/puppetdb/docker-entrypoint.d/30-configure-ssl.sh
+++ b/docker/puppetdb/docker-entrypoint.d/30-configure-ssl.sh
@@ -1,15 +1,21 @@
 #!/bin/sh
 
+# when certs need to be generated and haven't been user supplied
 if [ ! -f "${SSLDIR}/certs/${CERTNAME}.pem" ] && [ "$USE_PUPPETSERVER" = true ]; then
   set -e
 
   DNS_ALT_NAMES="${HOSTNAME},${DNS_ALT_NAMES}" /ssl.sh "$CERTNAME"
+fi
+
+# cert files are present from Puppetserver OR have been user supplied
+if [ -f "${SSLDIR}/private_keys/${CERTNAME}.pem" ]; then
   openssl pkcs8 -inform PEM -outform DER -in ${SSLDIR}/private_keys/${CERTNAME}.pem -topk8 -nocrypt -out ${SSLDIR}/private_keys/${CERTNAME}.pk8
 
   # for Jetty to use statically named files
-  ln -s ${SSLDIR}/private_keys/${CERTNAME}.pem ${SSLDIR}/private_keys/private.pem
-  ln -s ${SSLDIR}/certs/${CERTNAME}.pem ${SSLDIR}/certs/public.pem
+  ln -s -f ${SSLDIR}/private_keys/${CERTNAME}.pem ${SSLDIR}/private_keys/private.pem
+  ln -s -f ${SSLDIR}/certs/${CERTNAME}.pem ${SSLDIR}/certs/public.pem
 
+  # enable SSL in Jetty
   sed -i '/^# ssl-/s/^# //g' /etc/puppetlabs/puppetdb/conf.d/jetty.ini
 
   # make sure Java apps running as puppetdb can read these files


### PR DESCRIPTION
 - In some instances, users may be deriving from this container to
   specify well-known cert files (as is the case with Bolt specs).

   In this case, users are setting USE_PUPPETSERVER=false, but still
   desire SSL to be configured in Jetty, based on well known certs
   that have been supplied.

 - Adjust the script for these cases:

   * Only generate certs through puppetserver when no cert files are
     on disk *and* USE_PUPPETSERVER=true

   * When a private key exists at $SSLDIR/private_keys/$CERTNAME.pem:

     * always generate a corresponding pk8
     * always create / overwrite symlinks for Jetty
     * always enable SSL in Jetty
     * always correct ownership / perms

     This will handle scenarios where SSL files have been generated,
     or when they've been supplied by a user (as in the Bolt case)