### PR TITLE
(PDB-4502) Add a custom header for uncompressed command size

### DIFF
--- a/documentation/api/command/v1/commands.markdown
+++ b/documentation/api/command/v1/commands.markdown
@@ -83,6 +83,15 @@ first. The response will contain the following additional keys:
 * `error`, `exception`: If the command was processed but an error occurred,
   these two fields provide the specifics of what went wrong.
 
+### Custom headers
+
+When submitting a compressed command body you should indicate the uncompressed
+command size by setting the following custom header:
+`X-Uncompressed-Length: <uncompressed length in bytes>`.
+This header is used to update command size metrics and compared against
+`max-command-size` when `reject-large-commands` is set to true. All commands
+sent from the PuppetDB termini now include this header by default.
+
 ## Command semantics
 
 Commands are processed _asynchronously_. If PuppetDB returns a 200

--- a/puppet/lib/puppet/util/puppetdb/command.rb
+++ b/puppet/lib/puppet/util/puppetdb/command.rb
@@ -62,8 +62,11 @@ class Puppet::Util::Puppetdb::Command
     begin
       response = profile("Submit command HTTP post", [:puppetdb, :command, :submit]) do
         Http.action("#{CommandsUrl}?#{params}", :command) do |http_instance, path|
-          http_instance.post(path, payload, headers, {:compress => :gzip,
-                                                      :metric_id => [:puppetdb, :command, command]})
+          req_headers = headers
+          # custom header used in PDB to reject large compressed commands and update the size metric
+          req_headers["X-Uncompressed-Length"] = payload.bytesize.to_s
+          http_instance.post(path, payload, req_headers, {:compress => :gzip,
+                                                          :metric_id => [:puppetdb, :command, command]})
         end
       end
 


### PR DESCRIPTION
The 'Content-Length' header isn't sent when commands are compressed in the
terminus. As a result the PDB size metrics aren't updated and the
'max-command-size' configuration option which relies on 'Content-Length'
doesn't function as intended.

This commit adds a custom 'X-Uncompressed-Length' header to requests
sent from the terminus. The value of this header is the size in bytes of
the command before it is compressed. This value is used to update
the size metric and to decide when to discard commands based on
'max-command-size'.