### PR TITLE
(maint) Ensure Docker log directory exists

### DIFF
--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -74,7 +74,7 @@ COPY docker/puppetdb/logback.xml /etc/puppetlabs/puppetdb/logback.xml
 COPY docker/puppetdb/request-logging.xml /etc/puppetlabs/puppetdb/request-logging.xml
 COPY docker/puppetdb/conf.d /etc/puppetlabs/puppetdb/conf.d/
 COPY resources/puppetlabs/puppetdb/bootstrap.cfg /etc/puppetlabs/puppetdb/
-RUN mkdir -p /opt/puppetlabs/server/data/puppetdb
+RUN mkdir -p /opt/puppetlabs/server/data/puppetdb/logs
 
 RUN addgroup $GROUP && adduser --system $USER --ingroup $GROUP
 


### PR DESCRIPTION
 - There is a race in container startup where Java may not have a
   proper log directory to write to, and will fail with:

	OpenJDK 64-Bit Server VM warning: Cannot open file /opt/puppetlabs/server/data/puppetdb/logs/puppetdb_gc.log due to No such file or directory