### PR TITLE
(maint) Create LCOW logs path in VOLUME

### DIFF
--- a/docker/puppetdb/docker-entrypoint.d/00-lcow-volume-fix.sh
+++ b/docker/puppetdb/docker-entrypoint.d/00-lcow-volume-fix.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -ex
+
+# Creating log path as a workaround for LCOW VOLUME bug
+# https://github.com/moby/moby/issues/39892
+
+# when the log directory doesn't exist, there can be errors from apps logging there
+mkdir -p /opt/puppetlabs/server/data/puppetdb/logs


### PR DESCRIPTION
Follow on to #3092 to handle a specific LCOW issue

- Due to the LCOW bug https://github.com/moby/moby#39892 make
   certain that the logs path also exists in the LCOW volume before
   starting any applications