### PR TITLE
(PDB-4509) Throw error for invalid database configuration

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -312,6 +312,41 @@
     (future-cancel command-loader))
   context)
 
+;; A map of required postgres settings and their expected value.
+;; PuppetDB will refuse to start unless ALL of these values
+;; match the actual database configuration settings.
+(def required-pg-settings
+  {:standard_conforming_strings "on"})
+
+(defn verify-database-setting
+  "Given m, a map of database settings, verify 'expected', which has the form
+  [setting-name expected-value]."
+  [m [setting value]]
+  (let [map-path [setting :setting]]
+    (when-not (= (get-in m map-path) value)
+      {setting {:expected value :actual (get-in m map-path)}})))
+
+(defn request-database-settings
+  [db-conn-pool]
+  (jdbc/with-db-connection
+    db-conn-pool
+    (jdbc/query "show all;" )))
+
+(defn verify-database-settings
+  "Ensure the database configuration does not have any settings known
+  to break PuppetDB. If an invalid database configuration is found, throws
+  {:kind ::invalid-database-configuration :failed-validation failed-map}"
+  [database-settings]
+  (let [munged-settings (apply merge
+                               (map (fn [h]
+                                      {(keyword (:name h)) (dissoc h :name)})
+                                    database-settings))
+        invalid-settings (remove nil? (map #(verify-database-setting munged-settings %) required-pg-settings))]
+    (when (seq invalid-settings)
+      (throw (ex-info "One or more postgres settings failed validation"
+                      {:kind ::invalid-database-configuration
+                       :failed-validation (apply merge invalid-settings)})))))
+
 (defn initialize-schema
   "Ensures the database is migrated to the latest version, and returns
   true iff any migrations were run.  Throws
@@ -337,7 +372,9 @@
   `write-db-config`.  Blocks until the initialization is complete, and
   then returns an unspecified value.  Throws exceptions on errors.
   Throws {:type ::unsupported-database :current version :oldest
-  version} if the current database is not supported."
+  version} if the current database is not supported. Throws
+  {:kind ::invalid-database-configuration :failed-validation failed-map}
+  if the database contains a disallowed setting."
   [write-db-config config]
   ;; A C-c (SIGINT) will close the pool via the shutdown hook, which
   ;; will then cause the pool connection to throw a (generic)
@@ -356,6 +393,7 @@
                         (.setName "PuppetDB migration pool closer"))]
       (.addShutdownHook runtime on-shutdown)
       (try
+        (verify-database-settings (request-database-settings {:datasource db-pool}))
         (loop [i 0
                last-ex nil]
           (let [result (try
@@ -430,7 +468,8 @@
 
 (defn start-puppetdb
   "Throws {:type ::unsupported-database :current version :oldest version} if
-  the current database is not supported."
+  the current database is not supported. If a database setting is configured
+  incorrectly, throws {:kind ::invalid-database-configuration :failed-validation failed-map}"
   [context config service get-registered-endpoints]
   {:pre [(map? context)
          (map? config)]
@@ -515,6 +554,30 @@
        (first oldest)
        (second oldest)))
 
+(defn invalid-conf-msg
+  [invalid-settings]
+  (str (trs "Invalid database configuration settings: ")
+       (str/join ", "
+                  ;; This is used to construct a list of invalid database settings
+                  ;;
+                  ;; 0 : The name of a database setting
+                  ;; 1 : The expected value of that database setting
+                  ;; 2 : The actual value of that database setting
+                  (map (fn [[k v]] (trs "''{0}'' (expected ''{1}'', got ''{2}'')" (name k) (:expected v) (:actual v)))
+                       invalid-settings))))
+
+(defn log-start-error
+  [e]
+  (let [data (ex-data e)
+        kind (:kind data)
+        msg (case kind
+              ::invalid-database-configuration (invalid-conf-msg (:failed-validation data))
+              (trs "Unkown fatal start error {0}" e))
+        attn (utils/attention-msg msg)]
+    (utils/println-err attn)
+    (log/error attn)
+    msg))
+
 (defprotocol PuppetDBServer
   (shared-globals [this])
   (set-url-prefix [this url-prefix])
@@ -572,6 +635,10 @@
               (log/error attn)
               ;; Until TK-445 is resolved, we won't be able to avoid the
               ;; backtrace on exit this causes.
+              (shutdown-on-error (service-id this)
+                                 #(throw (Exception. msg)))))
+          (catch clojure.lang.ExceptionInfo e
+            (let [msg (log-start-error e)]
               (shutdown-on-error (service-id this)
                                  #(throw (Exception. msg)))))))
 

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -211,11 +211,13 @@
                  [9 4]
                  [9 5]]]
         (with-redefs [sutils/db-metadata (delay {:database nil :version v})]
-          (try+
+          (try
            (initialize-schema *db* config)
-           (catch [:type ::svcs/unsupported-database] {:keys [current oldest]}
-             (is (= v current))
-             (is (= expected-oldest oldest))))))
+           (catch clojure.lang.ExceptionInfo e
+             (let [{:keys [kind current oldest]} (ex-data e)]
+               (is (= ::svcs/unsupported-database kind))
+               (is (= v current))
+               (is (= expected-oldest oldest)))))))
       (with-redefs [sutils/db-metadata (delay {:database nil :version [9 6]})]
         (is (do
               ;; Assumes initialize-schema is idempotent, which it is


### PR DESCRIPTION
If a puppetdb was applying migrations on a database with `standard_conforming_strings = off` it would previously error with

```
2019-09-18T13:31:10.415-04:00 INFO  [p.p.s.migrate] Applying database migration version 43
2019-09-18T13:31:10.456-04:00 ERROR [p.p.s.migrate] Caught SQLException during migration
java.sql.BatchUpdateException: Batch entry 1 CREATE AGGREGATE sha1_agg (BYTEA)
    (
      sfunc = dual_sha1,
      stype = bytea,
      initcond = '\x00'
    ) was aborted: ERROR: invalid byte sequence for encoding "UTF8": 0x00
```

Now it will recognize the invalid configuration and exit after printing
```
********************
*
* Invalid database configuration settings: 'standard_conforming_strings' (expected 'on', got 'off')
*
********************
```