### PR TITLE
(maint) Rename `PACKAGING_VERSION` to `PACKAGING_LOCATION`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ end
 
 gem 'facter'
 gem 'rake'
-gem 'packaging', *location_for(ENV['PACKAGING_VERSION'] || '~> 0.99')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
 
 group :test do
   # Add test-unit for ruby 2.2+ support (has been removed from stdlib)


### PR DESCRIPTION
This commit renames the environment variable used to override the version of
the packaging dependency. `PACKATING_LOCATION` is the name used everywhere else
(in other projects and in shipping automation), so things break without this.