### PR TITLE
(maint) Update Docker k8s config

### DIFF
--- a/kubernetes/helm/puppetdb/templates/configmaps.yaml
+++ b/kubernetes/helm/puppetdb/templates/configmaps.yaml
@@ -9,6 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+  # TODO: I'm not so sure we should be doing this like this
   logback: |
     <configuration scan="true">
       <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/kubernetes/helm/puppetdb/templates/deployment.yaml
+++ b/kubernetes/helm/puppetdb/templates/deployment.yaml
@@ -69,12 +69,13 @@ spec:
           containerPort: 8080
         - name: https
           containerPort: 8081
+        # TODO: update this properly
         volumeMounts:
         - mountPath: /etc/puppetlabs/puppetdb/conf.d
           name: config
         - mountPath: /etc/puppetlabs/puppetdb/ssl
           name: ssl
-        - mountPath: /var/puppetdb
+        - mountPath: /opt/puppetlabs/server/data/puppetdb
           name: vardir
       volumes:
       - name: config

--- a/kubernetes/puppetdb-config.yml
+++ b/kubernetes/puppetdb-config.yml
@@ -1,6 +1,7 @@
 ---
 apiVersion: v1
 kind: ConfigMap
+# TODO: uggh, why are we doing this here?
 metadata:
   name: puppetdb-config
 data:

--- a/kubernetes/puppetdb.yml
+++ b/kubernetes/puppetdb.yml
@@ -49,14 +49,16 @@ spec:
         ports:
         - containerPort: 8080
         - containerPort: 8081
+        #TODO: all this stuff is wrong now
         volumeMounts:
         - mountPath: /etc/puppetlabs/puppetdb/conf.d
           name: config
         - mountPath: /etc/puppetlabs/puppetdb/ssl
           name: ssl
-        - mountPath: /var/puppetdb
+        - mountPath: /opt/puppetlabs/server/data/puppetdb
           name: vardir
       volumes:
+      #TODO: this doesn't make sense in containers anymore really
       - name: config
         configMap:
           name: puppetdb-config


### PR DESCRIPTION
 - With some changes to container internals, some k8s settings may not
   be relevant anymore - verify.

	 To support landing all files in a single VOLUME (certs, logs and
   data), ode changed in b728e289300b36deedd51994b3a8a30014cd2a83 and
   then again in dbf13568555337907b43404e946c171f6b0cefcf