### PR TITLE
(PDB-4540) Only set DNS_ALT_NAMES if an alt name is provided

### DIFF
--- a/docker/puppetdb/docker-entrypoint.d/30-configure-ssl.sh
+++ b/docker/puppetdb/docker-entrypoint.d/30-configure-ssl.sh
@@ -4,7 +4,13 @@
 if [ ! -f "${SSLDIR}/certs/${CERTNAME}.pem" ] && [ "$USE_PUPPETSERVER" = true ]; then
   set -e
 
-  DNS_ALT_NAMES="${HOSTNAME},$(hostname -s),$(hostname -f),${DNS_ALT_NAMES}" /ssl.sh "$CERTNAME"
+  # Only pass in extra DNS_ALT_NAMES if DNS_ALT_NAMES is already set
+  #
+  # This will help preserve backwards compatibility for container upgrades
+  if [ -n "${DNS_ALT_NAMES}" ]; then
+    DNS_ALT_NAMES="${HOSTNAME},$(hostname -s),$(hostname -f),${DNS_ALT_NAMES}"
+  fi
+  /ssl.sh "$CERTNAME"
 fi
 
 # cert files are present from Puppetserver OR have been user supplied


### PR DESCRIPTION
@Iristyle I'm not sure if there was something that required having DNS_ALT_NAMES for the puppetdb container always, but that change could break setups where puppetserver doesn't have DNS alt names enabled in the CA.