### PR TITLE
(maint) Bump ezbake to 2.1.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -298,7 +298,7 @@
                                                ;; in the final package.
                                                [puppetlabs/puppetdb ~pdb-version]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "2.1.4"]]}
+                      :plugins [[puppetlabs/lein-ezbake "2.1.5"]]}
              :testutils {:source-paths ^:replace ["test"]
                          :resource-paths ^:replace []
                          ;; Something else may need adjustment, but


### PR DESCRIPTION
This stops us from building fips packages for FOSS