### PR TITLE
(PDB-4547) Add wireformat validation for deactivate node cmds

### DIFF
--- a/src/puppetlabs/puppetdb/command/constants.clj
+++ b/src/puppetlabs/puppetdb/command/constants.clj
@@ -21,6 +21,7 @@
 (def latest-catalog-version (apply max (get supported-command-versions "replace catalog")))
 (def latest-report-version (apply max (get supported-command-versions "store report")))
 (def latest-facts-version (apply max (get supported-command-versions "replace facts")))
+(def latest-deactivate-node-version (apply max (get supported-command-versions "deactivate node")))
 
 (def latest-command-versions
   {:replace_catalog latest-catalog-version

--- a/src/puppetlabs/puppetdb/nodes.clj
+++ b/src/puppetlabs/puppetdb/nodes.clj
@@ -1,0 +1,12 @@
+(ns puppetlabs.puppetdb.nodes
+  "Puppet nodes parsing
+
+   Functions that handle conversion of nodes from wire format to
+   internal PuppetDB format, including validation."
+  (:require
+   [schema.core :as s]
+   [puppetlabs.puppetdb.schema :as pls]))
+
+(def deactivate-node-wireformat-schema
+  {:certname s/Str
+   (s/optional-key :producer_timestamp) (s/maybe pls/Timestamp)})


### PR DESCRIPTION
I can handle merge ups when this goes in. It's going to conflict with the other pr against 6.3.x