### PR TITLE
(PDB-3300) Add admin delete node command

### DIFF
--- a/src/puppetlabs/puppetdb/admin.clj
+++ b/src/puppetlabs/puppetdb/admin.clj
@@ -24,24 +24,22 @@
 
 (def ^:private validate-clean-command (s/validator clean-command-schema))
 
-(defn- invalid-clean-command-info [command]
+(defn- invalid-command-info [command validator]
   (try+
-   (validate-clean-command command)
+   (validator command)
    nil
    (catch [:type :schema.core/error] ex
      ex)))
 
-(defn- handle-clean-req [req clean]
-  (let [body (slurp (:body req))
-        command (json/parse-string body true)
-        invalid-info (invalid-clean-command-info command)]
+(defn- handle-clean-req [body cmd clean]
+  (let [invalid-info (invalid-command-info cmd validate-clean-command)]
     (cond
       invalid-info
       (http/bad-request-response (i18n/tru "Invalid command {0}: {1}"
                                            (pr-str body)
                                            (pr-str (:error invalid-info))))
 
-      (deref (future (clean (:payload command))))
+      (deref (future (clean (:payload cmd))))
       (http/json-response {:ok true})
 
       :else
@@ -51,11 +49,40 @@
         :details nil}
        http/status-conflict))))
 
+(def delete-command-schema
+  {:command (s/eq "delete")
+   :version (s/eq 1)
+   :payload {:certname s/Str}})
+
+(def ^:private validate-delete-command (s/validator delete-command-schema))
+
+(defn- handle-delete-req [body cmd delete-node]
+  (let [invalid-info (invalid-command-info cmd validate-delete-command)]
+    (if invalid-info
+      (http/bad-request-response (i18n/tru "Invalid command {0}: {1}"
+                                           (pr-str body)
+                                           (pr-str (:error invalid-info))))
+      (do
+        (let [certname (-> cmd :payload :certname)]
+          (delete-node certname)
+          (http/json-response {:deleted certname}))))))
+
+(defn- handle-cmd-req [req clean delete-node]
+  (let [body (slurp (:body req))
+        cmd (json/parse-string body true)]
+    (case (:command cmd)
+      "clean" (handle-clean-req body cmd clean)
+      "delete" (handle-delete-req body cmd delete-node)
+      (http/bad-request-response (i18n/tru "Invalid command {0}: {1}"
+                                           (pr-str body)
+                                           "Valid commands types are: 'clean' and 'delete'")))))
+
 (pls/defn-validated admin-routes :- bidi-schema/RoutePair
   [submit-command-fn :- (s/pred fn?)
    query-fn :- (s/pred fn?)
    get-shared-globals :- (s/pred fn?)
-   clean :- (s/pred fn?)]
+   clean :- (s/pred fn?)
+   delete-node :- (s/pred fn?)]
   (cmdi/context "/v1"
                 (cmdi/context "/archive"
                               (cmdi/wrap-routes
@@ -69,13 +96,14 @@
                                                                     (format "puppetdb-export-%s.tgz" (now)))))
                 (cmdi/context "/cmd"
                               (cmdi/POST "" request
-                                         (handle-clean-req request clean)))
+                                         (handle-cmd-req request clean delete-node)))
                 (cmdi/ANY "/summary-stats" []
                           (ss/collect-metadata get-shared-globals))))
 
 (defn build-app
-  [submit-command-fn query-fn get-shared-globals clean]
+  [submit-command-fn query-fn get-shared-globals clean delete-node]
   (mid/make-pdb-handler (admin-routes submit-command-fn
                                       query-fn
                                       get-shared-globals
-                                      clean)))
+                                      clean
+                                      delete-node)))

--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -35,7 +35,7 @@
   (compojure/context uri [] route))
 
 (defn pdb-core-routes [defaulted-config get-shared-globals enqueue-command-fn
-                       query-fn clean-fn]
+                       query-fn clean-fn delete-node-fn]
   (let [db-cfg #(select-keys (get-shared-globals) [:scf-read-db])]
     (map #(apply wrap-with-context %)
          (partition
@@ -56,7 +56,8 @@
            "/admin" (admin/build-app enqueue-command-fn
                                      query-fn
                                      db-cfg
-                                     clean-fn)]))))
+                                     clean-fn
+                                     delete-node-fn)]))))
 
 (defn pdb-app [root maint-mode-fn app-routes]
   (compojure/context root []
@@ -94,7 +95,7 @@
 
 (tk/defservice pdb-routing-service
   [[:WebroutingService add-ring-handler get-route]
-   [:PuppetDBServer clean shared-globals query set-url-prefix]
+   [:PuppetDBServer clean delete-node shared-globals query set-url-prefix]
    [:PuppetDBCommandDispatcher enqueue-command]
    [:MaintenanceMode enable-maint-mode maint-mode? disable-maint-mode]
    [:DefaultedConfig get-config]
@@ -118,7 +119,8 @@
                                          augmented-globals
                                          enqueue-command
                                          query
-                                         clean))
+                                         clean
+                                         delete-node))
                (mid/wrap-cert-authn cert-whitelist)
                mid/wrap-with-puppetdb-middleware))
 

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -215,6 +215,8 @@
   "Delete the given host from the db"
   [certname]
   {:pre [certname]}
+  (jdbc/delete! :resource_events ["certname_id in (select id from certnames where certname=?)" certname])
+  (jdbc/delete! :reports ["certname=?" certname])
   (jdbc/delete! :certname_packages ["certname_id in (select id from certnames where certname=?)" certname])
   (jdbc/delete! :certnames ["certname=?" certname]))
 


### PR DESCRIPTION
This command allows for the immediate deletion of all data associated with the
certname in the command payload.