### PR TITLE
(maint) Update healthcheck timeouts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,24 +33,28 @@ steps:
     bundle config --local path $gempath
     bundle install --with test
   displayName: Fetch Dependencies
+  timeoutInMinutes: 1
   name: fetch_deps
 
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
     Write-HostDiagnostics
   displayName: Diagnostic Host Information
+  timeoutInMinutes: 2
   name: hostinfo
 
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
     Lint-Dockerfile -Name $ENV:CONTAINER_NAME -Ignore ($ENV:LINT_IGNORES -split ' ')
   displayName: Lint $(CONTAINER_NAME) Dockerfile
+  timeoutInMinutes: 1
   name: lint_dockerfile
 
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
     Build-Container -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE -PathOrUri $ENV:CONTAINER_BUILD_PATH
   displayName: Build $(CONTAINER_NAME) Container
+  timeoutInMinutes: 10
   name: build_container
 
 - powershell: |
@@ -63,6 +67,7 @@ steps:
     . "$(bundle show pupperware)/ci/build.ps1"
     Invoke-ContainerTest -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE
   displayName: Test $(CONTAINER_NAME)
+  timeoutInMinutes: 10
   name: test_container
 
 - task: PublishTestResults@2
@@ -76,5 +81,5 @@ steps:
     . "$(bundle show pupperware)/ci/build.ps1"
     Clear-BuildState -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE
   displayName: Container Cleanup
-  timeoutInMinutes: 3
+  timeoutInMinutes: 4
   condition: always()

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -94,11 +94,11 @@ CMD ["services"]
 
 COPY docker/puppetdb/healthcheck.sh /
 RUN chmod +x /healthcheck.sh
-# The start-period is just a wild guess how long it takes PuppetDB to come
-# up in the worst case. The other timing parameters are set so that it
-# takes at most a minute to realize that PuppetDB has failed.
+# The start-period describes how long it takes PuppetDB to come
+# up in the worst case (LCOW). The other timing parameters are set so that it
+# takes at most 2 minutes to realize that PuppetDB has failed.
 # Probe failure during --start-period will not be counted towards the maximum number of retries
-HEALTHCHECK --start-period=5m --interval=10s --timeout=10s --retries=6 CMD ["/healthcheck.sh"]
+HEALTHCHECK --start-period=3m --interval=10s --timeout=10s --retries=12 CMD ["/healthcheck.sh"]
 
 # VOLUME definitions are always at end of Dockerfile to address an LCOW bug
 # https://github.com/moby/moby/issues/39892


### PR DESCRIPTION
- Set reasonable upper bounds for various stages in Azure to abort
   jobs quickly when Docker misbehaves

- Reduce both the start period by 2m and increase the retries
  by 1m to overall reduce wait time from 6m to 5m

- This time only needs to be longer than Postgres, which has a
  healthcheck timeout defined in docker-compose (given its the
  stock container), but which typically starts under LCOW in
  about 2m

  Additional time allotted is to cover migrations

- Restructure the scripted waiter to wait in the correct order for
  services (matching pe-puppetdb), and also to ensure that it roughly
  considers time already elapsed, rather than continually adding time.

  Even though SSL is not enabled here, the order is kept the same as
  pe-puppetdb for consistency:

  puppetserver
  postgres

  Once Postgres is up, this container can start!