### PR TITLE
(PDB-4255) remove taoensso warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -167,9 +167,8 @@
                  ;; Various
                  [cheshire]
                  [clj-stacktrace]
-                 [clj-time]
+                 [clj-time "0.15.2"]
                  [com.rpl/specter "0.5.7"]
-                 [com.taoensso/nippy :exclusions [org.tukaani/xz]]
                  [digest "1.4.3"]
                  [fast-zip-visit "1.0.2"]
                  [instaparse]


### PR DESCRIPTION
taoensso/nippy was only used in benchmark - it's not a crucial part of
the benchmarking process, so replaced it with built-in EDN reader and
writer.

This will clear this warning at startup:

    WARNING: pos-int? already refers to: #'clojure.core/pos-int? in namespace: taoensso.encore, being replaced by: #'taoensso.encore/pos-int?
    WARNING: bytes? already refers to: #'clojure.core/bytes? in namespace: taoensso.encore, being replaced by: #'taoensso.encore/bytes?