### PR TITLE
(maint) Remove IPv4 stack preference in Docker

### DIFF
--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -44,7 +44,7 @@ ENV PUPPETDB_REPORT_TTL=14d
 # NOTE: Docker ENV values cannot consume other ENV values, so full path to $LOGDIR is specified for -Xloggc
 # this value may be set by users, keeping in mind that some of these values are mandatory
 # -Djavax.net.debug=ssl may be particularly useful to set for debugging SSL
-ENV PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/opt/puppetlabs/server/data/puppetdb/logs/puppetdb_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
+ENV PUPPETDB_JAVA_ARGS="-Xms256m -Xmx256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/opt/puppetlabs/server/data/puppetdb/logs/puppetdb_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
 # used by entrypoint to determine if puppetserver should be contacted for config
 # set to false when container tests are run
 ENV USE_PUPPETSERVER=true


### PR DESCRIPTION
 - Based on the removal performed in pe-puppetdb-extensions,
   make this consistent based on the conversation that IPv4 is no
   loger necessary to prefer.

   PR https://github.com/puppetlabs/pe-puppetdb-extensions/pull/498/
   https://github.com/puppetlabs/pe-puppetdb-extensions/commit/db8c43847b25e434d21db45f3352ef7828a20a57