### PR TITLE
(maint) Re-enable Azure PRs on 6.3.x branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,15 +1,23 @@
+# Don't run Azure when a branch is updated, only when a PR is updated.
+# Prevents double builds when a PR is made from the main repo and not a fork.
+trigger: none
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - '*'
+
 pool:
-  # self-hosted agent on Windows 10 1709 environment
+  # self-hosted agent on Windows 10 1903 environment
   # includes newer Docker engine with LCOW enabled, new build of LCOW image
-  # includes Ruby 2.5, Go 1.10, Node.js 10.10, hadolint
+  # includes Ruby 2.5, Go 1.10, Node.js 10.10
   name: Default
 
 variables:
   NAMESPACE: puppet
 
-# completely disables the pipeline
-trigger: none
-pr: none
+workspace:
+  clean: resources
 
 steps:
 - checkout: self  # self represents the repo where the initial Pipelines YAML file was found


### PR DESCRIPTION
 - Undoes #2861 / 39f6bbbd467d0970140a7cddcdf9d42ebdb64d06 which disabled
   builds on this branch.

   Not sure why we did that at the time, but since we're still shiping
   2019.1.2 off of 6.3 and other PRs have targeted the 6.3 branch,
   let's turn Azure back on for pull requests