### PR TITLE
(PDB-4552) Add support for checking x-pdb-sync-ver header

### DIFF
--- a/src/puppetlabs/puppetdb/constants.clj
+++ b/src/puppetlabs/puppetdb/constants.clj
@@ -6,3 +6,8 @@
 (def sha1-hex-length
   "The length (in ASCII/UTF-8 bytes) of a SHA1 sum when encoded in hexadecimal."
   40)
+
+;; Use to signal when a change isn't backwards compatible with pdbext ha-sync.
+;; Bumping this version number will cause pdbext sync requests to fail with 409s
+;; until both pdbs are upgraded and on the same sync version.
+(def pdb-sync-ver 1)

--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -9,7 +9,8 @@
                                                     wrap-with-illegal-argument-catch
                                                     verify-accepts-json
                                                     verify-content-type
-                                                    make-pdb-handler]]
+                                                    make-pdb-handler
+                                                    verify-sync-version]]
             [ring.util.response :as rr]
             [puppetlabs.comidi :as cmdi]
             [puppetlabs.puppetdb.http.handlers :as handlers]
@@ -71,6 +72,7 @@
                       wrap-with-illegal-argument-catch
                       verify-accepts-json
                       (verify-content-type ["application/json"])
+                      verify-sync-version
                       (wrap-with-metrics (atom {}) http/leading-uris)
                       (wrap-with-globals get-shared-globals))]
       (handler req))))

--- a/test/puppetlabs/puppetdb/http/sync_version_checking.clj
+++ b/test/puppetlabs/puppetdb/http/sync_version_checking.clj
@@ -1,0 +1,40 @@
+(ns puppetlabs.puppetdb.http.sync-version-checking
+  (:require  [clojure.test :refer :all]
+             [puppetlabs.puppetdb.constants :as constants]
+             [puppetlabs.puppetdb.http :as http]
+             [puppetlabs.puppetdb.testutils.http
+              :refer [deftest-http-app query-response *app*]]
+             [puppetlabs.puppetdb.testutils :refer [query-request]]))
+
+(def endpoints [[:v4 "/v4"]])
+
+(deftest-http-app sync-version-checking-headers
+  [[version endpoint] endpoints
+   method [:get :post]]
+  (let [req-with-sync-ver (fn [ver]
+                            (*app*
+                             (query-request
+                              method endpoint
+                              ["from" "nodes"]
+                              {:headers {"x-pdb-sync-ver" ver}})))
+        sync-ver constants/pdb-sync-ver]
+
+    (testing "should succeed when sync versions are equal"
+      (is (= 200 (:status (req-with-sync-ver (str sync-ver))))))
+
+    (testing "should succed when sync version missing"
+      (is (= 200 (:status (query-response method endpoint ["from" "nodes"])))))
+
+    (testing "should fail when sync versions mismatched"
+      (is (= (req-with-sync-ver (str (inc sync-ver)))
+             {:status 409
+              :headers {"Content-Type" http/error-response-content-type}
+              :body
+              "Conflicting PDB sync versions, each PDB syncing must be on the same version"})))
+
+    (testing "should fail when x-pdb-sync-ver input is invalid"
+      (is (= (req-with-sync-ver "abc")
+             {:status 400
+              :headers {"Content-Type" http/error-response-content-type}
+              :body
+              "The x-pdb-sync-ver header: abc cannot be converted to an int."})))))


### PR DESCRIPTION
This commit adds checking for the x-pdb-sync-ver header which is sent from
all pe-puppetdb sync requests. If there is a mismatch detected the incoming
sync request will receive a 409 conflict response until it is upgraded and
starts emitting a matching sync version. This is needed during pe-puppetdb
ha-sync to detect and avoid syncing with a pdb that has been recently upgraded
in a way that's not backwards compatible.