### PR TITLE
(PDB-4576) Update clj-parent to 2.7.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -62,7 +62,6 @@
      [puppetlabs/trapperkeeper :classifier "test"]
      [puppetlabs/kitchensink :classifier "test"]
      [puppetlabs/trapperkeeper-webserver-jetty9 :classifier "test"]
-     [org.flatland/ordered "1.5.7"]
      [org.clojure/test.check "0.9.0"]
      [com.gfredericks/test.chuck "0.2.7"
       :exclusions [com.andrewmcveigh/cljs-time]]
@@ -160,6 +159,9 @@
                  [puppetlabs/structured-logging]
                  [puppetlabs/tools.namespace "0.2.4.1"]
                  [puppetlabs/trapperkeeper]
+                 ;; trapperkeeper began pulling in clj-parent's 1.5.3
+                 ;; which is not compatible with java 11
+                 [org.flatland/ordered "1.5.7"]
                  [puppetlabs/trapperkeeper-webserver-jetty9]
                  [puppetlabs/trapperkeeper-metrics]
                  [puppetlabs/trapperkeeper-status]

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def pdb-version "6.3.7-SNAPSHOT")
-(def clj-parent-version "2.6.0")
+(def clj-parent-version "2.7.2")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
clj-parent differences since 2.6.0
- updated jackson-databind for CVE-2019-14439
- updated jvm-ssl-utils for minor security fixes
- nrepl updates
- use clojure 1.10.1