### PR TITLE
(PDB-4576) Update clj-parent to 4.2.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def pdb-version "6.7.3-SNAPSHOT")
-(def clj-parent-version "4.2.4")
+(def clj-parent-version "4.2.6")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
Changes since 4.2.4
- updated jackson-databind for CVE-2019-14439
- updated trapperkeeper-webserver-jetty9 to fix excessive loggings and
  FIPS cipher-suite
- updated dujour-version-check for FIPS and Java 11