### PR TITLE
(PDB-4577) fix tests for pgsql 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,8 +86,12 @@ jobs:
       env: PDB_TEST=core+ext/openjdk8/pg-9.6
       script: *run-core-and-ext-tests
 
-    - stage: ❧ pdb tests with FIPS
+    - stage: ❧ pdb tests
       env: PDB_TEST=core+ext/openjdk8/pg-9.6 LEIN_PROFILES=fips
+      script: *run-core-and-ext-tests
+
+    - stage: ❧ pdb tests
+      env: PDB_TEST=core+ext/openjdk8/pg-12
       script: *run-core-and-ext-tests
 
     - stage: ❧ pdb tests

--- a/ext/travisci/prep-os-essentials-for
+++ b/ext/travisci/prep-os-essentials-for
@@ -80,7 +80,7 @@ case "$flavor" in
                      postgresql-client-common postgresql-client postgresql-common
                 sudo -i apt-get -y install \
                      postgresql-9.6 postgresql-contrib-9.6 \
-                     postgresql-11
+                     postgresql-11 postgresql-12
                 ;;
         esac
         mkdir -p ext/travisci/local

--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -309,7 +309,7 @@ FROM pg_index AS idx
   JOIN pg_namespace AS NS ON i.relnamespace = NS.OID
   JOIN pg_user AS U ON i.relowner = U.usesysid
 WHERE NOT nspname LIKE 'pg%'
-ORDER BY i.relname ASC;")
+ORDER BY idx.indrelid :: REGCLASS, i.relname;")
 
 (defn db->index-map
   "Converts the metadata columns from their database names/formats to


### PR DESCRIPTION
Apply an ordering to the indexes-sql results, so that all versions of
postgresql return this the same.

pgsql 12 has a different default ordering than 9.x and 11.