### PR TITLE
(PDB-4512) Centralize query params and provide global set

### DIFF
--- a/src/puppetlabs/puppetdb/http/handlers.clj
+++ b/src/puppetlabs/puppetdb/http/handlers.clj
@@ -133,7 +133,9 @@
 ;; query parameter sets
 (def paging-params {:optional paging/query-params})
 (def pretty-params {:optional ["pretty"]})
-(def typical-params (merge-param-specs paging-params pretty-params))
+(def typical-params (merge-param-specs paging-params
+                                       pretty-params
+                                       {:optional ["include_package_inventory"]}))
 
 (pls/defn-validated root-routes :- bidi-schema/RoutePair
   [version :- s/Keyword]

--- a/src/puppetlabs/puppetdb/http/handlers.clj
+++ b/src/puppetlabs/puppetdb/http/handlers.clj
@@ -5,7 +5,8 @@
             [puppetlabs.puppetdb.query.paging :as paging]
             [puppetlabs.puppetdb.query-eng :refer [produce-streaming-body
                                                    stream-query-result]]
-            [puppetlabs.puppetdb.middleware :refer [validate-query-params
+            [puppetlabs.puppetdb.middleware :refer [params-schema
+                                                    validate-query-params
                                                     parent-check
                                                     handler-schema]]
             [puppetlabs.comidi :as cmdi]
@@ -17,9 +18,6 @@
             [puppetlabs.puppetdb.utils :refer [assoc-when]]
             [clojure.walk :refer [keywordize-keys]]
             [puppetlabs.i18n.core :refer [trs]]))
-
-(def params-schema {(s/optional-key :optional) [s/Str]
-                    (s/optional-key :required) [s/Str]})
 
 ;; General route/handler construction functions
 

--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -316,7 +316,6 @@
       (if puppetdb-query
         req
         (let [param-spec (-> param-spec
-                             (update :optional conj "pretty")
                              (update :optional conj "include_package_inventory"))
               query-map (create-query-map req param-spec parse-fn)
               pretty-print (:pretty query-map

--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -315,9 +315,7 @@
      (handler
       (if puppetdb-query
         req
-        (let [param-spec (-> param-spec
-                             (update :optional conj "include_package_inventory"))
-              query-map (create-query-map req param-spec parse-fn)
+        (let [query-map (create-query-map req param-spec parse-fn)
               pretty-print (:pretty query-map
                                     (get-in req [:globals :pretty-print]))]
           (-> req

--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -170,6 +170,18 @@
                           :else
                           (app req))))
 
+(defn merge-param-specs
+  [& specs]
+  (letfn [(assoc-distinct-vals [result key & maps]
+            (cond-> result
+              (some key maps) (assoc key (distinct (mapcat key maps)))))]
+    (reduce (fn [result spec]
+              (-> (merge result spec)
+                  (assoc-distinct-vals :required result spec)
+                  (assoc-distinct-vals :optional result spec)))
+            nil
+            specs)))
+
 (defn validate-no-query-params
   "Ring middleware that verifies that there are no query params on the request.
   Convenience method for endpoints that do not support any query params.  If the

--- a/test/puppetlabs/puppetdb/middleware_test.clj
+++ b/test/puppetlabs/puppetdb/middleware_test.clj
@@ -247,3 +247,22 @@
                        :query-params {"foo" "bar"}}]
           (is (= post-req (middleware-fn post-req)))
           (is (= get-req (middleware-fn get-req))))))))
+
+(defn setify-map-vals [m]
+  (into {} (for [[k v] m] [k (set v)])))
+
+(deftest merge-param-specs-behavior
+  (is (= nil (merge-param-specs)))
+  (is (= {:optional ["x"] :required ["y"]}
+         (merge-param-specs {:optional ["x"] :required ["y"]})))
+  (is (= {:optional ["x"] :required ["y"] :x :y}
+         (merge-param-specs {:optional ["x"] :required ["y"]} {:x :y})))
+  (is (= {:optional (set ["x" "z"]) :required (set ["y"])}
+         (setify-map-vals
+          (merge-param-specs {:optional ["x"] :required ["y"]}
+                             {:optional ["z"]}))))
+  (is (= {:optional (set ["x" "z"]) :required (set ["v" "w" "y"])}
+         (setify-map-vals
+          (merge-param-specs {:optional ["x"] :required ["y"]}
+                             {:optional ["z"]
+                              :required ["v" "w"]})))))


### PR DESCRIPTION
See the commit messages for additional context -- this is intended as underpinnings for the drop-joins parameter in master, but I thought we might want to consider laying the foundations in 5.2 to help minimize future merge conflicts (assuming we're comfortable with making the changes there otherwise).  I've added the don't merge tag for now, because we'll need some coordination, e.g., I'll need to rebase the corresponding master pr onto these change.