### PR TITLE
(PDB-3417) Normalize all command metric names

### DIFF
--- a/src/puppetlabs/puppetdb/command/constants.clj
+++ b/src/puppetlabs/puppetdb/command/constants.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.puppetdb.command.constants
-  (:require [clojure.set :as set]))
+  (:require [clojure.set :as set]
+            [clojure.string :as str]))
 
 (def command-names
   {:replace-catalog "replace catalog"
@@ -27,3 +28,7 @@
   {:replace_catalog latest-catalog-version
    :store_report latest-report-version
    :replace_facts latest-facts-version})
+
+(defn normalize-command-name [command]
+  "Normalize command name from an incoming request's query param"
+  (str/replace command "_" " "))

--- a/src/puppetlabs/puppetdb/http/command.clj
+++ b/src/puppetlabs/puppetdb/http/command.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.puppetdb.http.command
   (:require [clojure.set :as set]
-            [puppetlabs.puppetdb.command.constants :refer [command-names]]
+            [puppetlabs.puppetdb.command.constants :refer [command-names
+                                                           normalize-command-name]]
             [puppetlabs.puppetdb.utils :refer [content-encoding->file-extension
                                                supported-content-encodings]]
             [puppetlabs.trapperkeeper.core :refer [defservice]]
@@ -127,7 +128,7 @@
 (defn-validated normalize-new-request
   [{:keys [params body] :as req} :- new-request-schema]
   (-> req
-      (update-in [:params "command"] str/replace "_" " ")
+      (update-in [:params "command"] normalize-command-name)
       (update-in [:params "version"] #(Integer/parseInt %))))
 
 (def old-request-schema

--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -25,7 +25,8 @@
             [bidi.schema :as bidi-schema]
             [puppetlabs.puppetdb.schema :as pls]
             [schema.core :as s]
-            [puppetlabs.puppetdb.command :as cmd]))
+            [puppetlabs.puppetdb.command :as cmd]
+            [puppetlabs.puppetdb.command.constants :as const]))
 
 (def handler-schema (s/=> s/Any {s/Any s/Any}))
 
@@ -290,8 +291,10 @@
             (do (log/debug (trs "Processing command with a content-length of {0} bytes" length-in-bytes))
                 (update! (cmd/global-metric :size) length-in-bytes)
                 (when (and command version)
-                  (cmd/create-metrics-for-command! command version)
-                  (update! (cmd/cmd-metric command version :size) length-in-bytes)))
+                  (let [command (const/normalize-command-name command)]
+                    ;; command name must be normalized so correct metrics are updated
+                    (cmd/create-metrics-for-command! command version)
+                    (update! (cmd/cmd-metric command version :size) length-in-bytes))))
             (log/warn (trs "Neither Content-Length or X-Uncompressed-Length header is set.
                             This {0} command will not be counted in command size metrics"
                            command))))


### PR DESCRIPTION
Prior to this commit duplicate metrics could be created for incoming commands.
When the create-metrics-for-command! func was called with the query param
command name directly it would create a metric entry for "store_report" when all
other metrics updates used the normalized name "store report". This commit fixes
this issue for all command types so the normalized name is now used everywhere.