### PR TITLE
(PDB-4579) fix connection tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -197,7 +197,7 @@
                     ;; Database connectivity
                     [com.zaxxer/HikariCP]
                     [honeysql "0.6.3"]
-                    [org.postgresql/postgresql "9.4.1208.jre7"]
+                    [org.postgresql/postgresql "42.2.8.jre7"]
 
                     ;; MQ connectivity
                     [org.apache.activemq/activemq-broker "5.13.2" :exclusions [org.slf4j/slf4j-api]]


### PR DESCRIPTION
PostgreSQL JDBC driver has a bug where the isValid() call on a
connection does not respect timeouts. This causes our connection pool to
not detect a dead connection, which will eventually exhaust our
connection pool entirely. See pgjdbc/pgjdbc#1557

This fix is specific to PuppetDB 5.2.x and should not be applied to
newer branches.