### PR TITLE
(PDB-4590) store reports with no events properly

### DIFF
--- a/src/puppetlabs/puppetdb/reports.clj
+++ b/src/puppetlabs/puppetdb/reports.clj
@@ -187,7 +187,7 @@
                      :corrective_change))))
 
 (pls/defn-validated munge-resource-events-for-v8
-  [resource-events :- resource-events-expanded-query-schema]
+  [resource-events :- (s/maybe resource-events-expanded-query-schema)]
   (->> resource-events
        :data
        (map #(dissoc %

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1383,9 +1383,9 @@
                             ;; section 5.10.6
                             remove-dupes
                             insert!
-                            dorun))
+                            dorun)))
                    (when update-latest-report?
-                     (update-latest-report! certname report-id producer_timestamp))))))))))
+                     (update-latest-report! certname report-id producer_timestamp)))))))))
 
 (defn delete-resource-events-older-than!
   "Delete all resource events in the database by dropping any partition older than the day of the year of the given

--- a/test/puppetlabs/puppetdb/testutils/nodes.clj
+++ b/test/puppetlabs/puppetdb/testutils/nodes.clj
@@ -4,7 +4,9 @@
             [puppetlabs.puppetdb.examples :refer :all]
             [puppetlabs.puppetdb.zip :as zip]
             [puppetlabs.puppetdb.reports :as report]
-            [puppetlabs.puppetdb.time :refer [now plus seconds]]))
+            [puppetlabs.puppetdb.time :refer [now plus seconds]]
+            [puppetlabs.puppetdb.testutils.db :refer [*db*]]
+            [puppetlabs.puppetdb.query-eng :as eng]))
 
 (defn change-certname
   "Changes [:certname certname] anywhere in `data` to `new-certname`"
@@ -94,3 +96,16 @@
 
 (defn deactivate-node [certname]
   (scf-store/deactivate-node! certname))
+
+(defn node-for-certname
+  "Convenience function; given a certname, return the corresponding node."
+  [version certname]
+  {:pre  [(string? certname)]
+   :post [(or (nil? %)
+              (map? %))]}
+  (first
+    (eng/stream-query-result version
+                             ["from" "nodes" ["=" "certname" certname]]
+                             {}
+                             {:scf-read-db *db*
+                              :url-prefix "/pdb"})))


### PR DESCRIPTION
A report with no events does not get the latest_report pointer in its
certname entry set. This occurred because of a nesting error.

The schema for reports does not allow an empty set of events, but that
was only used at testing time. In production, this happens frequently
(due to truncation of the resource events table, and other conditions.)