### PR TITLE
(PDB-4579) fix connection tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def pdb-version "6.3.7-SNAPSHOT")
-(def clj-parent-version "2.7.2")
+(def clj-parent-version "2.7.4")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
PostgreSQL JDBC driver has a bug where the isValid() call on a
connection does not respect timeouts. This causes our connection pool to
not detect a dead connection, which will eventually exhaust our
connection pool entirely. See pgjdbc/pgjdbc#1557