### PR TITLE
(PDB-4606) partition the reports table

### DIFF
--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -69,6 +69,6 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 73$' "$tmpdir/out"
+grep -qE ' 74$' "$tmpdir/out"
 
 test ! -e "$PDBBOX"/var/mq-migrated

--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -182,7 +182,7 @@
   whether or not two reports contain the same things (certname,
   configuration version, timestamps, events)."
   [{:keys [certname puppet_version report_format configuration_version
-           start_time end_time producer_timestamp resource_events transaction_uuid] :as report}]
+           start_time end_time producer_timestamp transaction_uuid] :as report}]
   (generic-identity-hash
    {:certname certname
     :puppet_version puppet_version
@@ -191,7 +191,6 @@
     :start_time start_time
     :end_time end_time
     :producer_timestamp producer_timestamp
-    :resource_events (sort (map resource-event-identity-string resource_events))
     :transaction_uuid transaction_uuid}))
 
 (defn resource-event-identity-pkey

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1590,21 +1590,20 @@
    "DROP AGGREGATE IF EXISTS md5_agg(BYTEA)"
    "DROP FUNCTION IF EXISTS dual_md5(BYTEA, BYTEA)"))
 
-(defn autovacuum-vacuum-scale-factor-factsets-catalogs-certnames-reports []
+(defn autovacuum-vacuum-scale-factor-factsets-catalogs-certnames []
   (jdbc/do-commands
    "ALTER TABLE factsets  SET ( autovacuum_vacuum_scale_factor=0.80 )"
    "ALTER TABLE catalogs  SET ( autovacuum_vacuum_scale_factor=0.75 )"
-   "ALTER TABLE certnames SET ( autovacuum_vacuum_scale_factor=0.75 )"
-   "ALTER TABLE reports   SET ( autovacuum_vacuum_scale_factor=0.01 )"))
+   "ALTER TABLE certnames SET ( autovacuum_vacuum_scale_factor=0.75 )"))
 
 ;; for testing via with-redefs
 ;; used to account for the possibility of the name column being added in the
 ;; original version of migration 69 before a user has applied migration 73
 (defn migration-69-stub [])
 
-(defn reporting-partitioned-tables
+(defn resource-events-partitioning
   ([]
-   (reporting-partitioned-tables 500))
+   (resource-events-partitioning 500))
   ([batch-size]
    (jdbc/do-commands
      "ALTER TABLE resource_events RENAME TO resource_events_premigrate"
@@ -1777,6 +1776,180 @@
    "DROP TABLE resource_events_premigrate"
    "DROP FUNCTION find_resource_events_unique_dates()")))
 
+(defn reports-partitioning
+  ([]
+   (reports-partitioning 500))
+  ([batch-size]
+
+   (jdbc/do-commands
+     ;; detach the sequence so it isn't modified during the migration
+     "ALTER SEQUENCE reports_id_seq OWNED BY NONE"
+
+     "DROP INDEX idx_reports_noop_pending"
+     "DROP INDEX idx_reports_prod"
+     "DROP INDEX idx_reports_producer_timestamp"
+     "DROP INDEX idx_reports_producer_timestamp_by_hour_certname"
+     "DROP INDEX reports_cached_catalog_status_on_fail"
+     "DROP INDEX reports_catalog_uuid_idx"
+     "DROP INDEX reports_certname_idx"
+     "DROP INDEX reports_end_time_idx"
+     "DROP INDEX reports_environment_id_idx"
+     "DROP INDEX reports_hash_expr_idx"
+     "DROP INDEX reports_job_id_idx"
+     "DROP INDEX reports_noop_idx"
+     "DROP INDEX reports_status_id_idx"
+     "DROP INDEX reports_tx_uuid_expr_idx"
+     "ALTER TABLE certnames DROP CONSTRAINT certnames_reports_id_fkey"
+
+     "ALTER TABLE reports DROP CONSTRAINT reports_pkey"
+
+     "ALTER TABLE reports RENAME TO reports_premigrate"
+
+     "CREATE TABLE reports (
+        id bigint NOT NULL,
+        hash bytea NOT NULL,
+        transaction_uuid uuid,
+        certname text NOT NULL,
+        puppet_version text NOT NULL,
+        report_format smallint NOT NULL,
+        configuration_version text NOT NULL,
+        start_time timestamp with time zone NOT NULL,
+        end_time timestamp with time zone NOT NULL,
+        receive_time timestamp with time zone NOT NULL,
+        noop boolean,
+        environment_id bigint,
+        status_id bigint,
+        metrics_json json,
+        logs_json json,
+        producer_timestamp timestamp with time zone NOT NULL,
+        metrics jsonb,
+        logs jsonb,
+        resources jsonb,
+        catalog_uuid uuid,
+        cached_catalog_status text,
+        code_id text,
+        producer_id bigint,
+        noop_pending boolean,
+        corrective_change boolean,
+        job_id text)"
+
+     "CREATE OR REPLACE FUNCTION find_reports_unique_dates()
+     RETURNS TABLE (rowdate TIMESTAMP WITH TIME ZONE)
+     AS $$
+     DECLARE
+     BEGIN
+       EXECUTE 'SET local timezone to ''UTC''';
+       RETURN QUERY SELECT DISTINCT date_trunc('day', producer_timestamp) AS rowdate FROM reports_premigrate;
+     END;
+     $$ language plpgsql;")
+
+   ;; note: the reports table does *not* have an insert trigger because reports relies on the RETURNING *
+   ;; part of the INSERT INTO statement.
+
+   ;; create range of partitioned tables
+
+   (let [now (ZonedDateTime/now)
+         days (range -4 4)]
+     (doseq [day-offset days]
+       (partitioning/create-reports-partition (.plusDays now day-offset))))
+
+   ;; pre-create partitions
+   (log/info (trs "Creating partitions based on unique days in reports"))
+   (let [current-timezone (:current_setting (first (jdbc/query-to-vec "SELECT current_setting('TIMEZONE')")))]
+     (jdbc/call-with-query-rows
+       ["select rowdate from find_reports_unique_dates()"]
+       (fn [rows]
+         (doseq [row rows]
+           (partitioning/create-reports-partition (-> (:rowdate row)
+                                                      (.toInstant))))))
+     (jdbc/do-commands
+       ;; restore the transaction's timezone setting after creating the partitions
+       (str "SET local timezone to '" current-timezone "'")))
+
+   (let [event-count (-> "select count(*) from reports_premigrate"
+                         jdbc/query-to-vec first :count)
+         last-logged (atom (.getTime (java.util.Date.)))
+         reports-migrated (atom 0)]
+     (jdbc/call-with-query-rows
+       ["select * from (
+           select
+             id, transaction_uuid, certname, puppet_version, report_format, configuration_version, start_time, end_time,
+             receive_time, noop, environment_id, status_id, metrics_json, logs_json, producer_timestamp, metrics, logs,
+             resources, catalog_uuid, cached_catalog_status, code_id, producer_id, noop_pending, corrective_change,
+             job_id,
+             row_number() over ( partition by
+                                   certname, puppet_version, report_format, configuration_version, start_time, end_time,
+                                   receive_time, transaction_uuid
+                                 order by receive_time asc )
+           from reports_premigrate) as sub
+         where row_number = 1"]
+       (fn [rows]
+         (let [old-cols [:id :transaction_uuid :certname :puppet_version :report_format
+                         :configuration_version :start_time :end_time :receive_time :noop
+                         :environment_id :status_id :metrics_json :logs_json :producer_timestamp
+                         :metrics :logs :resources :catalog_uuid :cached_catalog_status :code_id
+                         :producer_id :noop_pending :corrective_change :job_id]
+               new-cols (into [:hash] old-cols)
+               update-row (apply juxt (comp sutils/munge-hash-for-storage
+                                            hash/report-identity-hash)
+                                 old-cols)
+               insert->hash (fn [batch]
+                              (swap! reports-migrated + (count batch))
+                              (let [batch (map update-row batch)]
+                                (when (seq batch)
+                                  (doseq [g (group-by (fn [o] (-> (get o 15) ;; producer_timestamp
+                                                                  (partitioning/to-zoned-date-time)
+                                                                  (partitioning/date-suffix))) batch)]
+                                    (jdbc/insert-multi! (str "reports_" (first g))
+                                                        new-cols
+                                                        (last g)))) )
+
+                              (let [now (.getTime (java.util.Date.))]
+                                (when (> (- now @last-logged) 60000)
+                                  (maplog :info
+                                          {:migration 74 :at @reports-migrated :of event-count}
+                                          #(trs "Migrated {0} of {1} reports" (:at %) (:of %)))
+                                  (reset! last-logged now))))]
+           (dorun (map insert->hash (partition batch-size batch-size [] rows)))))))
+
+   ;; migrate data
+
+   (jdbc/do-commands
+     ;; attach sequence
+     "ALTER SEQUENCE reports_id_seq OWNED BY reports.id"
+
+     ;; set default value on new table DEFAULT nextval('reports_id_seq'::regclass)
+     "ALTER TABLE reports ALTER COLUMN id SET DEFAULT nextval('reports_id_seq'::regclass)"
+
+     "ALTER TABLE reports ADD CONSTRAINT reports_pkey PRIMARY KEY (id)"
+     "CREATE INDEX idx_reports_noop_pending ON reports USING btree (noop_pending) WHERE (noop_pending = true)"
+     "CREATE INDEX idx_reports_prod ON reports USING btree (producer_id)"
+     "CREATE INDEX idx_reports_producer_timestamp ON reports USING btree (producer_timestamp)"
+     ["CREATE INDEX idx_reports_producer_timestamp_by_hour_certname ON reports USING btree "
+      "  (date_trunc('hour'::text, timezone('UTC'::text, producer_timestamp)), producer_timestamp, certname)"]
+     ["CREATE INDEX reports_cached_catalog_status_on_fail ON reports USING btree"
+      "  (cached_catalog_status) WHERE (cached_catalog_status = 'on_failure'::text)"]
+     "CREATE INDEX reports_catalog_uuid_idx ON reports USING btree (catalog_uuid)"
+     "CREATE INDEX reports_certname_idx ON reports USING btree (certname)"
+     "CREATE INDEX reports_end_time_idx ON reports USING btree (end_time)"
+     "CREATE INDEX reports_environment_id_idx ON reports USING btree (environment_id)"
+     "CREATE UNIQUE INDEX reports_hash_expr_idx ON reports USING btree (encode(hash, 'hex'::text))"
+     "CREATE INDEX reports_job_id_idx ON reports USING btree (job_id) WHERE (job_id IS NOT NULL)"
+     "CREATE INDEX reports_noop_idx ON reports USING btree (noop) WHERE (noop = true)"
+     "CREATE INDEX reports_status_id_idx ON reports USING btree (status_id)"
+     "CREATE INDEX reports_tx_uuid_expr_idx ON reports USING btree (((transaction_uuid)::text))"
+     ["ALTER TABLE reports"
+      "  ADD CONSTRAINT reports_certname_fkey FOREIGN KEY (certname) REFERENCES certnames(certname) ON DELETE CASCADE"]
+     ["ALTER TABLE reports"
+      "  ADD CONSTRAINT reports_env_fkey FOREIGN KEY (environment_id) REFERENCES environments(id) ON DELETE CASCADE"]
+     ["ALTER TABLE reports"
+      "  ADD CONSTRAINT reports_prod_fkey FOREIGN KEY (producer_id) REFERENCES producers(id)"]
+     ["ALTER TABLE reports"
+      "  ADD CONSTRAINT reports_status_fkey FOREIGN KEY (status_id) REFERENCES report_statuses(id) ON DELETE CASCADE"]
+
+     "DROP TABLE reports_premigrate"
+     "DROP FUNCTION find_reports_unique_dates()")))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1830,9 +2003,10 @@
    ;; replaced by reporting-partitioned-tables
    69 migration-69-stub
    70 migrate-md5-to-sha1-hashes
-   71 autovacuum-vacuum-scale-factor-factsets-catalogs-certnames-reports
+   71 autovacuum-vacuum-scale-factor-factsets-catalogs-certnames
    72 add-support-for-catalog-inputs
-   73 reporting-partitioned-tables})
+   73 resource-events-partitioning
+   74 reports-partitioning})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/src/puppetlabs/puppetdb/scf/partitioning.clj
+++ b/src/puppetlabs/puppetdb/scf/partitioning.clj
@@ -88,3 +88,56 @@
 
       (format "CREATE UNIQUE INDEX IF NOT EXISTS resource_events_hash_%s ON %s (event_hash)"
               iso-week-year full-table-name)])))
+
+(defn create-reports-partition
+  "Creates a partition in the reports table"
+  [date]
+  (create-partition
+    "reports" "\"producer_timestamp\""
+    date
+    (fn [full-table-name iso-week-year]
+      (let [alter-prefix "DO $$ BEGIN BEGIN "
+            alter-suffix "; EXCEPTION WHEN duplicate_object THEN RETURN; END; END $$;"
+            wrap-alter #(str alter-prefix % alter-suffix)]
+        [(format "CREATE INDEX IF NOT EXISTS idx_reports_compound_id_%s ON %s USING btree (producer_timestamp, certname, hash) WHERE (start_time IS NOT NULL)"
+                 iso-week-year full-table-name)
+         (format "CREATE INDEX IF NOT EXISTS idx_reports_noop_pending_%s ON %s USING btree (noop_pending) WHERE (noop_pending = true)"
+                 iso-week-year full-table-name)
+         (format "CREATE INDEX IF NOT EXISTS idx_reports_prod_%s ON %s USING btree (producer_id)"
+                 iso-week-year full-table-name)
+         (format "CREATE INDEX IF NOT EXISTS idx_reports_producer_timestamp_%s ON %s USING btree (producer_timestamp)"
+                 iso-week-year full-table-name)
+         (format "CREATE INDEX IF NOT EXISTS idx_reports_producer_timestamp_by_hour_certname_%s ON %s USING btree (date_trunc('hour'::text, timezone('UTC'::text, producer_timestamp)), producer_timestamp, certname)"
+                 iso-week-year full-table-name)
+         (format "CREATE INDEX IF NOT EXISTS reports_cached_catalog_status_on_fail_%s ON %s USING btree (cached_catalog_status) WHERE (cached_catalog_status = 'on_failure'::text)"
+                 iso-week-year full-table-name)
+         (format "CREATE INDEX IF NOT EXISTS reports_catalog_uuid_idx_%s ON %s USING btree (catalog_uuid)"
+                 iso-week-year full-table-name)
+         (format "CREATE INDEX IF NOT EXISTS reports_certname_idx_%s ON %s USING btree (certname)"
+                 iso-week-year full-table-name)
+         (format "CREATE INDEX IF NOT EXISTS reports_end_time_idx_%s ON %s USING btree (end_time)"
+                 iso-week-year full-table-name)
+         (format "CREATE INDEX IF NOT EXISTS reports_environment_id_idx_%s ON %s USING btree (environment_id)"
+                 iso-week-year full-table-name)
+         (format "CREATE UNIQUE INDEX IF NOT EXISTS reports_hash_expr_idx_%s ON %s USING btree (encode(hash, 'hex'::text))"
+                 iso-week-year full-table-name)
+         (format "CREATE INDEX IF NOT EXISTS reports_job_id_idx_%s ON %s USING btree (job_id) WHERE (job_id IS NOT NULL)"
+                 iso-week-year full-table-name)
+         (format "CREATE INDEX IF NOT EXISTS reports_noop_idx_%s ON %s USING btree (noop) WHERE (noop = true)"
+                 iso-week-year full-table-name)
+         (format "CREATE INDEX IF NOT EXISTS reports_status_id_idx_%s ON %s USING btree (status_id)"
+                 iso-week-year full-table-name)
+         (format "CREATE INDEX IF NOT EXISTS reports_tx_uuid_expr_idx_%s ON %s USING btree (((transaction_uuid)::text))"
+                 iso-week-year full-table-name)
+         (wrap-alter (format "ALTER TABLE ONLY %s ADD CONSTRAINT reports_certname_fkey_%s
+               FOREIGN KEY (certname) REFERENCES certnames(certname) ON DELETE CASCADE"
+                             full-table-name iso-week-year))
+         (wrap-alter (format "ALTER TABLE ONLY %s ADD CONSTRAINT reports_env_fkey_%s
+               FOREIGN KEY (environment_id) REFERENCES environments(id) ON DELETE CASCADE"
+                             full-table-name iso-week-year))
+         (wrap-alter (format "ALTER TABLE ONLY %s ADD CONSTRAINT reports_prod_fkey_%s
+               FOREIGN KEY (producer_id) REFERENCES producers(id)"
+                             full-table-name iso-week-year))
+         (wrap-alter (format "ALTER TABLE ONLY %s ADD CONSTRAINT reports_status_fkey_%s
+               FOREIGN KEY (status_id) REFERENCES report_statuses(id) ON DELETE CASCADE"
+                             full-table-name iso-week-year))]))))

--- a/test/puppetlabs/puppetdb/examples/reports.clj
+++ b/test/puppetlabs/puppetdb/examples/reports.clj
@@ -302,7 +302,7 @@
    {:certname "foo.local"
     :puppet_version "3.0.1"
     :report_format 4
-    :transaction_uuid "e1e561ba-212f-11e3-9d58-60a44c233a9d"
+    :transaction_uuid "e1e561ba-212f-11e3-9d58-60a44c233a9e"
     :catalog_uuid "5ea3a70b-84c8-426c-813c-dd6492fb829b"
     :code_id nil
     :job_id nil

--- a/test/puppetlabs/puppetdb/http/events_test.clj
+++ b/test/puppetlabs/puppetdb/http/events_test.clj
@@ -380,7 +380,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "675545f1e8e91b3f5ba2749756295688094fa34f"
+       :report "8bd4d65f561a73caf8022d1d654bde76a3b417ad"
        :resource_title "hi"
        :property nil
        :name nil
@@ -407,7 +407,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "675545f1e8e91b3f5ba2749756295688094fa34f"
+       :report "8bd4d65f561a73caf8022d1d654bde76a3b417ad"
        :resource_title "hi"
        :property nil
        :name nil
@@ -436,7 +436,7 @@
        :new_value nil
        :containing_class "Foo"
        :report_receive_time "2014-04-16T12:44:40.978Z"
-       :report "675545f1e8e91b3f5ba2749756295688094fa34f"
+       :report "8bd4d65f561a73caf8022d1d654bde76a3b417ad"
        :resource_title "hi"
        :property nil
        :name nil

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -146,12 +146,12 @@
                                             ["group_by" "status" "certname"]])
              #{{:certname "bar.local" :status "unchanged" :count 1}
                {:certname "foo.local" :status "unchanged" :count 1}}))
-      (is (= #{{:hash "a9216a84aacc2f34ff543050bc5b7ef7b6217bdc"}
-               {:hash "faa22ed1a9d2cfe1914f21d7a4a02322997cfb12"}}
+      (is (= #{{:hash "5bc5d561c7912570a7c7f525b815477cdaed70a2"}
+               {:hash "5067c5ac56f39501e504c0b76186d31ec1b5ca94"}}
              (query-result method endpoint ["extract" ["hash"]
                                             ["in" "hash"
-                                             ["array" ["a9216a84aacc2f34ff543050bc5b7ef7b6217bdc"
-                                                       "faa22ed1a9d2cfe1914f21d7a4a02322997cfb12"]]]])))
+                                             ["array" ["5bc5d561c7912570a7c7f525b815477cdaed70a2"
+                                                       "5067c5ac56f39501e504c0b76186d31ec1b5ca94"]]]])))
       (is (= (query-result method endpoint ["extract" [["function" "count"] "status" "certname"]
                                             ["or"
                                              ["in" "status" ["array" ["unchanged"]]]
@@ -425,7 +425,7 @@
         basic4 (assoc (:basic4 reports) :status "failed")
         _ (store-example-report! basic4 (now))]
 
-    (testing "should return all reports for a certname"
+    (testing "should return all reports based on their status"
       (let [unchanged-reports (query-result method endpoint ["=" "status" "unchanged"]
                                             {} munge-reports-for-comparison)
             changed-reports (query-result method endpoint ["=" "status" "changed"]
@@ -436,16 +436,16 @@
         (is (= 2 (count unchanged-reports)))
         (is (every? #(= "unchanged" (:status %)) unchanged-reports))
 
-        (is (= unchanged-reports
-               (munge-reports-for-comparison [basic basic2])))
+        (is (= (munge-reports-for-comparison [basic basic2])
+               unchanged-reports))
 
         (is (= 1 (count changed-reports)))
-        (is (= changed-reports
-               (munge-reports-for-comparison [basic3])))
+        (is (= (munge-reports-for-comparison [basic3])
+               changed-reports))
 
         (is (= 1 (count failed-reports)))
-        (is (= failed-reports
-               (munge-reports-for-comparison [basic4])))))))
+        (is (= (munge-reports-for-comparison [basic4])
+               failed-reports))))))
 
 (deftest-http-app query-by-certname-with-environment
   [[version endpoint] endpoints

--- a/test/puppetlabs/puppetdb/integration/reports.clj
+++ b/test/puppetlabs/puppetdb/integration/reports.clj
@@ -232,7 +232,7 @@
                               "  message => 'Hi my_agent' "
                               "}"))
 
-      (let [[report] (int/pql-query pdb "reports { certname = 'my_agent' }")
+      (let [[report] (int/pql-query pdb "reports { certname = 'my_agent' and noop = false }")
             metrics (get-href pdb (get-in report [:metrics :href]))
             logs  (get-href pdb (get-in report [:logs :href]))]
 

--- a/test/puppetlabs/puppetdb/scf/hash_test.clj
+++ b/test/puppetlabs/puppetdb/scf/hash_test.clj
@@ -154,7 +154,7 @@
                                      :line 15}]}]
 
       (testing "should return sorted predictable string output"
-        (is (= "3016159f704726b486f8b42309773ec625e2f3b7"
+        (is (= "f0dc33b54c9eea0a83444fa1fecfe6a2b2b6db39"
                (report-identity-hash sample))))
 
       (testing "should return the same value twice"
@@ -224,7 +224,7 @@
         (is (= hash tweaked-hash)
             (str catalog "\n has hash: " hash "\n and \n" tweaked-catalog "\n has hash: " tweaked-hash))))))
 
-(deftest report-dedupe
+(deftest report-dupe-only-events-differ
   (let [report-query->hash (comp report-identity-hash
                                  normalize-report
                                  reports/report-query->wire-v8)
@@ -235,9 +235,8 @@
         report2-hash (report-query->hash report2)
         report3-hash (report-query->hash
                       (update-in report [:resource_events :data] rest))]
-    (testing "Reports with the same metadata but different events should have different hashes"
-      (is (not= report-hash report2-hash))
-      (is (not= report-hash report3-hash)))
+    (testing "Reports with the same metadata but different events should have the same hashes"
+      (is (= report-hash report2-hash report3-hash)))
 
     (testing "Reports with different metadata but the same events should have different hashes"
       (let [mod-report-fns [#(assoc % :certname (str (:certname %) "foo"))

--- a/test/puppetlabs/puppetdb/scf/migrate_partitioning_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_partitioning_test.clj
@@ -591,3 +591,676 @@
                                          :same nil}]))
                                    dates))}
            (diff-schema-maps before-migration (schema-info-map *db*))))))
+
+(deftest migration-74-schema-diff
+  (clear-db-for-testing!)
+  (fast-forward-to-migration! 73)
+
+  (let [before-migration (schema-info-map *db*)
+        today (ZonedDateTime/now (ZoneId/of "UTC"))
+        days-range (range -4 4)
+        dates (map #(.plusDays today %) days-range)
+        part-names (map #(str/lower-case (partitioning/date-suffix %)) dates)]
+    (apply-migration-for-testing! 74)
+
+    (is (= {:index-diff (into
+                          []
+                          cat
+                          (map
+                            (fn [part-name]
+                              (let [table-name (str "reports_" part-name)]
+                                [{:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "reports_tx_uuid_expr_idx_" part-name)
+                                               :index_keys ["(transaction_uuid::text)"]
+                                               :type "btree"
+                                               :unique? false
+                                               :functional? true
+                                               :is_partial false
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "reports_cached_catalog_status_on_fail_" part-name)
+                                               :index_keys ["cached_catalog_status"]
+                                               :type "btree"
+                                               :unique? false
+                                               :functional? false
+                                               :is_partial true
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "reports_catalog_uuid_idx_" part-name)
+                                               :index_keys ["catalog_uuid"]
+                                               :type "btree"
+                                               :unique? false
+                                               :functional? false
+                                               :is_partial false
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "reports_certname_idx_" part-name)
+                                               :index_keys ["certname"]
+                                               :type "btree"
+                                               :unique? false
+                                               :functional? false
+                                               :is_partial false
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "reports_hash_expr_idx_" part-name)
+                                               :index_keys ["encode(hash, 'hex'::text)"]
+                                               :type "btree"
+                                               :unique? true
+                                               :functional? true
+                                               :is_partial false
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "reports_end_time_idx_" part-name)
+                                               :index_keys ["end_time"]
+                                               :type "btree"
+                                               :unique? false
+                                               :functional? false
+                                               :is_partial false
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "reports_environment_id_idx_" part-name)
+                                               :index_keys ["environment_id"]
+                                               :type "btree"
+                                               :unique? false
+                                               :functional? false
+                                               :is_partial false
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "reports_job_id_idx_" part-name)
+                                               :index_keys ["job_id"]
+                                               :type "btree"
+                                               :unique? false
+                                               :functional? false
+                                               :is_partial true
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "reports_noop_idx_" part-name)
+                                               :index_keys ["noop"]
+                                               :type "btree"
+                                               :unique? false
+                                               :functional? false
+                                               :is_partial true
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "idx_reports_noop_pending_" part-name)
+                                               :index_keys ["noop_pending"]
+                                               :type "btree"
+                                               :unique? false
+                                               :functional? false
+                                               :is_partial true
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "idx_reports_prod_" part-name)
+                                               :index_keys ["producer_id"]
+                                               :type "btree"
+                                               :unique? false
+                                               :functional? false
+                                               :is_partial false
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "idx_reports_producer_timestamp_" part-name)
+                                               :index_keys ["producer_timestamp"]
+                                               :type "btree"
+                                               :unique? false
+                                               :functional? false
+                                               :is_partial false
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "reports_status_id_idx_" part-name)
+                                               :index_keys ["status_id"]
+                                               :type "btree"
+                                               :unique? false
+                                               :functional? false
+                                               :is_partial false
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only {:schema "public"
+                                               :table table-name
+                                               :index (str "idx_reports_producer_timestamp_by_hour_certname_" part-name)
+                                               :index_keys ["date_trunc('hour'::text, timezone('UTC'::text, producer_timestamp))"
+                                                            "producer_timestamp"
+                                                            "certname"]
+                                               :type "btree"
+                                               :unique? false
+                                               :functional? true
+                                               :is_partial false
+                                               :primary? false
+                                               :user "pdb_test"}
+                                  :same nil}
+                                 {:left-only nil
+                                  :right-only
+                                  {:schema "public"
+                                   :table table-name
+                                   :index (str "idx_reports_compound_id_" part-name)
+                                   :index_keys ["producer_timestamp" "certname" "hash"]
+                                   :type "btree"
+                                   :unique? false
+                                   :functional? false
+                                   :is_partial true
+                                   :primary? false
+                                   :user "pdb_test"}
+                                  :same nil}]))
+                            part-names))
+            :table-diff (into
+                          []
+                          cat
+                          (map (fn [part-name]
+                                 (let [table-name (str "reports_" part-name)]
+                                   [{:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length 1073741824
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "text"
+                                                  :column_name "cached_catalog_status"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "uuid"
+                                                  :column_name "catalog_uuid"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length 1073741824
+                                                  :datetime_precision nil
+                                                  :nullable? "NO"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "text"
+                                                  :column_name "certname"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length 1073741824
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "text"
+                                                  :column_name "code_id"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length 1073741824
+                                                  :datetime_precision nil
+                                                  :nullable? "NO"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "text"
+                                                  :column_name "configuration_version"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "boolean"
+                                                  :column_name "corrective_change"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision 6
+                                                  :nullable? "NO"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "timestamp with time zone"
+                                                  :column_name "end_time"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale 0
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision 64
+                                                  :numeric_precision_radix 2
+                                                  :data_type "bigint"
+                                                  :column_name "environment_id"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "NO"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "bytea"
+                                                  :column_name "hash"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale 0
+                                                  :column_default "nextval('reports_id_seq'::regclass)"
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "NO"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision 64
+                                                  :numeric_precision_radix 2
+                                                  :data_type "bigint"
+                                                  :column_name "id"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length 1073741824
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "text"
+                                                  :column_name "job_id"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "jsonb"
+                                                  :column_name "logs"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "json"
+                                                  :column_name "logs_json"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "jsonb"
+                                                  :column_name "metrics"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "json"
+                                                  :column_name "metrics_json"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "boolean"
+                                                  :column_name "noop"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "boolean"
+                                                  :column_name "noop_pending"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale 0
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision 64
+                                                  :numeric_precision_radix 2
+                                                  :data_type "bigint"
+                                                  :column_name "producer_id"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision 6
+                                                  :nullable? "NO"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "timestamp with time zone"
+                                                  :column_name "producer_timestamp"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length 1073741824
+                                                  :datetime_precision nil
+                                                  :nullable? "NO"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "text"
+                                                  :column_name "puppet_version"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision 6
+                                                  :nullable? "NO"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "timestamp with time zone"
+                                                  :column_name "receive_time"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale 0
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "NO"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision 16
+                                                  :numeric_precision_radix 2
+                                                  :data_type "smallint"
+                                                  :column_name "report_format"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "jsonb"
+                                                  :column_name "resources"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision 6
+                                                  :nullable? "NO"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "timestamp with time zone"
+                                                  :column_name "start_time"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale 0
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision 64
+                                                  :numeric_precision_radix 2
+                                                  :data_type "bigint"
+                                                  :column_name "status_id"
+                                                  :table_name table-name}
+                                     :same nil}
+                                    {:left-only nil
+                                     :right-only {:numeric_scale nil
+                                                  :column_default nil
+                                                  :character_octet_length nil
+                                                  :datetime_precision nil
+                                                  :nullable? "YES"
+                                                  :character_maximum_length nil
+                                                  :numeric_precision nil
+                                                  :numeric_precision_radix nil
+                                                  :data_type "uuid"
+                                                  :column_name "transaction_uuid"
+                                                  :table_name table-name}
+                                     :same nil}]))
+                               part-names))
+            :constraint-diff (into
+                               [{:left-only {:constraint_name "certnames_reports_id_fkey"
+                                             :table_name "certnames"
+                                             :constraint_type "FOREIGN KEY"
+                                             :initially_deferred "NO"
+                                             :deferrable? "NO"}
+                                 :right-only nil
+                                 :same nil}]
+                               cat
+                               (map (fn [date-of-week]
+                                      (let [part-name (str/lower-case (partitioning/date-suffix date-of-week))
+                                            table-name (str "reports_" part-name)
+                                            date-formatter (.withZone (DateTimeFormatter/ofPattern "yyyy-MM-dd HH:mm:ssx")
+                                                                      (ZoneId/systemDefault))
+                                            start-of-day (.format date-formatter
+                                                                  (.truncatedTo date-of-week (ChronoUnit/DAYS)))
+                                            end-of-day (.format date-formatter
+                                                                (.plusDays (.truncatedTo date-of-week (ChronoUnit/DAYS)) 1))]
+                                        [{:left-only nil
+                                          :right-only {:constraint_name
+                                                       (format "(((producer_timestamp >= '%s'::timestamp with time zone) AND (producer_timestamp < '%s'::timestamp with time zone)))"
+                                                               start-of-day end-of-day)
+                                                       :table_name table-name
+                                                       :constraint_type "CHECK"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name "certname IS NOT NULL"
+                                                       :table_name table-name
+                                                       :constraint_type "CHECK"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name "configuration_version IS NOT NULL"
+                                                       :table_name table-name
+                                                       :constraint_type "CHECK"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name "end_time IS NOT NULL"
+                                                       :table_name table-name
+                                                       :constraint_type "CHECK"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name "hash IS NOT NULL"
+                                                       :table_name table-name
+                                                       :constraint_type "CHECK"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name "id IS NOT NULL"
+                                                       :table_name table-name
+                                                       :constraint_type "CHECK"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name "producer_timestamp IS NOT NULL"
+                                                       :table_name table-name
+                                                       :constraint_type "CHECK"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name "puppet_version IS NOT NULL"
+                                                       :table_name table-name
+                                                       :constraint_type "CHECK"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name "receive_time IS NOT NULL"
+                                                       :table_name table-name
+                                                       :constraint_type "CHECK"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name "report_format IS NOT NULL"
+                                                       :table_name table-name
+                                                       :constraint_type "CHECK"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name (str "reports_certname_fkey_" part-name)
+                                                       :table_name table-name
+                                                       :constraint_type "FOREIGN KEY"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name (str "reports_env_fkey_" part-name)
+                                                       :table_name table-name
+                                                       :constraint_type "FOREIGN KEY"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name (str "reports_prod_fkey_" part-name)
+                                                       :table_name table-name
+                                                       :constraint_type "FOREIGN KEY"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name (str "reports_status_fkey_" part-name)
+                                                       :table_name table-name
+                                                       :constraint_type "FOREIGN KEY"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}
+                                         {:left-only nil
+                                          :right-only {:constraint_name "start_time IS NOT NULL"
+                                                       :table_name table-name
+                                                       :constraint_type "CHECK"
+                                                       :initially_deferred "NO"
+                                                       :deferrable? "NO"}
+                                          :same nil}]))
+                                    dates))}
+           (diff-schema-maps before-migration (schema-info-map *db*))))))


### PR DESCRIPTION
Partition the reports table on producer_timestamp. This creates
a partition per day, and allows garbage collection to occur by
dropping expired tables. This follows the same pattern as PDB-4420.

The report hash has been changed to remove resource_events from the
hash calculation. The resource_events table can be garbage collected
separately from the reports table, and if the hash is still including
the resource_events, we end up with duplicate reports during a pdb
sync. The hash is rewritten during the migration.

There is no trigger to direct inserts to the appropriate partition.
This is because the usage of the reports table relies on the behavior
of a RETURNING clause on the INSERT INTO statement. You cannot rewrite
the query and combine it with a RETURNING clause. All INSERTs occur
directly into the appropriate partition.

During garbage collection, an UPDATE statement is ran across the
certnames table to ensure latest_report_id is set to null when the
report is deleted. Previously, this relied on a cascade during the
delete.