### PR TITLE
(maint) Bump clj-parent to 4.2.11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def pdb-version "6.7.4-SNAPSHOT")
-(def clj-parent-version "4.2.10")
+(def clj-parent-version "4.2.11")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
This has changes to clj-http-client that are necessary for Java 11