### PR TITLE
 (PDB-4479) Omit "gc-able" nodes from queries for inactive nodes

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -486,7 +486,7 @@
                 puppetdb command-processing
                 emit-cmd-events?]} config
         {:keys [pretty-print max-enqueued]} developer
-        {:keys [gc-interval]} database
+        {:keys [gc-interval node-purge-ttl]} database
         {:keys [disable-update-checking]} puppetdb
         {:keys [cmd-event-mult cmd-event-ch]} context
 
@@ -522,6 +522,7 @@
                    :dlo (dlo/initialize (get-path stockdir "discard")
                                         (get-in metrics-registries
                                                 [:dlo :registry]))
+                   :node-purge-ttl node-purge-ttl
                    :command-chan command-chan
                    :cmd-event-mult cmd-event-mult
                    :maybe-send-cmd-event! maybe-send-cmd-event!}
@@ -664,7 +665,7 @@
   (query [this version query-expr paging-options row-callback-fn]
          (let [sc (service-context this)
                query-options (-> (get sc :shared-globals)
-                                 (select-keys [:scf-read-db :warn-experimental])
+                                 (select-keys [:scf-read-db :warn-experimental :node-purge-ttl])
                                  (assoc :url-prefix @(get sc :url-prefix)))]
            (qeng/stream-query-result version
                                      query-expr

--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -364,11 +364,12 @@
 (defn narrow-globals
   "Reduces the number of globals to limit their reach in the codebase"
   [globals]
-  (select-keys globals [:scf-read-db :warn-experimental :url-prefix :pretty-print]))
+  (select-keys globals [:scf-read-db :warn-experimental :url-prefix :pretty-print :node-purge-ttl]))
 
 (defn valid-query?
-  [scf-read-db version query-map]
-  (let [{:keys [remaining-query entity query-options]} (qeng/user-query->engine-query version query-map)]
+  [scf-read-db version query-map query-options]
+  (let [{:keys [remaining-query entity query-options]}
+        (qeng/user-query->engine-query version query-map (:node-purge-ttl query-options))]
     (jdbc/with-db-connection scf-read-db
       (when (qeng/query->sql remaining-query entity version query-options)
         true))))
@@ -376,8 +377,9 @@
 (defn query-handler
   [version]
   (fn [{:keys [params globals puppetdb-query]}]
-    (if (and (:ast_only puppetdb-query) (valid-query? (:scf-read-db globals) version puppetdb-query))
-      (http/json-response (:query puppetdb-query))
-      (qeng/produce-streaming-body version
-                              (validate-distinct-options! (merge (keywordize-keys params) puppetdb-query))
-                              (narrow-globals globals)))))
+    (let [query-options (narrow-globals globals)]
+      (if (and (:ast_only puppetdb-query) (valid-query? (:scf-read-db globals) version puppetdb-query query-options))
+        (http/json-response (:query puppetdb-query))
+        (qeng/produce-streaming-body version
+                                (validate-distinct-options! (merge (keywordize-keys params) puppetdb-query))
+                                query-options)))))

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.puppetdb.query-eng
-  (:import [org.postgresql.util PGobject])
+  (:import [org.postgresql.util PGobject]
+           [org.joda.time Period])
   (:require [clojure.core.match :as cm]
             [clojure.java.jdbc :as sql]
             [clojure.tools.logging :as log]
@@ -125,6 +126,7 @@
 (def query-options-schema
   {:scf-read-db s/Any
    :url-prefix String
+   :node-purge-ttl Period
    (s/optional-key :warn-experimental) Boolean
    (s/optional-key :pretty-print) (s/maybe Boolean)})
 
@@ -162,8 +164,8 @@
     :else obj))
 
 (defn user-query->engine-query
-  ([version query-map] (user-query->engine-query version query-map false))
-  ([version query-map warn-experimental]
+  ([version query-map node-purge-ttl] (user-query->engine-query version query-map node-purge-ttl false))
+  ([version query-map node-purge-ttl warn-experimental]
    (let [query (:query query-map)
          {:keys [remaining-query entity paging-clauses]} (eng/parse-query-context
                                                           version query warn-experimental)
@@ -173,7 +175,7 @@
                                 utils/strip-nil-values)
          query-options (->> (dissoc query-map :query)
                             utils/strip-nil-values
-                            (merge {:limit nil :offset nil :order_by nil}
+                            (merge {:node-purge-ttl node-purge-ttl :limit nil :offset nil :order_by nil}
                                    paging-options))
          entity (cond
                   (and (= entity :factsets) (:include_package_inventory query-options)) :factsets-with-packages
@@ -188,10 +190,11 @@
   [version :- s/Keyword
    query-map
    options :- query-options-schema]
-  (let [{:keys [scf-read-db url-prefix warn-experimental pretty-print]
+  (let [{:keys [scf-read-db url-prefix node-purge-ttl warn-experimental pretty-print]
          :or {warn-experimental true
               pretty-print false}} options
-        {:keys [query remaining-query entity query-options]} (user-query->engine-query version query-map warn-experimental)]
+        {:keys [query remaining-query entity query-options]}
+        (user-query->engine-query version query-map node-purge-ttl warn-experimental)]
 
     (try
       (jdbc/with-transacted-connection scf-read-db

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -17,7 +17,7 @@
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.scf.storage-utils :as su]
             [puppetlabs.puppetdb.schema :as pls]
-            [puppetlabs.puppetdb.time :refer [to-timestamp]]
+            [puppetlabs.puppetdb.time :as t]
             [puppetlabs.puppetdb.zip :as zip]
             [schema.core :as s]
             [puppetlabs.puppetdb.scf.storage :as scf-store]
@@ -895,6 +895,17 @@
                :entity :events
                :source-table "resource_events"}))
 
+(def active-nodes-query
+  (map->Query {::which-query :active-nodes
+               :projections {"certname" {:type :string
+                                         :queryable? true
+                                         :field :active_nodes.certname}}
+               :selection {:from [:active_nodes]}
+               :subquery? false
+               :alias "active_nodes"
+               :source-table "active_nodes"}))
+
+
 (def inactive-nodes-query
   (map->Query {::which-query :inactive-nodes
                :projections {"certname" {:type :string
@@ -1140,18 +1151,28 @@
                      [honeysql-fncall (get pg-fns->pdb-fns function)]
                      honeysql-fncall)))))
 
-(defn wrap-with-inactive-nodes-cte
+(defn wrap-with-node-state-cte
   "Wrap a selection in a CTE representing expired or deactivated certnames"
-  [selection]
-  (assoc selection :with {:inactive_nodes {:select [:certname]
+  [selection node-purge-ttl]
+  (let [timestamp (-> node-purge-ttl t/ago t/to-string)]
+    (assoc selection :with {:inactive_nodes {:select [:certname]
+                                             :from [:certnames]
+                                             ;; Since we use our own bespoke parameter extraction, we cannot use any parameters
+                                             ;; in this wrapping honeysql cte, so we have to format the string ourselves.
+                                             ;; If we can switch to using honeysql for parameter extraction, we can define this
+                                             ;; filter in honeysql and let it convert the timestamps to SQL.
+                                             :where (hcore/raw
+                                                      (str "(deactivated IS NOT NULL AND deactivated > '" timestamp "')"
+                                                           " OR (expired IS NOT NULL and expired > '" timestamp "')"))}
+                            :active_nodes {:select [:certname]
                                            :from [:certnames]
-                                           :where [:or
-                                                   [:is-not :deactivated nil]
-                                                   [:is-not :expired nil]]}}))
+                                           :where [:and
+                                                   [:is :deactivated nil]
+                                                   [:is :expired nil]]}})))
 
 (defn honeysql-from-query
   "Convert a query to honeysql format"
-  [{:keys [projected-fields group-by call selection projections entity subquery?]}]
+  [{:keys [projected-fields group-by call selection projections entity subquery?]} {:keys  [node-purge-ttl]}]
   (let [fs (seq (map (comp hcore/raw :statement) call))
         select (if (and fs
                         (empty? projected-fields))
@@ -1161,33 +1182,33 @@
                                    (mapv (fn [[name {:keys [field]}]]
                                            [field name])))
                               fs)))
-        new-selection (-> (cond-> selection (not subquery?) wrap-with-inactive-nodes-cte)
+        new-selection (-> (cond-> selection (not subquery?) (wrap-with-node-state-cte node-purge-ttl))
                           (assoc :select select)
                           (cond-> group-by (assoc :group-by group-by)))]
     (log/spy new-selection)))
 
 (pls/defn-validated sql-from-query :- String
   "Convert a query to honeysql, then to sql"
-  [query]
+  [query options]
   (-> query
-      honeysql-from-query
+      (honeysql-from-query options)
       hcore/format
       first
       log/spy))
 
 (defprotocol SQLGen
-  (-plan->sql [query] "Given the `query` plan node, convert it to a SQL string"))
+  (-plan->sql [query options] "Given the `query` plan node, convert it to a SQL string"))
 
 (extend-protocol SQLGen
   Query
-  (-plan->sql [{:keys [projections projected-fields where] :as query}]
+  (-plan->sql [{:keys [projections projected-fields where] :as query} options]
     (s/validate [projection-schema] projected-fields)
     (let [has-where? (boolean where)
           has-projections? (not (empty? projected-fields))
           sql (-> query
                   (utils/update-cond has-where?
                                      [:selection]
-                                     #(hsql/merge-where % (-plan->sql where)))
+                                     #(hsql/merge-where % (-plan->sql where options)))
                   ;; Note that even if has-projections? is false, the
                   ;; projections are still relevant.
                   ;; i.e. projected-fields doesn't tell the
@@ -1196,14 +1217,14 @@
                   (utils/update-cond has-projections?
                                      [:projections]
                                      (constantly projected-fields))
-                  sql-from-query)]
+                  (sql-from-query options))]
 
       (if (:subquery? query)
         (htypes/raw (str " ( " sql " ) "))
         sql)))
 
   InExpression
-  (-plan->sql [{:keys [column subquery] :as this}]
+  (-plan->sql [{:keys [column subquery] :as this} options]
     ;; 'column' is actually a vector of columns.
     (s/validate [column-schema] column)
     ;; if a field has type jsonb, cast that field in the subquery to jsonb
@@ -1215,21 +1236,21 @@
           coercions (mapv convert-type inner-columns inner-types outer-types)]
       [:in fields
        {:select coercions
-        :from [[(-plan->sql subquery) :sub]]}]))
+        :from [[(-plan->sql subquery options) :sub]]}]))
 
   JsonContainsExpression
-  (-plan->sql [{:keys [field column-data array-in-path]}]
+  (-plan->sql [{:keys [field column-data array-in-path]} options]
     (su/json-contains (if (instance? SqlRaw (:field column-data))
                         (-> column-data :field :s)
                         field)
                       array-in-path))
 
   FnBinaryExpression
-  (-plan->sql [{:keys [value function args operator]}]
+  (-plan->sql [{:keys [value function args operator]} options]
     (su/fn-binary-expression operator function args))
 
   JsonbPathBinaryExpression
-  (-plan->sql [{:keys [field value column-data operator]}]
+  (-plan->sql [{:keys [field value column-data operator]} options]
     (su/jsonb-path-binary-expression operator
                                      (if (instance? SqlRaw (:field column-data))
                                        (-> column-data :field :s)
@@ -1237,14 +1258,14 @@
                                      value))
 
   JsonbScalarRegexExpression
-  (-plan->sql [{:keys [field]}]
+  (-plan->sql [{:keys [field]} options]
     (su/jsonb-scalar-regex field))
 
   BinaryExpression
-  (-plan->sql [{:keys [column operator value]}]
+  (-plan->sql [{:keys [column operator value]} options]
     (apply vector
            :or
-           (map #(vector operator (-plan->sql %1) (-plan->sql %2))
+           (map #(vector operator (-plan->sql %1 options) (-plan->sql %2 options))
                 (cond
                   (map? column) [(:field column)]
                   (vector? column) (mapv :field column)
@@ -1252,29 +1273,29 @@
                 (utils/vector-maybe value))))
 
   InArrayExpression
-  (-plan->sql [{:keys [column]}]
+  (-plan->sql [{:keys [column]} options]
     (s/validate column-schema column)
     (su/sql-in-array (:field column)))
 
   ArrayBinaryExpression
-  (-plan->sql [{:keys [column]}]
+  (-plan->sql [{:keys [column]} options]
     (s/validate column-schema column)
     (su/sql-array-query-string (:field column)))
 
   RegexExpression
-  (-plan->sql [{:keys [column]}]
+  (-plan->sql [{:keys [column]} options]
     (s/validate column-schema column)
     (su/sql-regexp-match (:field column)))
 
   ArrayRegexExpression
-  (-plan->sql [{:keys [column]}]
+  (-plan->sql [{:keys [column]} options]
     (s/validate column-schema column)
     (su/sql-regexp-array-match (:field column)))
 
   NullExpression
-  (-plan->sql [{:keys [column] :as expr}]
+  (-plan->sql [{:keys [column] :as expr} options]
     (s/validate column-schema column)
-    (let [lhs (-plan->sql (:field column))
+    (let [lhs (-plan->sql (:field column) options)
           json? (= :jsonb-scalar (:type column))]
       (if (:null? expr)
         (if json?
@@ -1285,25 +1306,25 @@
           [:is-not lhs nil]))))
 
   AndExpression
-  (-plan->sql [expr]
-    (concat [:and] (map -plan->sql (:clauses expr))))
+  (-plan->sql [expr options]
+    (concat [:and] (map #(-plan->sql % options) (:clauses expr))))
 
   OrExpression
-  (-plan->sql [expr]
-    (concat [:or] (map -plan->sql (:clauses expr))))
+  (-plan->sql [expr options]
+    (concat [:or] (map #(-plan->sql % options) (:clauses expr))))
 
   NotExpression
-  (-plan->sql [expr]
-    [:not (-plan->sql (:clause expr))])
+  (-plan->sql [expr options]
+    [:not (-plan->sql (:clause expr) options)])
 
   Object
-  (-plan->sql [obj]
+  (-plan->sql [obj options]
     obj))
 
 (defn plan->sql
   "Convert `query` to a SQL string"
-  [query]
-  (-plan->sql query))
+  [query options]
+  (-plan->sql query options))
 
 (defn binary-expression?
   "True if the plan node is a binary expression"
@@ -1422,6 +1443,7 @@
    "select_fact_contents" fact-contents-query
    "select_fact_paths" fact-paths-query
    "select_nodes" nodes-query
+   "select_active_nodes" active-nodes-query
    "select_inactive_nodes" inactive-nodes-query
    "select_latest_report" latest-report-query
    "select_latest_report_id" latest-report-id-query
@@ -1520,9 +1542,9 @@
 
             [["=" "node_state" value]]
             (case (str/lower-case (str value))
-              "active" ["not" ["in" "certname"
-                               ["extract" "certname"
-                                ["select_inactive_nodes"]]]]
+              "active" ["in" "certname"
+                        ["extract" "certname"
+                         ["select_active_nodes"]]]
               "inactive" ["in" "certname"
                           ["extract" "certname"
                            ["select_inactive_nodes"]]]
@@ -1848,7 +1870,7 @@
 (defn try-parse-timestamp
   "Try to convert a string to a timestamp, throwing an exception if it fails"
   [ts]
-  (or (to-timestamp ts)
+  (or (t/to-timestamp ts)
       (throw (IllegalArgumentException. (tru "''{0}'' is not a valid timestamp value" ts)))))
 
 (defn user-node->plan-node
@@ -1912,7 +1934,7 @@
                 (map->InArrayExpression {:column cinfo
                                          :value (su/array-to-param "timestamp"
                                                                    java.sql.Timestamp
-                                                                   (map to-timestamp value))})
+                                                                   (map t/to-timestamp value))})
                 :integer
                 (map->InArrayExpression {:column cinfo
                                          :value (su/array-to-param "bigint"
@@ -2375,11 +2397,11 @@
   "Given a user provided query and a Query instance, convert the
    user provided query to SQL and extract the parameters, to be used
    in a prepared statement"
-  [query-rec user-query & [{:keys [include_total] :as paging-options}]]
+  [query-rec user-query & [{:keys [include_total] :as query-options}]]
   ;; Call the query-rec so we can evaluate query-rec functions
   ;; which depend on the db connection type
   (let [allowed-fields (map keyword (queryable-fields query-rec))
-        paging-options (some->> paging-options
+        paging-options (some->> query-options
                                 (paging/validate-order-by! allowed-fields)
                                 (paging/dealias-order-by query-rec))
         [query-rec user-query] (rewrite-fact-query query-rec user-query)
@@ -2389,7 +2411,7 @@
                                    optimize-user-query
                                    (convert-to-plan query-rec paging-options)
                                    extract-all-params)
-        sql (plan->sql plan)
+        sql (plan->sql plan paging-options)
         paged-sql (jdbc/paged-sql sql paging-options)]
     (cond-> {:results-query (apply vector paged-sql params)}
       include_total (assoc :count-query (apply vector (jdbc/count-sql sql) params)))))

--- a/test/puppetlabs/puppetdb/generative/submit_command.clj
+++ b/test/puppetlabs/puppetdb/generative/submit_command.clj
@@ -11,7 +11,7 @@
             [puppetlabs.puppetdb.generative.overridable-generators :as gen]
             [puppetlabs.puppetdb.generative.generators :as pdb-gen]
             [puppetlabs.puppetdb.examples.reports :as example-reports]
-            [puppetlabs.puppetdb.time :refer [now parse-wire-datetime]]))
+            [puppetlabs.puppetdb.time :refer [now parse-wire-datetime parse-period]]))
 
 (def ten-timestamps #{"2016-12-19T23:30:00.000Z"
                       "2016-12-19T23:31:00.000Z"
@@ -47,7 +47,9 @@
                              ["from" "catalogs"]
                              {:order_by [[:certname :descending]
                                          [:producer_timestamp :descending]]}
-                             {:scf-read-db db, :url-prefix "/pdb"})
+                             {:scf-read-db db
+                              :url-prefix "/pdb"
+                              :node-purge-ttl (parse-period "14d")})
        (map (fn [row]
               (-> row
                   (update :resources #(json/parse (str % ) true))
@@ -59,7 +61,9 @@
                                  ["from" "factsets"]
                                  {:order_by [[:certname :descending]
                                              [:producer_timestamp :descending]]}
-                                 {:scf-read-db db, :url-prefix "/pdb"})
+                                 {:scf-read-db db
+                                  :url-prefix "/pdb"
+                                  :node-purge-ttl (parse-period "14d")})
        (map (fn [row]
               (-> row
                   (update :facts #(json/parse (str % ) true))
@@ -70,7 +74,9 @@
                                  ["from" "reports"]
                                  {:order_by [[:certname :descending]
                                              [:producer_timestamp :descending]]}
-                                 {:scf-read-db db, :url-prefix "/pdb"})
+                                 {:scf-read-db db
+                                  :url-prefix "/pdb"
+                                  :node-purge-ttl (parse-period "14d")})
        (map (fn [row]
               (-> row
                   (update :logs #(json/parse (str %) true))
@@ -82,7 +88,10 @@
   (qeng/stream-query-result :v4
                             ["from" "nodes"]
                             {:order_by [[:certname :descending]]}
-                            {:scf-read-db db, :url-prefix "/pdb"}) )
+                            {:scf-read-db db
+                             :url-prefix "/pdb"
+                             :node-purge-ttl (parse-period "14d")}) )
+
 
 (defn state-snapshot [db]
   {:nodes (all-nodes db)

--- a/test/puppetlabs/puppetdb/testutils/events.clj
+++ b/test/puppetlabs/puppetdb/testutils/events.clj
@@ -5,7 +5,7 @@
             [clojure.walk :as walk]
             [puppetlabs.puppetdb.utils :refer [assoc-when]]
             [puppetlabs.puppetdb.scf.storage :as scf-store]
-            [puppetlabs.puppetdb.time :refer [to-string to-timestamp]]))
+            [puppetlabs.puppetdb.time :refer [to-string to-timestamp parse-period]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Utility functions for massaging results and example data into formats that
@@ -65,4 +65,5 @@
                             ["from" "events" query]
                             query-options
                             {:scf-read-db *db*
-                             :url-prefix "/pdb"})))
+                             :url-prefix "/pdb"
+                             :node-purge-ttl (parse-period "14d")})))

--- a/test/puppetlabs/puppetdb/testutils/http.clj
+++ b/test/puppetlabs/puppetdb/testutils/http.clj
@@ -5,6 +5,7 @@
             [puppetlabs.puppetdb.testutils.db :refer [*db* with-test-db]]
             [puppetlabs.puppetdb.utils :as utils]
             [puppetlabs.puppetdb.http :as http]
+            [puppetlabs.puppetdb.time :as t]
             [puppetlabs.puppetdb.middleware
              :refer [wrap-with-puppetdb-middleware]]
             [puppetlabs.puppetdb.cheshire :as json]
@@ -84,7 +85,8 @@
       :globals (merge {:update-server "FOO"
                        :scf-read-db          *db*
                        :scf-write-db         *db*
-                       :product-name         "puppetdb"}
+                       :product-name         "puppetdb"
+                       :node-purge-ttl       (t/parse-period "14d")}
                       global-overrides)}))
 
 (defn internal-request-post
@@ -111,7 +113,8 @@
   ([f adjust-globals]
    (let [get-shared-globals #(adjust-globals {:scf-read-db *db*
                                               :scf-write-db *db*
-                                              :url-prefix ""})]
+                                              :url-prefix ""
+                                              :node-purge-ttl (t/parse-period "14d")})]
      (binding [*app* (wrap-with-puppetdb-middleware
                       (server/build-app get-shared-globals))]
        (f)))))

--- a/test/puppetlabs/puppetdb/testutils/reports.clj
+++ b/test/puppetlabs/puppetdb/testutils/reports.clj
@@ -29,7 +29,8 @@
                             ["from" "reports" ["=" "hash" hash]]
                             {}
                             {:scf-read-db *db*
-                             :url-prefix "/pdb"})))
+                             :url-prefix "/pdb"
+                             :node-purge-ttl (time-coerce/parse-period "14d")})))
 
 (defn store-example-report!
   "Store an example report (from examples/report.clj) for use in tests.  Params:

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -46,6 +46,7 @@
   {:nrepl {}
    :global {:vardir (testutils/temp-dir)}
    :puppetdb {:disable-update-checking "true"}
+   :node-purge-ttl "14d"
    :jetty {:port 0}
    :command-processing {}})
 


### PR DESCRIPTION
This modifies the definition of inactive_nodes in the query engine to
omit nodes that are eligible for garbage collection. These nodes are in
essence 'dead', in that the only reason we haven't deleted them is we
haven't hit the user's gc-interval.

We add an explicit definition of active_nodes because an "active node"
was previosuly defined as the complement of inactive_nodes and we
obviously don't want nodes that have been inactive for `node-purge-ttl`
and about to be garbage collected to temporarily enter "active" status.
The new definition for active_nodes is logically equivalent to the
complement of the _old_ definition of inactive_nodes because the
criteria for being an active node has not changed.

This solves a problem in pe-puppetdb where a node would be garbage
collected on one PuppetDB, but garbage collection had not yet run on the
other PuppetDB so that node was stil 'inactive' so the next sync run
would recreate and the node. This caused a never-ending ping pong effect
where a deactivated node would never be deleted from both PuppetDBs.
By omitting nodes that are eligible for garbage collection" from query
results for inactive_nodes, multiple PuppetDB's will agree on what
nodes are inactive regardless of when they last ran garbage collection.

For this change to solve the sync issue, it assumes that the times of
your PuppetDB's are in-sync, they have the same `node-purge-ttl`
setting, and when routing one command to multiple PuppetDB's the
command's producer_timestamp is set to a single timestamp for all copies
of the command. In our case, this is handled by the PuppetDB terminus.