### PR TITLE
(PDB-4626) date_trunc uses different semantics

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1668,7 +1668,7 @@
    ;; pre-create partitions
    (log/info (trs "Creating partitions based on unique days in resource_events"))
    (jdbc/call-with-query-rows
-    ["select distinct date_trunc('day', \"timestamp\" AT TIME ZONE 'UTC') as rowdate
+    ["select distinct date_trunc('day', \"timestamp\") as rowdate
       from resource_events_premigrate"]
     (fn [rows]
       (doseq [row rows]


### PR DESCRIPTION
The query to determine which partitions to create in advance of the
migration uses the postgresql function date_trunc, which will work and
match the trigger and other code if you do not attempt to coerce to UTC
at the same time.

Tested by switching my local machine to CET (UTC+01:00) and running the
tests, to match the customer use-case.