### PR TITLE
(PDB-4641) get unique dates properly in UTC

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1649,12 +1649,12 @@
      FOR EACH ROW EXECUTE PROCEDURE resource_events_insert_trigger();"
 
      "CREATE OR REPLACE FUNCTION find_resource_events_unique_dates()
-     RETURNS TABLE (rowdate DATE)
+     RETURNS TABLE (rowdate TIMESTAMP WITH TIME ZONE)
      AS $$
      DECLARE
      BEGIN
        EXECUTE 'SET local timezone to ''UTC''';
-       RETURN QUERY SELECT DISTINCT \"timestamp\"::DATE AS rowdate FROM resource_events_premigrate;
+       RETURN QUERY SELECT DISTINCT date_trunc('day', \"timestamp\") AS rowdate FROM resource_events_premigrate;
      END;
      $$ language plpgsql;")
 
@@ -1693,8 +1693,7 @@
        (fn [rows]
          (doseq [row rows]
            (partitioning/create-resource-events-partition (-> (:rowdate row)
-                                                              (.toLocalDate)
-                                                              (.atStartOfDay (ZoneId/of "UTC")))))))
+                                                              (.toInstant))))))
      (jdbc/do-commands
        ;; restore the transaction's timezone setting after creating the partitions
        (str "SET local timezone to '" current-timezone "'")))


### PR DESCRIPTION
Force the timezone to UTC for determining the unique dates of
resource_events.

PostgreSQL returns dates in the client's timezone. What we need to do
here is force the connection into UTC. We want the date of the event, in
UTC, so that we can create the partition for it. To do this, we have the
find_resource_events_unique_dates plpgsql function above. For the
duration of this migration transaction, dates will be displayed in UTC.
If the timezone is in the local timezone (say, EST, or CEST), you get
the date in that timezone with the time cut off. So,
2020-01-30T05:00:00Z, which truncates to 2020-01-30 using the pgsql date
functions. In reality, this is actually 2020-01-31 in UTC, which is the
date we need for creating the partition successfully.