### PR TITLE
(PDB-4640) Make catalog resources file trgm index optional

### DIFF
--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -69,6 +69,6 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 74$' "$tmpdir/out"
+grep -qE ' 73$' "$tmpdir/out"
 
 test ! -e "$PDBBOX"/var/mq-migrated

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1755,12 +1755,6 @@
    ;; Indexes are created on the individual partitions, not on the base table
    "DROP TABLE resource_events_premigrate")))
 
-(defn add-gin-index-on-catalog-resources-file
-  []
-  (jdbc/do-commands
-    "create index catalog_resources_file_idx on catalog_resources using gin (file gin_trgm_ops) where file is not null"
-    "alter table catalog_resources set (autovacuum_analyze_scale_factor = 0.01)"))
-
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {28 init-through-2-3-8
@@ -1816,8 +1810,7 @@
    70 migrate-md5-to-sha1-hashes
    71 autovacuum-vacuum-scale-factor-factsets-catalogs-certnames-reports
    72 add-support-for-catalog-inputs
-   73 reporting-partitioned-tables
-   74 add-gin-index-on-catalog-resources-file})
+   73 reporting-partitioned-tables})
 
 (def desired-schema-version (apply max (keys migrations)))
 

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -1273,34 +1273,7 @@
       (is (not (contains? procs "md5_agg")))
       (is (not (contains? procs "dual_md5"))))))
 
-
-(deftest migration-74-adds-catalog-resoureces-file-idx
-  (clear-db-for-testing!)
-  (fast-forward-to-migration! 73)
-  (let [before-migration (schema-info-map *db*)]
-    (apply-migration-for-testing! 74)
-    (is (= {:index-diff (set
-                          [{:left-only nil
-                            :right-only
-                            {:schema "public"
-                             :table "catalog_resources"
-                             :index "catalog_resources_file_idx"
-                             :index_keys ["file"]
-                             :type "gin"
-                             :unique? false
-                             :functional? false
-                             :is_partial true
-                             :primary? false
-                             :user "pdb_test"}
-                            :same nil}])
-            :table-diff nil
-            :constraint-diff nil}
-           (update
-             (diff-schema-maps before-migration (schema-info-map *db*))
-             :index-diff
-             set)))))
-
-(deftest autovacuum-vacuum-scale-factor-test
+(deftest autovacuum-vacuum-scale-factor-factsets-catalogs-certnames-reports-test
   (clear-db-for-testing!)
   ;; intentionally apply all of the migrations before looking to ensure our autovacuum scale factors aren't lost
   (fast-forward-to-migration! desired-schema-version)
@@ -1308,19 +1281,9 @@
                 "catalogs" "0.75"
                 "certnames" "0.75"
                 "reports" "0.01"}]
-    (doseq [[table factor] values]
-      (is (= [{:reloptions [(format "autovacuum_vacuum_scale_factor=%s" factor)]}]
-             (jdbc/query-to-vec
-               (format "SELECT reloptions FROM pg_class WHERE relname = '%s' AND CAST(reloptions as text) LIKE '{autovacuum_vacuum_scale_factor=%s}'"
-                       table factor)))))))
-
-(deftest autovacuum-analyze-scale-factor-test
-  (clear-db-for-testing!)
-  ;; intentionally apply all of the migrations before looking to ensure our autovacuum scale factors aren't lost
-  (fast-forward-to-migration! desired-schema-version)
-  (let [values {"catalog_resources" "0.01"}]
-    (doseq [[table factor] values]
-      (is (= [{:reloptions [(format "autovacuum_analyze_scale_factor=%s" factor)]}]
-             (jdbc/query-to-vec
-               (format "SELECT reloptions FROM pg_class WHERE relname = '%s' AND CAST(reloptions as text) LIKE '{autovacuum_analyze_scale_factor=%s}'"
-                       table factor)))))))
+    (doall
+     (map (fn [[table factor]]
+            (is (seq (jdbc/query-to-vec
+                      (format "SELECT reloptions FROM pg_class WHERE relname = '%s' AND CAST(reloptions as text) LIKE '{autovacuum_vacuum_scale_factor=%s}'"
+                              table factor)))))
+          values))))


### PR DESCRIPTION
Without this, the index could introduce a breaking change for FOSS users
not following the recommendation of installing `pg_trgm` and
unwilling/unable to install it from the postgresql-contrib pacakge.

Instead we make this index optional for now, deprecate running without
`pg_trgm` and will require `pg_trgm` in a later release.