### PR TITLE
(maint) Only build a release build if it makes sense

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,12 @@ on:
 
 jobs:
   build-and-publish:
+    env:
+      PUPPERWARE_ANALYTICS_STREAM: production
+      IS_LATEST: true
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+
     runs-on: ubuntu-latest
 
     steps:
@@ -16,22 +22,33 @@ jobs:
         with:
           ruby-version: 2.6.x
       - run: gem install bundler
-      - name: Lint container
-        working-directory: docker
-        run: |
-          make lint
       - name: Build container
-        env:
-          PUPPERWARE_ANALYTICS_STREAM: production
-          IS_LATEST: true
         working-directory: docker
-        run: make build test
+        run: make lint build test
       - name: Publish container
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-          IS_LATEST: true
         working-directory: docker
         run: |
           docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
           make publish
+      - name: Build release container
+        env:
+          IS_RELEASE: true
+        working-directory: docker
+        run: |
+          make prep
+          if [ $? -eq 0 ]; then
+            make lint build test
+          else
+            echo "Skipping release container building and testing"
+          fi
+      - name: Publish release container
+        env:
+          IS_RELEASE: true
+        working-directory: docker
+        run: |
+          make prep
+          if [ $? -eq 0 ]; then
+            make publish
+          else
+            echo "Skipping release container publishing"
+          fi


### PR DESCRIPTION
In our github actions configuration, we always want to try to make a release
build so that we don't have to kick that off manually. But we also only
want to build and publish a release build if it doesn't already exists.

This adds some safeguards so we don't try to build the release build yet
if it hasn't been published and updated in dujour, and also so that we
only build and publish the release build if we haven't already pushed
that tag.