### PR TITLE
(docs) Update initial-report-threshold docs

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -1005,12 +1005,11 @@ unless you are experiencing an issue.
 
 ### `initial-report-threshold`
 
-PuppetDB's initial sync, which occurs during startup, will only sync reports
-newer than `initial-report-threshold` (default: `"14d"`). While starting up,
-PuppetDB will not respond to queries or accept command submissions, so this can
-be used to get PuppetDB online faster, at the expense that it could return query
-responses that are not up to date. Subsequent periodic syncs will transfer the
-remaining data.
+If set, PuppetDB's initial sync, which occurs during startup, will only sync reports
+newer than `initial-report-threshold` . While starting up, PuppetDB will not respond
+to queries or accept command submissions, so this can be used to get PuppetDB online
+faster, at the expense that it could return query responses that are not up to date.
+Subsequent periodic syncs will transfer the remaining data.
 
 #### HOCON
 


### PR DESCRIPTION
This parameter no longer has a default for 5.2.x, while unset it
does nothing