### PR TITLE
(PDB-4636) Allow disabling migrations

### DIFF
--- a/ext/bin/run-external-tests
+++ b/ext/bin/run-external-tests
@@ -31,6 +31,7 @@ export PDB_JAR="$(pwd)/target/puppetdb.jar"
 
 run ext/test/top-level-cli
 run ext/test/upgrade-and-exit
+run ext/test/database-migration-config
 
 if test "$failures" -eq 0; then
     echo "failures: $failures" 1>&2

--- a/ext/test/database-migration-config
+++ b/ext/test/database-migration-config
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_name=test-database-migration-config
+
+usage() { echo 'Usage: [PDB_JAR=JAR] $(basename "$0") --pgbin PGBIN --pgport PGPORT'; }
+misuse() { usage 1>&2; exit 2; }
+
+argv=("$(cd "$(dirname "$0")" && pwd)/$(basename "$0")" "$@")
+declare -A opt
+
+while test $# -gt 0; do
+    case "$1" in
+        --pgbin|--pgport)
+            test $# -gt 1 || misuse
+            opt["${1:2}"]="$2"
+            shift 2
+            ;;
+        *)
+            misuse
+    esac
+done
+
+if test -z "${opt[pgbin]:-}"; then
+    opt[pgbin]="$(ext/bin/test-config --get pgbin)"
+    if test  -z "${opt[pgbin]:-}"; then
+        echo 'Please specify --pgbin or set pgbin with ext/bin/test-config' 1>&2
+        exit 2
+    fi
+fi
+
+if test -z "${opt[pgport]:-}"; then
+    opt[pgport]="$(ext/bin/test-config --get pgport)"
+     if test  -z "${opt[pgport]:-}"; then
+        echo 'Please specify --pgport or set pgport with ext/bin/test-config' 1>&2
+        exit 2
+    fi
+fi
+
+set -x
+
+if test -z "${PDBBOX:-}"; then
+    # No PDBBOX, set one up and run ourselves again
+    tmpdir="$(mktemp -d "$test_name-pdbbox-XXXXXX")"
+    tmpdir="$(cd "$tmpdir" && pwd)"
+    trap "$(printf 'rm -rf %q' "$tmpdir")" EXIT
+    # Don't exec (or we'll never run the trap)
+    ext/bin/with-pdbbox --box "$tmpdir/box" \
+                        --pgbin "${opt[pgbin]}" --pgport "${opt[pgport]}" \
+                        -- "${argv[@]}"
+    exit 0
+fi
+
+tmpdir="$(mktemp -d "$test_name-XXXXXX")"
+tmpdir="$(cd "$tmpdir" && pwd)"
+trap "$(printf 'rm -rf %q' "$tmpdir")" EXIT
+
+
+# Since we have an empty database, we need all the migrations, so we
+# can just set the option to false to test whether it blocks them.
+
+# Append "migrate? = false" just after the [database] section header
+sed -i '/\[database\]/a migrate? = false' "$PDBBOX/pdb.ini"
+
+for cmd in services upgrade; do
+    rc=0
+    ./pdb "$cmd" -c "$PDBBOX/pdb.ini" 1>"$tmpdir/out" 2>"$tmpdir/err" || rc=$?
+    cat "$tmpdir/out" "$tmpdir/err"
+    # This will become 109 once trapperkeeper supports custom exit statuses/
+    test "$rc" -eq 1
+    grep -F 'Database is not fully migrated and migration is disallowed' \
+         "$tmpdir/err"
+done

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -369,7 +369,7 @@
                          :current current
                          :oldest oldest})))
       @sutils/db-metadata
-      (let [migrated? (migrate! db-conn-pool)]
+      (let [migrated? (migrate!)]
         (indexes! config)
         migrated?))))
 

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -83,7 +83,8 @@
             :report-ttl (pls/defaulted-maybe String "14d")
             :node-purge-ttl (pls/defaulted-maybe String "14d")
             :node-purge-gc-batch-limit (pls/defaulted-maybe s/Int 25)
-            :node-ttl (pls/defaulted-maybe String "7d")})))
+            :node-ttl (pls/defaulted-maybe String "7d")
+            :migrate? (pls/defaulted-maybe String "true")})))
 
 (def database-config-out
   "Schema for parsed/processed database config"
@@ -117,7 +118,8 @@
           :report-ttl Period
           :node-purge-ttl Period
           :node-purge-gc-batch-limit (s/constrained s/Int (complement neg?))
-          :node-ttl Period}))
+          :node-ttl Period
+          :migrate? Boolean}))
 
 (defn half-the-cores*
   "Function for computing half the cores of the system, useful

--- a/src/puppetlabs/puppetdb/core.clj
+++ b/src/puppetlabs/puppetdb/core.clj
@@ -24,7 +24,7 @@
     (println (str/join "\n" usage-lines))))
 
 (defn run-command
-  "Does the real work of invoking a command by attempting to result it and
+  "Does the real work of invoking a command by attempting to resolve it and
    passing in args. `success-fn` is a no-arg function that is called when the
    command successfully executes.  `fail-fn` is called when a bad command is given
    or a failure executing a command."

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1608,7 +1608,7 @@
        (difference applied-migrations)))
 
 (defn run-migrations
-  [db-connection-pool]
+  []
   (let [applied-migration-versions (applied-migrations)
         latest-applied-migration (last applied-migration-versions)
         known-migrations (apply sorted-set (keys migrations))
@@ -1663,13 +1663,13 @@
         (analyze small-tables)
         false))))
 
-(defn migrate! [db-connection-pool]
+(defn migrate! []
   "Migrates database to the latest schema version. Does nothing if
   database is already at the latest schema version.  Requires a
   connection pool because some operations may require an indepdendent
   database connection.  Returns true if there were any migrations."
   (try
-    (run-migrations db-connection-pool)
+    (run-migrations)
     (catch java.sql.SQLException e
       (log/error e (trs "Caught SQLException during migration"))
       (loop [ex (.getNextException e)]

--- a/test/puppetlabs/puppetdb/admin_clean_test.clj
+++ b/test/puppetlabs/puppetdb/admin_clean_test.clj
@@ -155,7 +155,7 @@
                                               [[3 4] 3]
                                               [[100] 0]]]
           (clear-db-for-testing!)
-          (migrate! *db*)
+          (migrate!)
           (dotimes [i 10]
             (let [name (str "foo-" i)]
               (scf-store/add-certname! name)

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -261,7 +261,7 @@
                                           [7 3]
                                           [100 0]]]
         (clear-db-for-testing!)
-        (migrate! *db*)
+        (migrate!)
         (dotimes [i 10]
           (let [name (str "foo-" i)]
             (scf-store/add-certname! name)

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -212,7 +212,8 @@
                  [9 5]]]
         (with-redefs [sutils/db-metadata (delay {:database nil :version v})]
           (try
-           (initialize-schema *db* config)
+            (jdbc/with-db-connection *db*
+              (prep-db *db* config))
            (catch clojure.lang.ExceptionInfo e
              (let [{:keys [kind current oldest]} (ex-data e)]
                (is (= ::svcs/unsupported-database kind))
@@ -220,15 +221,16 @@
                (is (= expected-oldest oldest)))))))
       (with-redefs [sutils/db-metadata (delay {:database nil :version [9 6]})]
         (is (do
-              ;; Assumes initialize-schema is idempotent, which it is
-              (initialize-schema *db* config)
+              ;; Assumes prep-db is idempotent, which it is
+              (jdbc/with-db-connection *db*
+                (prep-db *db* config))
               true))))))
 
 (deftest unsupported-database-settings-trigger-shutdown
   (svc-utils/with-single-quiet-pdb-instance
     (let [config (-> (get-service svc-utils/*server* :DefaultedConfig)
                      conf/get-config)
-          settings (request-database-settings *db*)]
+          settings (request-database-settings)]
       (doseq [[setting err-value] [[:standard_conforming_strings "off"]]]
         (try
          (verify-database-settings (map #(when (= (:name %) (name setting))

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -165,7 +165,17 @@
                        (configure-section :database write-database-config-in write-database-config-out)
                        configure-read-db)]
         (is (= (get-in config [:read-database :maximum-pool-size]) 25))
-        (is (= (get-in config [:database :maximum-pool-size]) 25))))))
+        (is (= (get-in config [:database :maximum-pool-size]) 25))))
+
+    (testing "migrate? defaults to true"
+      (let [config (-> {:database {:classname "something"
+                                   :subname "stuff"
+                                   :subprotocol "more stuff"}}
+                       (configure-section :database
+                                          write-database-config-in
+                                          write-database-config-out)
+                       configure-read-db)]
+        (is (= true (get-in config [:database :migrate?])))))))
 
 (deftest garbage-collection
   (let [config-with (fn [base-config]

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -47,7 +47,7 @@
     (testing "should return nothing if the *db* is completely migrated"
       (jdbc/with-db-connection *db*
         (clear-db-for-testing!)
-        (migrate! *db*)
+        (migrate!)
         (is (empty? (pending-migrations)))))
 
     (testing "should return missing migrations if the *db* is partially migrated"
@@ -66,11 +66,11 @@
         (clear-db-for-testing!)
         (is (= (applied-migrations) #{}))
         (testing "should migrate the database"
-          (migrate! *db*)
+          (migrate!)
           (is (= (applied-migrations) expected-migrations)))
 
         (testing "should not do anything the second time"
-          (migrate! *db*)
+          (migrate!)
           (is (= (applied-migrations) expected-migrations)))
 
         (testing "should attempt a partial migration if there are migrations missing"
@@ -80,16 +80,16 @@
           (doseq [m (filter (fn [[i migration]] (not= i 36)) (pending-migrations))]
             (apply-migration-for-testing! (first m)))
           (is (= (keys (pending-migrations)) '(36)))
-          (migrate! *db*)
+          (migrate!)
           (is (= (applied-migrations) expected-migrations))))))
 
   (testing "should throw error if *db* is at a higher schema rev than we support"
     (jdbc/with-transacted-connection *db*
-      (migrate! *db*)
+      (migrate!)
       (jdbc/insert! :schema_migrations
                     {:version (inc migrate/desired-schema-version)
                      :time (to-timestamp (now))})
-      (is (thrown? IllegalStateException (migrate! *db*))))))
+      (is (thrown? IllegalStateException (migrate!))))))
 
 (deftest migration-29
   (testing "should contain same reports before and after migration"
@@ -295,7 +295,7 @@
 
       ;; Currently sql-current-connection-table-names only looks in public.
       (is (empty? (sutils/sql-current-connection-table-names)))
-      (migrate! *db*)
+      (migrate!)
       (indexes! db-config)
       (indexes! db-config))))
 
@@ -503,7 +503,7 @@
   (record-migration! 27)
   (is (thrown-with-msg? IllegalStateException
                         #"Found an old and unuspported database migration.*"
-                        (migrate! *db*))))
+                        (migrate!))))
 
 (deftest md5-agg-test
   (with-test-db
@@ -573,7 +573,7 @@
   (record-migration! 27)
   (is (thrown-with-msg? IllegalStateException
                         #"Found an old and unuspported database migration.*"
-                        (migrate! *db*))))
+                        (migrate!))))
 
 (deftest md5-agg-test
   (with-test-db

--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -64,7 +64,7 @@
       name)))
 
 (defn init-db [db]
-  (jdbc/with-db-connection db (migrate! db)))
+  (jdbc/with-db-connection db (migrate!)))
 
 (defn drop-table!
   "Drops a table from the database.  Expects to be called from within a db binding.
@@ -130,7 +130,7 @@
          "create extension if not exists pgcrypto"))
       (let [cfg (db-user-config template-name)]
         (jdbc/with-db-connection cfg
-          (migrate! cfg)))
+          (migrate!)))
       (reset! template-created true))))
 
 (def ^:private test-db-counter (atom 0))


### PR DESCRIPTION
This won't have the custom exit status values until we have a tk that supports them (i.e. maybe not in 5.2.x.), and you should be able to run the new `ext/test/database-migration-config` test directly.

Suggest looking at the individual commits and commit messages, and in some cases ignoring whitespace may make it easier to follow along.

Oh, and we'll also have backtraces being dumped when migration is rejected until we have the newer tk, where we can make the handling friendlier.