### PR TITLE
(PDB-4639) Add connection init check to Hikari pools

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -467,6 +467,13 @@ legal value), the names will be matched as [Java regular
 expresions][java-patterns].  See the `facts-blacklist` description
 above for additional information.
 
+### `schema-check-interval`
+
+This controls how often, in milliseconds, to check the schema version PuppetDB
+is compatible with against the database's schema version. The default is every
+30 seconds. If a mismatch is detected PuppetDB will exit with an error message
+suggesting appropriate action. If set to zero, this check is disabled.
+
 ## Deprecated settings
 
 ### `classname`

--- a/ext/bin/run-external-tests
+++ b/ext/bin/run-external-tests
@@ -32,6 +32,7 @@ export PDB_JAR="$(pwd)/target/puppetdb.jar"
 run ext/test/top-level-cli
 run ext/test/upgrade-and-exit
 run ext/test/database-migration-config
+run ext/test/schema-mismatch-causes-pdb-shutdown
 
 if test "$failures" -eq 0; then
     echo "failures: $failures" 1>&2

--- a/ext/test/schema-mismatch-causes-pdb-shutdown
+++ b/ext/test/schema-mismatch-causes-pdb-shutdown
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() { echo 'Usage: [PDB_JAR=JAR] $(basename "$0") --pgbin PGBIN --pgport PGPORT'; }
+misuse() { usage 1>&2; exit 2; }
+
+argv=("$(cd "$(dirname "$0")" && pwd)/$(basename "$0")" "$@")
+declare -A opt
+
+while test $# -gt 0; do
+    case "$1" in
+        --pgbin|--pgport)
+            test $# -gt 1 || misuse
+            opt["${1:2}"]="$2"
+            shift 2
+            ;;
+        *)
+            misuse
+    esac
+done
+
+if test -z "${opt[pgbin]:-}"; then
+    opt[pgbin]="$(ext/bin/test-config --get pgbin)"
+    if test  -z "${opt[pgbin]:-}"; then
+        echo 'Please specify --pgbin or set pgbin with ext/bin/test-config' 1>&2
+        exit 2
+    fi
+fi
+
+if test -z "${opt[pgport]:-}"; then
+    opt[pgport]="$(ext/bin/test-config --get pgport)"
+     if test  -z "${opt[pgport]:-}"; then
+        echo 'Please specify --pgport or set pgport with ext/bin/test-config' 1>&2
+        exit 2
+    fi
+fi
+
+set -x
+
+if test -z "${PDBBOX:-}"; then
+    # No PDBBOX, set one up and run ourselves again
+    tmpdir="$(mktemp -d "test-schema-mismatch-bails-XXXXXX")"
+    tmpdir="$(cd "$tmpdir" && pwd)"
+    trap "$(printf 'rm -rf %q' "$tmpdir")" EXIT
+    # Don't exec (or we'll never run the trap)
+    ext/bin/with-pdbbox --box "$tmpdir/box" \
+                        --pgbin "${opt[pgbin]}" --pgport "${opt[pgport]}" \
+                        -- "${argv[@]}"
+    exit 0
+fi
+
+tmpdir="$(mktemp -d "test-schema-mismatch-bails-XXXXXX")"
+tmpdir="$(cd "$tmpdir" && pwd)"
+trap "$(printf 'rm -rf %q' "$tmpdir")" EXIT
+
+sed -i '/\[database\]/a schema-check-interval = 500' "$PDBBOX/pdb.ini"
+
+# use upgrade command to init pdb and apply all migrations
+./pdb upgrade -c "$PDBBOX/pdb.ini"
+
+# start pdb in the background
+./pdb services -c "$PDBBOX/pdb.ini" 1>"$tmpdir/pdb-out" 2>"$tmpdir/pdb-err"  & pdb_pid=$!
+
+# allow time for pdb to start before changing migration level
+while ! grep -F "Finished database garbage collection" "$tmpdir/pdb-out" > /dev/null
+do
+    echo 'Waiting for pdb to start...'
+    cat "$tmpdir/pdb-out" "$tmpdir/pdb-err"
+    sleep 3
+done
+
+# simulate a different pdb completing a new migration
+psql -U puppetdb puppetdb -c 'INSERT INTO schema_migrations (version, time) VALUES (10000, now());'
+
+# wait for the background pdb to notice the migration change and exit
+rc=0
+wait $pdb_pid || rc=$?
+test "$rc" -eq 1
+
+cat "$tmpdir/pdb-out" "$tmpdir/pdb-err"
+grep -F 'Please upgrade PuppetDB' "$tmpdir/pdb-out"

--- a/src-gems/puppetlabs/puppetdb/integration/install_gems.clj
+++ b/src-gems/puppetlabs/puppetdb/integration/install_gems.clj
@@ -11,7 +11,7 @@
     (jruby-core/cli-run! jruby-config "gem" args)))
 
 (defn install-gems [gem-list-name config _]
-  (gem-run! config "install" "facter")
+  (gem-run! config "install" "facter" "-v" "2.5.7")
   (gem-run! config "install" "hiera")
 
   ;; Install the puppetserver vendored gems listed inside its jar; this is where

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -500,17 +500,43 @@
   (when emit-cmd-events?
     (async/>!! cmd-event-ch (queue/make-cmd-event cmdref kind))))
 
+(defn check-schema-version
+  [desired-schema-version context db service shutdown-on-error]
+  {:pre [(integer? desired-schema-version)]}
+  (when-not (= #{:stopping} @(:stop-status context))
+    (let [schema-version (-> (jdbc/with-transacted-connection db
+                               (jdbc/query "select max(version) from schema_migrations"))
+                             first
+                             :max)]
+      (when-not (= schema-version desired-schema-version)
+        (let [ex-msg (cond
+                       (> schema-version desired-schema-version)
+                       (str
+                        (trs "Please upgrade PuppetDB: ")
+                        (trs "your database contains schema migration {0} which is too new for this version of PuppetDB."
+                             schema-version))
+
+                       (< schema-version desired-schema-version)
+                       (str
+                        (trs "Please run PuppetDB with the migrate? option set to true to upgrade your database. ")
+                        (trs "The detected migration level {0} is out of date." schema-version))
+
+                       :else
+                       (throw (Exception. "Unknown state when checking schema versions")))]
+          (shutdown-on-error (service-id service)
+                             #(throw (ex-info ex-msg {:kind ::schema-mismatch}))))))))
+
 (defn start-puppetdb
   "Throws {:kind ::unsupported-database :current version :oldest version} if
   the current database is not supported. If a database setting is configured
   incorrectly, throws {:kind ::invalid-database-configuration :failed-validation failed-map}"
-  [context config service get-registered-endpoints]
+  [context config service get-registered-endpoints shutdown-on-error]
   (let [{:keys [developer jetty
                 database read-database
                 puppetdb command-processing
                 emit-cmd-events?]} config
         {:keys [pretty-print max-enqueued]} developer
-        {:keys [gc-interval node-purge-ttl]} database
+        {:keys [gc-interval node-purge-ttl schema-check-interval]} database
         {:keys [disable-update-checking]} puppetdb
         {:keys [cmd-event-mult cmd-event-ch]} context
 
@@ -569,6 +595,14 @@
             gc-interval-millis (to-millis gc-interval)]
         (when-not disable-update-checking
           (maybe-check-for-updates config read-db job-pool))
+        (when (pos? schema-check-interval)
+          (interspaced schema-check-interval
+                       #(check-schema-version desired-schema-version
+                                              context
+                                              (:scf-read-db globals)
+                                              service
+                                              shutdown-on-error)
+                       job-pool))
         (when (pos? gc-interval-millis)
           (let [request (db-config->clean-request database)]
             (interspaced gc-interval-millis
@@ -609,7 +643,7 @@
          (map? config)]
    :post [(map? %)]}
   (try
-    (start-puppetdb context config service get-registered-endpoints)
+    (start-puppetdb context config service get-registered-endpoints shutdown-on-error)
     (catch ExceptionInfo ex
       (let [{:keys [kind] :as data} (ex-data ex)
             stop (fn [msg]

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -62,7 +62,8 @@
             [puppetlabs.puppetdb.query-eng :as qeng]
             [puppetlabs.puppetdb.query.population :as pop]
             [puppetlabs.puppetdb.scf.migrate
-             :refer [migrate! indexes! pending-migrations require-valid-schema]]
+             :refer [migrate! indexes! pending-migrations
+                     require-valid-schema desired-schema-version]]
             [puppetlabs.puppetdb.scf.storage :as scf-store]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.schema :as pls :refer [defn-validated]]
@@ -513,9 +514,14 @@
         {:keys [disable-update-checking]} puppetdb
         {:keys [cmd-event-mult cmd-event-ch]} context
 
-        write-db (jdbc/pooled-datasource (assoc database :pool-name "PDBWritePool")
+        write-db (jdbc/pooled-datasource (assoc database
+                                                :pool-name "PDBWritePool"
+                                                :expected-schema desired-schema-version)
                                          database-metrics-registry)
-        read-db (jdbc/pooled-datasource (assoc read-database :read-only? true :pool-name "PDBReadPool")
+        read-db (jdbc/pooled-datasource (assoc read-database
+                                               :read-only? true
+                                               :pool-name "PDBReadPool"
+                                               :expected-schema desired-schema-version)
                                         database-metrics-registry)]
 
     (when-let [v (version/version)]

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -73,7 +73,8 @@
      :statements-cache-size (pls/defaulted-maybe s/Int 0)
      :connection-timeout (pls/defaulted-maybe s/Int 3000)
      :facts-blacklist pls/Blacklist
-     :facts-blacklist-type (pls/defaulted-maybe (s/enum "literal" "regex") "literal")}))
+     :facts-blacklist-type (pls/defaulted-maybe (s/enum "literal" "regex") "literal")
+     :schema-check-interval (pls/defaulted-maybe s/Int (* 30 1000))}))
 
 (def write-database-config-in
   "Includes the common database config params, also the write-db specific ones"
@@ -109,7 +110,8 @@
    (s/optional-key :password) String
    (s/optional-key :syntax_pgs) String
    (s/optional-key :facts-blacklist) clojure.lang.PersistentVector
-   :facts-blacklist-type String})
+   :facts-blacklist-type String
+   :schema-check-interval s/Int})
 
 (def write-database-config-out
   "Schema for parsed/processed database config that includes write database params"

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -175,7 +175,18 @@
                                           write-database-config-in
                                           write-database-config-out)
                        configure-read-db)]
-        (is (= true (get-in config [:database :migrate?])))))))
+        (is (= true (get-in config [:database :migrate?])))))
+
+    (testing "schema-check-interval defaults to 30 seconds"
+      (let [config (-> {:database {:classname "something"
+                                   :subname "stuff"
+                                   :subprotocol "more stuff"}}
+                       (configure-section :database
+                                          write-database-config-in
+                                          write-database-config-out)
+                       configure-read-db)
+            thirty-seconds-in-millis 30000]
+        (is (= (get-in config [:database :schema-check-interval]) thirty-seconds-in-millis))))))
 
 (deftest garbage-collection
   (let [config-with (fn [base-config]

--- a/test/puppetlabs/puppetdb/migration_coordination_test.clj
+++ b/test/puppetlabs/puppetdb/migration_coordination_test.clj
@@ -1,0 +1,83 @@
+(ns puppetlabs.puppetdb.migration-coordination-test
+  (:require
+   [clojure.test :refer :all]
+   [puppetlabs.puppetdb.command.constants :as cmd-consts]
+   [puppetlabs.puppetdb.jdbc :as jdbc]
+   [puppetlabs.puppetdb.scf.migrate :refer [desired-schema-version]]
+   [puppetlabs.puppetdb.testutils.db :as tdb :refer [*db*]]
+   [puppetlabs.puppetdb.testutils.services :as svc-utils]
+   [puppetlabs.puppetdb.time :refer [now to-timestamp]]
+   [puppetlabs.puppetdb.testutils.cli :refer [example-report]]))
+
+(deftest schema-mismatch-causes-new-connections-to-throw-expected-errors
+  (doseq [db-upgraded? [true false]]
+    (tdb/with-test-db
+      (svc-utils/call-with-puppetdb-instance
+       (-> (svc-utils/create-temp-config)
+           (assoc :database *db*)
+           ;; Allow client connections to timeout more quickly to speed test
+           (assoc-in [:database :connection-timeout] 300)
+           (assoc-in [:database :gc-interval] 0))
+       (fn []
+         (jdbc/with-transacted-connection *db*
+           ;; Simulate either the db or pdb being upgraded before the other.
+           ;; This is added after initial startup and should cause any future
+           ;; connection attempts to fail the HikariCP connectionInitSql check
+           (if db-upgraded?
+             (jdbc/insert! :schema_migrations {:version (inc desired-schema-version)
+                                               :time (to-timestamp (now))})
+             ;; removing the most recent schema version makes the connectionInitSql
+             ;; check think the database doesn't have the correct migration applied
+             (jdbc/delete! :schema_migrations ["version = ?" desired-schema-version])))
+
+         ;; Kick out any existing connections belonging to the test db user. This
+         ;; will cause HikariCP to create new connections which should all error
+         (jdbc/with-transacted-connection
+           (tdb/db-admin-config)
+           (jdbc/query
+            (format "SELECT pg_terminate_backend(pid)
+                      FROM pg_stat_activity
+                      WHERE usename = '%s';" (:user *db*))))
+
+         (loop [retries 0]
+           ;; Account for a race condition where connnections kicked out of PG by
+           ;; the command above aren't yet cleaned from the pool. If Hikari attempts to
+           ;; use these stale connections the error message in any resp will say the
+           ;; connection was closed due to an administrator command which isn't what
+           ;; we want to test. By allowing time for cleanup we can test that the
+           ;; expected error message about a migration mismatch is present
+           (let [ex (is (thrown? Exception
+                                 (svc-utils/get-or-throw
+                                  (svc-utils/query-url-str "/facts"))))
+                 resp (-> ex ex-data :response)
+                 err-msg (if db-upgraded?
+                           "ERROR: Please upgrade PuppetDB"
+                           "ERROR: Please run PuppetDB with the migrate\\? option set to true")]
+             (is (= 500 (:status resp)))
+             (cond
+               (some? (re-find (re-pattern err-msg) (:body resp))) :found
+               (> retries 10) (throw (Exception. "Unable to find expected migration level error"))
+               :else
+               (do
+                 (Thread/sleep 100)
+                 (recur (inc retries))))))
+
+         ;; Check that cmd submission isn't possible once migration level has been updated.
+         ;; In this case the migration specific error doesn't propagate up to the cmd client
+         ;; but is seen later in the logs during cmd retries. The client only receives a 503
+         ;; service unavailable response in this case
+         (loop [retries 0]
+           (let [ex (is (thrown? Exception
+                                 (svc-utils/sync-command-post
+                                  (svc-utils/pdb-cmd-url)
+                                  "foo.1"
+                                  "store report"
+                                  cmd-consts/latest-report-version
+                                  (assoc example-report :certname "foo.1"))))]
+             (cond
+               (= 503 (-> ex ex-data :response :status)) :found
+               (> retries 10) (throw (Exception. "Unable to find expected cmd submission status"))
+               :else
+               (do
+                 (Thread/sleep 100)
+                 (recur (inc retries)))))))))))


### PR DESCRIPTION
This commit uses the HikariCP connectionInitSql option to block the creation of
new connections when there is a migration mismatch detected between the database
and PDB. This guards against a situation that could arise with PDB on compilers
where the database is migrated to a newer version before the local PDB has been
upgraded.