### PR TITLE
(maint) Fix testutil that clears db

### DIFF
--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -78,6 +78,12 @@
   [sequence-name]
   (jdbc/do-commands (format "DROP SEQUENCE IF EXISTS %s" sequence-name)))
 
+(defn drop-aggregate!
+  "Drops a function from the database.  Expects to be called from within a db binding.
+  Exercise extreme caution when calling this function!"
+  [function-name]
+  (jdbc/do-commands (format "DROP AGGREGATE IF EXISTS %s CASCADE" function-name)))
+
 (defn drop-function!
   "Drops a function from the database.  Expects to be called from within a db binding.
   Exercise extreme caution when calling this function!"
@@ -97,6 +103,8 @@
      (drop-table! table-name))
    (doseq [sequence-name (cons "test" (sutils/sql-current-connection-sequence-names))]
      (drop-sequence! sequence-name))
+   (doseq [aggregate-name (sutils/sql-current-connection-aggregate-names)]
+          (drop-aggregate! aggregate-name))
    (doseq [function-name (sutils/sql-current-connection-function-names)]
           (drop-function! function-name))))
 


### PR DESCRIPTION
If clear-db-for-testing! is called on a migrated db, it will attempt to
delete the sha1_agg aggregate function via the drop-function! testutils
method. Because aggregates and function are deleted differently (ie.
"DROP AGGREGATE" instead of "DROP FUNCTION") this would cause the test
to fail with
```
java.sql.BatchUpdateException: Batch entry 0 DROP FUNCTION IF EXISTS sha1_agg(bytea) CASCADE was aborted: ERROR: "sha1_agg" is an aggregate function
  Hint: Use DROP AGGREGATE to drop aggregate functions.
```
This adds a DROP AGGREGATE section to the clear-db-for-testing!
function. It also changes the sql-current-connection-function-names to
exclude aggregates and adds a new version of that function to lookup
aggregate names.