### PR TITLE
(PDB-4678) Update PostgreSQL SSL documentation

### DIFF
--- a/documentation/postgres_ssl.markdown
+++ b/documentation/postgres_ssl.markdown
@@ -15,72 +15,34 @@ When configuring SSL, you need to decide whether you will use:
 
 Both methodologies are valid, but while self-signed certificates are far more common in the real world, this type of configuration must be set up with care.
 
-If you wish to use self-signed certificates, you have two options:
-
-1. Place your private CA in a Java KeyStore and tell Java to use that KeyStore for its system KeyStore
-2. Disable SSL verification
-
-Each option has a different impact on your configuration, as discussed below.
-
 Before beginning, take a look at PostgreSQL's [secure TCP/IP connections with SSL documentation](http://www.postgresql.org/docs/current/static/ssl-tcp.html), which explains in detail how to configure SSL on the server side.
 
 *Note:* Our guide focuses on server-based SSL. Client certificate support is not documented at this time.
 
-### Using Puppet certificates with the Java KeyStore
+### Using Puppet's certificates for SSL
+
+If you don't have a signed Puppet certificate on your PostgreSQL server, see the [ssl documentaion](https://jdbc.postgresql.org/documentation/head/ssl-client.html) for
+alternate SSL connection options.
 
 Using Puppet certificates to secure your PostgreSQL server has the following benefits:
 
 * Because you are using PuppetDB, we can presume that you are using Puppet on each server. This means you can reuse the local Puppet agent certificate for PostgreSQL.
-* Because your local Puppet agent's certificate must be signed for Puppet to work, you likely have an established workflow for getting these signed. 
+* Because your local Puppet agent's certificate must be signed for Puppet to work, you likely have an established workflow for getting these signed.
 * We also recommend this methodology for securing the HTTPS interface for PuppetDB.
 
-To begin, configure your PostgreSQL server to use the host's Puppet server certificate and key. The location of these files can be found by using the following commands:
-
-    # Certificate
-    puppet config print hostcert
-    # Key
-    puppet config print hostprivkey
-
-Copy these files to the relevant directories as specified by the PostgreSQL configuration items `ssl_cert_file` and `ssl_key_file`. This process is explained in detail [here](http://www.postgresql.org/docs/current/static/ssl-tcp.html).
-
-Make sure that `ssl` is set to `on` in `postgresql.conf`, and then restart PostgreSQL.
-
-Next, create a TrustStore containing your Puppet CA certificate. If you have been using PuppetDB for a while, you might already have such a file in `/etc/puppetdb/ssl/truststore.jks`. If not, the quickest way to create this file is:
-
-    $ sudo keytool -import -alias "My CA" -file $(puppet master --configprint ssldir)/ca/ca_crt.pem -keystore /etc/puppetdb/ssl/truststore.jks
-
-Tell Java to use this TrustStore instead of the system's default by specifying values for the properties for `trustStore` and `trustStorePassword`. These properties can be applied by modifying your service settings for PuppetDB and appending the required settings to the JAVA_ARGS variable. In Red Hat, the path to this file is `/etc/sysconfig/puppetdb`. In Debian, use `/etc/default/puppetdb`. For example:
-
-    # Modify this if you'd like to change the memory allocation, enable JMX, etc.
-    JAVA_ARGS="-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/puppetlabs/puppetdb/puppetdb-oom.hprof -Djavax.net.ssl.trustStore=/etc/puppetlabs/puppetdb/ssl/truststore.jks -Djavax.net.ssl.trustStorePassword=<PASSWORD>"
-
-*Note:* Replace `<PASSWORD>` with the password you used to create the KeyStore, or the one found in `/etc/puppetdb/ssl/puppetdb_keystore_pw.txt`.
-
-After this is complete, modify the database JDBC connection URL in your PuppetDB configuration as follows:
-
-    [database]
-    classname = org.postgresql.Driver
-    subprotocol = postgresql
-    subname = //<HOST>:<PORT>/<DATABASE>?ssl=true
-    username = <USERNAME>
-    password = <PASSWORD>
-
-Restart PuppetDB and monitor your logs for errors. Your connection should now be SSL.
-
-### Using your own self-signed CA
-
-If you wish, you can follow the [PostgreSQL JDBC SSL client setup instructions](http://jdbc.postgresql.org/documentation/head/ssl-client.html). This documentation will help you to generate a new SSL certificate, key, and CA. Make sure you place your signed certificate and private key in the locations specified by the `ssl_cert_file` and `ssl_key_file` locations, and that you change the `ssl` setting to `on` in your `postgresql.conf`. Don't forget to give the correct permissions for each file (such as `chmod 0600 file`). Otherwise, PostgreSQL will reject the key and cert files.
+Make sure you place your signed certificate and private key in the locations specified by the `ssl_cert_file` and `ssl_key_file` locations, and that you change the `ssl` setting to `on` in your `postgresql.conf`. Don't forget to give the correct permissions for each file (such as `chmod 0600 file`). Otherwise, PostgreSQL will reject the key and cert files.
 
 After this is done, modify the JDBC URL in the database configuration section for PuppetDB. For example:
 
     [database]
     classname = org.postgresql.Driver
     subprotocol = postgresql
-    subname = //<HOST>:<PORT>/<DATABASE>?ssl=true&sslfactory=org.postgresql.ssl.jdbc4.LibPQFactory&sslmode=verify-full&sslrootcert=/etc/puppetlabs/puppetdb/ssl/ca.pem
+    subname = //<HOST>:<PORT>/<DATABASE>?ssl=true&sslfactory=org.postgresql.ssl.LibPQFactory&sslmode=verify-full&sslrootcert=/etc/puppetlabs/puppetdb/ssl/ca.pem
     username = <USERNAME>
     password = <PASSWORD>
 
 Restart PuppetDB and monitor your logs for errors. If all goes well your connection should now be SSL.
+If you are on a PuppetDB version before 6.8.0, the `sslfactory` will be `org.postgresql.ssl.jdbc4.LibPQFactory`
 
 ### Setting up SSL with a publicly signed certificate on the PuppetDB server
 
@@ -97,11 +59,35 @@ For example:
     [database]
     classname = org.postgresql.Driver
     subprotocol = postgresql
-    subname = //<HOST>:<PORT>/<DATABASE>?ssl=true
+    subname = //<HOST>:<PORT>/<DATABASE>?ssl=true&sslmode=verify-full&sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory
     username = <USERNAME>
     password = <PASSWORD>
 
 Restart PuppetDB and monitor your logs for errors. Your connection should now be SSL.
+
+#### Using a custom Java keystore
+
+If your CA cert is not in Java's default keystore, it may be necessary to create your own. Create a
+TrustStore containing your CA certificate. If you have been using PuppetDB for a while, you might
+already have such a file in `/etc/puppetdb/ssl/truststore.jks`. If not, the quickest way to create
+this file is:
+
+    $ sudo keytool -import -alias "My CA" -file /path/to/ca_crt.pem -keystore /etc/puppetdb/ssl/truststore.jks
+
+Tell Java to use this TrustStore instead of the system's default by specifying values for the
+properties for `trustStore` and `trustStorePassword`. These properties can be applied by modifying
+your service settings for PuppetDB and appending the required settings to the JAVA_ARGS variable.
+In Red Hat, the path to this file is `/etc/sysconfig/puppetdb`. In Debian, use
+`/etc/default/puppetdb`. For example:
+
+    # Modify this if you'd like to change the memory allocation, enable JMX, etc.
+    JAVA_ARGS="-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/puppetlabs/puppetdb/puppetdb-oom.hprof -Djavax.net.ssl.trustStore=/etc/puppetlabs/puppetdb/ssl/truststore.jks -Djavax.net.ssl.trustStorePassword=<PASSWORD>"
+
+*Note:* Replace `<PASSWORD>` with the password you used to create the KeyStore, or the one found in
+`/etc/puppetdb/ssl/puppetdb_keystore_pw.txt`.
+
+After this is complete, modify the database JDBC connection URL in your PuppetDB configuration as
+the documentation describes above for publicly signed certificates.
 
 ### Disabling SSL verification
 


### PR DESCRIPTION
The main change is we will no longer document that FOSS users can use
their Puppet CA cert for postgres SSL via a Java keystore. They should
use libPQFactory because this is what is used in PE so it is more
tested. The documentation for creating a Java keystore remains, but is
downgraded to being recommended only if your cert comes from another CA
and is not able to be verified by the default Java keystore.