### PR TITLE
(maint) Bump clj-parent to 4.4.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def pdb-version "6.9.2-SNAPSHOT")
-(def clj-parent-version "4.3.3")
+(def clj-parent-version "4.4.1")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
This version was released publicly to clojars.

4.3.3 was an internal-only release