### PR TITLE
(PDB-4675) Fix deadlock issue in partitioned tables

### DIFF
--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -393,9 +393,9 @@
   [{:keys [payload id received]} start-time db]
   (let [{:keys [certname puppet_version] :as report} payload
         producer-timestamp (to-timestamp (:producer_timestamp payload (now)))]
-    (jdbc/with-transacted-connection db
-      (scf-storage/maybe-activate-node! certname producer-timestamp)
-      (scf-storage/add-report! report received))
+    ;; Unlike the other storage functions, add-report! manages its own
+    ;; transaction, so that it can dynamically create table partitions
+    (scf-storage/add-report! report received db)
     (log-command-processed-messsage id received start-time :store-report certname
                                     {:puppet-version puppet_version})))
 

--- a/test/puppetlabs/puppetdb/testutils/nodes.clj
+++ b/test/puppetlabs/puppetdb/testutils/nodes.clj
@@ -86,9 +86,10 @@
     (scf-store/add-report! (-> web1
                                basic-report-for-node
                                (assoc :job_id "0987654321"))
-                           (now))
-    (scf-store/add-report! (basic-report-for-node puppet) (plus (now) (seconds 2)))
-    (scf-store/add-report! (basic-report-for-node db) (plus (now) (seconds 3)))
+                           (now)
+                           *db*)
+    (scf-store/add-report! (basic-report-for-node puppet) (plus (now) (seconds 2)) *db*)
+    (scf-store/add-report! (basic-report-for-node db) (plus (now) (seconds 3)) *db*)
     {:web1    web1
      :web2    web2
      :db      db

--- a/test/puppetlabs/puppetdb/testutils/reports.clj
+++ b/test/puppetlabs/puppetdb/testutils/reports.clj
@@ -48,8 +48,7 @@
    (let [example-report (reports/report-query->wire-v8 example-report)
          report-hash (shash/report-identity-hash
                       (scf-store/normalize-report example-report))]
-     (scf-store/maybe-activate-node! (:certname example-report) timestamp)
-     (scf-store/add-report!* example-report timestamp update-latest-report?)
+     (scf-store/add-report! example-report timestamp *db* update-latest-report?)
      (report-for-hash :v4 report-hash))))
 
 (defmacro with-or-without-corrective-change


### PR DESCRIPTION
In partitioned tables, we attempted every insertion to CREATE TABLE IF
NOT EXISTS and then INSERT the data. This caused a issue where when
processing multiple insertions concurrently, we could deadlock between
the table creation in one command processor and the insertion in
another.

This instead switched the CREATE TABLE step to be opportunistic, and
will only happen when an attempt to store the data failed with a "table
undefined" error. If multiple reports are being processed at once, we
can still see some errors in the postgresql logs about the table already
existing, but that is an example of rollbacks properly rectifying the
error.

By moving partition creation to another transaction, the insertion of
reports is returned to its previous complexity and the deadlocks no
longer occur.