### PR TITLE
(PDB-2398) Fix ezbake config `:build-type` is `:is_pe_build`

### DIFF
--- a/resources/ext/cli/delete-reports.erb
+++ b/resources/ext/cli/delete-reports.erb
@@ -5,7 +5,7 @@ set -e
 pdb_service=<%= EZBake::Config[:user] %>
 pdb_db_name="$pdb_service"
 pg_port=5432
-<% if EZBake::Config[:build_type] == "pe" %>
+<% if EZBake::Config[:is_pe_build] %>
 pg_user=pe-postgres
 psql_cmd=/opt/puppetlabs/server/bin/psql
 <% else %>


### PR DESCRIPTION
In the ezbake packaging process, the `:build-type` option is converted
to `:is-pe-build` boolean, it is true only if `:build-type` is `"pe"`.

The rename happens in clojure [here](https://github.com/puppetlabs/ezbake/blob/master/src/puppetlabs/ezbake/core.clj#L623-L624).

An example usage of `:is_pe_build` can be seen [here](https://github.com/puppetlabs/ezbake/blob/72c9a33a01f15cb4b24800979848d60dfac88c8c/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb#L160-L162).