### PR TITLE
(maint) Create files before background redirection

### DIFF
--- a/ext/test/schema-mismatch-causes-pdb-shutdown
+++ b/ext/test/schema-mismatch-causes-pdb-shutdown
@@ -61,6 +61,7 @@ sed '/\[database\]/a schema-check-interval = 500' "$PDBBOX/pdb.ini" \
 ./pdb upgrade -c "$tmpdir/pdb.ini"
 
 # start pdb in the background
+touch "$tmpdir/pdb-out" "$tmpdir/pdb-err"
 ./pdb services -c "$tmpdir/pdb.ini" 1>"$tmpdir/pdb-out" 2>"$tmpdir/pdb-err"  & pdb_pid=$!
 
 # allow time for pdb to start before changing migration level


### PR DESCRIPTION
Redirection does create the file while the command is running, and does
so even before any output is produced. But the `&` operator takes
precendence here and runs the entire command in the background,
including the redirections, so its possible for the files to not
exist when they are read below.