### PR TITLE
(maint) with-pdbbox: use ::1 for localhost to fix macos tests

### DIFF
--- a/ext/bin/with-pdbbox
+++ b/ext/bin/with-pdbbox
@@ -63,7 +63,7 @@ trap "$(printf 'rm -rf %q' "$box")" EXIT
 export PDBBOX="$box"
 "$script_home"/pdbbox-init --sandbox "$box" --pgbin "$pgbin" \
               --pgport "$pgport" \
-              --bind-addr ip6-localhost --bind-addr localhost
+              --bind-addr ::1 --bind-addr localhost
 
 # Use a subshell for a nested EXIT trap
 (trap '"$script_home"/pdbbox-env pg_ctl stop' EXIT


### PR DESCRIPTION
Looks like macos doesn't define ip6-localhost