### PR TITLE
(maint) Switch Travis to Ubuntu 20.04 builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ dist: xenial
 sudo: required
 
 services:
-  # bionic uses 18.06 but need 19.03+ for buildkit so upgrade later in relevant cell
   - docker
 
 # The test specifications are all extracted from the PDB_TEST value.
@@ -69,9 +68,6 @@ aliases:
 
   - &run-docker-tests |
     set -ex
-    sudo apt update -y && sudo apt install -y docker.io
-    sudo systemctl unmask docker.service
-    sudo systemctl start docker
     sudo rm /usr/local/bin/docker-compose
     curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
     chmod +x docker-compose
@@ -180,9 +176,9 @@ jobs:
       os: osx
 
     - stage: ❧ pdb container tests
-      dist: bionic
+      dist: focal
       language: ruby
-      rvm: 2.6.5
+      rvm: 2.6.6
       # necessary to prevent overwhelming TravisCI build output limits
       env: DOCKER_COMPOSE_VERSION=1.25.5 DOCKER_BUILD_FLAGS="--progress plain"
       script: *run-docker-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,17 +66,18 @@ aliases:
     ext/bin/check-spec-env "$PDB_TEST"
     ext/bin/run-rspec-tests "$puppet_ref"
 
-  - &run-docker-tests |
-    set -ex
-    sudo rm /usr/local/bin/docker-compose
-    curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
-    chmod +x docker-compose
-    sudo mv docker-compose /usr/local/bin
-    cd docker
-    make lint
-    make build
-    make test
-    set +x
+  - &before-docker-tests
+    - sudo rm /usr/local/bin/docker-compose
+    - curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
+    - chmod +x docker-compose
+    - sudo mv docker-compose /usr/local/bin
+
+  - &run-docker-tests
+    - set -e
+    - cd docker
+    - make lint
+    - make build
+    - make test
 
 jobs:
   allow_failures:
@@ -181,6 +182,7 @@ jobs:
       rvm: 2.6.6
       # necessary to prevent overwhelming TravisCI build output limits
       env: DOCKER_COMPOSE_VERSION=1.25.5 DOCKER_BUILD_FLAGS="--progress plain"
+      before_install: *before-docker-tests
       script: *run-docker-tests
 
 on_success: ext/travisci/on-success


### PR DESCRIPTION
 - Focal fossa time!
 - No need to upgrade Docker for buildkit as image has 19.03 already,
   so this should remove ~30s of setup time
 - Switch to Ruby 2.6.6 for specs, which is known good and installed
 - docker-compose in the 19.03 release included here is 1.23.1, so
   continue to upgrade it on Travis to 1.25.5
 - Separate out Travis operations so that logs have timings for lint, build and test