### PR TITLE
(PDB-4741) Fix errors with agent report filter

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/default_reports.clj
+++ b/src/puppetlabs/puppetdb/query_eng/default_reports.clj
@@ -10,7 +10,7 @@
 
 (defn is-page-order-opt?
   [page-order-opts]
-  (let [valid-opts ["limit" "group_by" "order_by"]]
+  (let [valid-opts ["limit" "group_by" "order_by" "offset"]]
     (every? (fn [opt] (some #(= % (first opt)) valid-opts)) page-order-opts)))
 
 (defn mentions-report-type?
@@ -26,6 +26,7 @@
   (cm/match
    [ast]
 
+   [nil] false
    [[]] false
    [::elide] false
    [[(op :guard #{"=" ">" "<" "<=" ">=" "~" "~>"}) field value]] (= field "type")
@@ -34,7 +35,6 @@
    [["null?" field bool]] (= field "type")
    [["in" field ["array" & values]]] (= field "type")
 
-   ;; This needs to precede (or maybe just obviates?) the "from" below.
    ;; New-style explicit subquery
    [["in" fields ["from" entity ["extract" sub-fields expr] & page-order-opts]]]
    false
@@ -90,6 +90,7 @@
   (cm/match
    [ast]
 
+   [nil] ast
    [[]] ast
    [::elide] ast
    [[(op :guard #{"=" ">" "<" "<=" ">=" "~" "~>"}) field value]] ast

--- a/test/puppetlabs/puppetdb/query_eng/default_reports_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng/default_reports_test.clj
@@ -76,7 +76,20 @@
     (doseq [op ["and" "or"]]
       (is (= [op ["=" "foo" "bar"] ["=" "bar" "baz"]] (t/maybe-add-agent-report-filter-to-subqueries [op ["=" "foo" "bar"] ["=" "bar" "baz"]]))))
 
-      (is (= ["in" "foo" ["array" "foo" "bar"]] (t/maybe-add-agent-report-filter-to-subqueries ["in" "foo" ["array" "foo" "bar"]])))))
+      (is (= ["in" "foo" ["array" "foo" "bar"]] (t/maybe-add-agent-report-filter-to-subqueries ["in" "foo" ["array" "foo" "bar"]]))))
+
+  (testing "nil expression is allowed"
+    (let [query ["in" ["package_name" "version" "provider"] ["from" "packages" ["extract" ["package_name" "version" "provider"] nil]]]]
+      (is (= query (t/maybe-add-agent-report-filter-to-subqueries query)))))
+
+  (testing "paging options"
+    (let [query ["in" ["package_name" "version" "provider"]
+                 ["from" "packages"
+                  ["extract" ["package_name" "version" "provider"]]
+                  ["order_by" ["package_name" "version" "provider"]]
+                  ["limit" 1000000]
+                  ["offset" 0]]]]
+      (is (= query (t/maybe-add-agent-report-filter-to-subqueries query))))))
 
 (deftest test-random-bits
 


### PR DESCRIPTION
Adds `nil` as a basecase because `nil` is a valid expression.

Adds `"offset"` as one of the allowed paging operators.