### PR TITLE
(maint) Bump clj-parent to 4.5.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def pdb-version "6.10.2-SNAPSHOT")
-(def clj-parent-version "4.5.1")
+(def clj-parent-version "4.5.2")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))
@@ -20,7 +20,7 @@
    :password :env/nexus_jenkins_password
    :sign-releases false})
 
-(def i18n-version "0.9.0")
+(def i18n-version "0.8.0")
 
 (def need-permgen?
   (= "1.7" (System/getProperty "java.specification.version")))
@@ -215,8 +215,6 @@
             [lein-cloverage "1.0.6"]
             [lein-parent "0.3.7"]
             [puppetlabs/i18n ~i18n-version]]
-
-  :prep-tasks [["i18n" "make"] "compile" "javac"]
 
   :lein-release {:scm        :git
                  :deploy-via :lein-deploy}


### PR DESCRIPTION
This reverts the clj-i18n bump that seems to be breaking reloads on
certain OS's