### PR TITLE
(PDB-4769) Revert definition of active_nodes

### DIFF
--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -46,7 +46,7 @@
 
 (deftest test-plan-cte
   (is (re-matches
-         #"WITH inactive_nodes AS \(SELECT certname FROM certnames WHERE \(deactivated IS NOT NULL AND deactivated > '\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ'\) OR \(expired IS NOT NULL and expired > '\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ'\)\), active_nodes AS \(SELECT certname FROM certnames WHERE \(deactivated IS NULL AND expired IS NULL\)\) SELECT table.foo AS foo FROM table WHERE \(1 = 1\)"
+         #"WITH inactive_nodes AS \(SELECT certname FROM certnames WHERE \(deactivated IS NOT NULL AND deactivated > '\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ'\) OR \(expired IS NOT NULL and expired > '\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ'\)\), not_active_nodes AS \(SELECT certname FROM certnames WHERE \(deactivated IS NOT NULL OR expired IS NOT NULL\)\) SELECT table.foo AS foo FROM table WHERE \(1 = 1\)"
          (plan->sql (map->Query {:projections {"foo" {:type :string
                                            :queryable? true
                                            :field :table.foo}}
@@ -78,9 +78,9 @@
          (expand-user-query [["=" "prop" "foo"]])))
 
   (is (= [["=" "prop" "foo"]
-          ["in" "certname"
-           ["extract" "certname"
-            ["select_active_nodes"]]]]
+          ["not" ["in" "certname"
+                  ["extract" "certname"
+                   ["select_not_active_nodes"]]]]]
          (expand-user-query [["=" "prop" "foo"]
                              ["=" ["node" "active"] true]])))
   (is (= [["=" "prop" "foo"]


### PR DESCRIPTION
Prior to PDB-4479 (commit 262573c)
an "active node" was anything that was not an inactive node. The
definition of an inactive node was too broad so it was reduced in scope
and active_nodes was explicitly described. The result was the
active_nodes definition changed from

```
WITH inactive_nodes AS
  (SELECT certname from certnames
   WHERE (deactivated IS NOT NULL OR expired IS NOT NULL)
...
WHERE NOT (certname in (SELECT certname FROM inactive_nodes))
```

to
```
WITH active_nodes AS
  (SELECT certname from certnames
   WHERE (deactivated IS NULL AND expired IS NULL)
...
WHERE (certname in (SELECT certname FROM active_nodes))
```

While the two are logically equivalent, the Postgres query planner
treats them very differently. The planner began filtering via the
active_nodes CTE using a HashAggregate step that, due to the planner
having limited ability to push filters into the CTE, operated on a huge
numbers of rows.

See: https://medium.com/@hakibenita/be-careful-with-cte-in-postgresql-fca5e24d2119
for more info on why CTE's can produce slow queries.