### PR TITLE
(PDB-4599) Don't spam log with HTTP request received

### DIFF
--- a/src/puppetlabs/puppetdb/pdb_routing.clj
+++ b/src/puppetlabs/puppetdb/pdb_routing.clj
@@ -27,7 +27,6 @@
 (defn maint-mode-handler [maint-mode-fn]
   (fn [req]
     (when (maint-mode-fn)
-      (log/info (trs "HTTP request received while in maintenance mode"))
       {:status 503
        :body (tru "PuppetDB is currently down. Try again later.")})))
 


### PR DESCRIPTION
In active installs, this makes the startup logs (especially migration
progress logs), nearly unreadable because the vast majority of the lines
are this message.

The 503 error code can also be found in the puppetdb_access.log to
monitor declined HTTP requests.