### PR TITLE
(maint) Bump clj-parent to 4.5.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def pdb-version "6.11.2-SNAPSHOT")
-(def clj-parent-version "4.5.2")
+(def clj-parent-version "4.5.3")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
This updates pgjdbc to 42.2.14, which includes the fix for
CVE-2020-13692. We were not vulnerable to this CVE because we don't use
the PgSQLXML code, but are updating for peace of mind and to ensure that
we pass security scans.