### PR TITLE
(maint) Bump clj-parent to 4.5.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def pdb-version "6.11.2-SNAPSHOT")
-(def clj-parent-version "4.5.3")
+(def clj-parent-version "4.5.4")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
This includes an update to trapperkeeper-metrics that adds trapperkeeper
authentication to its endpoints.