### PR TITLE
Revert "(maint) Bump ezbake version to 2.1.7"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -297,7 +297,7 @@
                                                ;; in the final package.
                                                [puppetlabs/puppetdb ~pdb-version]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "2.1.7"]]}
+                      :plugins [[puppetlabs/lein-ezbake "2.1.6"]]}
              :testutils {:source-paths ^:replace ["test"]
                          :resource-paths ^:replace []
                          ;; Something else may need adjustment, but


### PR DESCRIPTION
This reverts commit 66855297fe6696d2d0e842e3b1631f482b436f2b.