### PR TITLE
(maint) Update jackson-databind version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -90,7 +90,8 @@
     ;;   CVE-2017-7658 (PDB-4161)
     ;;   CVE-2018-19360 CVE-2018-19361 CVE-2018-19362 (PDB-4364)
     ;; (logstash depends on jackson-databind)
-    [com.fasterxml.jackson.core/jackson-databind "2.9.10"]
+    [com.fasterxml.jackson.core/jackson-databind "2.9.10.4"]
+    [com.fasterxml.jackson.core/jackson-core "2.9.10"]
     ;; CVE-2020-7943
     [puppetlabs/trapperkeeper-metrics "1.2.2" :exclusions [ring/ring-defaults org.slf4j/slf4j-api]]])
 


### PR DESCRIPTION
Update version for databind for another CVE from jackson-databind that
we are likely not vulnerable to (CVE-2020-9548).

Pin jackson-core to 2.9.10 since that was being held back by our
version of clj-parent.