### PR TITLE
(maint) travis: run drop-joins test in main stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ jobs:
       env: PDB_TEST=core+ext/openjdk11/pg-11 LEIN_PROFILES=fips
       script: *run-core-and-ext-tests
 
-    - stage: ❧ pdb tests with drop-joins optimization
+    - stage: ❧ pdb tests
       env: PDB_TEST=core+ext/openjdk11/pg-11 PDB_QUERY_OPTIMIZE_DROP_UNUSED_JOINS=always
       script: *run-core-and-ext-tests
 


### PR DESCRIPTION
Run all puppetdb tests in one stage to save time. After this commit,
there are only two stages, clojure/ruby tests and container tests.