### PR TITLE
(PDB-4836) Document status bug as a known issue

### DIFF
--- a/documentation/known_issues.markdown
+++ b/documentation/known_issues.markdown
@@ -12,6 +12,14 @@ Bugs and feature requests
 
 PuppetDB's bugs and feature requests are managed in [Puppet's issue tracker][tracker]. Search this database if you're having problems and please report any new issues to us!
 
+PuppetDB returns an error from the status endpoint
+-----
+
+In PuppetDB 6.11.0, 6.11.1, and 6.11.2, when PuppetDB cannot connect to the
+database and a user queries the `/status/v1/services/puppetdb-status` endpoint
+it would return an exception in the status response instead of reporting the
+databases as down.  [PDB-4836](https://tickets.puppetlabs.com/browse/PDB-4836)
+
 PuppetDB rejects Puppet Server SSL connections
 -----
 

--- a/src/puppetlabs/puppetdb/scf/storage_utils.clj
+++ b/src/puppetlabs/puppetdb/scf/storage_utils.clj
@@ -373,7 +373,7 @@
               [{:keys [answer]}] (jdbc/query [select-42])]
           (= answer 42)))
       (catch Exception e
-        (log/warn e "Query to check if the database is up failed")
+        (log/debug e "Query to check if the database is up failed")
         false))))
 
 (defn analyze-small-tables


### PR DESCRIPTION
Expected `/status/v1/services/puppetdb-status` response
```
{
  "service_version": "6.11.2",
  "service_status_version": 1,
  "detail_level": "info",
  "state": "error",
  "status": {
    "maintenance_mode?": false,
    "queue_depth": 0,
    "read_db_up?": false,
    "write_db_up?": false,
    "write_dbs_up?": false,
    "write_db": {
      "default": {
        "up?": false
      }
    }
  },
  "active_alerts": [],
  "service_name": "puppetdb-status"
}
```

Actual response
```
{
  "service_version": "6.11.2",
  "service_status_version": 1,
  "detail_level": "info",
  "state": "unknown",
  "status": "Status check for puppetdb-status threw an exception: clojure.lang.ExceptionInfo: Output of status-details does not match schema: \n\n\t \u001b[0;33m  {:write_db_up? (not (instance? java.lang.Boolean nil))} \u001b[0m \n\n {:type :schema.core/error, :schema {:maintenance_mode? java.lang.Boolean, :queue_depth (maybe Int), :read_db_up? java.lang.Boolean, :write_db_up? java.lang.Boolean, :write_dbs_up? java.lang.Boolean, :write_db {java.lang.String {:up? java.lang.Boolean}}}, :value {:maintenance_mode? false, :queue_depth 0, :read_db_up? false, :write_db_up? nil, :write_dbs_up? false, :write_db {\"default\" {:up? false}}}, :error {:write_db_up? (not (instance? java.lang.Boolean nil))}}",
  "active_alerts": [],
  "service_name": "puppetdb-status"
}
```