### PR TITLE
(PDB-4839) Standardize getting names of table partitions 

### DIFF
--- a/src/puppetlabs/puppetdb/scf/partitioning.clj
+++ b/src/puppetlabs/puppetdb/scf/partitioning.clj
@@ -13,14 +13,13 @@
 (defn get-partition-names
   "Return all partition names given the parent table name"
   [table]
-  (let [inhparent (str "public." table)]
     (->> ["SELECT inhrelid::regclass AS child
             FROM pg_catalog.pg_inherits
             WHERE inhparent = ?::regclass;"
-          inhparent]
+          table]
          jdbc/query-to-vec
          (map :child)
-         (map #(.toString %)))))
+         (map str)))
 
 (defn get-temporal-partitions
   "Returns a vector of {:table full-table-name :part partition-key}

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -1423,7 +1423,7 @@
           (let [assert-index-exists (fn [index indexes]
                                       (is (true? (some #(str/includes? % index) indexes))))]
             ;; check that idx_reports_id is present in all paritions
-            (dorun (->> (utils/partition-names "reports")
+            (dorun (->> (part/get-partition-names "reports")
                         (map utils/table-indexes)
                         (map (partial assert-index-exists "idx_reports_id"))))))))))
 
@@ -1465,7 +1465,7 @@
             ;; check that idx_reports_id is present in all paritions
             check-idx-reports-id #(dorun
                                    (->>
-                                    (utils/partition-names "reports")
+                                    (part/get-partition-names "reports")
                                     (map utils/table-indexes)
                                     (map (partial assert-index-exists "idx_reports_id"))))]
         (fast-forward-to-migration! 75)
@@ -1486,13 +1486,13 @@
       (let [assert-no-index (fn [index indexes]
                               (is (nil? (some #(str/includes? % index) indexes))))]
         ;; check that idx_reports_id wasn't added by migration 74
-        (dorun (->> (utils/partition-names "reports")
+        (dorun (->> (part/get-partition-names "reports")
                     (map utils/table-indexes)
                     (map (partial assert-no-index "idx_reports_id")))))
       (apply-migration-for-testing! 76)
       (let [assert-index-exists (fn [index indexes]
                                   (is (some #(str/includes? % index) indexes)))]
         ;; check that idx_reports_id is now present in all paritions
-        (dorun (->> (utils/partition-names "reports")
+        (dorun (->> (part/get-partition-names "reports")
                     (map utils/table-indexes)
                     (map (partial assert-index-exists "idx_reports_id"))))))))

--- a/test/puppetlabs/puppetdb/scf/storage_test.clj
+++ b/test/puppetlabs/puppetdb/scf/storage_test.clj
@@ -24,6 +24,7 @@
             [puppetlabs.puppetdb.testutils.events :refer :all]
             [puppetlabs.puppetdb.testutils.nodes :refer :all]
             [puppetlabs.puppetdb.random :as random]
+            [puppetlabs.puppetdb.scf.partitioning :refer [get-partition-names]]
             [puppetlabs.puppetdb.scf.storage :refer :all]
             [clojure.test :refer :all]
             [clojure.math.combinatorics :refer [combinations subsets]]
@@ -1755,7 +1756,7 @@
       (let [assert-index-exists (fn [index indexes]
                                   (is (true? (some #(str/includes? % index) indexes))))
 
-            partition (tu/partition-names "reports")]
+            partition (get-partition-names "reports")]
         ;; check that idx_reports_id index is present in on demand paritions
         (is (= 1 (count partition)))
         (dorun (->> partition

--- a/test/puppetlabs/puppetdb/testutils.clj
+++ b/test/puppetlabs/puppetdb/testutils.clj
@@ -429,18 +429,6 @@
 (def default-timeout-ms
   (* 1000 60 5))
 
-(defn partition-names
-  "Return all partition names given the parent table name"
-  [table]
-  (let [inhparent (str "public." table)]
-    (->> ["SELECT inhrelid::regclass AS child
-            FROM pg_catalog.pg_inherits
-            WHERE inhparent = ?::regclass;"
-          inhparent]
-         jdbc/query-to-vec
-         (map :child)
-         (map #(.toString %)))))
-
 (defn table-indexes
   "Return the index definitions for the given table name"
   [table]


### PR DESCRIPTION
This removes our usage of pg_tables and regex to identify table
partitions, and instead we ask postgres's own tables what the partitions
of a given parent table are.

The second commit ensures that we continue to support a non-public schema, as long as our tables show up on the search path before any other tables with the same name in a different schema.

We should not merge this until **_after_** we have released 6.11.3