### PR TITLE
(PDB-4752) Update link for DR overview docs

### DIFF
--- a/documentation/ha.markdown
+++ b/documentation/ha.markdown
@@ -16,7 +16,7 @@ availability in order to withstand network partitions or system failure.
 
 PuppetDB is automatically configured for high availability as part of an HA
 deployment of Puppet Enterprise. For more information about high availability in
-Puppet Enterprise, see [High availability overview]({{pe}}/ha_overview.html).
+Puppet Enterprise, see [High availability overview]({{pe}}/dr_overview.html).
 
 HA Overview
 -----


### PR DESCRIPTION
HA was renamed to DR in PE 2019 docs. We'll need the DR link in master and the HA link in 5.2.x.  
https://puppet.com/docs/pe/2019.8/dr_overview.html
https://puppet.com/docs/pe/2018.1/high_availability_overview.html