### PR TITLE
(maint) travis: test in a single stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,19 +115,6 @@ jobs:
       env: PDB_TEST=int/openjdk8/pup-master/srv-master/pg-9.6/rich
       script: *run-integration-tests
 
-    # === integration with current platform
-      #- stage: ❧ pdb tests
-      #  env: PDB_TEST=int/openjdk8/pup-6.4.x/srv-6.3.x/pg-11
-      #  script: *run-integration-tests
-
-      #- stage: ❧ pdb tests
-      #env: PDB_TEST=int/openjdk8/pup-6.4.x/srv-6.3.x/pg-11/rich
-      #script: *run-integration-tests
-
-      #- stage: ❧ pdb tests
-      #env: PDB_TEST=int/openjdk11/pup-6.4.x/srv-6.3.x/pg-11/rich
-      #script: *run-integration-tests
-
     # === rspec tests
     - stage: ❧ pdb tests
       name: rspec pup-master
@@ -140,7 +127,8 @@ jobs:
       script: *run-spec-tests
 
     # === container tests
-    - stage: ❧ pdb container tests
+    - stage: ❧ pdb tests
+      name: container tests
       dist: focal
       language: ruby
       rvm: 2.6.6


### PR DESCRIPTION
Also removes commented out integration tests. In the new release cadence
we don't have any STS releases with z's, which is what the commented out
tests were testing. We'll need to think of the proper way to ensure
backwards compatibility without testing every single platform Y release.