### PR TITLE
(PDB-4745) disable gc in config-expiration test

### DIFF
--- a/test/puppetlabs/puppetdb/acceptance/node_ttl.clj
+++ b/test/puppetlabs/puppetdb/acceptance/node_ttl.clj
@@ -62,6 +62,7 @@
       (svc-utils/call-with-single-quiet-pdb-instance
        (-> (svc-utils/create-temp-config)
            (assoc :database *db*)
+           (assoc-in [:database :gc-interval] 0)
            (assoc-in [:database :node-ttl] lifetime-cfg)
            (assoc-in [:database :node-purge-ttl] lifetime-cfg))
        (fn []


### PR DESCRIPTION
Two things acquire the `clean-lock`, periodic garbage collection and the
admin clean endpoint. Garbage collection uses `(.lock clean-lock)`,
which means it will block until the lock is available. The admin
endpoint uses `(when (.tryLock clean-lock) <clean>)` which means if the
lock is not available it will return `false` and skip the attempt to
perform the admin clean action.  Sometimes, when this test runs, gc can
be running in the background and cause the initial call to
`(cli-svc/clean pdb ["expire_nodes"])` to be skipped, which puts the db
into an incorrect state for the following test checks.