### PR TITLE
Honor env var PUPPETDB_JAVA_ARGS

### DIFF
--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -31,7 +31,7 @@ ENV PUPPERWARE_ANALYTICS_ENABLED=false \
 # note: LOGDIR cannot be defined in the same ENV block it's used in
 # this value may be set by users, keeping in mind that some of these values are mandatory
 # -Djavax.net.debug=ssl may be particularly useful to set for debugging SSL
-ENV PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Djdk.tls.ephemeralDHKeySize=2048"
+ENV PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Xlog:gc*:file=$LOGDIR/puppetdb_gc.log::filecount=16,filesize=65536 -Djdk.tls.ephemeralDHKeySize=2048"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -161,6 +161,7 @@ COPY docker/puppetdb/logback.xml \
      docker/puppetdb/request-logging.xml \
      /etc/puppetlabs/puppetdb/
 COPY docker/puppetdb/conf.d /etc/puppetlabs/puppetdb/conf.d/
+COPY docker/puppetdb/puppetdb /etc/default/puppetdb
 
 ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream" \
     PUPPETDB_VERSION="$version"

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -31,7 +31,7 @@ ENV PUPPERWARE_ANALYTICS_ENABLED=false \
 # note: LOGDIR cannot be defined in the same ENV block it's used in
 # this value may be set by users, keeping in mind that some of these values are mandatory
 # -Djavax.net.debug=ssl may be particularly useful to set for debugging SSL
-ENV PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Xlog:gc*:file=$LOGDIR/puppetdb_gc.log::filecount=16,filesize=65536 -Djdk.tls.ephemeralDHKeySize=2048"
+ENV PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Djdk.tls.ephemeralDHKeySize=2048"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \

--- a/docker/puppetdb/puppetdb
+++ b/docker/puppetdb/puppetdb
@@ -1,0 +1,40 @@
+###########################################
+# Init settings for puppetdb
+###########################################
+
+# Location of your Java binary (version 8)
+JAVA_BIN="/usr/bin/java"
+
+# Modify this if you'd like to change the memory allocation, enable JMX, etc
+JAVA_ARGS=$PUPPETDB_JAVA_ARGS
+
+# Modify this as you would JAVA_ARGS but for non-service related subcommands
+JAVA_ARGS_CLI="${JAVA_ARGS_CLI:-}"
+
+# Modify this if you'd like TrapperKeeper specific arguments
+TK_ARGS=""
+
+# These normally shouldn't need to be edited if using OS packages
+USER="puppetdb"
+GROUP="puppetdb"
+INSTALL_DIR="/opt/puppetlabs/server/apps/puppetdb"
+CONFIG="/etc/puppetlabs/puppetdb/conf.d"
+
+# Bootstrap path
+BOOTSTRAP_CONFIG="/etc/puppetlabs/puppetdb/bootstrap.cfg"
+
+# SERVICE_STOP_RETRIES can be set here to alter the default stop timeout in
+# seconds.  For systemd, the shorter of this setting or 'TimeoutStopSec' in
+# the systemd.service definition will effectively be the timeout which is used.
+SERVICE_STOP_RETRIES=60
+
+# START_TIMEOUT can be set here to alter the default startup timeout in
+# seconds.  For systemd, the shorter of this setting or 'TimeoutStartSec'
+# in the service's systemd.service configuration file will effectively be the
+# timeout which is used.
+START_TIMEOUT=14400
+
+
+# Maximum number of seconds that can expire for a service reload attempt before
+# the result of the attempt is interpreted as a failure.
+RELOAD_TIMEOUT=120


### PR DESCRIPTION
Creates support for the environment variable PUPPETDB_JAVA_ARGS through to the JVM args at application startup.