### PR TITLE
(PDB-4855) Fix initialization of duplicate-pct metric

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -209,9 +209,9 @@
          :duplicate-catalog  (counter storage-metrics-registry [(pname "duplicate-catalogs")])
          :duplicate-pct      (gauge-fn storage-metrics-registry [(pname "duplicate-pct")]
                                        (fn []
-                                         (let [dupes (value ((mutils/maybe-prefix-key :duplicate-catalog)
+                                         (let [dupes (value ((mutils/maybe-prefix-key prefix :duplicate-catalog)
                                                              @storage-metrics))
-                                               new   (value ((mutils/maybe-prefix-key :updated-catalog)
+                                               new   (value ((mutils/maybe-prefix-key prefix :updated-catalog)
                                                              @storage-metrics))]
                                            (float (kitchensink/quotient dupes (+ dupes new))))))
          :catalog-volatility (histogram storage-metrics-registry [(pname "catalog-volitilty")])

--- a/test/puppetlabs/puppetdb/dashboard_test.clj
+++ b/test/puppetlabs/puppetdb/dashboard_test.clj
@@ -26,9 +26,17 @@
       (is (= (count body)
              (->> body (map :id) distinct count))))))
 
-(deftest root-dashboard-routing
+(deftest dashboard-routing
   (svc-utils/call-with-single-quiet-pdb-instance
    (fn []
      (let [root-resp (svc-utils/get-unparsed (svc-utils/root-url-str))]
        (tu/assert-success! root-resp)
-       (is (dtu/dashboard-page? root-resp))))))
+       (is (dtu/dashboard-page? root-resp)))
+
+     (let [data-resp (-> svc-utils/*base-url*
+                         (assoc :prefix "/pdb/dashboard/data")
+                         base-url->str-with-prefix
+                         svc-utils/get-unparsed)]
+       (tu/assert-success! data-resp)
+       (is (http/json-utf8-ctype? (get-in data-resp [:headers "content-type"]) ))
+       (is (seq? (json/parse-string (:body data-resp) true)))))))


### PR DESCRIPTION
This was breaking the dashboard data query, and resulted in a blank
dashboard page.

While adding support for multiple write dbs we used a metric prefix to
distinguish between the two dbs metrics. We omitted providing the prefix
to this function, so the "value" of the metric was this string instead
of a duplication percentage.
```
"javax.management.RuntimeMBeanException: clojure.lang.ArityException: Wrong number of args (1) passed to: puppetlabs.puppetdb.utils.metrics/maybe-prefix-key"
```

This caused an error when we later tried to multiply this metric value.

```
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number
at clojure.lang.Numbers.multiply(Numbers.java:173)
at puppetlabs.puppetdb.dashboard$fn_42532$get_dashboard_data42537$fn42538$iter4253942543$fn42544$fn_42545.invoke(dashboard.clj:162)
```