### PR TITLE
(PDB-4788) Enable ubuntu20 acceptance tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ if ENV['NO_ACCEPTANCE'] != 'true'
       gem 'beaker', '~> 4.1'
     end
   end
-  gem 'beaker-hostgenerator', '1.1.26'
+  gem 'beaker-hostgenerator', '~> 1.2.6'
   gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.2')
   gem 'beaker-vmpooler', *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1.3")
   gem 'beaker-puppet', '~> 1.0'

--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -285,6 +285,10 @@ module PuppetDBExtensions
     return test_config[:os_families].has_key? 'ubuntu1804-64-1'
   end
 
+  def is_focal()
+    return test_config[:os_families].has_key? 'ubuntu2004-64-1'
+  end
+
   def is_buster()
     return test_config[:os_families].has_key? 'debian10-64-1'
   end
@@ -309,9 +313,9 @@ module PuppetDBExtensions
     when :install, :upgrade_latest
       test_config[:platform_version]
     when :upgrade_oldest
-      # Redhat8, Redhat7-fips, Debian 10
+      # Redhat8, Redhat7-fips, Debian 10, Ubuntu 20
       # only have builds starting somewhere in the 6 series.
-      if is_rhel8 || is_rhel7fips || is_buster
+      if is_rhel8 || is_rhel7fips || is_buster || is_focal
         :puppet6
       else
         :puppet5
@@ -332,6 +336,8 @@ module PuppetDBExtensions
       '6.4.0'
     elsif is_buster
       '6.7.0'
+    elsif is_focal
+      '6.12.0'
     else
       '5.2.0'
     end

--- a/acceptance/setup/pre_suite/75_clean_out_puppet5_repos.rb
+++ b/acceptance/setup/pre_suite/75_clean_out_puppet5_repos.rb
@@ -3,7 +3,7 @@ if (test_config[:install_mode] == :upgrade_oldest) \
 
   step "Clean out puppet5 repos to prepare for puppet6 upgrade" do
     # skip this step for rhel8 beacause it only installs puppet6 in upgrade_oldest
-    if test_config[:install_mode] == :upgrade_oldest && !(is_rhel8 || is_rhel7fips || is_buster)
+    if test_config[:install_mode] == :upgrade_oldest && !(is_rhel8 || is_rhel7fips || is_buster || is_focal)
       databases.each do |database|
 
         # need to remove puppet5 repos to avoid conflicts when upgrading


### PR DESCRIPTION
Specify the oldest supported version for Ubuntu focal

Update beaker hostgenerator to a version new enough to know about Ubuntu
20 when using ABS (which is what we use in CI).