### PR TITLE
(maint) Bump ezbake to 2.2.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -297,7 +297,7 @@
                                                ;; in the final package.
                                                [puppetlabs/puppetdb ~pdb-version]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "2.2.0"]]}
+                      :plugins [[puppetlabs/lein-ezbake "2.2.1"]]}
              :testutils {:source-paths ^:replace ["test"]
                          :resource-paths ^:replace []
                          ;; Something else may need adjustment, but


### PR DESCRIPTION
Ensures we use the right OutOfMemory cli flag based on the java version