### PR TITLE
(PDB-4769) Revert definition of active_nodes

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -896,15 +896,15 @@
                :entity :events
                :source-tables #{:resource_events}}))
 
-(def active-nodes-query
-  (map->Query {::which-query :active-nodes
+(def not-active-nodes-query
+  (map->Query {::which-query :not-active-nodes
                :projections {"certname" {:type :string
                                          :queryable? true
-                                         :field :active_nodes.certname}}
-               :selection {:from [:active_nodes]}
+                                         :field :not_active_nodes.certname}}
+               :selection {:from [:not_active_nodes]}
                :subquery? false
-               :alias "active_nodes"
-               :source-tables #{:active_nodes}}))
+               :alias "not_active_nodes"
+               :source-tables #{:not_active_nodes}}))
 
 
 (def inactive-nodes-query
@@ -1165,11 +1165,11 @@
                                              :where (hcore/raw
                                                       (str "(deactivated IS NOT NULL AND deactivated > '" timestamp "')"
                                                            " OR (expired IS NOT NULL and expired > '" timestamp "')"))}
-                            :active_nodes {:select [:certname]
+                            :not_active_nodes {:select [:certname]
                                            :from [:certnames]
-                                           :where [:and
-                                                   [:is :deactivated nil]
-                                                   [:is :expired nil]]}})))
+                                           :where [:or
+                                                   [:is-not :deactivated nil]
+                                                   [:is-not :expired nil]]}})))
 
 (defn honeysql-from-query
   "Convert a query to honeysql format"
@@ -1447,7 +1447,7 @@
    "select_fact_contents" fact-contents-query
    "select_fact_paths" fact-paths-query
    "select_nodes" nodes-query
-   "select_active_nodes" active-nodes-query
+   "select_not_active_nodes" not-active-nodes-query
    "select_inactive_nodes" inactive-nodes-query
    "select_latest_report" latest-report-query
    "select_latest_report_id" latest-report-id-query
@@ -1546,9 +1546,9 @@
 
             [["=" "node_state" value]]
             (case (str/lower-case (str value))
-              "active" ["in" "certname"
-                        ["extract" "certname"
-                         ["select_active_nodes"]]]
+              "active" ["not" ["in" "certname"
+                               ["extract" "certname"
+                                ["select_not_active_nodes"]]]]
               "inactive" ["in" "certname"
                           ["extract" "certname"
                            ["select_inactive_nodes"]]]

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -44,7 +44,7 @@
 
 (deftest test-plan-cte
   (is (re-matches
-         #"WITH inactive_nodes AS \(SELECT certname FROM certnames WHERE \(deactivated IS NOT NULL AND deactivated > '\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ'\) OR \(expired IS NOT NULL and expired > '\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ'\)\), active_nodes AS \(SELECT certname FROM certnames WHERE \(deactivated IS NULL AND expired IS NULL\)\) SELECT table.foo AS foo FROM table WHERE \(1 = 1\)"
+         #"WITH inactive_nodes AS \(SELECT certname FROM certnames WHERE \(deactivated IS NOT NULL AND deactivated > '\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ'\) OR \(expired IS NOT NULL and expired > '\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ'\)\), not_active_nodes AS \(SELECT certname FROM certnames WHERE \(deactivated IS NOT NULL OR expired IS NOT NULL\)\) SELECT table.foo AS foo FROM table WHERE \(1 = 1\)"
          (plan->sql (map->Query {:projections {"foo" {:type :string
                                            :queryable? true
                                            :field :table.foo}}
@@ -76,9 +76,9 @@
          (expand-user-query [["=" "prop" "foo"]])))
 
   (is (= [["=" "prop" "foo"]
-          ["in" "certname"
-           ["extract" "certname"
-            ["select_active_nodes"]]]]
+          ["not" ["in" "certname"
+                  ["extract" "certname"
+                   ["select_not_active_nodes"]]]]]
          (expand-user-query [["=" "prop" "foo"]
                              ["=" ["node" "active"] true]])))
   (is (= [["=" "prop" "foo"]


### PR DESCRIPTION
Prior to PDB-4479 (commit 262573c053f9912e6659e9422c33ff3ee148e243)
an "active node" was anything that was not an inactive node. The
definition of an inactive node was too broad so it was reduced in scope
and active_nodes was explicitly described. The result was the
active_nodes definition changed from

```
WITH inactive_nodes AS
  (SELECT certname from certnames
   WHERE (deactivated IS NOT NULL OR expired IS NOT NULL)
...
WHERE NOT (certname in (SELECT certname FROM inactive_nodes))
```

to
```
WITH active_nodes AS
  (SELECT certname from certnames
   WHERE (deactivated IS NULL AND expired IS NULL)
...
WHERE (certname in (SELECT certname FROM active_nodes))
```

While the two are logically equivalent, the Postgres query planner
treats them very differently. The planner began filtering via the
active_nodes CTE using a HashAggregate step that, due to the planner
having limited ability to push filters into the CTE, operated on a huge
numbers of rows.

See: https://medium.com/@hakibenita/be-careful-with-cte-in-postgresql-fca5e24d2119
for more info on why CTE's can produce slow queries.

For example, this report query from the PE Console, spent over two
thirds of its total processing time (1 hour 40 minutes) performing the
HashAggregate in order to incorporate the active_nodes CTE into the rest
of the query.

QUERY PLAN
------------------------------------------------------------------------
GroupAggregate  (cost=130641.82..130641.85 rows=1 width=28) (actual time=6015539.183..6015667.053 rows=16 loops=1)
  Group Key: reports_20200602z.cached_catalog_status, reports_20200602z.corrective_change, reports_20200602z.noop, reports_20200602z.noop_pending, report_statuses.status
  CTE active_nodes
    ->  Seq Scan on certnames certnames_1  (cost=0.00..52964.88 rows=119214 width=30) (actual time=0.014..530.783 rows=117521 loops=1)
          Filter: ((deactivated IS NULL) AND (expired IS NULL))
          Rows Removed by Filter: 2270
  ->  Sort  (cost=77676.94..77676.94 rows=1 width=20) (actual time=6015539.160..6015613.529 rows=103452 loops=1)
        Sort Key: reports_20200602z.cached_catalog_status, reports_20200602z.corrective_change, reports_20200602z.noop, reports_20200602z.noop_pending, report_statuses.status
        Sort Method: quicksort  Memory: 11155kB
        ->  Nested Loop  (cost=56698.66..77676.93 rows=1 width=20) (actual time=3423.353..6013845.296 rows=103452 loops=1)
              Join Filter: (certnames.certname = active_nodes.certname)
              Rows Removed by Join Filter: 6076909911
              ->  Nested Loop Left Join  (cost=54016.34..74990.11 rows=1 width=80) (actual time=1905.149..26707.278 rows=103452 loops=1)
                    ->  Nested Loop Left Join  (cost=54016.21..74989.96 rows=1 width=80) (actual time=1905.104..23644.235 rows=103452 loops=1)
                          ->  Gather  (cost=54015.79..74986.49 rows=1 width=80) (actual time=1905.039..7003.227 rows=103452 loops=1)
                                Workers Planned: 2
                                Workers Launched: 0
                                ->  Parallel Hash Join  (cost=53015.79..73986.39 rows=1 width=80) (actual time=1905.038..6734.687 rows=103452 loops=1)
                                      Hash Cond: ((reports_20200602z.certname = certnames.certname) AND (reports_20200602z.id = certnames.latest_report_id))
                                      ->  Parallel Append  (cost=0.29..20759.17 rows=40328 width=66) (actual time=0.047..3189.007 rows=104700 loops=1)
                                            ->  Parallel Index Scan using reports_end_time_idx_20200602z on reports_20200602z  (cost=0.42..2271.49 rows=5307 width=66) (actual time=0.046..1514.980 rows=16642 loops=1)
                                                  Index Cond: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                                            ->  Parallel Index Scan using reports_end_time_idx_20200601z on reports_20200601z  (cost=0.29..4.52 rows=1 width=66) (actual time=0.027..0.028 rows=0 loops=1)
                                                  Index Cond: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                                            ->  Parallel Seq Scan on reports_20200603z  (cost=0.00..18226.01 rows=36462 width=66) (actual time=0.030..1598.928 rows=88058 loops=1)
                                                  Filter: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                                                  Rows Removed by Filter: 1
                                            ->  Parallel Seq Scan on reports_20200528z  (cost=0.00..11.10 rows=29 width=91) (actual time=0.011..0.011 rows=0 loops=1)
                                                  Filter: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                                            ->  Parallel Seq Scan on reports_20200529z  (cost=0.00..11.10 rows=29 width=91) (actual time=0.004..0.004 rows=0 loops=1)
                                                  Filter: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                                            ->  Parallel Seq Scan on reports_20200530z  (cost=0.00..11.10 rows=29 width=91) (actual time=0.011..0.011 rows=0 loops=1)
                                                  Filter: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                                            ->  Parallel Seq Scan on reports_20200531z  (cost=0.00..11.10 rows=29 width=91) (actual time=0.010..0.010 rows=0 loops=1)
                                                  Filter: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                                            ->  Parallel Seq Scan on reports_20200604z  (cost=0.00..11.10 rows=29 width=91) (actual time=0.004..0.004 rows=0 loops=1)
                                                  Filter: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                                            ->  Parallel Seq Scan on reports  (cost=0.00..0.00 rows=1 width=91) (actual time=0.004..0.004 rows=0 loops=1)
                                                  Filter: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                                      ->  Parallel Hash  (cost=52256.20..52256.20 rows=50620 width=38) (actual time=1904.192..1904.193 rows=116643 loops=1)
                                            Buckets: 131072  Batches: 1  Memory Usage: 9367kB
                                            ->  Parallel Seq Scan on certnames  (cost=0.00..52256.20 rows=50620 width=38) (actual time=0.017..1457.477 rows=119791 loops=1)
                          ->  Index Scan using catalogs_certname_idx on catalogs  (cost=0.42..3.45 rows=1 width=38) (actual time=0.134..0.148 rows=1 loops=103452)
                                Index Cond: (certname = certnames.certname)
                    ->  Index Scan using report_statuses_pkey on report_statuses  (cost=0.13..0.15 rows=1 width=16) (actual time=0.021..0.021 rows=1 loops=103452)
                          Index Cond: (reports_20200602z.status_id = id)
              ->  HashAggregate  (cost=2682.32..2684.32 rows=200 width=32) (actual time=0.013..45.063 rows=58742 loops=103452)
                    Group Key: active_nodes.certname
                    ->  CTE Scan on active_nodes  (cost=0.00..2384.28 rows=119214 width=32) (actual time=0.016..718.387 rows=117521 loops=1)

With this change, the report query avoids the HashAggregate step and
operates over 550x faster

QUERY PLAN
-----------------------------------------------------------------------
GroupAggregate (cost=194693.21..194693.24 rows=1 width=28) (actual time=10783.999..10815.261 rows=15 loops=1)
  Group Key: reports.cached_catalog_status, reports.corrective_change, reports.noop, reports.noop_pending, report_statuses.status
  CTE not_active_nodes
      -> Seq Scan on certnames certnames_1 (cost=0.00..4297.08 rows=2499 width=30) (actual time=0.990..109.841 rows=2506 loops=1)
          Filter: ((deactivated IS NOT NULL) OR (expired IS NOT NULL))
          Rows Removed by Filter: 117303
  -> Sort (cost=190397.13..190396.13 rows=1 width=20) (actual time=10783.981..10792.413 rows=116706 loops=1)
      Sort Key: reports.cached_catalog_status, reports.corrective_change, reports.noop, reports.noop_pending, report_statuses.status
      Sort Method: quicksort Memory: 12190kB
      -> Nested Loop Left Join (cost=5551.94..190396.12 rows=1 width=20) (actual time=607.562..10703.227 rows=116706 loops=1)
          -> Nested Loop Left Join (cost=5551.81..190395.96 rows=1 width=20) (actual time=607.523..10541.417 rows=116706 loops=1)
              -> Hash Join (cost=5551.39..190394.92 rows=1 width=50) (actual time=607.453..8816.443 rows=116706 loops=1)
                  Hash Cond: ((reports.certname = certnames.certname) AND (reports.id = certnames.latest_report_id))
                  -> Append (cost=0.00..180482.93 rows=830592 width=66) (actual time=8.760..7093.393 rows=845403 loops=1)
                      -> Seq Scan on reports (cost=0.00..0.00 rows=1 width=91) (actual time=0.005..0.005 rows=0 loops=1)
                          Filter: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                      -> Seq Scan on reports_20200529z (cost=0.00..11.88 rows=50 width=91) (actual time=0.003..0.003 rows=0 loops=1)
                          Filter: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                      -> Seq Scan on reports_20200530z (cost=0.00..11.88 rows=50 width=91) (actual time=0.009..0.009 rows=0 loops=1)
                          Filter: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                      -> Seq Scan on reports_20200531z (cost=0.00..11.88 rows=50 width=91) (actual time=0.003..0.003 rows=0 loops=1)
                          Filter: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                      -> Index Scan using reports_end_time_idx_20200601z on reports_20200601z (cost=0.29..4.53 rows=1 width=66) (actual time=0.013..0.013 rows=0 loops=1)
                          Index Cond: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                      -> Index Scan using reports_end_time_idx_20200602z on reports_20200602z (cost=0.42..2308.64 rows=9022 width=66) (actual time=8.725..316.116 rows=16642 loops=1)
                          Index Cond: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                      -> Seq Scan on reports_20200603z (cost=0.00..143410.69 rows=677299 width=66) (actual time=0.025..6136.937 rows=684682 loops=1)
                          Filter: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                          Rows Removed by Filter: 2
                      -> Seq Scan on reports_20200604z (cost=0.00..30570.49 rows=144119 width=66) (actual time=0.024..475.950 rows=144079 loops=1)
                          Filter: (end_time >= '2020-06-02 23:15:09.162+00'::timestamp with time zone)
                  -> Hash (cost=4652.83..4652.83 rows=59904 width=38) (actual time=381.336..381.337 rows=116804 loops=1)
                      Buckets: 131072 (originally 65536) Batches: 1 (originally 1) Memory Usage: 9378kB
                      -> Seq Scan on certnames (cost=56.23..4652.83 rows=59904 width=38) (actual time=129.134..236.641 rows=117303 loops=1)
                          Filter: (NOT (hashed SubPlan 2))
                          Rows Removed by Filter: 2506
                          SubPlan 2
                              -> CTE Scan on not_active_nodes (cost=0.00..49.98 rows=2499 width=32) (actual time=0.995..110.780 rows=2506 loops=1)
                  -> Index Scan using catalogs_certname_idx on catalogs (cost=0.42..1.03 rows=1 width=38) (actual time=0.014..0.014 rows=1 loops=116706)
                      Index Cond: (certname = certnames.certname)
              -> Index Scan using report_statuses_pkey on report_statuses (cost=0.13..0.15 rows=1 width=16) (actual time=0.001..0.001 rows=1 loops=116706)
                  Index Cond: (reports.status_id = id)
 Planning Time: 214.883 ms
 Execution Time: 10817.596 ms
(44 rows)