### PR TITLE
(PDB-4881) Add primary key to catalog_inputs table

### DIFF
--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -69,6 +69,6 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 76$' "$tmpdir/out"
+grep -qE ' 77$' "$tmpdir/out"
 
 test ! -e "$PDBBOX"/var/mq-migrated

--- a/resources/ext/cli/delete-reports.erb
+++ b/resources/ext/cli/delete-reports.erb
@@ -87,7 +87,7 @@ chown "$pg_user:$pg_user" "$tmp_dir"
 
 # Verify that the PuppetDB schema version it the expected value
 # so that we do not incorrectly delete the report data.
-expected_schema_ver=76
+expected_schema_ver=77
 su - "$pg_user" -s /bin/sh -c "$psql_cmd -p $pg_port -d $pdb_db_name -c 'COPY ( SELECT max(version) FROM schema_migrations ) TO STDOUT;' > $tmp_dir/schema_ver"
 actual_schema_ver="$(cat "$tmp_dir/schema_ver")"
 if test "$actual_schema_ver" -ne $expected_schema_ver; then

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1964,6 +1964,11 @@
              (jdbc/double-quote idx-name)
              (jdbc/double-quote table)))))
 
+(defn add-catalog-inputs-pkey
+  []
+  (jdbc/do-commands
+   "ALTER TABLE catalog_inputs ADD CONSTRAINT catalog_inputs_pkey PRIMARY KEY (type, name, certname_id)"))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {00 require-schema-migrations-table
@@ -2023,7 +2028,8 @@
    73 resource-events-partitioning
    74 reports-partitioning
    75 add-report-type-to-reports
-   76 add-report-partition-indexes-on-id})
+   76 add-report-partition-indexes-on-id
+   77 add-catalog-inputs-pkey})
    ;; Make sure that if you change the structure of reports
    ;; or resource events, you also update the delete-reports
    ;; cli command.

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -2021,12 +2021,12 @@
    71 autovacuum-vacuum-scale-factor-factsets-catalogs-certnames
    72 add-support-for-catalog-inputs
    73 resource-events-partitioning
-   ; Make sure that if you change the structure of reports
-   ; or resource events, you also update the delete-reports
-   ; cli command.
    74 reports-partitioning
    75 add-report-type-to-reports
    76 add-report-partition-indexes-on-id})
+   ;; Make sure that if you change the structure of reports
+   ;; or resource events, you also update the delete-reports
+   ;; cli command.
 
 (defn desired-schema-version []
   "The newest migration this PuppetDB instance knows about.  Anything


### PR DESCRIPTION
Before there was no primary key, which meant the `pg_repack` could not
be used on the table.

By adding a primary key we can now use `pg_repack` to maintain the
table. Also by making the compound index on (type, name, certname_id) we
allow queries like this to use an index.
```
catalog-inputs-contents[] {
  type = "hiera"
  name = "puppetdb::globals::version"
}
```