### PR TITLE
(PDB-4908) prune-daily-partitions: don't nest do-commands

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1470,7 +1470,7 @@
                       (update-lock-status status-key dec))))
         drop #(if incremental?
                 (when (seq candidates)
-                  (jdbc/do-commands (drop-one (last candidates)))
+                  (drop-one (last candidates))
                   (when (> (bounded-count 3 candidates) 2)
                     (log/warn (trs "More than 2 partitions to prune: {0}"
                                    (pr-str (butlast candidates))))))


### PR DESCRIPTION
Accidentally introduced by the refactoring related to lock-statuses
cf. f240694492b0bf783190cfdb5630ad1218400afa

Causes the normal periodic garbage collections to fail like this:

  ERROR puppetlabs.puppetdb.cli.services - Error while sweeping reports and resource events
  java.sql.BatchUpdateException: Batch entry 0 0 was aborted: ERROR: syntax error at or near "0"
    Position: 1  Call getNextException to see other errors in the batch.

The garbage collections at startup and those triggered by the admin
endpoint should be unaffected.