### PR TITLE
(maint) Fix log message db-name

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -606,7 +606,7 @@
   ;; A C-c (SIGINT) will close the pool via the shutdown hook, which
   ;; will then cause the pool connection to throw a (generic)
   ;; SQLException.
-  (log/info (trs "Ensuring {0} database is up to date" name))
+  (log/info (trs "Ensuring {0} database is up to date" db-name))
   (let  [migrator (:migrator-username db-config)]
     (with-open [db-pool (-> (assoc db-config
                                    :pool-name (if db-name


### PR DESCRIPTION
Before this used `name` which logged the clojure function instead of the
`db-name`

```
Ensuring clojure.core$name@5d616d65 database is up to date
```

Now it will log a more intelligible name like

```
Ensuring default database is up to date
```