### PR TITLE
(maint) Ship to puppet7 streams

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,6 +1,4 @@
 ---
 project: 'puppetdb'
-repo_name: 'puppet6'
-nonfinal_repo_name: 'puppet6-nightly'
-repo_link_target: 'puppet'
-nonfinal_repo_link_target: 'puppet-nightly'
+repo_name: 'puppet7'
+nonfinal_repo_name: 'puppet7-nightly'

--- a/project.clj
+++ b/project.clj
@@ -230,8 +230,8 @@
                        :build-type "foss"
                        :main-namespace "puppetlabs.puppetdb.cli.services"
                        :start-timeout 14400
-                       :repo-target "puppet6"
-                       :nonfinal-repo-target "puppet6-nightly"
+                       :repo-target "puppet7"
+                       :nonfinal-repo-target "puppet7-nightly"
                        :logrotate-enabled false}
                 :config-dir "ext/config/foss"
                 }


### PR DESCRIPTION
These project.clj variables control where ezbake builds get
published to when shipping to nightlies or release repos.

It's unclear what exactly `build_defaults.yaml` controls, but to be
safe, this commit also updates those values.