### PR TITLE
(PDB-4939) Fix postgres install in centos8 tests

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -293,8 +293,9 @@ module PuppetDBExtensions
     return test_config[:os_families].has_key? 'debian10-64-1'
   end
 
-  def is_rhel8()
-    return test_config[:os_families].has_key? 'redhat8-64-1'
+  def is_el8()
+    return test_config[:os_families].has_key?('redhat8-64-1') ||
+           test_config[:os_families].has_key?('centos8-64-1')
   end
 
   def is_rhel7fips
@@ -315,7 +316,7 @@ module PuppetDBExtensions
     when :upgrade_oldest
       # Redhat8, Redhat7-fips, Debian 10, Ubuntu 20
       # only have builds starting somewhere in the 6 series.
-      if is_rhel8 || is_rhel7fips || is_buster || is_focal
+      if is_el8 || is_rhel7fips || is_buster || is_focal
         :puppet6
       else
         :puppet5
@@ -330,7 +331,7 @@ module PuppetDBExtensions
     # account for bionic/rhel8 not having build before certian versions
     if is_bionic
       '5.2.4'
-    elsif is_rhel8
+    elsif is_el8
       '6.0.3'
     elsif is_rhel7fips
       '6.4.0'

--- a/acceptance/setup/pre_suite/15_setup_repos.rb
+++ b/acceptance/setup/pre_suite/15_setup_repos.rb
@@ -1,7 +1,7 @@
 unless (test_config[:skip_presuite_provisioning])
   step "Install Puppet Labs repositories" do
 
-    if is_rhel8
+    if is_el8
       on(hosts, 'update-crypto-policies --set LEGACY')
     end
 

--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -12,7 +12,7 @@ unless (test_config[:skip_presuite_provisioning])
     end
   end
 
-  if is_rhel8
+  if is_el8
     # work around for testing on rhel8 and the repos on the image not finding the pg packages it needs
     step "Install PostgreSQL manually" do
       on master, "dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"

--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -15,12 +15,8 @@ unless (test_config[:skip_presuite_provisioning])
   if is_rhel8
     # work around for testing on rhel8 and the repos on the image not finding the pg packages it needs
     step "Install PostgreSQL manually" do
-      on master, "sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/dnf/dnf.conf"
-      on master, "dnf config-manager --add-repo https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-8-x86_64/"
-      on master, "dnf clean all"
-      on master, "dnf install -y https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-8-x86_64/postgresql96-9.6.16-2PGDG.rhel8.x86_64.rpm"
-      on master, "dnf install -y https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-8-x86_64/postgresql96-server-9.6.16-2PGDG.rhel8.x86_64.rpm"
-      on master, "dnf install -y https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-8-x86_64/postgresql96-contrib-9.6.16-2PGDG.rhel8.x86_64.rpm"
+      on master, "dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
+      on master, "dnf -qy module disable postgresql"
     end
   end
 end

--- a/acceptance/setup/pre_suite/75_clean_out_puppet5_repos.rb
+++ b/acceptance/setup/pre_suite/75_clean_out_puppet5_repos.rb
@@ -3,7 +3,7 @@ if (test_config[:install_mode] == :upgrade_oldest) \
 
   step "Clean out puppet5 repos to prepare for puppet6 upgrade" do
     # skip this step for rhel8 beacause it only installs puppet6 in upgrade_oldest
-    if test_config[:install_mode] == :upgrade_oldest && !(is_rhel8 || is_rhel7fips || is_buster || is_focal)
+    if test_config[:install_mode] == :upgrade_oldest && !(is_el8 || is_rhel7fips || is_buster || is_focal)
       databases.each do |database|
 
         # need to remove puppet5 repos to avoid conflicts when upgrading


### PR DESCRIPTION
Also includes some maintainence work on the test setup

>  (PDB-4939) Use PostgreSQL repo on el8
>
> When we first added testing for redhat8, postgres provided packages, but
not a repo for redhat8 because it was not yet released. Now, instead of
installing each package on its own, we can simply enable to repo and let
the module do the rest.

