### PR TITLE
(maint) Puppet::HTTP::Response#nethttp is going away

### DIFF
--- a/puppet/spec/spec_helper.rb
+++ b/puppet/spec/spec_helper.rb
@@ -41,6 +41,14 @@ def assert_valid_producer_ts(path)
   Time.iso8601(params["producer-timestamp"].first)
 end
 
+def create_http_response(url, nethttp)
+  if Puppet::PUPPETVERSION.to_f < 7
+    Puppet::HTTP::Response.new(nethttp, url)
+  else
+    Puppet::HTTP::ResponseNetHTTP.new(url, nethttp)
+  end
+end
+
 RSpec.configure do |config|
 
   config.before :each do

--- a/puppet/spec/unit/indirector/node/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/node/puppetdb_spec.rb
@@ -25,32 +25,32 @@ describe Puppet::Node::Puppetdb do
 
   describe "#destroy" do
     let(:nethttpok) { Net::HTTPOK.new('1.1', 200, 'OK') }
-    let(:response) { Puppet::HTTP::Response.new(nethttpok, "mock url") }
+    let(:responseok) { create_http_response("mock url", nethttpok) }
     let(:http)     { mock 'http' }
     before :each do
       Puppet::HTTP::Client.expects(:new).returns http
     end
 
     it "should POST a '#{CommandDeactivateNode}' command" do
-      response.stubs(:body).returns '{"uuid": "a UUID"}'
+      responseok.stubs(:body).returns '{"uuid": "a UUID"}'
       http.expects(:post).with do |uri,body,headers|
         req = JSON.parse(body)
         req["certname"] == node &&
           extract_producer_timestamp(req) <= Time.now.to_i
-      end.returns response
+      end.returns responseok
 
       destroy
     end
 
     it "should log a deprecation warning if one is returned from PuppetDB" do
-      response.nethttp['x-deprecation'] = 'A horrible deprecation warning!'
-      response.stubs(:body).returns '{"uuid": "a UUID"}'
+      nethttpok['x-deprecation'] = 'A horrible deprecation warning!'
+      responseok.stubs(:body).returns '{"uuid": "a UUID"}'
 
       Puppet.expects(:deprecation_warning).with do |msg|
         msg =~ /A horrible deprecation warning!/
       end
 
-      http.stubs(:post).returns response
+      http.stubs(:post).returns responseok
 
       destroy
     end

--- a/puppet/spec/unit/reports/puppetdb_spec.rb
+++ b/puppet/spec/unit/reports/puppetdb_spec.rb
@@ -23,7 +23,7 @@ describe processor do
 
     let(:http) { mock "http" }
     let(:nethttpok) { Net::HTTPOK.new('1.1', 200, '') }
-    let(:httpok) { Puppet::HTTP::Response.new(nethttpok, "mock url") }
+    let(:responseok) { create_http_response("mock url", nethttpok) }
 
     def without_producer_timestamp(json_body)
       parsed = JSON.parse(json_body)
@@ -32,7 +32,7 @@ describe processor do
     end
 
     it "should POST the report command as a URL-encoded JSON string" do
-      httpok.stubs(:body).returns '{"uuid": "a UUID"}'
+      nethttpok.stubs(:body).returns '{"uuid": "a UUID"}'
       subject.stubs(:run_duration).returns(10)
 
       expected_body = subject.report_to_hash(Time.now.utc).to_json
@@ -44,7 +44,7 @@ describe processor do
         # producer_timestamp is generated at submission time, so remove it from
         # the comparison
         expect(without_producer_timestamp(body)).to eq(without_producer_timestamp(expected_body))
-      }.returns(httpok)
+      }.returns(responseok)
 
       subject.process
     end


### PR DESCRIPTION
The Puppet::HTTP::Response#nethttp method is going away, because puppetserver's http client implementation is not based on Net::HTTP.

This adds a create_http_response helper to create the correct HTTP response adapter based on the puppet version.