### PR TITLE
(FEAT) Add (certname,endtime) index to reports

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1964,6 +1964,23 @@
              (jdbc/double-quote idx-name)
              (jdbc/double-quote table)))))
 
+(defn add-report-partition-indexes-on-certname-end-time
+  []
+  (doseq [{:keys [table part] :as huh} (get-temporal-partitions "reports")
+          :let [idx-name (str "reports_certname_idx" part)]]
+    (jdbc/do-commands
+     (format "drop index if exists %s"
+             (jdbc/double-quote idx-name))))
+  (doseq [{:keys [table part] :as huh} (get-temporal-partitions "reports")
+          :let [idx-name (str "idx_reports_certname_end_time_" part)]]
+    (jdbc/do-commands
+     (format "create index if not exists %s on %s using btree (certname,end_time)"
+             (jdbc/double-quote idx-name)
+             (jdbc/double-quote table))))
+  (jdbc/do-commands
+   "drop index reports_certname_idx"
+   "create index idx_reports_certname_end_time on reports using btree (certname,end_time)"))
+
 (defn add-catalog-inputs-pkey
   []
   (jdbc/do-commands
@@ -2035,7 +2052,8 @@
    75 add-report-type-to-reports
    76 add-report-partition-indexes-on-id
    77 add-catalog-inputs-pkey
-   78 add-catalog-inputs-hash})
+   78 add-catalog-inputs-hash
+   79 add-report-partition-indexes-on-certname-end-time})
    ;; Make sure that if you change the structure of reports
    ;; or resource events, you also update the delete-reports
    ;; cli command.

--- a/src/puppetlabs/puppetdb/scf/partitioning.clj
+++ b/src/puppetlabs/puppetdb/scf/partitioning.clj
@@ -158,7 +158,7 @@
                      iso-week-year full-table-name)
              (format "CREATE INDEX IF NOT EXISTS reports_catalog_uuid_idx_%s ON %s USING btree (catalog_uuid)"
                      iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS reports_certname_idx_%s ON %s USING btree (certname)"
+             (format "CREATE INDEX IF NOT EXISTS idx_reports_certname_end_time_%s ON %s USING btree (certname,end_time)"
                      iso-week-year full-table-name)
              (format "CREATE INDEX IF NOT EXISTS reports_end_time_idx_%s ON %s USING btree (end_time)"
                      iso-week-year full-table-name)


### PR DESCRIPTION
Prior to this commit, we had a certname index on reports
and an endtime index on reports.  For queries that want
certname sorted by endtime they were scanning the
endtime index and removing rows that don't match the certname
causing the query to read way more data pages into memory than
is desirable.

After this commit, we remove the certname index and replace it
with a certname,endtime index.  This allows for finding a certname
in the index and also getting the reports for it in the endtime
order that the query desires.  This drastically reduces the number
of data pages that need to be read into memory.

Also, any queries that previously used the certname index can still
use the certname,endtime index to satisfy their needs.