### PR TITLE
(PDB-4961) State that postgres <11 is unsupported

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -548,7 +548,7 @@
                        :current current
                        :oldest supported})))
     (when (neg? (compare current supported))
-      (log/error (trs "PostgreSQL {0}.{1} is deprecated. Please upgrade to PostgreSQL {2}"
+      (log/error (trs "PostgreSQL {0}.{1} is unsupported. Please upgrade to PostgreSQL {2}"
                      (first current)
                      (second current)
                      (first supported))))


### PR DESCRIPTION
Since this is now a non-fatal error, we've gone further than deprecating
postgresql less than 11. In PuppetDB 7+ it will be officially
unsupported and may break in any release.