### PR TITLE
(PDB-4947) Pin bounncycastle to 1.65

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -85,6 +85,7 @@
 (def pdb-dep-pins
   `[;; Use jetty 9.4.11.v20180605 to fix CVE-2017-7656 (PDB-4160)
     [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-ver]
+    [org.bouncycastle/bcpkix-jdk15on "1.65"]
     ;; Pin jackson-databind to fix CVEs -- currently covers at least:
     ;;   CVE-2018-5968 (PDB-3809)
     ;;   CVE-2017-7658 (PDB-4161)


### PR DESCRIPTION
With the release of java-1.8.0_272
[a bug in bouncycastle](https://github.com/bcgit/bc-java/issues/633)
started showing up in tests, specfically integration tests and PE
2016.4 to 2018.1 upgrade tests.

The bug was fixed in bc 1.65 so we are upgrading to that version in
order to test that PE upgrades are fixed. It appears that puppetserver
is not compatible with bc 1.65 (at least in our integration tests) so if
it fixes PE upgrade tests, we will either need to update puppetserver as
well or retire the integration tests before the `5.2.x` branch is
officially EOL.