### PR TITLE
(maint) Upgrade ssl.sh script, hide SSLDIR / LOGDIR, honor PUPETDB_JAVA_ARGS

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -36,7 +36,7 @@ Docker Compose.
 | **PUPPETDB_NODE_TTL**                   | Mark as ‘expired’ nodes that haven’t seen any activity (no new catalogs, facts, or reports) in the specified amount of time<br><br>`7d`                                            |
 | **PUPPETDB_NODE_PURGE_TTL**             | Automatically delete nodes that have been deactivated or expired for the specified amount of time<br><br>`14d`                                                                     |
 | **PUPPETDB_REPORT_TTL**                 | Automatically delete reports that are older than the specified amount of time<br><br>`14d`                                                                                         |
-| **PUPPETDB_JAVA_ARGS**                  | Arguments passed directly to the JVM when starting the service<br><br>`-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Xlog:gc*:file=/opt/puppetlabs/server/data/puppetdb/logs/puppetdb_gc.log::filecount=16,filesize=65536 -Djdk.tls.ephemeralDHKeySize=2048` |
+| **PUPPETDB_JAVA_ARGS**                  | Arguments passed directly to the JVM when starting the service<br><br>`-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Xloggc:/opt/puppetlabs/server/data/puppetdb/logs/puppetdb_gc.log -Djdk.tls.ephemeralDHKeySize=2048` |
 | **PUPPERWARE_ANALYTICS_ENABLED**        | Set to 'true' to enable Google Analytics.<br><br>`false`                                                                                                                           |
 
 ### Cert File Locations

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -30,7 +30,7 @@ ENV PUPPERWARE_ANALYTICS_ENABLED=false \
     USE_PUPPETSERVER=true \
 # this value may be set by users, keeping in mind that some of these values are mandatory
 # -Djavax.net.debug=ssl may be particularly useful to set for debugging SSL
-    PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Xlog:gc*:file=$LOGDIR/puppetdb_gc.log::filecount=16,filesize=65536 -Djdk.tls.ephemeralDHKeySize=2048"
+    PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Xloggc:$LOGDIR/puppetdb_gc.log -Djdk.tls.ephemeralDHKeySize=2048"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
@@ -161,6 +161,7 @@ COPY docker/puppetdb/logback.xml \
      docker/puppetdb/request-logging.xml \
      /etc/puppetlabs/puppetdb/
 COPY docker/puppetdb/conf.d /etc/puppetlabs/puppetdb/conf.d/
+COPY docker/puppetdb/puppetdb /etc/default/puppetdb
 
 ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream" \
     PUPPETDB_VERSION="$version"

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -1,6 +1,8 @@
 # Determines source "edge" or binary "release" builds
 ARG build_type=edge
 ARG UBUNTU_CODENAME=bionic
+# NOTE: never pass as a build-arg / must match .dockerenv -- used in logback.xml
+ARG LOGDIR=/opt/puppetlabs/server/data/puppetdb/logs
 
 ######################################################
 # base
@@ -9,14 +11,12 @@ ARG UBUNTU_CODENAME=bionic
 FROM ubuntu:18.04 as base
 
 ARG DUMB_INIT_VERSION="1.2.2"
+ARG LOGDIR
 
 ENV PUPPERWARE_ANALYTICS_ENABLED=false \
     PUPPETDB_POSTGRES_HOSTNAME="postgres" \
     PUPPETDB_POSTGRES_PORT="5432" \
     PUPPETDB_POSTGRES_DATABASE="puppetdb" \
-# NOTE: SSLDIR should never be set externally or it will break jetty.ini
-    SSLDIR=/opt/puppetlabs/server/data/puppetdb/certs \
-    LOGDIR=/opt/puppetlabs/server/data/puppetdb/logs \
     CERTNAME=puppetdb \
     DNS_ALT_NAMES="" \
     WAITFORCERT="" \
@@ -27,11 +27,10 @@ ENV PUPPERWARE_ANALYTICS_ENABLED=false \
     PUPPETDB_REPORT_TTL=14d \
     # used by entrypoint to determine if puppetserver should be contacted for config
     # set to false when container tests are run
-    USE_PUPPETSERVER=true
-# note: LOGDIR cannot be defined in the same ENV block it's used in
+    USE_PUPPETSERVER=true \
 # this value may be set by users, keeping in mind that some of these values are mandatory
 # -Djavax.net.debug=ssl may be particularly useful to set for debugging SSL
-ENV PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Xlog:gc*:file=$LOGDIR/puppetdb_gc.log::filecount=16,filesize=65536 -Djdk.tls.ephemeralDHKeySize=2048"
+    PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Xlog:gc*:file=$LOGDIR/puppetdb_gc.log::filecount=16,filesize=65536 -Djdk.tls.ephemeralDHKeySize=2048"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
@@ -141,6 +140,7 @@ ARG deb_uri
 # used by entrypoint to submit metrics to Google Analytics;
 # published images should use "production" for this build_arg
 ARG pupperware_analytics_stream="dev"
+ARG LOGDIR
 
 # hadolint ignore=DL3020
 ADD $deb_uri /puppet.deb

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -55,7 +55,7 @@ CMD ["foreground"]
 HEALTHCHECK --start-period=5m --interval=10s --timeout=10s --retries=6 CMD ["/healthcheck.sh"]
 
 # hadolint ignore=DL3020
-ADD https://raw.githubusercontent.com/puppetlabs/pupperware/1a81f54cca38d9cc9ac4c2d124757cf9d909752c/shared/ssl.sh \
+ADD https://raw.githubusercontent.com/puppetlabs/pupperware/a2493ad0f9965996ea313a69b9e991e1a8de53bf/shared/ssl.sh \
     https://raw.githubusercontent.com/puppetlabs/wtfc/6aa5eef89728cc2903490a618430cc3e59216fa8/wtfc.sh \
     https://github.com/Yelp/dumb-init/releases/download/v"$DUMB_INIT_VERSION"/dumb-init_"$DUMB_INIT_VERSION"_amd64.deb \
     docker/puppetdb/docker-entrypoint.sh \

--- a/docker/puppetdb/conf.d/.dockerenv
+++ b/docker/puppetdb/conf.d/.dockerenv
@@ -1,0 +1,4 @@
+# must match Dockerfile / used in logback.xml
+export LOGDIR=/opt/puppetlabs/server/data/puppetdb/logs
+# used by ssl.sh / consumed in jetty.ini
+export SSLDIR=/opt/puppetlabs/server/data/puppetdb/certs

--- a/docker/puppetdb/conf.d/jetty.ini
+++ b/docker/puppetdb/conf.d/jetty.ini
@@ -20,10 +20,10 @@ port = 8080
 # ssl-port = 8081
 
 # Private key path
-# ssl-key = /opt/puppetlabs/server/data/puppetdb/certs/private_keys/private.pem
+# ssl-key = /opt/puppetlabs/server/data/puppetdb/certs/private_keys/server.key
 
 # Public certificate path
-# ssl-cert = /opt/puppetlabs/server/data/puppetdb/certs/certs/public.pem
+# ssl-cert = /opt/puppetlabs/server/data/puppetdb/certs/certs/server.crt
 
 # Certificate authority path
 # ssl-ca-cert = /opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem

--- a/docker/puppetdb/conf.d/jetty.ini
+++ b/docker/puppetdb/conf.d/jetty.ini
@@ -28,6 +28,9 @@ port = 8080
 # Certificate authority path
 # ssl-ca-cert = /opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem
 
+# Allow for token authentication
+client-auth = want
+
 # Access logging configuration path. To turn off access logging
 # comment out the line with `access-log-config=...`
 access-log-config = /etc/puppetlabs/puppetdb/request-logging.xml

--- a/docker/puppetdb/docker-entrypoint.d/20-configure-ssl.sh
+++ b/docker/puppetdb/docker-entrypoint.d/20-configure-ssl.sh
@@ -12,14 +12,11 @@ fi
 if [ -f "${SSLDIR}/private_keys/${CERTNAME}.pem" ]; then
   openssl pkcs8 -inform PEM -outform DER -in ${SSLDIR}/private_keys/${CERTNAME}.pem -topk8 -nocrypt -out ${SSLDIR}/private_keys/${CERTNAME}.pk8
 
-  # for Jetty to use statically named files
-  ln -s -f ${SSLDIR}/private_keys/${CERTNAME}.pem ${SSLDIR}/private_keys/private.pem
-  ln -s -f ${SSLDIR}/certs/${CERTNAME}.pem ${SSLDIR}/certs/public.pem
-
   # enable SSL in Jetty
   sed -i '/^# ssl-/s/^# //g' /etc/puppetlabs/puppetdb/conf.d/jetty.ini
 
   # make sure Java apps running as puppetdb can read these files
+  echo "Setting ownership for $SSLDIR to puppetdb:puppetdb"
   chown -R puppetdb:puppetdb ${SSLDIR}
 
   # and that they're further restricted

--- a/docker/puppetdb/docker-entrypoint.sh
+++ b/docker/puppetdb/docker-entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+. /etc/puppetlabs/puppetdb/conf.d/.dockerenv
+
 chmod +x /docker-entrypoint.d/*.sh
 # sync prevents aufs from sometimes returning EBUSY if you exec right after a chmod
 sync

--- a/docker/puppetdb/puppetdb
+++ b/docker/puppetdb/puppetdb
@@ -1,0 +1,40 @@
+###########################################
+# Init settings for puppetdb
+###########################################
+
+# Location of your Java binary (version 8)
+JAVA_BIN="/usr/bin/java"
+
+# Modify this if you'd like to change the memory allocation, enable JMX, etc
+JAVA_ARGS="${PUPPETDB_JAVA_ARGS}"
+
+# Modify this as you would JAVA_ARGS but for non-service related subcommands
+JAVA_ARGS_CLI="${JAVA_ARGS_CLI:-}"
+
+# Modify this if you'd like TrapperKeeper specific arguments
+TK_ARGS=""
+
+# These normally shouldn't need to be edited if using OS packages
+USER="puppetdb"
+GROUP="puppetdb"
+INSTALL_DIR="/opt/puppetlabs/server/apps/puppetdb"
+CONFIG="/etc/puppetlabs/puppetdb/conf.d"
+
+# Bootstrap path
+BOOTSTRAP_CONFIG="/etc/puppetlabs/puppetdb/bootstrap.cfg"
+
+# SERVICE_STOP_RETRIES can be set here to alter the default stop timeout in
+# seconds.  For systemd, the shorter of this setting or 'TimeoutStopSec' in
+# the systemd.service definition will effectively be the timeout which is used.
+SERVICE_STOP_RETRIES=60
+
+# START_TIMEOUT can be set here to alter the default startup timeout in
+# seconds.  For systemd, the shorter of this setting or 'TimeoutStartSec'
+# in the service's systemd.service configuration file will effectively be the
+# timeout which is used.
+START_TIMEOUT=14400
+
+
+# Maximum number of seconds that can expire for a service reload attempt before
+# the result of the attempt is interpreted as a failure.
+RELOAD_TIMEOUT=120


### PR DESCRIPTION
- Upgrades ssl.sh - uses static files produced from there in jetty.ini
- Enable token auth in jetty.ini
- Hide SSLDIR / LOGDIR from users (they're not settable ENV vars)
- Make sure that PUPPETDB_JAVA_ARGS works in containers!

Supersedes #3314