### PR TITLE
(maint) travis: remove integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,15 +75,6 @@ jobs:
       env: PDB_TEST=core+ext/openjdk8/pg-11
       script: *run-core-and-ext-tests
 
-    # === integration tests
-    - stage: ❧ pdb tests
-      env: PDB_TEST=int/openjdk8/pup-5.5.x/srv-5.3.x/pg-9.6
-      script: *run-integration-tests
-
-    - stage: ❧ pdb tests
-      env: PDB_TEST=int/openjdk8/pup-5.5.x/srv-5.3.x/pg-11
-      script: *run-integration-tests
-
     # === rspec tests
     - stage: ❧ pdb tests
       env: PDB_TEST=rspec/pup-5.5.x
@@ -95,12 +86,6 @@ jobs:
     - stage: ❧ pdb tests
       env: PDB_TEST=core+ext/openjdk8/pg-9.6
       script: *run-core-and-ext-tests
-      os: osx
-
-    # === integration tests
-    - stage: ❧ pdb tests
-      env: PDB_TEST=int/openjdk8/pup-5.5.x/srv-5.3.x/pg-9.6
-      script: *run-integration-tests
       os: osx
 
     # === rspec tests


### PR DESCRIPTION
See [RE-13716](https://tickets.puppetlabs.com/browse/RE-13716) for more
information on the issue that forced us to upgrade bouncycastle to 1.65.

Puppetserver is not compatible with bouncycastle 1.65, and the upgrade
path is not as simple as ours. As a result our integration tests will
not pass. Since this branch will EOL on Jan 31, they don't plan to
upgrade at all, so we should stop attempting to run integration tests.