### PR TITLE
(PDB-4974) Wait for schedulers to shut down (and replace at-at)

### DIFF
--- a/pdb
+++ b/pdb
@@ -3,8 +3,8 @@
 set -e
 
 jar="${PDB_JAR:-target/puppetdb.jar}"
-bcprov="${BCPROV_JAR:-$HOME/.m2/repository/org/bouncycastle/bcprov-jdk15on/1.66/bcprov-jdk15on-1.66.jar}"
-bcpkix="${BCPKIX_JAR:-$HOME/.m2/repository/org/bouncycastle/bcpkix-jdk15on/1.66/bcpkix-jdk15on-1.66.jar}"
+bcprov="${BCPROV_JAR:-$HOME/.m2/repository/org/bouncycastle/bcprov-jdk15on/1.68/bcprov-jdk15on-1.68.jar}"
+bcpkix="${BCPKIX_JAR:-$HOME/.m2/repository/org/bouncycastle/bcpkix-jdk15on/1.68/bcpkix-jdk15on-1.68.jar}"
 
 if ! test -e "$jar"; then
     printf 'Unable to find the puppetdb jar %q; have you run "lein uberjar"?\n' \

--- a/project.clj
+++ b/project.clj
@@ -184,9 +184,6 @@
 
                  ;; Filesystem utilities
                  [org.apache.commons/commons-lang3]
-                 ;; Version information
-                 ;; Job scheduling
-                 [overtone/at-at "1.2.0"]
 
                  ;; Database connectivity
                  [com.zaxxer/HikariCP]


### PR DESCRIPTION
Although we'd expected to be waiting for our schedulers (at-at pools)
to stop before returning from our start/stop methods, we weren't
because at-at runs the relevant ScheduledThreadPoolExecutor shutdown
function in a future and returns immediately.

Since our needs are fairly straightforward, and since the relevant
blocking function in at-at is private, just manage the
ScheduledThreadPoolExecutors ourselves.

cf. PDB-4932