### PR TITLE
(PDB-4975) Deliver on promise even if gc disabled

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -841,22 +841,29 @@
 (defn start-garbage-collection
   [{:keys [clean-lock stop-status] :as context}
    job-pool db-configs db-pools db-lock-statuses shutdown-for-ex finished-initial-gc]
-  (doseq [[cfg db lock-status] (map vector db-configs db-pools db-lock-statuses)
-          :let [interval (to-millis (:gc-interval cfg))]
-          :when (pos? interval)]
-    (let [request (db-config->clean-request cfg)
-          initial-gc? (atom true)
-          gc (fn [first?]
-               (with-nonfatal-exceptions-suppressed
-                 (with-monitored-execution shutdown-for-ex
-                   (let [incremental? (not @first?)]
-                     (coordinate-gc-with-shutdown db clean-lock cfg lock-status
-                                                  request stop-status
-                                                  incremental?)
-                     (when-not incremental?
-                       (reset! first? false)
-                       (deliver finished-initial-gc true))))))]
-      (interspaced interval #(invoke-periodic-gc gc initial-gc?) job-pool))))
+  (let [count-initial-gc (atom 0)
+        deliver-if-finished (fn [] (when (= 0 @count-initial-gc)
+                                     (deliver finished-initial-gc true)))]
+    (doseq [[cfg db lock-status] (map vector db-configs db-pools db-lock-statuses)
+            :let [interval (to-millis (:gc-interval cfg))]
+            :when (pos? interval)]
+      (let [request (db-config->clean-request cfg)
+            initial-gc? (atom true)
+            gc (fn [first?]
+                 (with-nonfatal-exceptions-suppressed
+                   (with-monitored-execution shutdown-for-ex
+                     (let [incremental? (not @first?)]
+                       (coordinate-gc-with-shutdown db clean-lock cfg lock-status
+                                                    request stop-status
+                                                    incremental?)
+                       (when @first?
+                         (reset! first? false)
+                         (swap! count-initial-gc dec)
+                         (deliver-if-finished))))))]
+        (swap! count-initial-gc inc)
+        (interspaced interval #(invoke-periodic-gc gc initial-gc?) job-pool)))
+    ;; If no gc's were started, ensure we deliver on the promise
+    (deliver-if-finished)))
 
 (defn database-lock-status []
   ;; These track the number of threads either waiting


### PR DESCRIPTION
When gc is disabled, PuppetDB would never deliver on the
initial-gc-finished promise. This would cause sync to never run, and
puppetdb to never exit maintenance mode on startup. Now we'll deliver on
the promise if gc is disabled or once all initial garbage collections
have finished. Before this, gc would deliver at the end of its first
initial gc, even if there were multiple databases.