### PR TITLE
(PDB-4971) Remove Ruby 2.7 deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,6 @@ group :test do
   # Add test-unit for ruby 2.2+ support (has been removed from stdlib)
   gem 'test-unit'
 
-  # Pinning for Ruby 1.9.3 support
-  gem 'json_pure', '~> 1.8'
   # Pinning for Ruby < 2.2.0 support
   gem 'activesupport', '~> 4.2'
 

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -1,4 +1,4 @@
-require 'uri'
+require 'cgi'
 require 'puppet/node/facts'
 require 'puppet/indirector/rest'
 require 'puppet/util/puppetdb'
@@ -57,7 +57,7 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
     profile("facts#find", [:puppetdb, :facts, :find, request.key]) do
       begin
         response = Http.action("/pdb/query/v4/nodes/#{CGI.escape(request.key)}/facts", :query) do |http_instance, uri, ssl_context|
-          profile("Query for nodes facts: #{URI.unescape(uri.path)}",
+          profile("Query for nodes facts: #{CGI.unescape(uri.path)}",
                   [:puppetdb, :facts, :find, :query_nodes, request.key]) do
             http_instance.get(uri, {headers: headers,
                                     options: {metric_id: [:puppetdb, :facts, :find],
@@ -127,7 +127,7 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
 
       begin
         response = Http.action("/pdb/query/v4/nodes?query=#{query_param}", :query) do |http_instance, uri|
-          profile("Fact query request: #{URI.unescape(uri.path)}",
+          profile("Fact query request: #{CGI.unescape(uri.path)}",
                   [:puppetdb, :facts, :search, :query_request, request.key]) do
             http_instance.get(uri, {headers: headers,
                                     options: { :metric_id => [:puppetdb, :facts, :search] }})

--- a/puppet/lib/puppet/indirector/resource/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/resource/puppetdb.rb
@@ -1,7 +1,7 @@
 require 'puppet/indirector/rest'
 require 'puppet/util/puppetdb'
 require 'json'
-require 'uri'
+require 'cgi'
 
 class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
   include Puppet::Util::Puppetdb
@@ -30,7 +30,7 @@ class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
       begin
         response = Http.action("/pdb/query/v4/resources?query=#{query_param}", :query) do |http_instance, uri, ssl_context|
           uri_ref = uri
-          profile("Resources query: #{URI.unescape(uri.path)}",
+          profile("Resources query: #{CGI.unescape(uri.path)}",
                   [:puppetdb, :resource, :search, :query, request.key]) do
             http_instance.get(uri, {headers: headers,
                                     options: {:metric_id => [:puppetdb, :resource, :search],

--- a/puppet/spec/unit/indirector/node/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/node/puppetdb_spec.rb
@@ -10,8 +10,6 @@ require 'time'
 
 describe Puppet::Node::Puppetdb do
 
-  CommandDeactivateNode = Puppet::Util::Puppetdb::CommandNames::CommandDeactivateNode
-
   before :each do
     Puppet::Node.indirection.stubs(:terminus).returns(subject)
   end
@@ -31,7 +29,7 @@ describe Puppet::Node::Puppetdb do
       Puppet::HTTP::Client.expects(:new).returns http
     end
 
-    it "should POST a '#{CommandDeactivateNode}' command" do
+    it "should POST a '#{Puppet::Util::Puppetdb::CommandNames::CommandDeactivateNode}' command" do
       responseok.stubs(:body).returns '{"uuid": "a UUID"}'
       http.expects(:post).with do |uri,body,headers|
         req = JSON.parse(body)


### PR DESCRIPTION
* Remove dependency on json_pure
    * This is an old an unused dependency that was causing deprecation warnings on Ruby 2.7
* Replace URI with CGI
    * The URI functions we were using were obsoleted by CGI replacements
* rspec: fix a deprecation warning
    * The name shadowing was producing a warning

