### PR TITLE
(PDB-4971) Explicitly splat the http options

### DIFF
--- a/puppet/lib/puppet/face/node/status.rb
+++ b/puppet/lib/puppet/face/node/status.rb
@@ -20,8 +20,8 @@ Puppet::Face.define(:node, '0.0.1') do
       args.map do |node|
         begin
           response = Puppet::Util::Puppetdb::Http.action("/pdb/query/v4/nodes/#{CGI.escape(node)}", :query) do |http_instance, path, ssl_context|
-             http_instance.get(path, {headers: headers,
-                                      options: {ssl_context: ssl_context}})
+             http_instance.get(path, **{headers: headers,
+                                        options: {ssl_context: ssl_context}})
           end
           if response.success?
             result = JSON.parse(response.body)

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -59,9 +59,9 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
         response = Http.action("/pdb/query/v4/nodes/#{CGI.escape(request.key)}/facts", :query) do |http_instance, uri, ssl_context|
           profile("Query for nodes facts: #{CGI.unescape(uri.path)}",
                   [:puppetdb, :facts, :find, :query_nodes, request.key]) do
-            http_instance.get(uri, {headers: headers,
-                                    options: {metric_id: [:puppetdb, :facts, :find],
-                                              ssl_context: ssl_context}})
+            http_instance.get(uri, **{headers: headers,
+                                      options: {metric_id: [:puppetdb, :facts, :find],
+                                                ssl_context: ssl_context}})
           end
         end
         log_x_deprecation_header(response)

--- a/puppet/lib/puppet/indirector/resource/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/resource/puppetdb.rb
@@ -32,9 +32,9 @@ class Puppet::Resource::Puppetdb < Puppet::Indirector::REST
           uri_ref = uri
           profile("Resources query: #{CGI.unescape(uri.path)}",
                   [:puppetdb, :resource, :search, :query, request.key]) do
-            http_instance.get(uri, {headers: headers,
-                                    options: {:metric_id => [:puppetdb, :resource, :search],
-                                              ssl_context: ssl_context}})
+            http_instance.get(uri, **{headers: headers,
+                                      options: {:metric_id => [:puppetdb, :resource, :search],
+                                                ssl_context: ssl_context}})
           end
         end
 

--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -72,9 +72,9 @@ module Puppet::Util::Puppetdb
       headers = { "Accept" => "application/json",
                   "Content-Type" => "application/json; charset=UTF-8" }
       response = Puppet::Util::Puppetdb::Http.action("/pdb/query/v4", :query) do |http_instance, path, ssl_context|
-        http_instance.post(path, { 'query' => query }.to_json, {headers: headers,
-                                                                options: {metric_id: [:puppetdb, :query],
-                                                                          ssl_context: ssl_context}})
+        http_instance.post(path, { 'query' => query }.to_json, **{headers: headers,
+                                                                  options: {metric_id: [:puppetdb, :query],
+                                                                            ssl_context: ssl_context}})
       end
       JSON.parse(response.body)
     end

--- a/puppet/lib/puppet/util/puppetdb/command.rb
+++ b/puppet/lib/puppet/util/puppetdb/command.rb
@@ -65,10 +65,10 @@ class Puppet::Util::Puppetdb::Command
           req_headers = headers
           # custom header used in PDB to reject large compressed commands and update the size metric
           req_headers["X-Uncompressed-Length"] = payload.bytesize.to_s
-          http_instance.post(path, payload, {headers: req_headers,
-                                             options: {compress: :gzip,
-                                                       metric_id: [:puppetdb, :command, command],
-                                                       ssl_context: ssl_context}})
+          http_instance.post(path, payload, **{headers: req_headers,
+                                               options: {compress: :gzip,
+                                                         metric_id: [:puppetdb, :command, command],
+                                                         ssl_context: ssl_context}})
         end
       end
 


### PR DESCRIPTION
In Ruby 3.0 they are aiming to separate positional and keyword
arguements, so in 2.7 they deprecated the implicit use of keyword
arguments as the last parameter. Adding the "hash splat" operator to the
function call makes it explicit that the hash is to be parsed as keyword
arguments.