### PR TITLE
(PDB-4975) Prevent delivering initial gc promise early

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -841,29 +841,30 @@
 (defn start-garbage-collection
   [{:keys [clean-lock stop-status] :as context}
    job-pool db-configs db-pools db-lock-statuses shutdown-for-ex finished-initial-gc]
-  (let [count-initial-gc (atom 0)
-        deliver-if-finished (fn [] (when (= 0 @count-initial-gc)
-                                     (deliver finished-initial-gc true)))]
-    (doseq [[cfg db lock-status] (map vector db-configs db-pools db-lock-statuses)
-            :let [interval (to-millis (:gc-interval cfg))]
-            :when (pos? interval)]
-      (let [request (db-config->clean-request cfg)
+  (let [dbs-with-gc-enabled (filter (fn [[cfg _ _]] (-> cfg :gc-interval to-millis pos?))
+                                    (map vector db-configs db-pools db-lock-statuses))
+        pending-initial-gcs (atom (count dbs-with-gc-enabled))]
+    (when (zero? @pending-initial-gcs)
+      (deliver finished-initial-gc true))
+    (doseq [[cfg db lock-status] dbs-with-gc-enabled]
+      (let [interval (to-millis (:gc-interval cfg))
+            request (db-config->clean-request cfg)
             initial-gc? (atom true)
             gc (fn [first?]
-                 (with-nonfatal-exceptions-suppressed
-                   (with-monitored-execution shutdown-for-ex
-                     (let [incremental? (not @first?)]
-                       (coordinate-gc-with-shutdown db clean-lock cfg lock-status
-                                                    request stop-status
-                                                    incremental?)
-                       (when @first?
-                         (reset! first? false)
-                         (swap! count-initial-gc dec)
-                         (deliver-if-finished))))))]
-        (swap! count-initial-gc inc)
-        (interspaced interval #(invoke-periodic-gc gc initial-gc?) job-pool)))
-    ;; If no gc's were started, ensure we deliver on the promise
-    (deliver-if-finished)))
+                 (try
+                   (with-nonfatal-exceptions-suppressed
+                     (with-monitored-execution shutdown-for-ex
+                       (let [incremental? (not @first?)]
+                           (coordinate-gc-with-shutdown db clean-lock cfg lock-status
+                                                      request stop-status
+                                                      incremental?))))
+                   (finally
+                     (when @first?
+                       (reset! first? false)
+                       (swap! pending-initial-gcs dec)
+                       (when (zero? @pending-initial-gcs)
+                         (deliver finished-initial-gc true))))))]
+        (interspaced interval #(invoke-periodic-gc gc initial-gc?) job-pool)))))
 
 (defn database-lock-status []
   ;; These track the number of threads either waiting


### PR DESCRIPTION
Initialize the count to the number of databases and only count down to
prevent a race where one gc starts and finishes, delivers the promise,
and then another gc starts on a second database, but the initial gc
promise was already delivered on.