### PR TITLE
(maint) Log when deleting nodes

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -435,7 +435,9 @@
   (loop [[db & dbs] (get-in context [:shared-globals :scf-write-dbs])
          ex nil]
     (if-not db
-      (when ex (throw ex))
+      (when ex
+        (log/error ex (trs "Failed to delete all data for host {0}" certname))
+        (throw ex))
       (let [ex (try
                  (jdbc/with-transacted-connection db
                    (scf-store/delete-certname! certname))
@@ -1161,7 +1163,9 @@
    [this certname]
    (throw-unless-started (service-context this))
    (throw-if-shutdown-pending (get-shutdown-reason))
-   (delete-node-from-puppetdb (service-context this) certname))
+   (kitchensink/demarcate
+     (trs "delete of all data for host {0}" certname)
+     (delete-node-from-puppetdb (service-context this) certname)))
 
   (cmd-event-mult
    [this]


### PR DESCRIPTION
In the success case this will create two log messages
```
INFO Starting delete of all data for host foo.example.com
INFO Finished delete of all data for host foo.example.com
```

If it errors it will throw and not log the finished messages so the logs
will look like.
```
INFO  Starting delete of all data for host foo.example.com
ERROR Failed to delete all data for host foo.example.com
<with an exception here>
```