### PR TITLE
(maint) Update ssl.sh agent script

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,10 @@ jobs:
       - run: gem install bundler
       - name: Build container
         working-directory: docker
-        run: make lint build test
+        run: |
+          docker system prune --all --force --volumes
+          docker builder prune --force --keep-storage=10GB
+          make lint build test
       - name: Publish container
         working-directory: docker
         run: |

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -54,7 +54,7 @@ CMD ["foreground"]
 HEALTHCHECK --start-period=5m --interval=10s --timeout=10s --retries=6 CMD ["/healthcheck.sh"]
 
 # hadolint ignore=DL3020
-ADD https://raw.githubusercontent.com/puppetlabs/pupperware/a2493ad0f9965996ea313a69b9e991e1a8de53bf/shared/ssl.sh \
+ADD https://raw.githubusercontent.com/puppetlabs/pupperware/69a7ff4a7af4783a30dd405560cf9f25ba5cad58/shared/ssl.sh \
     https://raw.githubusercontent.com/puppetlabs/wtfc/6aa5eef89728cc2903490a618430cc3e59216fa8/wtfc.sh \
     https://github.com/Yelp/dumb-init/releases/download/v"$DUMB_INIT_VERSION"/dumb-init_"$DUMB_INIT_VERSION"_amd64.deb \
     docker/puppetdb/docker-entrypoint.sh \


### PR DESCRIPTION
 - Improves script robustness under a number of specific scenarios:

   - keypair generated on disk, CSR never submitted
   - keypair generated on disk, CSR submitted, cert never downloaded
     (i.e. cert matches keypair on disk)
   - keypair generated on disk, cert exists but doesn't match
   - keypair generated, CA down, CSR requires multiple resubmits until
     CA ready
   - no keypair generated, certname exists for another host

 - Additionally make improvements:

   - Verify that there is a 200 response from the masters CA as well to
     determine CA readiness to prevent:

      - Error: cannot reach CA host 'pe-puppet'
      - Error: cannot reach CRL host 'pe-puppet'

   - Under rare circumstances *any* HTTP response may not be blank, but
     may be malformed with a unparseable status code.

     In such instances, fail fast -- otherwise, the code may reach the
     end and perform a `return ""`

   - Fix a number of minor bugs in the scripts

 - See https://github.com/puppetlabs/pupperware/pull/230 for details

Verified as working by `(/ssl.sh) Submitting CSR...`

```

2020-12-29T04:10:44.568312700Z  (/ssl.sh) * CERTNAME: 'puppetdb' (/CN=puppetdb)
2020-12-29T04:10:44.568320800Z  (/ssl.sh) * DNS_ALT_NAMES: ''
2020-12-29T04:10:44.568327600Z  (/ssl.sh) * CA: 'puppet:8140/puppet-ca/v1'
2020-12-29T04:10:44.568333600Z  (/ssl.sh) * SSLDIR: '/opt/puppetlabs/server/data/puppetdb/certs'
2020-12-29T04:10:44.568339600Z  (/ssl.sh) * WAITFORCERT: '300' seconds
2020-12-29T04:10:44.568345600Z  (/ssl.sh) Waiting for master puppet to be running to generate certificates...
2020-12-29T04:10:45.536180700Z  subject=CN = "Puppet Enterprise CA generated on puppet at 2020-12-29 04:09:24 +0000"
2020-12-29T04:10:45.543871200Z  issuer=CN = Puppet Root CA: 221e4d0aea8396
2020-12-29T04:10:46.125805200Z  Generating RSA private key, 4096 bit long modulus (2 primes)
2020-12-29T04:10:47.004835100Z  .................................................................................................++++
2020-12-29T04:10:48.422966400Z  ........................................................................................................................................................++++
2020-12-29T04:10:48.423993700Z  e is 65537 (0x010001)
2020-12-29T04:10:48.441301100Z  writing RSA key
2020-12-29T04:10:48.452808100Z  Can't load /root/.rnd into RNG
2020-12-29T04:10:48.452831900Z  139635919684032:error:2406F079:random number generator:RAND_load_file:Cannot open file:../crypto/rand/randfile.c:88:Filename=/root/.rnd
2020-12-29T04:10:48.485976600Z  (/ssl.sh) Submitting CSR...
2020-12-29T04:10:49.250236100Z  subject=CN = puppetdb
2020-12-29T04:10:49.250274100Z  issuer=CN = "Puppet Enterprise CA generated on puppet at 2020-12-29 04:09:24 +0000"
2020-12-29T04:10:49.250284600Z          X509v3 extensions:
2020-12-29T04:10:49.250291700Z              Netscape Comment: 
2020-12-29T04:10:49.250312100Z                  Puppet Server Internal Certificate
2020-12-29T04:10:49.250324200Z              X509v3 Authority Key Identifier: 
2020-12-29T04:10:49.250331200Z                  keyid:EF:18:62:E2:48:C6:A5:0B:32:C2:B9:42:82:2F:48:3D:6A:84:64:9D
2020-12-29T04:10:49.250515100Z  
2020-12-29T04:10:49.250526000Z              X509v3 Subject Key Identifier: 
2020-12-29T04:10:49.250530800Z                  31:7A:54:16:E7:6C:99:95:DB:4F:0F:0D:4E:9D:A0:9C:F1:21:C7:0A
2020-12-29T04:10:49.250535900Z              X509v3 Basic Constraints: critical
2020-12-29T04:10:49.250540700Z                  CA:FALSE
2020-12-29T04:10:49.250545400Z              X509v3 Extended Key Usage: critical
2020-12-29T04:10:49.250550100Z                  TLS Web Server Authentication, TLS Web Client Authentication
2020-12-29T04:10:49.250555000Z              X509v3 Key Usage: critical
2020-12-29T04:10:49.250559800Z                  Digital Signature, Key Encipherment
2020-12-29T04:10:49.251429000Z  (/ssl.sh) Successfully signed certificate '/opt/puppetlabs/server/data/puppetdb/certs/certs/puppetdb.pem'

```