### PR TITLE
 (PDB-4811) Add tk-auth to tk-metrics endpoint

### DIFF
--- a/docker/puppetdb/conf.d/auth.conf
+++ b/docker/puppetdb/conf.d/auth.conf
@@ -1,0 +1,29 @@
+authorization: {
+    version: 1
+    rules: [
+        {
+            # Allow nodes to access the metrics service
+            # for puppetdb, the metrics service is the only
+            # service using the authentication service
+            match-request: {
+                path: "/metrics/v2/([^/]+)$"
+                type: regex
+                method: [get, head, post, put]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs puppetdb metrics"
+        },
+        {
+            # Deny everything else. This ACL is not strictly
+            # necessary, but illustrates the default policy
+            match-request: {
+                path: "/"
+                type: path
+            }
+            deny: "*"
+            sort-order: 999
+            name: "puppetlabs deny all"
+        }
+    ]
+}

--- a/docker/puppetdb/conf.d/auth.conf
+++ b/docker/puppetdb/conf.d/auth.conf
@@ -27,9 +27,9 @@ authorization: {
             # for puppetdb, the metrics service is the only
             # service using the authentication service
             match-request: {
-                path: "/metrics/v2/([^/]+)$"
-                type: regex
-                method: [get, head, post, put]
+                path: "/metrics"
+                type: path
+                method: [get, post]
             }
             allow: "*"
             sort-order: 500

--- a/docker/puppetdb/conf.d/auth.conf
+++ b/docker/puppetdb/conf.d/auth.conf
@@ -2,6 +2,27 @@ authorization: {
     version: 1
     rules: [
         {
+            # Allow unauthenticated access to the status service endpoint
+            match-request: {
+                path: "/status/v1/services"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status service - full"
+        },
+        {
+            match-request: {
+                path: "/status/v1/simple"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status service - simple"
+        },
+        {
             # Allow nodes to access the metrics service
             # for puppetdb, the metrics service is the only
             # service using the authentication service

--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -207,7 +207,7 @@ sandbox:
 
     $ export PDBBOX="$(pwd)/test-sandbox"
     $ ext/bin/pdbbox-env lein run services \
-        -c test-sandbox/pdb.ini
+        -c test-sandbox/conf.d
 
 And finally, you can of course set up and [configure your own
 PostgreSQL server][configure_postgres] for testing, but then you'll

--- a/ext/bin/pdbbox-init
+++ b/ext/bin/pdbbox-init
@@ -187,7 +187,9 @@ EOF
 
 host=${bind_addr[${#bind_addr[@]}-1]}
 
-cat > "$pdbbox/pdb.ini" <<EOF
+confdir="$pdbbox/conf.d"
+mkdir "$confdir"
+cat > "$confdir/pdb.ini" <<EOF
 
 [global]
 vardir = $abs_pdbbox/var
@@ -204,12 +206,44 @@ enabled = false
 [jetty]
 port = 8080
 ssl-port = 8081
-ssl-ca-cert = $abs_pdbbox/ssl/ca.crt.pem
-ssl-cert = $abs_pdbbox/ssl/pdb.crt.pem
-ssl-key = $abs_pdbbox/ssl/pdb.key.pem
+ssl-ca-cert = test-resources/ca.pem
+ssl-cert = test-resources/localhost.pem
+ssl-key = test-resources/localhost.key
 
 [puppetdb]
 disable-update-checking = true
+EOF
+
+cat > "$confdir/auth.conf" <<EOF
+authorization: {
+    version: 1
+    rules: [
+        {
+            # Allow nodes to access the metrics service
+            # for puppetdb, the metrics service is the only
+            # service using the authentication service
+            match-request: {
+                path: "/metrics"
+                type: path
+                method: [get, post]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs puppetdb metrics"
+        },
+        {
+            # Deny everything else. This ACL is not strictly
+            # necessary, but illustrates the default policy
+            match-request: {
+                path: "/"
+                type: path
+            }
+            deny: "*"
+            sort-order: 999
+            name: "puppetlabs puppetdb deny all"
+        }
+    ]
+}
 EOF
 
 # do some tuning on PostgreSQL

--- a/ext/bin/pdbbox-init
+++ b/ext/bin/pdbbox-init
@@ -219,6 +219,27 @@ authorization: {
     version: 1
     rules: [
         {
+            # Allow unauthenticated access to the status service endpoint
+            match-request: {
+                path: "/status/v1/services"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status service - full"
+        },
+        {
+            match-request: {
+                path: "/status/v1/simple"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status service - simple"
+        },
+        {
             # Allow nodes to access the metrics service
             # for puppetdb, the metrics service is the only
             # service using the authentication service

--- a/ext/bin/render-pdb-schema
+++ b/ext/bin/render-pdb-schema
@@ -85,7 +85,7 @@ tmpdir="$(mktemp -d "test-upgrade-and-exit-XXXXXX")"
 tmpdir="$(cd "$tmpdir" && pwd)"
 trap "$(printf 'rm -rf %q' "$tmpdir")" EXIT
 
-./pdb upgrade -c "$PDBBOX/pdb.ini"
+./pdb upgrade -c "$PDBBOX/conf.d"
 
 postgresql_autodoc -t dot -u puppetdb -d puppetdb -f "$tmpdir/pdb"
 dot -Tsvg "$tmpdir/pdb.dot" -o "$dest"

--- a/ext/test/database-migration-config
+++ b/ext/test/database-migration-config
@@ -65,11 +65,12 @@ trap "$(printf 'rm -rf %q' "$tmpdir")" EXIT
 sed '/\[database\]/a\
   migrate = false
 ' \
-    "$PDBBOX/pdb.ini" > "$tmpdir/pdb.ini"
+    "$PDBBOX/conf.d/pdb.ini" > "$tmpdir/pdb.ini"
+mv "$tmpdir/pdb.ini" "$PDBBOX/conf.d/pdb.ini"
 
 for cmd in services upgrade; do
     rc=0
-    ./pdb "$cmd" -c "$tmpdir/pdb.ini" 1>"$tmpdir/out" 2>"$tmpdir/err" || rc=$?
+    ./pdb "$cmd" -c "$PDBBOX/conf.d" 1>"$tmpdir/out" 2>"$tmpdir/err" || rc=$?
     cat "$tmpdir/out" "$tmpdir/err"
     echo  # in case the output doesn't end with a newline
     # This will become 109 once trapperkeeper supports custom exit statuses/

--- a/ext/test/oom-causes-shutdown
+++ b/ext/test/oom-causes-shutdown
@@ -61,7 +61,7 @@ set -x
 rc=0
 # Show err and out, but save them separately
 PDB_TEST_ALLOCATE_AT_LEAST_MB_AT_STARTUP=4096 \
-  ./pdb services -c "$PDBBOX/pdb.ini" \
+  ./pdb services -c "$PDBBOX/conf.d" \
       > >(tee -a "$tmpdir/pdb-out") \
       2> >(tee -a "$tmpdir/pdb-err") \
     || rc=$?

--- a/ext/test/schema-mismatch-causes-pdb-shutdown
+++ b/ext/test/schema-mismatch-causes-pdb-shutdown
@@ -58,18 +58,19 @@ trap "$(printf 'rm -rf %q' "$tmpdir")" EXIT
 sed '/\[database\]/a\
   schema-check-interval = 500
 ' \
-    "$PDBBOX/pdb.ini" > "$tmpdir/pdb.ini"
+    "$PDBBOX/conf.d/pdb.ini" > "$tmpdir/pdb.ini"
+mv "$tmpdir/pdb.ini" "$PDBBOX/conf.d/pdb.ini"
 
 set -x
-cat "$tmpdir/pdb.ini"
+cat "$PDBBOX/conf.d/"*
 set +x
 
 # use upgrade command to init pdb and apply all migrations
-./pdb upgrade -c "$tmpdir/pdb.ini"
+./pdb upgrade -c "$PDBBOX/conf.d"
 
 # start pdb in the background
 touch "$tmpdir/pdb-out" "$tmpdir/pdb-err"
-./pdb services -c "$tmpdir/pdb.ini" 1>"$tmpdir/pdb-out" 2>"$tmpdir/pdb-err"  & pdb_pid=$!
+./pdb services -c "$PDBBOX/conf.d" 1>"$tmpdir/pdb-out" 2>"$tmpdir/pdb-err"  & pdb_pid=$!
 
 # allow time for pdb to start before changing migration level
 while ! grep -F "Finished database garbage collection" "$tmpdir/pdb-out" > /dev/null

--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -63,7 +63,7 @@ cat "$tmpdir/err"
 grep 'No relations found' "$tmpdir/out" \
     || grep 'Did not find any relations' "$tmpdir/err"
 
-./pdb upgrade -c "$PDBBOX/pdb.ini"
+./pdb upgrade -c "$PDBBOX/conf.d"
 
 psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"

--- a/project.clj
+++ b/project.clj
@@ -71,7 +71,6 @@
      [io.forward/yaml "1.0.5"]
 
      ;; Only needed for :integration tests
-     [puppetlabs/trapperkeeper-authorization nil]
      [puppetlabs/trapperkeeper-filesystem-watcher nil]]
    puppetserver-test-deps))
 
@@ -161,6 +160,7 @@
                  [puppetlabs/trapperkeeper-webserver-jetty9]
                  [puppetlabs/trapperkeeper-metrics]
                  [puppetlabs/trapperkeeper-status]
+                 [puppetlabs/trapperkeeper-authorization]
 
                  ;; Various
                  [cheshire]

--- a/resources/ext/config/conf.d/auth.conf
+++ b/resources/ext/config/conf.d/auth.conf
@@ -1,0 +1,29 @@
+authorization: {
+    version: 1
+    rules: [
+        {
+            # Allow nodes to access the metrics service
+            # for puppetdb, the metrics service is the only
+            # service using the authentication service
+            match-request: {
+                path: "/metrics/v2/([^/]+)$"
+                type: regex
+                method: [get, head, post, put]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs puppetdb metrics"
+        },
+        {
+            # Deny everything else. This ACL is not strictly
+            # necessary, but illustrates the default policy
+            match-request: {
+                path: "/"
+                type: path
+            }
+            deny: "*"
+            sort-order: 999
+            name: "puppetlabs deny all"
+        }
+    ]
+}

--- a/resources/ext/config/conf.d/auth.conf
+++ b/resources/ext/config/conf.d/auth.conf
@@ -27,9 +27,9 @@ authorization: {
             # for puppetdb, the metrics service is the only
             # service using the authentication service
             match-request: {
-                path: "/metrics/v2/([^/]+)$"
-                type: regex
-                method: [get, head, post, put]
+                path: "/metrics"
+                type: path
+                method: [get, post]
             }
             allow: "*"
             sort-order: 500

--- a/resources/ext/config/conf.d/auth.conf
+++ b/resources/ext/config/conf.d/auth.conf
@@ -2,6 +2,27 @@ authorization: {
     version: 1
     rules: [
         {
+            # Allow unauthenticated access to the status service endpoint
+            match-request: {
+                path: "/status/v1/services"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status service - full"
+        },
+        {
+            match-request: {
+                path: "/status/v1/simple"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status service - simple"
+        },
+        {
             # Allow nodes to access the metrics service
             # for puppetdb, the metrics service is the only
             # service using the authentication service

--- a/resources/puppetlabs/puppetdb/bootstrap.cfg
+++ b/resources/puppetlabs/puppetdb/bootstrap.cfg
@@ -9,8 +9,10 @@ puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
 # Webrouting
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 
-# TK status
+# TK metrics - the authorization service is currently only used by the metrics service
+puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
 puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice
+# TK status
 puppetlabs.trapperkeeper.services.status.status-service/status-service
 puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
 


### PR DESCRIPTION
Assuming puppetdb's jetty is configured to use the same certs, metrics
can be access via authenticated GET requests like the curl command
below.

```
curl -G https://localhost:8081/metrics/v2/list \
  --cacert test-resources/ca.pem \
  --cert test-resources/localhost.pem \
  --key test-resources/localhost.key
```

