### PR TITLE
(maint) Bump hocon version support via clj-parent

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def pdb-version "6.13.2-SNAPSHOT")
-(def clj-parent-version "4.6.8")
+(def clj-parent-version "4.6.11")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
 - Bumps clj-parent to 4.6.11 to pick up an updated typesafe/config
   version via typesafe 1.4.1 (from 1.2.0)

   Includes feature to load environment variables into lists
   like:

    FOO.1
    FOO.2

   More info is available at
   https://github.com/lightbend/config/blob/master/NEWS.md

   https://github.com/puppetlabs/clj-parent/pull/27