### PR TITLE
(maint) Support dotted env vars in containers

### DIFF
--- a/docker/puppetdb/docker-entrypoint.sh
+++ b/docker/puppetdb/docker-entrypoint.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+# bash is required to pass ENV vars with dots as sh cannot
 
 set -e
 


### PR DESCRIPTION
 - Both docker (per https://github.com/moby/moby/issues/16585) and
   Kubernetes (per https://github.com/kubernetes/kubernetes/issues/2707)
   support passing environment variables with dots as config, despite
   dot not technically being supported in POSIX.

   This is necessary to be able to specify hocon array values like
   FOO.0, FOO.1, etc now that the Hocon library is updated to
   typesafe/config 1.4.1 via puppetlabs/typesafe-config 0.2.0 /
   clj-parent 4.6.11

   /bin/sh will not add such variables to the environment, but /bin/bash
   will properly expose them, so that they may be consumed by
   puppetserver and hocon.

   NOTE: ElasticSearch is notorious for passing such values, and it also
   uses the tini init system, so it served as a good design to follow:

   https://github.com/elastic/elasticsearch/tree/master/distribution/docker