### PR TITLE
(PDB-5000) Remove dependency on pantomime

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def pdb-version "6.13.2-SNAPSHOT")
-(def clj-parent-version "4.6.14")
+(def clj-parent-version "4.6.17")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))

--- a/project.clj
+++ b/project.clj
@@ -192,7 +192,6 @@
                  ;; WebAPI support libraries.
                  [bidi]
                  [clj-http "2.0.1"]
-                 [com.novemberain/pantomime "2.1.0"]
                  [compojure]
                  [ring/ring-core]
 

--- a/test/puppetlabs/puppetdb/middleware_test.clj
+++ b/test/puppetlabs/puppetdb/middleware_test.clj
@@ -266,3 +266,13 @@
           (merge-param-specs {:optional ["x"] :required ["y"]}
                              {:optional ["z"]
                               :required ["v" "w"]})))))
+
+(deftest base-type-test
+  (is (= "application/json" (base-type "application/json")))
+  (is (= "application/json" (base-type "application/json;charset=UTF-8")))
+  (is (= "application/json" (base-type "application/json  ;  charset=UTF-8")))
+
+  (is (= "foo/bar" (base-type "foo/bar;someparam=baz")))
+
+  (is (nil? (base-type "application/json:charset=UTF-8")))
+  (is (nil? (base-type "appl=ication/json ; charset=UTF-8"))))


### PR DESCRIPTION
There was a vulnerability in tika-core, but upgrading pantomime was
going to pull in a bunch of new dependencies. We only used it for
parsing the Content-Type header for its basetype, so this replaces that
call with a custom regex matching the RFC definition of base type.

Also bumps clj-parent for vulnerabilities
