### PR TITLE
(PDB-5003) Add (certname,end_time) index to reports

### DIFF
--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -69,6 +69,6 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 78$' "$tmpdir/out"
+grep -qE ' 79$' "$tmpdir/out"
 
 test ! -e "$PDBBOX"/var/mq-migrated

--- a/resources/ext/cli/delete-reports.erb
+++ b/resources/ext/cli/delete-reports.erb
@@ -87,7 +87,7 @@ chown "$pg_user:$pg_user" "$tmp_dir"
 
 # Verify that the PuppetDB schema version it the expected value
 # so that we do not incorrectly delete the report data.
-expected_schema_ver=78
+expected_schema_ver=79
 su - "$pg_user" -s /bin/sh -c "$psql_cmd -p $pg_port -d $pdb_db_name -c 'COPY ( SELECT max(version) FROM schema_migrations ) TO STDOUT;' > $tmp_dir/schema_ver"
 actual_schema_ver="$(cat "$tmp_dir/schema_ver")"
 if test "$actual_schema_ver" -ne $expected_schema_ver; then

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -1957,12 +1957,27 @@
 
 (defn add-report-partition-indexes-on-id
   []
-  (doseq [{:keys [table part] :as huh} (get-temporal-partitions "reports")
+  (doseq [{:keys [table part]} (get-temporal-partitions "reports")
           :let [idx-name (str "idx_reports_id_" part)]]
     (jdbc/do-commands
      (format "create unique index if not exists %s on %s using btree (id)"
              (jdbc/double-quote idx-name)
              (jdbc/double-quote table)))))
+
+(defn add-report-partition-indexes-on-certname-end-time
+  []
+  (doseq [{:keys [table part]} (get-temporal-partitions "reports")
+          :let [old-idx-name (str "reports_certname_idx_" part)
+                new-idx-name (str "idx_reports_certname_end_time_" part)]]
+    (jdbc/do-commands
+     (format "drop index if exists %s"
+             (jdbc/double-quote old-idx-name))
+     (format "create index if not exists %s on %s using btree (certname,end_time)"
+             (jdbc/double-quote new-idx-name)
+             (jdbc/double-quote table))))
+  (jdbc/do-commands
+   "drop index reports_certname_idx"
+   "create index idx_reports_certname_end_time on reports using btree (certname,end_time)"))
 
 (defn add-catalog-inputs-pkey
   []
@@ -2035,7 +2050,8 @@
    75 add-report-type-to-reports
    76 add-report-partition-indexes-on-id
    77 add-catalog-inputs-pkey
-   78 add-catalog-inputs-hash})
+   78 add-catalog-inputs-hash
+   79 add-report-partition-indexes-on-certname-end-time})
    ;; Make sure that if you change the structure of reports
    ;; or resource events, you also update the delete-reports
    ;; cli command.

--- a/src/puppetlabs/puppetdb/scf/partitioning.clj
+++ b/src/puppetlabs/puppetdb/scf/partitioning.clj
@@ -158,7 +158,7 @@
                      iso-week-year full-table-name)
              (format "CREATE INDEX IF NOT EXISTS reports_catalog_uuid_idx_%s ON %s USING btree (catalog_uuid)"
                      iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS reports_certname_idx_%s ON %s USING btree (certname)"
+             (format "CREATE INDEX IF NOT EXISTS idx_reports_certname_end_time_%s ON %s USING btree (certname,end_time)"
                      iso-week-year full-table-name)
              (format "CREATE INDEX IF NOT EXISTS reports_end_time_idx_%s ON %s USING btree (end_time)"
                      iso-week-year full-table-name)

--- a/src/puppetlabs/puppetdb/scf/partitioning.clj
+++ b/src/puppetlabs/puppetdb/scf/partitioning.clj
@@ -117,12 +117,6 @@
       (format "CREATE UNIQUE INDEX IF NOT EXISTS resource_events_hash_%s ON %s (event_hash)"
               iso-week-year full-table-name)])))
 
-;; This var is used in testing to simulate migration 74 being applied without
-;; adding the idx_reports_id index to partitions. Changing this behavior in
-;; migration 74 should be safe because the index creation is guarded by
-;; 'if not exists' in both the changed migration 74 and in the newer 76.
-(def ^:dynamic add-report-id-idx? true)
-
 (defn create-reports-partition
   "Creates a partition in the reports table"
   [date]
@@ -143,38 +137,35 @@
                     " FOREIGN KEY (status_id) REFERENCES report_statuses(id) ON DELETE CASCADE")
                iso-week-year)])
     (fn [full-table-name iso-week-year]
-      (let [indexes
-            [(format "CREATE INDEX IF NOT EXISTS idx_reports_compound_id_%s ON %s USING btree (producer_timestamp, certname, hash) WHERE (start_time IS NOT NULL)"
-                     iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS idx_reports_noop_pending_%s ON %s USING btree (noop_pending) WHERE (noop_pending = true)"
-                     iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS idx_reports_prod_%s ON %s USING btree (producer_id)"
-                     iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS idx_reports_producer_timestamp_%s ON %s USING btree (producer_timestamp)"
-                     iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS idx_reports_producer_timestamp_by_hour_certname_%s ON %s USING btree (date_trunc('hour'::text, timezone('UTC'::text, producer_timestamp)), producer_timestamp, certname)"
-                     iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS reports_cached_catalog_status_on_fail_%s ON %s USING btree (cached_catalog_status) WHERE (cached_catalog_status = 'on_failure'::text)"
-                     iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS reports_catalog_uuid_idx_%s ON %s USING btree (catalog_uuid)"
-                     iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS idx_reports_certname_end_time_%s ON %s USING btree (certname,end_time)"
-                     iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS reports_end_time_idx_%s ON %s USING btree (end_time)"
-                     iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS reports_environment_id_idx_%s ON %s USING btree (environment_id)"
-                     iso-week-year full-table-name)
-             (format "CREATE UNIQUE INDEX IF NOT EXISTS reports_hash_expr_idx_%s ON %s USING btree (encode(hash, 'hex'::text))"
-                     iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS reports_job_id_idx_%s ON %s USING btree (job_id) WHERE (job_id IS NOT NULL)"
-                     iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS reports_noop_idx_%s ON %s USING btree (noop) WHERE (noop = true)"
-                     iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS reports_status_id_idx_%s ON %s USING btree (status_id)"
-                     iso-week-year full-table-name)
-             (format "CREATE INDEX IF NOT EXISTS reports_tx_uuid_expr_idx_%s ON %s USING btree (((transaction_uuid)::text))"
-                     iso-week-year full-table-name)]]
-        (if add-report-id-idx?
-          (conj indexes (format "CREATE UNIQUE INDEX IF NOT EXISTS idx_reports_id_%s ON %s USING btree (id)"
-                                iso-week-year full-table-name))
-          indexes)))))
+      [(format "CREATE INDEX IF NOT EXISTS idx_reports_compound_id_%s ON %s USING btree (producer_timestamp, certname, hash) WHERE (start_time IS NOT NULL)"
+               iso-week-year full-table-name)
+       (format "CREATE INDEX IF NOT EXISTS idx_reports_noop_pending_%s ON %s USING btree (noop_pending) WHERE (noop_pending = true)"
+               iso-week-year full-table-name)
+       (format "CREATE INDEX IF NOT EXISTS idx_reports_prod_%s ON %s USING btree (producer_id)"
+               iso-week-year full-table-name)
+       (format "CREATE INDEX IF NOT EXISTS idx_reports_producer_timestamp_%s ON %s USING btree (producer_timestamp)"
+               iso-week-year full-table-name)
+       (format "CREATE INDEX IF NOT EXISTS idx_reports_producer_timestamp_by_hour_certname_%s ON %s USING btree (date_trunc('hour'::text, timezone('UTC'::text, producer_timestamp)), producer_timestamp, certname)"
+               iso-week-year full-table-name)
+       (format "CREATE INDEX IF NOT EXISTS reports_cached_catalog_status_on_fail_%s ON %s USING btree (cached_catalog_status) WHERE (cached_catalog_status = 'on_failure'::text)"
+               iso-week-year full-table-name)
+       (format "CREATE INDEX IF NOT EXISTS reports_catalog_uuid_idx_%s ON %s USING btree (catalog_uuid)"
+               iso-week-year full-table-name)
+       (format "CREATE INDEX IF NOT EXISTS idx_reports_certname_end_time_%s ON %s USING btree (certname,end_time)"
+               iso-week-year full-table-name)
+       (format "CREATE INDEX IF NOT EXISTS reports_end_time_idx_%s ON %s USING btree (end_time)"
+               iso-week-year full-table-name)
+       (format "CREATE INDEX IF NOT EXISTS reports_environment_id_idx_%s ON %s USING btree (environment_id)"
+               iso-week-year full-table-name)
+       (format "CREATE UNIQUE INDEX IF NOT EXISTS reports_hash_expr_idx_%s ON %s USING btree (encode(hash, 'hex'::text))"
+               iso-week-year full-table-name)
+       (format "CREATE INDEX IF NOT EXISTS reports_job_id_idx_%s ON %s USING btree (job_id) WHERE (job_id IS NOT NULL)"
+               iso-week-year full-table-name)
+       (format "CREATE INDEX IF NOT EXISTS reports_noop_idx_%s ON %s USING btree (noop) WHERE (noop = true)"
+               iso-week-year full-table-name)
+       (format "CREATE INDEX IF NOT EXISTS reports_status_id_idx_%s ON %s USING btree (status_id)"
+               iso-week-year full-table-name)
+       (format "CREATE INDEX IF NOT EXISTS reports_tx_uuid_expr_idx_%s ON %s USING btree (((transaction_uuid)::text))"
+               iso-week-year full-table-name)
+       (format "CREATE UNIQUE INDEX IF NOT EXISTS idx_reports_id_%s ON %s USING btree (id)"
+               iso-week-year full-table-name)])))

--- a/test/puppetlabs/puppetdb/scf/migrate_partitioning_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_partitioning_test.clj
@@ -694,19 +694,6 @@
                                                :user "pdb_test"}
                                   :same nil}
                                  {:left-only nil
-                                  :right-only
-                                  {:schema "public"
-                                   :table table-name
-                                   :index (str "idx_reports_id_" part-name)
-                                   :index_keys ["id"]
-                                   :type "btree"
-                                   :unique? true
-                                   :functional? false
-                                   :is_partial false
-                                   :primary? false
-                                   :user "pdb_test"}
-                                  :same nil}
-                                 {:left-only nil
                                   :right-only {:schema "public"
                                                :table table-name
                                                :index (str "reports_job_id_idx_" part-name)
@@ -1280,9 +1267,7 @@
 
 (deftest migration-76-schema-diff
   (clear-db-for-testing!)
-  ;; don't add the idx_reports_id index when fast forwarding past migration 74
-  (binding [partitioning/add-report-id-idx? false]
-    (fast-forward-to-migration! 75))
+  (fast-forward-to-migration! 75)
 
   (let [before-migration (schema-info-map *db*)
         today (ZonedDateTime/now (ZoneId/of "UTC"))

--- a/test/puppetlabs/puppetdb/scf/migrate_partitioning_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_partitioning_test.clj
@@ -1314,3 +1314,76 @@
             :table-diff nil
             :constraint-diff nil}
            (diff-schema-maps before-migration (schema-info-map *db*))))))
+
+(deftest migration-79-schema-diff
+  (clear-db-for-testing!)
+  (fast-forward-to-migration! 78)
+
+  (let [before-migration (schema-info-map *db*)
+        today (ZonedDateTime/now (ZoneId/of "UTC"))
+        days-range (range -4 4)
+        dates (map #(.plusDays today %) days-range)
+        part-names (map #(str/lower-case (partitioning/date-suffix %)) dates)]
+    (apply-migration-for-testing! 79)
+
+    (is (= {:index-diff (into
+                          [{:left-only
+                            {:schema "public"
+                             :table "reports"
+                             :index "reports_certname_idx"
+                             :index_keys  ["certname"]
+                             :type "btree"
+                             :unique? false
+                             :functional? false
+                             :is_partial false
+                             :primary? false
+                             :user "pdb_test"}
+                            :right-only nil
+                            :same nil}
+                           {:left-only nil
+                            :right-only
+                            {:schema "public"
+                             :table "reports"
+                             :index "idx_reports_certname_end_time"
+                             :index_keys  ["certname" "end_time"]
+                             :type "btree"
+                             :unique? false
+                             :functional? false
+                             :is_partial false
+                             :primary? false
+                             :user "pdb_test"}
+                            :same nil}]
+                          cat
+                          (map
+                            (fn [part-name]
+                              (let [table-name (str "reports_" part-name)]
+                                 [{:left-only
+                                   {:schema "public"
+                                    :table table-name
+                                    :index (str "reports_certname_idx_" part-name)
+                                    :index_keys  ["certname"]
+                                    :type "btree"
+                                    :unique? false
+                                    :functional? false
+                                    :is_partial false
+                                    :primary? false
+                                    :user "pdb_test"}
+                                   :right-only nil
+                                   :same nil}
+                                  {:left-only nil
+                                   :right-only
+                                   {:schema "public"
+                                    :table table-name
+                                    :index (str "idx_reports_certname_end_time_" part-name)
+                                    :index_keys ["certname" "end_time"]
+                                    :type "btree"
+                                    :unique? false
+                                    :functional? false
+                                    :is_partial false
+                                    :primary? false
+                                    :user "pdb_test"}
+                                   :same nil}]))
+                            part-names))
+            :table-diff nil
+            :constraint-diff nil}
+           (diff-schema-maps before-migration (schema-info-map *db*))))))

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -1417,15 +1417,7 @@
         (is (= 1
                (count hashes)))
         (is (= expected
-               (first hashes)))
-
-        (testing "idx_reports_id index present in all partitions"
-          (let [assert-index-exists (fn [index indexes]
-                                      (is (true? (some #(str/includes? % index) indexes))))]
-            ;; check that idx_reports_id is present in all paritions
-            (dorun (->> (part/get-partition-names "reports")
-                        (map utils/table-indexes)
-                        (map (partial assert-index-exists "idx_reports_id"))))))))))
+               (first hashes)))))))
 
 (deftest migration-75-add-report-type-column-with-default
   (testing "reports should get default value of 'agent' for report_type"
@@ -1456,33 +1448,11 @@
         (is (= "agent" (-> (query-to-vec "select * from reports")
                            first :report_type)))))))
 
-(deftest migration-76-is-a-no-op-if-74-already-added-idx-reports-id
-  (testing "Index created with new version of migration 74"
-    (jdbc/with-db-connection *db*
-      (clear-db-for-testing!)
-      (let [assert-index-exists (fn [index indexes]
-                                  (is (true? (some #(str/includes? % index) indexes))))
-            ;; check that idx_reports_id is present in all paritions
-            check-idx-reports-id #(dorun
-                                   (->>
-                                    (part/get-partition-names "reports")
-                                    (map utils/table-indexes)
-                                    (map (partial assert-index-exists "idx_reports_id"))))]
-        (fast-forward-to-migration! 75)
-        ;; migration 74 should have added the parition indexes
-        (check-idx-reports-id)
-
-        (apply-migration-for-testing! 76)
-        ;; migration 76 should be a no-op
-        (check-idx-reports-id)))))
-
 (deftest migration-76-adds-report-id-idx-when-not-added-by-migration-74
   (testing "All report paritions have idx_reports_id index when old version of 74 applied"
     (jdbc/with-db-connection *db*
       (clear-db-for-testing!)
-      ;; don't add the idx_reports_id index when fast forwarding past migration 74
-      (binding [part/add-report-id-idx? false]
-        (fast-forward-to-migration! 75))
+      (fast-forward-to-migration! 75)
       (let [assert-no-index (fn [index indexes]
                               (is (nil? (some #(str/includes? % index) indexes))))]
         ;; check that idx_reports_id wasn't added by migration 74


### PR DESCRIPTION
Also structures migration 74 in a way that future changes to `partitioning/create-report-partition` won't cause changes to the migration and its schema diff test. This allowed the simplification of the testing for migration 76 because it no longer has two cases to test.