### PR TITLE
(PDB-4934-2) PuppetDB does not support username@hostname auth for Azure PostgreSQL

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -491,6 +491,14 @@ this if your PostgreSQL server is using SSL.
 The database user specified for connections performing normal
 operations (queries, command processing, etc.).
 
+### `connection-username`
+The database user for special cases when the database connection username
+is different from the username reported by the database.
+An example is managed PostgreSQL in Azure, in order to connect we need to specify
+`username@hostname`, but the user reported by the database is `username`.
+If not specified, it will default to `username`
+
+
 ### `password`
 
 This is the password to use when connecting. Only used with PostgreSQL.
@@ -500,6 +508,13 @@ This is the password to use when connecting. Only used with PostgreSQL.
 The database user specified for database migration operations, in
 particular the database validation and migration at startup.  Defaults
 to the `username`.
+
+### `connection-migrator-username`
+The database migrator user for special cases when the database connection username
+is different from the username reported by the database.
+An example is managed PostgreSQL in Azure, in order to connect we need to specify
+`username@hostname`, but the user reported by the database is `username`.
+If not specified, it will default to `migrator-username`
 
 ### `migrator-password`
 

--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -772,11 +772,16 @@
             :let [config (get databases name)
                   pool-name (if (::conf/unnamed config)
                               "PDBWritePool"
-                              (str "PDBWritePool: " name))]]
+                              (str "PDBWritePool: " name))
+                  connection-username (:connection-username config)
+                  connection-password (:connection-password config)
+                  ]]
       (swap! pools conj
              (-> config
                  (assoc :pool-name pool-name
-                        :expected-schema desired-schema)
+                        :expected-schema desired-schema
+                        :user connection-username
+                        :password connection-password)
                  (jdbc/pooled-datasource database-metrics-registry))))
     {:write-db-names db-names
      :write-db-cfgs (mapv #(get databases %) db-names)

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -61,6 +61,10 @@
      :conn-lifetime (s/maybe s/Int)
      :maximum-pool-size (pls/defaulted-maybe s/Int 25)
      :subname (s/maybe String)
+     :connection-migrator-username String
+     :connection-migrator-password String
+     :connection-username String
+     :connection-password String
      :user String
      :username String
      :password String
@@ -121,6 +125,10 @@
    :connection-timeout s/Int
    :maximum-pool-size s/Int
    (s/optional-key :conn-lifetime) (s/maybe Minutes)
+   (s/optional-key :connection-migrator-username) String
+   (s/optional-key :connection-migrator-password) String
+   (s/optional-key :connection-username) String
+   (s/optional-key :connection-password) String
    (s/optional-key :user) String
    (s/optional-key :username) String
    (s/optional-key :password) String

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -409,8 +409,7 @@
   (assert (:migrator-username config))
   (-> config
       (update :connection-username #(or % (:user config)))
-      (update :connection-migrator-username #(or % (:migrator-username config))))
-  )
+      (update :connection-migrator-username #(or % (:migrator-username config)))))
 
 (defn fix-up-db-settings
   [section-key settings]

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -402,6 +402,16 @@
       (update :migrator-username #(or % (:user config)))
       (update :migrator-password #(or % (:password config)))))
 
+(defn ensure-connection-users-info [config]
+  ;; This expects to run after ensure-migrator-info and prefer-db-user-on-username-mismatch,
+  ;; so the :user and :migrator-user should already be set
+  (assert (:user config))
+  (assert (:migrator-username config))
+  (-> config
+      (update :connection-username #(or % (:user config)))
+      (update :connection-migrator-username #(or % (:migrator-username config))))
+  )
+
 (defn fix-up-db-settings
   [section-key settings]
   ;; FIXME: double-check this reordering wrt each function,
@@ -416,7 +426,8 @@
       gc-interval->ms
       default-events-ttl
       (prefer-db-user-on-username-mismatch (name section-key))
-      ensure-migrator-info))
+      ensure-migrator-info
+      ensure-connection-users-info))
 
 (defn configure-read-db
   "Ensures that the config contains a suitable [read-database].  If the

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -62,9 +62,7 @@
      :maximum-pool-size (pls/defaulted-maybe s/Int 25)
      :subname (s/maybe String)
      :connection-migrator-username String
-     :connection-migrator-password String
      :connection-username String
-     :connection-password String
      :user String
      :username String
      :password String
@@ -126,9 +124,7 @@
    :maximum-pool-size s/Int
    (s/optional-key :conn-lifetime) (s/maybe Minutes)
    (s/optional-key :connection-migrator-username) String
-   (s/optional-key :connection-migrator-password) String
    (s/optional-key :connection-username) String
-   (s/optional-key :connection-password) String
    (s/optional-key :user) String
    (s/optional-key :username) String
    (s/optional-key :password) String


### PR DESCRIPTION
### The problem
For some databases the user we use for connecting to the databse can be different from the one reported by the database. For example the Azure managed PostgreSQL uses `username@hostname` to connect to a database, but the user that is reported by the database is `username`.  

PuppetDB does not make a distinction between the two users and will fail when it compares the connection user to the user reported by the database.

### The solution
Added two new users `connection-migrator-username` and `connection-username`. The new users are used to establish connections to the database when the connection username is different form the database username (this is the case for managed PostgreSQL in Azure)

`database.ini` example

```
[database]

# The database address, i.e. //HOST:PORT/DATABASE_NAME
subname = //<databse_url>:5432/puppetdb

# Credentials used to establish migration connections
connection-migrator-username = puppetdb@ghost-db

# Credentials used to establish connections
connection-username = puppetdb@ghost-db

# Connect as a specific user
username = puppetdb

# Use a specific password
password = <password_value>

# How often (in minutes) to compact the database
# gc-interval = 60
```