### PR TITLE
(PDB-4934-3) Add connection users.

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -619,7 +619,8 @@
   ;; will then cause the pool connection to throw a (generic)
   ;; SQLException.
   (log/info (trs "Ensuring {0} database is up to date" db-name))
-  (let  [migrator (:migrator-username db-config)]
+  (let  [migrator (:migrator-username db-config)
+         connection-migrator-username (:connection-migrator-username db-config)]
     (with-open [db-pool (-> (assoc db-config
                                    :pool-name (if db-name
                                                 (str "PDBMigrationsPool: " db-name)
@@ -643,7 +644,7 @@
                  last-ex nil]
             (let [result (try
                            (let [datasource {:datasource db-pool}]
-                             (require-db-connection-as datasource migrator)
+                             (require-db-connection-as datasource connection-migrator-username)
                              (jdbc/with-db-connection datasource
                                (prep-db db-config)))
                            true

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -61,6 +61,8 @@
      :conn-lifetime (s/maybe s/Int)
      :maximum-pool-size (pls/defaulted-maybe s/Int 25)
      :subname (s/maybe String)
+     :connection-migrator-username String
+     :connection-username String
      :user String
      :username String
      :password String
@@ -121,6 +123,8 @@
    :connection-timeout s/Int
    :maximum-pool-size s/Int
    (s/optional-key :conn-lifetime) (s/maybe Minutes)
+   (s/optional-key :connection-migrator-username) String
+   (s/optional-key :connection-username) String
    (s/optional-key :user) String
    (s/optional-key :username) String
    (s/optional-key :password) String
@@ -397,6 +401,17 @@
   (-> config
       (update :migrator-username #(or % (:user config)))
       (update :migrator-password #(or % (:password config)))))
+
+
+(defn ensure-connection-users-info [config]
+  ;; This expects to run after ensure-migrator-info and prefer-db-user-on-username-mismatch,
+  ;; so the :user and :migrator-user should already be set
+  (assert (:user config))
+  (assert (:migrator-username config))
+  (-> config
+      (update :connection-username #(or % (:user config)))
+      (update :connection-migrator-username #(or % (:migrator-username config))))
+  )
 
 (defn fix-up-db-settings
   [section-key settings]


### PR DESCRIPTION
`database.ini` example

```
[database]

# The database address, i.e. //HOST:PORT/DATABASE_NAME
subname = //<database_url>:5432/puppetdb

# Credentials used to establish migration connections
connection-migrator-username = puppetdb

# Credentials used to establish connections
connection-username = puppetdb

# Connect as a specific user
username = puppetdb@ghost-db

# Use a specific password
password = <password_value>

# How often (in minutes) to compact the database
# gc-interval = 60
```