### PR TITLE
(maint) Update container pk8 filename

### DIFF
--- a/docker/puppetdb/docker-entrypoint.d/20-configure-ssl.sh
+++ b/docker/puppetdb/docker-entrypoint.d/20-configure-ssl.sh
@@ -10,7 +10,10 @@ fi
 
 # cert files are present from Puppetserver OR have been user supplied
 if [ -f "${SSLDIR}/private_keys/${CERTNAME}.pem" ]; then
-  openssl pkcs8 -inform PEM -outform DER -in ${SSLDIR}/private_keys/${CERTNAME}.pem -topk8 -nocrypt -out ${SSLDIR}/private_keys/${CERTNAME}.pk8
+
+  openssl pkcs8 -topk8 -nocrypt -inform PEM -outform DER \
+    -in "${SSLDIR}/private_keys/server.key" \
+    -out "${SSLDIR}/private_keys/server.private_key.pk8"
 
   # enable SSL in Jetty
   sed -i '/^# ssl-/s/^# //g' /etc/puppetlabs/puppetdb/conf.d/jetty.ini


### PR DESCRIPTION
 - This simply makes it consistent with the filename used in
   orchestration services and console services. Changes will be made to
   ssl.sh to produce this file, and it makes sense to have all
   containers have the same naming convention