### PR TITLE
(PDB-2488) Invalid AST query is ignored

### DIFF
--- a/src/puppetlabs/puppetdb/catalogs.clj
+++ b/src/puppetlabs/puppetdb/catalogs.clj
@@ -92,6 +92,7 @@
             [puppetlabs.puppetdb.schema :as pls]
             [puppetlabs.puppetdb.time :refer [to-timestamp]]
             [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.utils.string-formatter :as formatter]
             [puppetlabs.kitchensink.core :as kitchensink]
             [schema.core :as s]
             [puppetlabs.i18n.core :refer [trs]]))
@@ -220,7 +221,7 @@
 (defn wire-v5->wire-v9 [catalog]
   (-> catalog
       (set/rename-keys {:name :certname})
-      utils/dash->underscore-keys
+      formatter/dash->underscore-keys
       (dissoc :api_version)
       wire-v6->wire-v9))
 

--- a/src/puppetlabs/puppetdb/cheshire.clj
+++ b/src/puppetlabs/puppetdb/cheshire.clj
@@ -123,6 +123,8 @@
 
 (def parse-strict-string core/parse-string-strict)
 
+(def parsed-seq core/parsed-seq)
+
 (def parse-stream core/parse-stream)
 
 (def byte-array-class (Class/forName "[B"))

--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -21,8 +21,8 @@
                                                       parse-order-by-json]]
             [puppetlabs.puppetdb.pql :as pql]
             [puppetlabs.puppetdb.time :refer [to-timestamp]]
-            [puppetlabs.puppetdb.utils :refer [update-when
-                                               pprint-json-parse-exception]])
+            [puppetlabs.puppetdb.utils :refer [update-when]]
+            [puppetlabs.puppetdb.utils.string-formatter :refer [pprint-json-parse-exception]])
   (:import (com.fasterxml.jackson.core JsonParseException)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -298,7 +298,7 @@
         (try
           (json/parse-string req-body true)
         (catch JsonParseException e
-          (throw (IllegalArgumentException. (tru (pprint-json-parse-exception e req-body)))))))
+          (throw (IllegalArgumentException. (pprint-json-parse-exception e req-body))))))
       (update :query (fn [query]
                        (if (vector? query)
                          query

--- a/src/puppetlabs/puppetdb/pql.clj
+++ b/src/puppetlabs/puppetdb/pql.clj
@@ -1,15 +1,13 @@
 (ns puppetlabs.puppetdb.pql
   (:import com.fasterxml.jackson.core.JsonParseException)
   (:require [clojure.string :refer [join]]
-            [clojure.tools.logging :as log]
             [instaparse.core :as insta]
             [instaparse.failure :as failure]
             [instaparse.print :as print]
-            [puppetlabs.i18n.core :as i18n]
+            [puppetlabs.i18n.core :refer [tru]]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.pql.transform :as transform]
-            [puppetlabs.i18n.core :refer [trs tru]]
-            [puppetlabs.puppetdb.utils :refer [pprint-json-parse-exception]]))
+            [puppetlabs.puppetdb.utils.string-formatter :refer [pprint-json-parse-exception]]))
 
 (defn transform
   "Transform parsed PQL to AST."
@@ -66,7 +64,7 @@
     (with-open [string-reader (java.io.StringReader. query)]
       (doall (json/parsed-seq string-reader)))
   (catch JsonParseException e
-    (throw (IllegalArgumentException. (tru (pprint-json-parse-exception e query)))))))
+    (throw (IllegalArgumentException. (pprint-json-parse-exception e query))))))
 
 (defn parse-json-query
   "Parse a query string as JSON. Multiple queries or any other
@@ -78,7 +76,7 @@
       (if (= query-count 1)
         (first parsed-query)
         (throw (IllegalArgumentException.
-                 (i18n/tru "Only one query may be sent in a request. You sent {0}." query-count)))))))
+                 (tru "Only one query may be sent in a request. You sent {0}." query-count)))))))
 
 (defn parse-pql-query
   "Parse a query string as PQL. Parse errors will result in an

--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -63,9 +63,9 @@
   (:require [clojure.string :as str]
             [puppetlabs.i18n.core :as i18n]
             [puppetlabs.kitchensink.core :as kitchensink]
-            [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.puppetdb.honeysql :as h]
             [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.utils.string-formatter :as formatter]
             [puppetlabs.puppetdb.time :refer [to-timestamp]]
             [puppetlabs.kitchensink.core :refer [parse-number keyset valset order-by-expr?]]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils
@@ -662,7 +662,7 @@
       (throw (IllegalArgumentException.
               (i18n/tru "= requires exactly two arguments, but {0} were supplied"
                         (count args)))))
-    (let [path (utils/dashes->underscores path)]
+    (let [path (formatter/dashes->underscores path)]
       (match [path]
              ["certname"]
              {:where "reports.certname = ?"
@@ -716,7 +716,7 @@
     (when-not (= (count args) 2)
       (throw (IllegalArgumentException.
                (i18n/tru "~ requires exactly two arguments, but {0} were supplied" (count args)))))
-    (let [path (utils/dashes->underscores path)]
+    (let [path (formatter/dashes->underscores path)]
       (match [path]
              ["certname"]
              {:where (legacy-sql-regexp-match "reports.certname")
@@ -752,7 +752,7 @@
   (when-not (= (count args) 2)
     (throw (IllegalArgumentException.
             (i18n/tru "= requires exactly two arguments, but {0} were supplied" (count args)))))
-  (let [db-field (utils/dashes->underscores path)]
+  (let [db-field (formatter/dashes->underscores path)]
     (match [db-field]
            [(field :guard fields)]
            {:where (format "%s = ?" field)

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -23,6 +23,7 @@
             [puppetlabs.puppetdb.scf.storage-utils :as sutils]
             [puppetlabs.puppetdb.schema :as pls]
             [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.utils.string-formatter :as formatter]
             [puppetlabs.puppetdb.query-eng.engine :as eng]
             [ring.util.io :as rio]
             [schema.core :as s])
@@ -92,7 +93,7 @@
     munge-result
     (throw (IllegalArgumentException.
             (tru "Invalid entity ''{0}'' in query"
-                 (utils/dashes->underscores (name entity)))))))
+                 (formatter/dashes->underscores (name entity)))))))
 
 (defn orderable-columns
   [query-rec]

--- a/src/puppetlabs/puppetdb/queue.clj
+++ b/src/puppetlabs/puppetdb/queue.clj
@@ -22,8 +22,9 @@
             [puppetlabs.puppetdb.nio :refer [get-path]]
             [puppetlabs.puppetdb.utils :refer [compression-file-extension-schema
                                                content-encodings->file-extensions
-                                               match-any-of re-quote utf8-length
+                                               match-any-of utf8-length
                                                utf8-truncate]]
+            [puppetlabs.puppetdb.utils.string-formatter :as formatter :refer [re-quote]]
             [schema.core :as s]
             [puppetlabs.puppetdb.time :as tcoerce]
             [puppetlabs.puppetdb.time :as time]
@@ -59,7 +60,7 @@
                    (->> "_"  ; our meta field separator
                         (conj constants/filename-forbidden-characters)
                         (map str)
-                        (map re-quote)
+                        (map formatter/re-quote)
                         (str/join "|"))
                    ")")))
 

--- a/src/puppetlabs/puppetdb/reports.clj
+++ b/src/puppetlabs/puppetdb/reports.clj
@@ -7,6 +7,7 @@
             [clojure.set :as set]
             [puppetlabs.puppetdb.schema :as pls]
             [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.utils.string-formatter :as formatter]
             [com.rpl.specter :as sp]))
 
 ;; SCHEMA
@@ -99,11 +100,11 @@
       (assoc :resource_events [resource-event-v5-wireformat-schema])))
 
 (def resource-event-v4-wireformat-schema
-  (utils/underscore->dash-keys resource-event-v5-wireformat-schema))
+  (formatter/underscore->dash-keys resource-event-v5-wireformat-schema))
 
 (def report-v4-wireformat-schema
   (-> report-v5-wireformat-schema
-      utils/underscore->dash-keys
+      formatter/underscore->dash-keys
       (assoc :resource-events [resource-event-v4-wireformat-schema])
       (dissoc :logs :metrics :noop :producer-timestamp)))
 
@@ -218,9 +219,9 @@
 
 (defn dash->underscore-report-keys [v5-report-or-older]
   (->> v5-report-or-older
-       utils/dash->underscore-keys
+       formatter/dash->underscore-keys
        (sp/transform [:resource_events sp/ALL sp/ALL]
-                     #(update % 0 utils/dashes->underscores))))
+                     #(update % 0 formatter/dashes->underscores))))
 
 (defn- resource-event->resource
   [resource-event]

--- a/src/puppetlabs/puppetdb/utils/string_formatter.clj
+++ b/src/puppetlabs/puppetdb/utils/string_formatter.clj
@@ -1,0 +1,108 @@
+(ns puppetlabs.puppetdb.utils.string-formatter
+  (:require [clojure.string :as string]
+            [com.rpl.specter :as spector]
+            [schema.core :as schema]
+            [puppetlabs.i18n.core :refer [tru]]
+            [puppetlabs.kitchensink.core :refer [parse-int]]
+            [puppetlabs.puppetdb.utils :refer [optional-key?]]))
+
+(defn re-quote
+  "Quotes s so that all of its characters will be matched literally."
+  [s]
+  ;; Wrap all segments not containing a \E in \Q...\E, and replace \E
+  ;; with \\E.
+  (apply str
+         "\\Q"
+         (concat (->> (string/split s #"\\E" -1)
+                      (interpose "\\E\\\\E\\Q"))
+                 ["\\E"])))
+
+(defn maybe-strip-escaped-quotes
+  [s]
+  (if (and (> (count s) 1)
+           (string/starts-with? s "\"")
+           (string/ends-with? s "\""))
+    (subs s 1 (dec (count s)))
+    s))
+
+(defn quoted
+  [s]
+  (str "'" s "'"))
+
+(defn comma-separated-keywords
+  [words]
+  (let [quoted-words (map quoted words)]
+    (if (> (count quoted-words) 2)
+      (str (string/join ", " (butlast quoted-words)) ", " "and " (last quoted-words))
+      (string/join " and " quoted-words))))
+
+(defn dashes->underscores
+  "Accepts a string or a keyword as an argument, replaces all occurrences of the
+  dash/hyphen character with an underscore, and returns the same type (string
+  or keyword) that was passed in.  This is useful for translating data structures
+  from their wire format to the format that is needed for JDBC."
+  [str]
+  (let [result (string/replace (name str) \- \_)]
+    (if (keyword? str)
+      (keyword result)
+      result)))
+
+(defn underscores->dashes
+  "Accepts a string or a keyword as an argument, replaces all occurrences of the
+   underscore character with a dash, and returns the same type (string
+   or keyword) that was passed in.  This is useful for translating data structures
+   from their JDBC-compatible representation to their wire format representation."
+  [s]
+  (let [opt-key? (optional-key? s)
+        result (if opt-key?
+                 (string/replace (name (:k s)) \_ \-)
+                 (string/replace (name s) \_ \-))]
+    (cond
+      opt-key? (if (keyword? (:k s))
+                 (schema/optional-key (keyword result))
+                 (schema/optional-key result))
+      (keyword? s) (keyword result)
+      :else result)))
+
+(defn dash->underscore-keys
+  "Converts all top-level keys (including nested maps) in `m` to use dashes
+  instead of underscores as word separators"
+  [m]
+  (spector/transform [spector/ALL]
+                #(update % 0 dashes->underscores)
+                m))
+
+(defn underscore->dash-keys
+  "Converts all top-level keys (including nested maps) in `m` to use underscores
+  instead of underscores as word separators"
+  [m]
+  (spector/transform [spector/ALL]
+                #(update % 0 underscores->dashes)
+                m))
+
+(defn pprint-json-parse-exception
+  "Returns a parsed JsonParseException message.
+  From the second line of the error message, the line and
+  column index are extracted, so that we can place an arrow,
+  pointing at that position."
+  [error query]
+  (let [error-lines (string/split-lines (.getMessage error))
+        [_ line column] (re-find #"line: (\d+), column: (\d+)" (second error-lines))
+        error-line-index (parse-int line)
+        error-column-index (parse-int column)
+
+        ;subtracting 1 from the line and column index, because they start from 1, not 0
+        query-line-index (dec error-line-index)
+        query-column-index (dec error-column-index)]
+
+    (tru "Json parse error at line {0}, column {1}:\n\n{2}\n{3}^\n\n{4}"
+         error-line-index,
+         error-column-index,
+         ;query line that produced the parsing error
+         ((string/split-lines query) query-line-index),
+         ;arrow that indicates which string in the line raised the error
+         ;subtracting an additional 1 from the column index,
+         ;to make room for the arrow sign
+         (apply str (repeat (dec query-column-index) " ")),
+         ;the error message
+         (first error-lines))))

--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -43,6 +43,7 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :refer [*logger-factory*]]
             [slingshot.test]
+            [puppetlabs.puppetdb.utils.string-formatter :refer [dash->underscore-keys]]
             [puppetlabs.puppetdb.utils :as utils
              :refer [await-scheduler-shutdown
                      schedule
@@ -1545,7 +1546,7 @@
   (let [recent-time (-> 1 seconds ago)]
     (with-message-handler {:keys [handle-message dlo delay-pool q]}
       (handle-message (queue/store-command q (report->command-req 4 v4-report)))
-      (is (= [(with-env (utils/dash->underscore-keys
+      (is (= [(with-env (dash->underscore-keys
                          (select-keys v4-report
                                       [:certname :configuration-version])))]
              (-> (str "select certname, configuration_version, environment_id"
@@ -1571,7 +1572,7 @@
         recent-time (-> 1 seconds ago)]
     (with-message-handler {:keys [handle-message dlo delay-pool q]}
       (handle-message (queue/store-command q (report->command-req 3 v3-report)))
-      (is (= [(with-env (utils/dash->underscore-keys
+      (is (= [(with-env (dash->underscore-keys
                          (select-keys v3-report
                                       [:certname :configuration-version])))]
              (-> (str "select certname, configuration_version, environment_id"

--- a/test/puppetlabs/puppetdb/examples.clj
+++ b/test/puppetlabs/puppetdb/examples.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.puppetdb.examples
-  (:require [puppetlabs.puppetdb.utils :as utils]))
+  (:require [puppetlabs.puppetdb.utils.string-formatter :as formatter]))
 
 (def catalogs
   {:empty
@@ -148,12 +148,12 @@
                          :job_id :catalog_uuid :producer)
                  (assoc :name (:certname v9-empty-wire-catalog)
                         :api_version 1)
-                 utils/underscore->dash-keys)}
+                 formatter/underscore->dash-keys)}
    5 {:empty (-> v9-empty-wire-catalog
                  (assoc :name (:certname v9-empty-wire-catalog)
                         :api_version 1)
                  (dissoc :certname :job_id :code_id :catalog_uuid :producer)
-                 utils/underscore->dash-keys)}
+                 formatter/underscore->dash-keys)}
    6 {:empty (-> v9-empty-wire-catalog
                  (dissoc :job_id :code_id :catalog_uuid :producer))}
    7 {:empty (-> v9-empty-wire-catalog

--- a/test/puppetlabs/puppetdb/examples/reports.clj
+++ b/test/puppetlabs/puppetdb/examples/reports.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.puppetdb.examples.reports
   (:require [puppetlabs.puppetdb.reports :as reports]
-            [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.utils.string-formatter :as formatter]
             [schema.core :as s]))
 
 (def reports
@@ -427,5 +427,5 @@
   (s/validate reports/report-v4-wireformat-schema
               (-> v5-report
                   (dissoc :producer_timestamp :metrics :logs :noop)
-                  utils/underscore->dash-keys
-                  (update :resource-events #(map utils/underscore->dash-keys %)))))
+                  formatter/underscore->dash-keys
+                  (update :resource-events #(map formatter/underscore->dash-keys %)))))

--- a/test/puppetlabs/puppetdb/http/index_test.clj
+++ b/test/puppetlabs/puppetdb/http/index_test.clj
@@ -94,8 +94,8 @@
         (is (= (str "Json parse error at line 1, column 25:\n\n"
                     "[\"from\",\"foobar\"] random-stuff\n"
                     "                       ^\n\n"
-                    "Unrecognized token random: was expecting "
-                    "(JSON String, Number, Array, Object or token null, true or false)") body))
+                    "Unrecognized token 'random': was expecting "
+                    "(JSON String, Number, Array, Object or token 'null', 'true' or 'false')") body))
         (are-error-response-headers headers)
         (is (= http/status-bad-request status)))
 

--- a/test/puppetlabs/puppetdb/http/index_test.clj
+++ b/test/puppetlabs/puppetdb/http/index_test.clj
@@ -75,7 +75,27 @@
 
       ;; Ensure we parse anything that looks like AST/JSON as JSON not PQL
       (let [{:keys [status body headers]} (query-response method endpoint "[\"from\",\"foobar\"")]
-        (is (= "Malformed JSON for query: [\"from\",\"foobar\"" body))
+        (is (= (str "Json parse error at line 1, column 17:\n\n"
+                    "[\"from\",\"foobar\"\n"
+                    "               ^\n\n"
+                    "Unexpected end-of-input: expected close marker for Array "
+                    "(start marker at [Source: (StringReader); line: 1, column: 1])") body))
+        (are-error-response-headers headers)
+        (is (= http/status-bad-request status)))
+
+      ;; Ensure we don't allow multiple queries in one request
+      (let [{:keys [status body headers]} (query-response method endpoint "[\"from\",\"foobar\"] [\"from\",\"foo\"]")]
+        (is (= "Only one query may be sent in a request. You sent 2." body))
+        (are-error-response-headers headers)
+        (is (= http/status-bad-request status)))
+
+      ;; Ensure we don't allow garbage after query
+      (let [{:keys [status body headers]} (query-response method endpoint "[\"from\",\"foobar\"] random-stuff")]
+        (is (= (str "Json parse error at line 1, column 25:\n\n"
+                    "[\"from\",\"foobar\"] random-stuff\n"
+                    "                       ^\n\n"
+                    "Unrecognized token random: was expecting "
+                    "(JSON String, Number, Array, Object or token null, true or false)") body))
         (are-error-response-headers headers)
         (is (= http/status-bad-request status)))
 

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -186,7 +186,11 @@
         {:keys [status body]} (query-response :get "/v4/reports" "[\"=\"")]
     (testing "malformed json queries don't return status 500 responses"
       (is (= 400 status))
-      (is (= "Malformed JSON for query: [\"=\"" body)))))
+      (is (= (str "Json parse error at line 1, column 5:\n\n"
+                  "[\"=\"\n"
+                  "   ^\n\n"
+                  "Unexpected end-of-input: expected close marker for Array "
+                  "(start marker at [Source: (StringReader); line: 1, column: 1])") body)))))
 
 (deftest-http-app query-report-data
   [[version field] [[:v4 :logs] [:v4 :metrics]]

--- a/test/puppetlabs/puppetdb/reports_test.clj
+++ b/test/puppetlabs/puppetdb/reports_test.clj
@@ -8,7 +8,7 @@
             [puppetlabs.puppetdb.reports :refer :all]
             [schema.core :as s]
             [com.rpl.specter :as sp]
-            [puppetlabs.puppetdb.utils :as utils]
+            [puppetlabs.puppetdb.utils.string-formatter :as formatter]
             [puppetlabs.puppetdb.time :refer [now]]
             [schema.core :as s]))
 
@@ -32,9 +32,9 @@
 
 (defn underscore->dash-report-keys [m]
   (->> m
-       utils/underscore->dash-keys
+       formatter/underscore->dash-keys
        (sp/transform [:resource-events sp/ALL sp/ALL]
-                     #(update % 0 utils/underscores->dashes))))
+                     #(update % 0 formatter/underscores->dashes))))
 
 (deftest test-v7-conversion
   (let [v8-report (wire-v7->wire-v8 v7-report)]

--- a/test/puppetlabs/puppetdb/utils/string_formatter_test.clj
+++ b/test/puppetlabs/puppetdb/utils/string_formatter_test.clj
@@ -1,0 +1,46 @@
+(ns puppetlabs.puppetdb.utils.string_formatter-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :as string]
+            [clojure.math.combinatorics :refer [selections]]
+            [puppetlabs.puppetdb.utils.string-formatter :refer :all]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [puppetlabs.i18n.core :refer [tru]]
+            [clojure.test.check.clojure-test :as cct]))
+
+(deftest re-quote-behavior
+  (doseq [x (map #(apply str %) (selections ["x" "\\Q" "\\E"] 6))]
+    (is (= x (re-matches (re-pattern (str (re-quote x) "$")) x)))))
+
+(def dash-keyword-generator
+  (gen/fmap (comp keyword #(string/join "-" %))
+            (gen/not-empty (gen/vector gen/string-alpha-numeric))))
+
+(def underscore-keyword-generator
+  (gen/fmap (comp keyword #(string/join "_" %))
+            (gen/not-empty (gen/vector gen/string-alpha-numeric))))
+
+(cct/defspec test-dash-conversions
+             50
+             (prop/for-all [w (gen/map dash-keyword-generator gen/any)]
+                           (= w
+                              (underscore->dash-keys (dash->underscore-keys w)))))
+
+(cct/defspec test-underscore-conversions
+             50
+             (prop/for-all [w (gen/map underscore-keyword-generator gen/any)]
+                           (= w
+                              (dash->underscore-keys (underscore->dash-keys w)))))
+
+(deftest test-pprint-json-parse-exception
+  (let [query "[\"from\", \"nodes\"] lk"
+        error-message (str "Unrecognized token random: was expecting "
+                           "(JSON String, Number, Array, Object or token null, true or false)\n"
+                           " at [String.Reader line: 1, column: 21]")
+        expected-message (str "Json parse error at line 1, column 21:\n\n"
+                              "[\"from\", \"nodes\"] lk\n"
+                              "                   ^\n\n"
+                              "Unrecognized token random: was expecting "
+                              "(JSON String, Number, Array, Object or token null, true or false)")
+        mock-exception (ex-info error-message {})]
+    (is (= expected-message (pprint-json-parse-exception  mock-exception query)))))

--- a/test/puppetlabs/puppetdb/utils_test.clj
+++ b/test/puppetlabs/puppetdb/utils_test.clj
@@ -94,3 +94,16 @@
 
   (testing "truncation doesn't add extra bytes"
     (is (= "foo" (utf8-truncate "foo" 256)))))
+
+(deftest test-pprint-json-parse-exception
+  (let [query "[\"from\", \"nodes\"] lk"
+        error-message (str "Unrecognized token random: was expecting "
+                           "(JSON String, Number, Array, Object or token null, true or false)\n"
+                           " at [String.Reader line: 1, column: 21]")
+        expected-message (str "Json parse error at line 1, column 21:\n\n"
+                              "[\"from\", \"nodes\"] lk\n"
+                              "                   ^\n\n"
+                              "Unrecognized token random: was expecting "
+                              "(JSON String, Number, Array, Object or token null, true or false)")
+        mock-exception (ex-info error-message {})]
+    (is (= expected-message (pprint-json-parse-exception  mock-exception query)))))


### PR DESCRIPTION
**Problem description**:
When submitting multiple queries in one request, the first one is resolved and the rest are ignored.
Example: `["from","facts"] ["not" ["=", "certname", "security-sensitive-host"]]`. This returns all the facts. 
Also if we add random strings after the query, they get ignored as well.
Example: `["from","facts"] this-is-trailing-garbage-and-not-part-of-the-query-that-gets-evaluated`. This returns all the facts.

With this PR, when multiple queries are submitted, an error message is returned, saying that no more than one 
query may be submitted in one request. 
When the query ends with a string, a `Malformed JSON` error is returned.
