### PR TITLE
(PDB-5017) Add missing arg to admin purge_resource_events path

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -265,7 +265,7 @@
       (jdbc/with-transacted-connection db
         (try
           (scf-store/delete-resource-events-older-than! rounded-ttl incremental?
-                                                        update-lock-status)
+                                                        update-lock-status db)
           ;; FIXME: do we really want sql errors appearing at this level?
           (catch SQLException ex
             (when-not (= (.getSQLState ex) (jdbc/sql-state :lock-not-available))

--- a/test/puppetlabs/puppetdb/admin_clean_test.clj
+++ b/test/puppetlabs/puppetdb/admin_clean_test.clj
@@ -67,6 +67,7 @@
     (is (= http/status-ok (:status (post-clean ["expire_nodes"]))))
     (is (= http/status-ok (:status (post-clean ["purge_nodes"]))))
     (is (= http/status-ok (:status (post-clean ["purge_reports"]))))
+    (is (= http/status-ok (:status (post-clean ["purge_resource_events"]))))
     (is (= http/status-ok (:status (post-clean ["gc_packages"]))))
     (is (= http/status-ok (:status (post-clean ["other"]))))
     (is (= http/status-bad-request (:status (post-clean ["?"]))))))


### PR DESCRIPTION
Prior to this commit there was an arg missing from the
scf-store/delete-resource-events-older-than! function which is
used when the admin endpoint gets a purge_resource_events clean
command.