### PR TITLE
(maint) Update ezbake to 2.2.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -292,7 +292,7 @@
                                                ;; in the final package.
                                                [puppetlabs/puppetdb ~pdb-version]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "2.2.1"]]}
+                      :plugins [[puppetlabs/lein-ezbake "2.2.2"]]}
              :testutils {:source-paths ^:replace ["test"]
                          :resource-paths ^:replace []
                          ;; Something else may need adjustment, but


### PR DESCRIPTION
will sign packages with the new gpg key