### PR TITLE
(PE-31121) Update clj-parent to 4.6.18

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def pdb-version "6.15.1-SNAPSHOT")
-(def clj-parent-version "4.6.17")
+(def clj-parent-version "4.6.18")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))

--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -132,16 +132,6 @@
                                   content-encoding)
                              http/status-unsupported-type)))))
 
-(defn base-type [content-type]
-  "Parse a base type out of a Content-Type, returns nil if there's no match.
-  Does not validate any parameters."
-  ;; Content-Type header grammar https://tools.ietf.org/html/rfc7231#section-3.1.1.1
-  ;; token definition https://tools.ietf.org/html/rfc7230#section-3.2.6
-  ;; white space definition https://tools.ietf.org/html/rfc7230#section-3.2.3
-  (let [token #"[a-zA-Z0-9!#$%&'*+.^_`|~-]+"
-        matcher (format "^(%s/%s)(?:[ \t;]|$)" token token)]
-    (second (re-find (re-pattern matcher) content-type))))
-
 (defn verify-content-type
   "Verification for the specified list of content-types."
   [app content-types]
@@ -151,7 +141,7 @@
     (if (= (:request-method req) :post)
       (let [content-type (headers "content-type")
             mediatype (if (nil? content-type) nil
-                          (base-type content-type))]
+                          (kitchensink/base-type content-type))]
         (if (or (nil? mediatype) (some #{mediatype} content-types))
           (app req)
           (http/error-response (tru "content type {0} not supported" mediatype)

--- a/test/puppetlabs/puppetdb/middleware_test.clj
+++ b/test/puppetlabs/puppetdb/middleware_test.clj
@@ -266,13 +266,3 @@
           (merge-param-specs {:optional ["x"] :required ["y"]}
                              {:optional ["z"]
                               :required ["v" "w"]})))))
-
-(deftest base-type-test
-  (is (= "application/json" (base-type "application/json")))
-  (is (= "application/json" (base-type "application/json;charset=UTF-8")))
-  (is (= "application/json" (base-type "application/json  ;  charset=UTF-8")))
-
-  (is (= "foo/bar" (base-type "foo/bar;someparam=baz")))
-
-  (is (nil? (base-type "application/json:charset=UTF-8")))
-  (is (nil? (base-type "appl=ication/json ; charset=UTF-8"))))


### PR DESCRIPTION
the base-type function and tests are now in kitchensink