### PR TITLE
(SERVER-2500) Increase ephemeralDHKeySize to 2048

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -722,7 +722,7 @@ EOS
   # @param expected_output [Regexp] a regexp to use for matching the output
   # @return [void]
   def curl_with_retries(desc, host, curl_args, desired_exit_codes, max_retries = 60, retry_interval = 1, expected_output = /.*/)
-    command = "curl --tlsv1 #{curl_args}"
+    command = "curl --tlsv1.3 #{curl_args}"
     log_prefix = host.log_prefix
     logger.debug "\n#{log_prefix} #{Time.new.strftime('%H:%M:%S')}$ #{command}"
     logger.debug "  Trying command #{max_retries} times."

--- a/acceptance/setup/pre_suite/15_setup_repos.rb
+++ b/acceptance/setup/pre_suite/15_setup_repos.rb
@@ -1,10 +1,5 @@
 unless (test_config[:skip_presuite_provisioning])
   step "Install Puppet Labs repositories" do
-
-    if is_el8
-      on(hosts, 'update-crypto-policies --set LEGACY')
-    end
-
     hosts.each do |host|
       initialize_repo_on_host(host, test_config[:os_families][host.name], test_config[:nightly], puppet_repo_version)
     end

--- a/project.clj
+++ b/project.clj
@@ -228,9 +228,10 @@
                        :start-timeout 14400
                        :repo-target "puppet6"
                        :nonfinal-repo-target "puppet6-nightly"
-                       :logrotate-enabled false}
-                :config-dir "ext/config/foss"
-                }
+                       :logrotate-enabled false
+                       :java-args ~(str "-Xmx192m "
+                                        "-Djdk.tls.ephemeralDHKeySize=2048")}
+                :config-dir "ext/config/foss"}
 
   :deploy-repositories [["releases" ~(deploy-info "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-releases__local/")]
                         ["snapshots" ~(deploy-info "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-snapshots__local/")]]


### PR DESCRIPTION
See [PDB-4643](https://tickets.puppetlabs.com/browse/PDB-4643) for background info. With both java 8 & java 11 I needed to add **-Djdk.tls.ephemeralDHKeySize=2048** to the JAVA_ARGS to get around the **routines:tls_process_ske_dhe:dh key too small** described in that ticket. 