### PR TITLE
(PDB-5059) Fix facts blocklist logic in command submission

### DIFF
--- a/src/puppetlabs/puppetdb/schema.clj
+++ b/src/puppetlabs/puppetdb/schema.clj
@@ -53,6 +53,7 @@
    or a sequence and return a vector of those facts"
   [fl]
   (cond
+    (= "" fl) []
     (string? fl) (->> (str/split fl #",")
                       (map str/trim)
                       (apply vector))


### PR DESCRIPTION
The options config passed to `prep-replace-facts` has more keys in it
than just blocklist options now. Update the function to only attempt to
filter blocked facts when the config option `facts-blocklist` is
present. We don't need to also check `facts-blocklist-type` because it
is defaulted in the config so it will always be present (except in some
tests). Also if a bug exists where a user sets a blocklist but we fail
to default the blocklist type, it would be better to error than store
potentially sensitive or gargantuan information in the database.