### PR TITLE
(PDB-1936) Rename parameters for more consistency

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -1123,16 +1123,16 @@
      (:shared-globals context)))
 
   (query
-   [this version query-expr paging-options row-callback-fn]
+   [this version query-expr options row-callback-fn]
    (throw-if-shutdown-pending (get-shutdown-reason))
    (let [sc (service-context this)
          _ (throw-unless-started sc)
-         query-options (-> (get sc :shared-globals)
+         context (-> (get sc :shared-globals)
                            http-q/narrow-globals
                            (assoc :url-prefix @(get sc :url-prefix)))]
      (qeng/stream-query-result version
                                query-expr
-                               paging-options query-options
+                               options context
                                row-callback-fn)))
 
   (clean


### PR DESCRIPTION
Rename "paging-options" parameter to "options" along the following calls:  [query](https://github.com/puppetlabs/puppetdb/blob/main/src/puppetlabs/puppetdb/cli/services.clj#L1126-L1137) -> [stream-query-result](https://github.com/puppetlabs/puppetdb/blob/main/src/puppetlabs/puppetdb/query_eng.clj#L197-L227) -> [query->sql](https://github.com/puppetlabs/puppetdb/blob/main/src/puppetlabs/puppetdb/query_eng.clj#L111-L173) -> [compile-user-query->sql](https://github.com/puppetlabs/puppetdb/blob/main/src/puppetlabs/puppetdb/query_eng/engine.clj#L3010-L3017) -> [compile-query](https://github.com/puppetlabs/puppetdb/blob/main/src/puppetlabs/puppetdb/query_eng/engine.clj#L2973-L3008)