### PR TITLE
(maint) Update ssl.sh script / entrypoint

### DIFF
--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -54,7 +54,7 @@ CMD ["foreground"]
 HEALTHCHECK --start-period=5m --interval=10s --timeout=10s --retries=6 CMD ["/healthcheck.sh"]
 
 # hadolint ignore=DL3020
-ADD https://raw.githubusercontent.com/puppetlabs/pupperware/69a7ff4a7af4783a30dd405560cf9f25ba5cad58/shared/ssl.sh \
+ADD https://raw.githubusercontent.com/puppetlabs/pupperware/59a6e0ad3f564189e180c26ef7906ff3476af179/shared/ssl.sh \
     https://raw.githubusercontent.com/puppetlabs/wtfc/6aa5eef89728cc2903490a618430cc3e59216fa8/wtfc.sh \
     https://github.com/Yelp/dumb-init/releases/download/v"$DUMB_INIT_VERSION"/dumb-init_"$DUMB_INIT_VERSION"_amd64.deb \
     docker/puppetdb/docker-entrypoint.sh \

--- a/docker/puppetdb/docker-entrypoint.d/20-configure-ssl.sh
+++ b/docker/puppetdb/docker-entrypoint.d/20-configure-ssl.sh
@@ -1,31 +1,16 @@
 #!/bin/sh
 
 # when certs need to be generated and haven't been user supplied
-if [ ! -f "${SSLDIR}/certs/${CERTNAME}.pem" ] && [ "$USE_PUPPETSERVER" = true ]; then
+if [ "$USE_PUPPETSERVER" = true ]; then
   set -e
 
   # previously DNS_ALT_NAMES was omitted if empty, but ssl.sh already skips setting when empty
   DNS_ALT_NAMES="${DNS_ALT_NAMES}" CERTNAME="$CERTNAME" /ssl.sh
-fi
-
-# cert files are present from Puppetserver OR have been user supplied
-if [ -f "${SSLDIR}/private_keys/${CERTNAME}.pem" ]; then
-
-  openssl pkcs8 -topk8 -nocrypt -inform PEM -outform DER \
-    -in "${SSLDIR}/private_keys/server.key" \
-    -out "${SSLDIR}/private_keys/server.private_key.pk8"
 
   # enable SSL in Jetty
   sed -i '/^# ssl-/s/^# //g' /etc/puppetlabs/puppetdb/conf.d/jetty.ini
-
-  # make sure Java apps running as puppetdb can read these files
-  echo "Setting ownership for $SSLDIR to puppetdb:puppetdb"
-  chown -R puppetdb:puppetdb ${SSLDIR}
-
-  # and that they're further restricted
-  chmod u=rwx,g=,o= ${SSLDIR}/private_keys
-  chmod u=rw,g=,o= ${SSLDIR}/private_keys/*
-
-  chmod u=rwx,g=,o= ${SSLDIR}/certs
-  chmod u=rw,g=,o= ${SSLDIR}/certs/*
 fi
+
+# make sure Java apps running as puppetdb can read these files
+echo "Setting ownership for $SSLDIR to puppetdb:puppetdb"
+chown -R puppetdb:puppetdb ${SSLDIR}


### PR DESCRIPTION
 - Includes a number of new features in ssl.sh, including:

   * Much better logging during failed HTTP requests
   * Produce pk8 private key files for apps like orch, console services,
     pdb (so that their entrypoints can remove code to generate them)
   * Set permissions on cert files - 700 for dirs, 600 for files
     (so that entrypoint scripts are not responsible)
   * Always generate canonical symlinks to certs up front (rather than
     as files are generated), which repairs bad links on disk
   * Add ability to retry HTTP requests and do this when:
       - Grabbing CA
       - Grabbing CRL
       - Retrieving signed certs
   * Warning when new a different certname is used when a cert already
     exists on disk

 - Additionally simplifes the entrypoint script to always run ssl.sh
   when USE_PUPPETSERVER is true, given ssl.sh is idempotent.

 - Always set perms on SSLDIR, noting that this won't work in k8s
   when using non-root containers