### PR TITLE
(PDB-5055) Add :explain query parameter

### DIFF
--- a/src/puppetlabs/puppetdb/http/handlers.clj
+++ b/src/puppetlabs/puppetdb/http/handlers.clj
@@ -68,7 +68,7 @@
 (def global-engine-params
   "Parameters that should always be forwarded from the incoming query to
   the engine."
-  [:optimize_drop_unused_joins :include_facts_expiration])
+  [:optimize_drop_unused_joins :include_facts_expiration :explain])
 
 (defn status-response
   "Executes `query` and if a result is found, calls `found-fn` with
@@ -147,7 +147,8 @@
 ;; query parameter sets
 (def global-params {:optional ["optimize_drop_unused_joins"
                                "include_facts_expiration"
-                               "include_package_inventory"]})
+                               "include_package_inventory"
+                               "explain"]})
 (def paging-params {:optional paging/query-params})
 (def pretty-params {:optional ["pretty"]})
 (def typical-params (merge-param-specs global-params

--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -16,7 +16,8 @@
             [puppetlabs.puppetdb.http :as http]
             [puppetlabs.puppetdb.schema :as pls]
             [ring.util.request :as request]
-            [puppetlabs.puppetdb.query.paging :refer [parse-limit
+            [puppetlabs.puppetdb.query.paging :refer [parse-explain
+                                                      parse-limit
                                                       parse-offset
                                                       parse-order-by
                                                       parse-order-by-json]]
@@ -39,6 +40,7 @@
    (s/optional-key :include_total) (s/maybe s/Bool)
    (s/optional-key :optimize_drop_unused_joins) (s/maybe s/Bool)
    (s/optional-key :pretty) (s/maybe s/Bool)
+   (s/optional-key :explain) (s/maybe s/Keyword)
    (s/optional-key :include_facts_expiration) (s/maybe s/Bool)
    (s/optional-key :include_package_inventory) (s/maybe s/Bool)
    (s/optional-key :order_by) (s/maybe [[(s/one s/Keyword "field")
@@ -275,6 +277,7 @@
       (update-when [:include_total] coerce-to-boolean)
       (update-when [:optimize_drop_unused_joins] coerce-to-boolean)
       (update-when [:pretty] coerce-to-boolean)
+      (update-when [:explain] parse-explain)
       (update-when [:include_facts_expiration] coerce-to-boolean)
       (update-when [:include_package_inventory] coerce-to-boolean)
       (update-when [:distinct_resources] coerce-to-boolean)))

--- a/src/puppetlabs/puppetdb/query/paging.clj
+++ b/src/puppetlabs/puppetdb/query/paging.clj
@@ -183,6 +183,25 @@
   [limit :- (s/maybe (s/cond-pre String s/Int))]
   (when limit (validate-limit limit)))
 
+(defn validate-explain
+  "Validates that the explain string is a string containing `analyze`. Returns the
+  keyword form if validation was successful, otherwise an
+  IllegalArgumentException is thrown."
+  [explain]
+  {:pre  [(string? explain)]
+   :post [(and (keyword? %) (= % :analyze))]}
+  (if (= explain "analyze")
+      (keyword explain)
+      (throw (IllegalArgumentException.
+              (tru "Illegal value ''{0}'' for :explain; expected `analyze`." explain)))))
+
+(pls/defn-validated parse-explain :- (s/maybe s/Keyword)
+  "Parse the optional `explain` query parameter. Returns a keyword
+  `explain` upon successful validation. Throws an exception if provided `explain` is
+  not a valid string"
+  [explain :- (s/maybe String)]
+  (when explain (validate-explain explain)))
+
 (defn validate-offset
   "Validates that the offset string is a non-negative integer. Returns the
   integer form if validation was successful, otherwise an

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -176,11 +176,13 @@
 (defn get-munge-fn
   [entity version paging-options url-prefix]
   (let [munge-fn (get-munge entity)]
-    (case entity
-      :event-counts
-      (munge-fn (:summarize_by paging-options) version url-prefix)
+    (if (= (:explain paging-options) :analyze)
+      identity
+      (case entity
+        :event-counts
+        (munge-fn (:summarize_by paging-options) version url-prefix)
 
-      (munge-fn version url-prefix))))
+        (munge-fn version url-prefix)))))
 
 (def use-preferred-streaming-method?
   (->> (or (System/getenv "PDB_USE_DEPRECATED_QUERY_STREAMING_METHOD") "yes")

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -2968,7 +2968,7 @@
   "EXPLAIN (VERBOSE,ANALYZE,BUFFERS,FORMAT JSON) ")
 
 (defn wrap-with-explain [query explain-options]
-  (if explain-options
+  (if (= explain-options :analyze)
     (str default-explain-form query)
     query))
 
@@ -2982,7 +2982,7 @@
   extracted parameters, to be used in a prepared statement.
   For :parameterized-plan, returns the final plan and parameters that
   would be used to generate the :sql result."
-  [query-rec user-query {:keys [include_total explain?] :as query-options} target]
+  [query-rec user-query {:keys [include_total explain] :as query-options} target]
   ;; Call the query-rec so we can evaluate query-rec functions
   ;; which depend on the db connection type
   (let [allowed-fields (map keyword (queryable-fields query-rec))
@@ -3006,7 +3006,7 @@
       :parameterized-plan parameterized-plan
       :sql (let [{:keys [plan params]} parameterized-plan
                  sql (plan->sql plan paging-options)
-                 paged-sql (wrap-with-explain (jdbc/paged-sql sql paging-options) explain?)]
+                 paged-sql (wrap-with-explain (jdbc/paged-sql sql paging-options) explain)]
              (cond-> {:results-query (apply vector paged-sql params)}
                include_total (assoc :count-query
                                     (apply vector (jdbc/count-sql sql)

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -144,7 +144,7 @@
   (svc-utils/with-single-quiet-pdb-instance
       (check-service-query
        :v4 ["from" "facts" ["=" "certname" "foo.local"]]
-       {:explain? true}
+       {:explain :analyze}
        (fn [result]
          (is (= true (contains? (first result) (keyword "query plan"))))
          (is (= true (instance? org.postgresql.util.PGobject ((keyword "query plan") (first result) ))))))))

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -442,6 +442,14 @@
         (is (> (count (clojure.string/split-lines results))
                (count (clojure.string/split-lines normal-results))))))))
 
+(deftest-http-app query-with-explain-printing
+  [[version endpoint] endpoints
+   method [:get :post]]
+    (testing "should support explain when quering in reports"
+      (let [results (slurp (:body (query-response method endpoint nil {:explain "analyze"})))]
+        (is (not (empty? (json/parse-string results))))
+        (is (= true (contains? (first (json/parse-string results)) "query plan"))))))
+
 (deftest-http-app aggregate-functions-on-nodes
   [[version endpoint] endpoints
    method [:get :post]]

--- a/test/puppetlabs/puppetdb/http/paging_test.clj
+++ b/test/puppetlabs/puppetdb/http/paging_test.clj
@@ -45,6 +45,20 @@
         (are-error-response-headers (:headers response))
         (is (re-find #"Illegal value '.*' for :limit; expected a positive non-zero integer" body)))))
 
+  (testing "'explain' should only accept `analyze` string"
+    (doseq [invalid-explain [:somekeyword
+                             :analyze
+                             "some_invalid_string"
+                             ""
+                             123]]
+      (let [response  (*app* (get-request endpoint
+                                          ["these" "are" "unused"]
+                                          {:explain invalid-explain}))
+            body      (get response :body "null")]
+        (is (= (:status response) http/status-bad-request))
+        (are-error-response-headers (:headers response))
+        (is (re-find #"Illegal value '.*' for :explain; expected `analyze`." body)))))
+
   (testing "'offset' should only accept positive integers"
     (doseq [invalid-offset [-1
                             1.1

--- a/test/puppetlabs/puppetdb/http/resources_test.clj
+++ b/test/puppetlabs/puppetdb/http/resources_test.clj
@@ -158,6 +158,16 @@ to the result of the form supplied to this method."
                               [["=" ["parameter" "acl"] ["john:rwx" "fred:rwx"]] #{bar1}]]]
         (is-response-equal (query-response method endpoint query) result)))))
 
+(deftest-http-app query-with-explain-printing
+  [[version endpoint] endpoints
+   method [:get :post]]
+    (testing "should support explain and not munge rows when quering in resources endpoint"
+      (let [results (json/parse-string
+                    (slurp (:body (query-response method endpoint nil
+                                                  {:explain "analyze"}))))]
+        (is (not (empty? results)))
+        (is (= true (contains? (first results) "query plan"))))))
+
 (deftest-http-app environments-resource-endpoint
   [[version endpoint] endpoints
    method [:get :post]]


### PR DESCRIPTION
This PR exposes a new query parameter (:explain) introduced in : https://github.com/puppetlabs/puppetdb/pull/3433 