### PR TITLE
ssl-setup: don't double "client-auth = want" in config file for -f

### DIFF
--- a/resources/ext/cli/ssl-setup.erb
+++ b/resources/ext/cli/ssl-setup.erb
@@ -349,7 +349,7 @@ if [ -f "$jettyfile" ] ; then
     "ssl-key:${private_file}"
     "ssl-cert:${public_file}"
     "ssl-ca-cert:${ca_file}"
-    "client-auth = want"
+    "client-auth:want"
   )
 
   for i in "${settings[@]}"; do


### PR DESCRIPTION
Previously "puppet ssl-setup -f" would append a line like this to
jetty.ini

  client-auth = want = client-auth = want

rather than

  client-auth = want