### PR TITLE
(REPLATS-150) Break words passed to upgrade exec when service user

### DIFF
--- a/resources/ext/cli/upgrade
+++ b/resources/ext/cli/upgrade
@@ -16,18 +16,18 @@ cli_defaults=${INSTALL_DIR}/cli/cli-defaults.sh
 CLASSPATH=${INSTALL_DIR}/puppetdb.jar
 
 if [ -e "$cli_defaults" ]; then
-  . $cli_defaults
+  . "$cli_defaults"
   if [ $? -ne 0 ]; then
     echo "Unable to initialize cli defaults, failing start." 1>&2
     exit 1
   fi
 fi
 
-cmd="$(printf "%q %s -Dlogappender=STDOUT -cp %q clojure.main -m puppetlabs.puppetdb.core upgrade -c %q" \
-         "$JAVA_BIN" "$JAVA_ARGS" "$CLASSPATH" "$CONFIG")"
+cmd=($(printf "%q %s -Dlogappender=STDOUT -cp %q clojure.main -m puppetlabs.puppetdb.core upgrade -c %q" \
+     "$JAVA_BIN" "$JAVA_ARGS" "$CLASSPATH" "$CONFIG"))
 
 if test "$(id -un)" = "$USER"; then
-    exec "$cmd $@"
+    exec "${cmd[@]}" "$@"
 else
-    exec su "$USER" -s /bin/sh -c "$cmd $@"
+    exec su "$USER" -s /bin/sh -c "${cmd[*]} ${*}"
 fi


### PR DESCRIPTION
Ran into this working on a k8s container runas the service user.
The quoting around the exec option for the case where id == $USER was
presenting the command unsplit and failing like so:

"/opt/puppetlabs/server/apps/puppetdb/cli/apps/upgrade: line 30: \
/opt/puppetlabs/server/bin/java \
-Xlog:gc*:file=/opt/puppetlabs/server/data/puppetdb/logs/puppetdb_gc.log::filecount=16,filesize=65536 \
-Djdk.tls.ephemeralDHKeySize=2048 -XX:+UseParallelGC -Xmx640m  \
-Dlogappender=STDOUT -cp \
/opt/puppetlabs/server/apps/puppetdb/puppetdb.jar:/opt/puppetlabs/share/java/bcprov-jdk15on.jar:/opt/puppetlabs/share/java/bcpkix-jdk15on.jar \
clojure.main -m puppetlabs.puppetdb.core upgrade \
-c /etc/puppetlabs/puppetdb/conf.d : No such file or directory"

Because it was treating the unsplit string as a single path to the command
to execute.

Switched to using an array, and expanding that (and the
args) split for the exec case (with '@'), and unsplit in the su -c case
(with '*') so that the command is still provided as a single string to
su's -c arg.