### PR TITLE
(PDB-5063) Return only error message on API

### DIFF
--- a/src/puppetlabs/puppetdb/http/server.clj
+++ b/src/puppetlabs/puppetdb/http/server.clj
@@ -7,6 +7,7 @@
             [puppetlabs.puppetdb.middleware :refer [wrap-with-globals
                                                     wrap-with-metrics
                                                     wrap-with-illegal-argument-catch
+                                                    wrap-with-exception-handling
                                                     verify-accepts-json
                                                     verify-content-type
                                                     make-pdb-handler
@@ -74,5 +75,7 @@
                       (verify-content-type ["application/json"])
                       verify-sync-version
                       (wrap-with-metrics (atom {}) http/leading-uris)
-                      (wrap-with-globals get-shared-globals))]
+                      (wrap-with-globals get-shared-globals)
+                      wrap-with-exception-handling)]
+
       (handler req))))

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -787,9 +787,9 @@
            (dotestseq [[version endpoint] endpoints
                       method [:get :post]]
              ;; This is abusing the existence of PDB-4734 to throw an error from a malformed AST query
-             (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                                   #"AST validation failed, but was successfully converted to SQL"
-                                   (query-response method endpoint query)))))))
+             (let [{:keys [status body]} (query-response method endpoint query)]
+                (is (= status http/status-internal-error))
+                (is (re-matches #"AST validation failed, but was successfully converted to SQL.*" body)))))))
 
     (testing "agent report filter can be disabled"
        (with-test-db

--- a/test/puppetlabs/puppetdb/middleware_test.clj
+++ b/test/puppetlabs/puppetdb/middleware_test.clj
@@ -49,6 +49,13 @@
       (is (= #{"oof/" "rab/" "zab/"} (keyset (@storage :timers))))
       (is (= #{"oof/" "rab/" "zab/"} (keyset (@storage :meters)))))))
 
+(deftest find-exception-cause
+  (testing "Should find the cause of nested exceptions"
+    (let [ex (IllegalArgumentException. (Exception. "The lower exception"))
+          ex2 (.initCause (Exception. "First exception") (Exception. "Second exception"))]
+      (is (= "The lower exception" (cause-finder ex)))
+      (is (= "Second exception" (cause-finder ex2))))))
+
 (defn create-authorizing-request [hostname]
   {:scheme :https
    :ssl-client-cn hostname})


### PR DESCRIPTION
When an exception is thrown on the server,
only return the error message to the API.
The stack trace is no longer returned,
it is logged as an error.