### PR TITLE
(maint) Set crypto-policies to LEGACY in el8 acceptance tests

### DIFF
--- a/acceptance/setup/pre_suite/15_setup_repos.rb
+++ b/acceptance/setup/pre_suite/15_setup_repos.rb
@@ -1,4 +1,9 @@
 unless (test_config[:skip_presuite_provisioning])
+
+  if is_el8 && ([:upgrade_latest].include? test_config[:install_mode])
+    on(hosts, 'update-crypto-policies --set LEGACY')
+  end
+
   step "Install Puppet Labs repositories" do
     hosts.each do |host|
       initialize_repo_on_host(host, test_config[:os_families][host.name], test_config[:nightly], puppet_repo_version)


### PR DESCRIPTION
This commit should be reverted once PDB 6.15.1 and PDB 7.2.1 are released.