### PR TITLE
(PDB-2488) Allow empty query string

### DIFF
--- a/src/puppetlabs/puppetdb/pql.clj
+++ b/src/puppetlabs/puppetdb/pql.clj
@@ -72,12 +72,11 @@
   data, after the query, will result in an IllegalArgumentException"
   [query]
   (when query
-    (let [parsed-query (parse-json-sequence query)
-          query-count (count parsed-query)]
-      (if (= query-count 1)
-        (first parsed-query)
+    (let [[parsed & others] (parse-json-sequence query)]
+      (when others
         (throw (IllegalArgumentException.
-                 (tru "Only one query may be sent in a request. You sent {0}." query-count)))))))
+                 (tru "Only one query may be sent in a request. Found JSON {0} after the query {1}" others parsed))))
+      parsed)))
 
 (defn parse-pql-query
   "Parse a query string as PQL. Parse errors will result in an

--- a/test/puppetlabs/puppetdb/http/catalog_inputs_test.clj
+++ b/test/puppetlabs/puppetdb/http/catalog_inputs_test.clj
@@ -33,6 +33,9 @@
 
     (let [cmd (input-cmds "host-1")
           exp (set (stringify-timestamp [cmd]))]
+      (testing "empty query string"
+        (let [resp (query-inputs "")]
+          (is (= (count all-expected) (count resp)))))
       (testing "certname match"
         (let [resp (query-inputs ["=" "certname" "host-1"])]
           (is (= (count exp) (count resp)))

--- a/test/puppetlabs/puppetdb/http/index_test.clj
+++ b/test/puppetlabs/puppetdb/http/index_test.clj
@@ -85,7 +85,7 @@
 
       ;; Ensure we don't allow multiple queries in one request
       (let [{:keys [status body headers]} (query-response method endpoint "[\"from\",\"foobar\"] [\"from\",\"foo\"]")]
-        (is (= "Only one query may be sent in a request. You sent 2." body))
+        (is (re-matches #"Only one query may be sent in a request. Found JSON .* after the query .*" body))
         (are-error-response-headers headers)
         (is (= http/status-bad-request status)))
 


### PR DESCRIPTION
On endpoints underneath `/pdb/query/v4` having an empty query string was
valid. This would get parsed as "PQL" because it does not contain a `"["`
(even though PQL is not valid at sub-endpoints). There are 0 pql queries
in the string, so the previous check `(= 1 ...)` would fail.

This fixes the following query (which is used by puppetserver acceptance
tests) that previously worked.
```
curl -X POST http://localhost:8080/pdb/query/v4/catalog-input-contents \
  -H 'Content-Type:application/json' \
  -d '{"query": "" }'
```