### PR TITLE
(maint) Update container with latest ssl.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ aliases:
     - curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
     - chmod +x docker-compose
     - sudo mv docker-compose /usr/local/bin
+    - docker buildx create --name travis_builder --use
 
   - &run-docker-tests
     - set -e
@@ -51,6 +52,9 @@ aliases:
     - make lint
     - make build
     - make test
+
+  - &after-docker-tests
+    - docker buildx rm travis_builder
 
 jobs:
   allow_failures:
@@ -146,6 +150,7 @@ jobs:
       env: DOCKER_COMPOSE_VERSION=1.28.6 DOCKER_BUILD_FLAGS="--progress plain" PUPPETSERVER_IMAGE="puppet/puppetserver:edge"
       before_install: *before-docker-tests
       script: *run-docker-tests
+      after_script: *after-docker-tests
 
 on_success: ci/bin/travis-on-success
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -52,8 +52,9 @@ else
 endif
 
 build: prep
-	docker build \
+	docker buildx build \
 		${DOCKER_BUILD_FLAGS} \
+		--load \
 		--pull \
 		--build-arg build_type=$(BUILD_TYPE) \
 		--build-arg vcs_ref=$(vcs_ref) \

--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -54,7 +54,7 @@ CMD ["foreground"]
 HEALTHCHECK --start-period=5m --interval=10s --timeout=10s --retries=6 CMD ["/healthcheck.sh"]
 
 # hadolint ignore=DL3020
-ADD https://raw.githubusercontent.com/puppetlabs/pupperware/3c2218f8782a4c051771ebc46686eec28404d418/gem/lib/pupperware/compose-services/pe-postgres-custom/00-ssl.sh /ssl.sh
+ADD https://raw.githubusercontent.com/puppetlabs/pupperware/1c8d5f7fdcf2a81dfaf34f5ee34435cc50526d35/gem/lib/pupperware/compose-services/pe-postgres-custom/00-ssl.sh /ssl.sh
 # hadolint ignore=DL3020
 ADD https://raw.githubusercontent.com/puppetlabs/wtfc/6aa5eef89728cc2903490a618430cc3e59216fa8/wtfc.sh \
     https://github.com/Yelp/dumb-init/releases/download/v"$DUMB_INIT_VERSION"/dumb-init_"$DUMB_INIT_VERSION"_amd64.deb \


### PR DESCRIPTION
 - Symlinks in the same directory for canonical filenames server.pub,
   server.key and server.crt - works better when initContainer mounts
   to a different path structure than a destination container in k8s.