### PR TITLE
(maint) Update clj-parent to 4.6.20

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def pdb-version "6.16.1-SNAPSHOT")
 
-(def clj-parent-version "4.6.19")
+(def clj-parent-version "4.6.20")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
Includes a bump to jetty that will keep us in line with puppetserver