### PR TITLE
(PDB-5021) Sort package_inventory when calculating hash

### DIFF
--- a/src/puppetlabs/puppetdb/scf/hash.clj
+++ b/src/puppetlabs/puppetdb/scf/hash.clj
@@ -230,7 +230,9 @@
                     ;; way to tell them apart during sync, and we need the the hashing
                     ;; to be consistent.
                     (if (seq (:package_inventory fact-data))
-                      fact-data
+                      ;; sort package_inventory to guard aganist random ordering
+                      ;; producing differing hashes when all else is equal.
+                      (update fact-data :package_inventory sort)
                       (dissoc fact-data :package_inventory))
                     (dissoc :timestamp :producer_timestamp :producer)
                     generic-identity-hash)

--- a/test/puppetlabs/puppetdb/scf/hash_test.clj
+++ b/test/puppetlabs/puppetdb/scf/hash_test.clj
@@ -176,7 +176,26 @@
 
       (testing "should return the same value twice"
         (is (= (fact-identity-hash sample)
-               (fact-identity-hash sample)))))))
+               (fact-identity-hash sample))))))
+
+  (testing "fact-identity-hash package_inventory ordering"
+    (let [sample {:certname "foo.com"
+                  :values {"domain" "mydomain.com"
+                           "fqdn" "myhost.mydomain.com"
+                           "hostname" "myhost"
+                           "kernel" "Linux"
+                           "operatingsystem" "Debian"}
+                  :environment nil
+                  :package_inventory [["acl" "2.2.52-3" "apt"]
+                                      ["beaker-pe" "1.9.1" "gem"]
+                                      ["cups" "2.2.1-8" "apt"]
+                                      ["diffutils" "1:3.5-1" "apt"]]}]
+
+      (testing "package_inventory order shouldn't affect hash"
+        (is (= (fact-identity-hash sample)
+               (-> sample
+                   (update :package_inventory reverse)
+                   fact-identity-hash)))))))
 
 (deftest catalog-dedupe
   (testing "Catalogs with the same metadata but different content should have different hashes"


### PR DESCRIPTION
Prior to this commit changes in the ordering of package_inventory
could produce differing hashes for a factset when all else was equal.

This could create a situation with pe-puppetdb sync that could cause a
factset to be pulled repeatedly even though both sides had stored the
same factset already. This could happen if the ordering of the
package_inventory for a factset pulled via sync didn't match the
order when the factset was first inserted. This mismatch could create
differing hashes and then sync would repeatedly decide it needed to
pull that factset from the remote and continue to calculate a
different hash due to the change in package_inventory ordering. This
problem could only happen when sync did the initial transfer of a
factset. If a factset was broadcast to both puppetdbs in a sync pair
from the start the package_inventory order would be the same and the
hashes would line up on both sides. This issue was transient in sync,
sometimes the order of the package_inventory pulled for a factset
would match the order first seen on the remote and avoid this issue.