### PR TITLE
(maint) Use Docker 19.03 in Travis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,13 @@ aliases:
     ci/bin/prep-and-run-in travis "$PDB_TEST"
 
   - &before-docker-tests
-    - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-    - sudo apt-get update
-    - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce docker-ce-cli containerd.io
     - sudo rm /usr/local/bin/docker-compose
     - curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
     - chmod +x docker-compose
     - sudo mv docker-compose /usr/local/bin
+    - mkdir -vp ~/.docker/cli-plugins
+    - curl --location https://github.com/docker/buildx/releases/download/v${DOCKER_BUILDX_VERSION}/buildx-v${DOCKER_BUILDX_VERSION}.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
+    - chmod +x ~/.docker/cli-plugins/docker-buildx
     - docker buildx create --name travis_builder --use
 
   - &run-docker-tests
@@ -147,7 +146,7 @@ jobs:
       language: ruby
       rvm: 2.6.6
       # necessary to prevent overwhelming TravisCI build output limits
-      env: DOCKER_COMPOSE_VERSION=1.28.6 DOCKER_BUILD_FLAGS="--progress plain" PUPPETSERVER_IMAGE="puppet/puppetserver:edge"
+      env: DOCKER_COMPOSE_VERSION=1.28.6 DOCKER_BUILDX_VERSION=0.5.1 DOCKER_BUILD_FLAGS="--progress plain" PUPPETSERVER_IMAGE="puppet/puppetserver:edge"
       before_install: *before-docker-tests
       script: *run-docker-tests
       after_script: *after-docker-tests


### PR DESCRIPTION
 - Instead of incurring the upgrade cost to Travis 20.10, use the
   existing 19.03 version.

   In practice, upgrading Docker in Travis turned out to be unreliable.

   To enable buildx requires installing the plugin from the github
   releases page. Using the experimental cli flag was supposed to enable
   the plugin for 19.03, but didn't seem to work in the Travis env.