### PR TITLE
(maint) test: fix pipefail error in jdk-info

### DIFF
--- a/ext/bin/jdk-info
+++ b/ext/bin/jdk-info
@@ -35,7 +35,7 @@ print-info() {
     #   openjdk version "1.8.0_171"
     #   openjdk version "10.0.2" 2018-07-17
     #   openjdk version "10.0.2-adoptopenjdk" 2018-07-17
-    ver=$(echo "$ver_out" | head -1 | cut -d' ' -f 3 | sed -E 's/^"(.+)"$/\1/')
+    ver=$(set +o pipefail; echo "$ver_out" | head -1 | cut -d' ' -f 3 | sed -E 's/^"(.+)"$/\1/')
 
     case "$what" in
         version) echo "$ver" ;;


### PR DESCRIPTION
The `echo` command needs to print multiple lines, but the `head -1`
command only reads the first line before completing. Sometimes this
means that the head command will finish and close its pipe before the
echo prints all its lines to the pipe. Due to the `-o pipefail` setting
in this file, this transient issue will cause the script to fail with
the error

```
+ ext/bin/check-spec-env lint/openjdk11
ext/bin/jdk-info: line 38: echo: write error: Broken pipe
Error: Process completed with exit code 1.
```

This allows the pipefail for this command to fix the transient error.