### PR TITLE
(PDB-5026) Switch context in query when using from

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -2522,10 +2522,10 @@
   (fn [node state]
     (when (vec? node)
       (cm/match [node]
-                [["from" entity query]]
+                [["from" entity query & _]]
                 (let [query (push-down-context (user-query->logical-obj (str "select_" entity)) query)
                       nested-qc (:query-context (meta query))]
-                  {:node (vary-meta ["from" entity query]
+                  {:node (vary-meta (assoc node 2 query)
                                     assoc :query-context nested-qc)
                    :state state
                    :cut true})

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -433,19 +433,18 @@
           (are-error-response-headers headers)
           (is (re-find msg body)))))))
 
-;TODO fix all skipped tests
-(deftest-http-app ^:skipped tests-for-PDB-5026
+(deftest-http-app query-with-from
   [[version endpoint] endpoints
-  method [:get :post]]
+   method [:get :post]]
 
-  ; enable this test after ticket https://tickets.puppetlabs.com/browse/PDB-5026 is solved
-  (testing "in a reports subquery"
-    (let [expected ["web1.example.com" "web2.example.com" "puppet.example.com" "db.example.com"]
-          result (query-result method endpoint  ["in", "certname",
-                                                 ["from", "reports",
-                                                  ["extract", "certname"],
-                                                  ["order_by", ["certname"]]]])]
-      (is (= (mapv :certname result) expected)))))
+  (testing "should change context to reports"
+    (store-example-nodes)
+    (let [expected ["db.example.com" "puppet.example.com" "web1.example.com"]
+          result (query-result method endpoint ["in" "certname"
+                                                ["from" "reports"
+                                                 ["extract" "certname"]
+                                                 ["order_by" ["certname"]]]])]
+      (is (= expected (sort (mapv :certname result)))))))
 
 (deftest-http-app query-with-pretty-printing
   [[version endpoint] endpoints


### PR DESCRIPTION
**Description of the problem:** If the options (limit, offset, order_by) are provided to a subquery that uses "from", the context isn't switched to the entity from the "from" syntax. This behaviour results in an error when the subquery is made on the reports table. Eg. 
```
["from" "nodes"
    ["and"
        ["in"
         "certname"
         ["from"
         "reports"
              ["extract" "certname" ["=" "type" "agent"]]
              ["limit" 1]
              ["order_by" [["certname" "desc"]]]]]
        ["=" "node_state" "active"]]]
```
Results in the following error: 
```'type' is not a queryable object for nodes. Known queryable objects are 'cached_catalog_status', 'catalog_environment', 'catalog_timestamp', 'certname', 'deactivated', 'expired', 'facts_environment', 'facts_timestamp', 'latest_report_corrective_change', 'latest_report_hash', 'latest_report_job_id', 'latest_report_noop', 'latest_report_noop_pending', 'latest_report_status', 'report_environment', and 'report_timestamp'```
**Description of the change:** Ensure that context is correctly set and switched when a subquery with "from" form is used. 