### PR TITLE
Revert "(PDB-2898) Disallow paging opts outside pql query"

### DIFF
--- a/src/puppetlabs/puppetdb/http/handlers.clj
+++ b/src/puppetlabs/puppetdb/http/handlers.clj
@@ -167,7 +167,7 @@
                             (some-> req :puppetdb-query :ast_only http-q/coerce-to-boolean) req
                             (no-certname-entities (get-entity req)) req
                             :else (http-q/restrict-query-to-active-nodes req))))
-                  (http-q/extract-pql-or-ast-query
+                  (http-q/extract-query-pql
                    (merge-param-specs typical-params
                                       {:optional ["ast_only"]
                                        :required ["query"]}))))))

--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -282,8 +282,6 @@
       (update-when [:include_package_inventory] coerce-to-boolean)
       (update-when [:distinct_resources] coerce-to-boolean)))
 
-(defn ast-format? [query] (re-find #"^\s*\[" query))
-
 (defn parse-json-sequence
   "Parse a query string as JSON. Parse errors
    will result in an IllegalArgumentException"
@@ -306,29 +304,18 @@
                      others parsed))))
       parsed)))
 
-(defn parse-pql-or-ast
+(defn parse-json-or-pql-to-ast
   "Parse a query string either as JSON or PQL to transform it to AST"
   [query]
   (when query
-    (if (ast-format? query)
+    (if (re-find #"^\s*\[" query)
       (parse-json-query query)
       (pql/parse-pql-query query))))
-
-(defn validate-pql-params
-  [query-body query-params]
-  (let [query-params (keywordize-keys query-params)]
-    (when (and query-body
-               (string? query-body)
-               (not (ast-format? query-body))
-               (some #(contains? query-params %) [:limit :order_by :offset]))
-      (throw (IllegalArgumentException.
-              (tru "Paging options (limit, order_by, offset) must be included in the PQL query"))))))
 
 (defn get-req->query
   "Converts parameters of a GET request to a pdb query map"
   [{:keys [params] :as req}
    parse-fn]
-  (validate-pql-params (get params "query") (:query-params req))
   (-> params
       (update-when ["query"] parse-fn)
       (update-when ["order_by"] parse-order-by-json)
@@ -343,11 +330,9 @@
   [req parse-fn]
   (-> (let [req-body (request/body-string req)]
         (try
-          (let [string-req-body (json/parse-string req-body true)]
-            (validate-pql-params (:query string-req-body) string-req-body)
-            string-req-body)
-          (catch JsonParseException e
-            (throw (IllegalArgumentException. (pprint-json-parse-exception e req-body))))))
+          (json/parse-string req-body true)
+        (catch JsonParseException e
+          (throw (IllegalArgumentException. (pprint-json-parse-exception e req-body))))))
       (update :query (fn [query]
                        (if (vector? query)
                          query
@@ -382,9 +367,9 @@
               (assoc :puppetdb-query query-map)
               (assoc-in [:globals :pretty-print] pretty-print))))))))
 
-(defn extract-pql-or-ast-query
+(defn extract-query-pql
   [handler param-spec]
-  (extract-query handler param-spec parse-pql-or-ast))
+  (extract-query handler param-spec parse-json-or-pql-to-ast))
 
 (defn validate-distinct-options!
   "Validate the HTTP query params related to a `distinct_resources` query.  Return a

--- a/test/puppetlabs/puppetdb/http/index_test.clj
+++ b/test/puppetlabs/puppetdb/http/index_test.clj
@@ -105,25 +105,17 @@
         (is (= status http/status-bad-request))))
 
     (testing "pagination"
-      (testing "AST with order_by parameter"
-        (let [results (ordered-query-result method endpoint ["from" "nodes"]
-                                            {:order_by
-                                             (vector-param method
-                                                           [{"field" "certname"
-                                                             "order" "ASC"}])})]
-          (is (= "host1" (:certname (first results))))
-          (is (= 3 (count results)))))
-
-      (testing "PQL with order_by parameter"
-        (doseq [query ["nodes {}"
+      (testing "with order_by parameter"
+        (doseq [query [["from" "nodes"]
+                       "nodes {}"
                        "nodes [] {}"]]
-          (let [{:keys [status body]} (query-response method endpoint query
-                                                      {:order_by
-                                                       (vector-param method
-                                                                     [{"field" "certname"
-                                                                       "order" "ASC"}])})]
-            (is (= "Paging options (limit, order_by, offset) must be included in the PQL query" body))
-            (is (= http/status-bad-request status)))))
+          (let [results (ordered-query-result method endpoint query
+                                              {:order_by
+                                               (vector-param method
+                                                             [{"field" "certname"
+                                                               "order" "ASC"}])})]
+            (is (= "host1" (:certname (first results))))
+            (is (= 3 (count results))))))
 
       (testing "with order_by in query"
         (let [results (ordered-query-result
@@ -131,28 +123,18 @@
           (is (= "host1" (:certname (first results))))
           (is (= 3 (count results)))))
 
-      (testing "AST with all options in parameters"
-        (let [results (ordered-query-result method endpoint ["from" "nodes"]
-                                            {:order_by
-                                                     (vector-param method
-                                                                   [{"field" "certname"
-                                                                     "order" "DESC"}])
-                                             :limit  2
-                                             :offset 1})]
-          (is (= "host2" (:certname (first results))))
-          (is (= 2 (count results)))))
-
-      (testing "query parameters are disallowed for PQL"
-        (doseq [query ["nodes {}"
-                       "nodes [] {}"]
-                params [{:offset 1}
-                        {:limit 1}
-                        {:order_by (vector-param method
-                                                 [{"field" "certname"
-                                                   "order" "DESC"}])}]]
-          (let [{:keys [status body]} (query-response method endpoint query params)]
-            (is (= "Paging options (limit, order_by, offset) must be included in the PQL query" body))
-            (is (= http/status-bad-request status)))))
+      (testing "with all options in parameters"
+        (doseq [query [["from" "nodes"]
+                       "nodes {}"]]
+          (let [results (ordered-query-result method endpoint query
+                                              {:order_by
+                                               (vector-param method
+                                                             [{"field" "certname"
+                                                               "order" "DESC"}])
+                                               :limit 2
+                                               :offset 1})]
+            (is (= "host2" (:certname (first results))))
+            (is (= 2 (count results))))))
 
       (testing "with all options in query"
         (let [results (ordered-query-result


### PR DESCRIPTION
The PE console was relying on this functionality.

This reverts commit c614d16b2fe26219ac6743f33c79ee6594a2b94f.