### PR TITLE
(PE-32070) Update Java security files for new BCFIPS

### DIFF
--- a/dev-resources/jdk11-fips-security
+++ b/dev-resources/jdk11-fips-security
@@ -61,7 +61,7 @@
 # List of providers and their preference orders (see above):
 #
 security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
-security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
+security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
 security.provider.3=SUN
 security.provider.4=SunRsaSign
 #security.provider.5=SunEC

--- a/dev-resources/jdk8-fips-security
+++ b/dev-resources/jdk8-fips-security
@@ -66,7 +66,7 @@
 # List of providers and their preference orders (see above):
 #
 security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
-security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
+security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
 security.provider.3=sun.security.provider.Sun
 security.provider.4=sun.security.rsa.SunRsaSign
 #security.provider.5=sun.security.ec.SunEC


### PR DESCRIPTION
There is an issue with bc-fips 1.0.2.1 involving circular provider
loading, that can be fixed by using the full class name for the
BCJSSE FIPS provider, rather than relying on an alias. This commit
updates our java-security files to use the full name. Note this only
caused issues on Java 11, but it is valid for both versions, so we are
updating it in both files for consistency.