### PR TITLE
(PDB-5104) Fixed order for query params

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -1698,7 +1698,7 @@
   "Zip through the query plan, replacing each user provided query parameter with '?'
   and return the parameters as a vector"
   [plan]
-  (let [{:keys [node state]} (zip/post-order-visit (zip/tree-zipper plan)
+  (let [{:keys [node state]} (zip/pre-order-visit (zip/tree-zipper plan)
                                                    []
                                                    [extract-params])]
     {:plan node

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -2254,7 +2254,7 @@
                        {"certname" "foo2" "value" "testing.com"}
                        {"certname" "foo3" "value" "testing.com"}]))))))
 
-(deftest-http-app  ^:skipped test-for-known-issues
+(deftest-http-app test-for-known-issues
   [[version endpoint] fact-contents-endpoints
    method [:get :post]]
 


### PR DESCRIPTION
**Description:** When using the `to_string` function in a query to the facts endpoint, no results were returned. This was caused by a small bug that did not generate the correct order for params in the SQL query (i.e. SQL queries have values escaped and sent as a ordered list for security reasons). In this case, the generated SQL was valid, but due to the fact that the params are not ordered correctly, the query would never return anything.

This solution is to change the traversing order of the plan used to generate the query. I did not find any parts of the code that would be affected by this and neither any queries or tests that we've tested with.

The only case I can see this being harmful is if the plan has a structure change, then it might not word as expected, but did not manage to reproduce anything in this direction.

A different implementation for this fix can be found [here](https://github.com/puppetlabs/puppetdb/pull/3506).