### PR TITLE
(PDB-5104) Fix to_string function on facts and fact-contents endpoint

### DIFF
--- a/src/puppetlabs/puppetdb/query.clj
+++ b/src/puppetlabs/puppetdb/query.clj
@@ -85,7 +85,8 @@
           (s/optional-key :min) s/Any
           (s/optional-key :max) s/Any
           (s/optional-key :avg) s/Any
-          (s/optional-key :sum) s/Any}))
+          (s/optional-key :sum) s/Any
+          (s/optional-key :to_string) s/Str}))
 
 (defn execute-paged-query*
   "Helper function to executed paged queries.  Builds up the paged sql string,

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -1710,14 +1710,14 @@
     {:node (assoc node :value "?")
      :state (apply conj (:params node) state)}
 
-    ;; Handle a parameterized :selection -- the query's :selection
-    ;; must already have question marks in all the right places, and
-    ;; have the corresponding parameter values in :selection-params.
+    ;; Handle a parameterized :selection -- when the :selection
+    ;; appears in the tree traversal put the corresponding parameter values
+    ;; from :selection-params.
     ;; See rewrite-fact-query for an example.
-    (and (instance? Query node)
-         (-> node :selection :selection-params))
+    (and (map? node)
+         (:selection-params node))
     {:node node
-     :state (apply conj (-> node :selection :selection-params) state)}))
+     :state (apply conj (:selection-params node) state)}))
 
 (defn extract-all-params
   "Zip through the query plan, replacing each user provided query parameter with '?'

--- a/test/puppetlabs/puppetdb/http/facts_test.clj
+++ b/test/puppetlabs/puppetdb/http/facts_test.clj
@@ -2254,20 +2254,18 @@
                        {"certname" "foo2" "value" "testing.com"}
                        {"certname" "foo3" "value" "testing.com"}]))))))
 
-(deftest-http-app  ^:skipped test-for-known-issues
-  [[version endpoint] fact-contents-endpoints
+(deftest-http-app to-string-function-with-mask
+  [[version endpoint] [[:v4 v4-facts-endpoint]
+                       [:v4 "/v4/fact-contents"]]
    method [:get :post]]
-
    (populate-for-structured-tests reference-time)
 
-   ; enable this test after ticket https://tickets.puppetlabs.com/browse/PDB-5104 is solved
-   (testing "to_string function on integers"
-      (is (= (query-result method endpoint
-                           ["extract" [["function" "to_string" "value" "FM9999"]]
-                            ["and"
+     (is (= (query-result method endpoint
+                          ["extract" [["function" "to_string" "value" "FM9999"]]
+                           ["and"
                             ["=" "name" "uptime_seconds"]
                             ["=" "certname" "foo1"]]])
-           #{{:to_string "1000"}}))))
+            #{{:to_string "4000"}})))
 
 (def no-parent-endpoints [[:v4 "/v4/factsets/foo/facts"]])
 


### PR DESCRIPTION
**Description of the problem (short):** Query with to_string function doesn't return anything on the facts endpoint and fails with the following error in fact-contents endpoint: 
```
Input to munge-result-row does not match schema:
           [(named {:to_string disallowed-key} row)]
```

**Description of the problem (long):** An optimisation was introduced, for queries that constrain the fact name to a
single value if they are made on the facts endpoint, in [this commit](https://github.com/puppetlabs/puppetdb/commit/8d5b509c9b6e5aa529bd0667694a8bd036100d42 ). Because the json -> operator for [the selection field](https://github.com/puppetlabs/puppetdb/blob/2126eb44069fb281330593b655fe95ffe97b72a2/src/puppetlabs/puppetdb/query_eng/engine.clj#L2740) was introduced, the parameters for the fact-name field (that will replace the "?" later) are added as the value of :selection-params. These :selection-params are extracted later in [extract-params method](https://github.com/puppetlabs/puppetdb/blob/2126eb44069fb281330593b655fe95ffe97b72a2/src/puppetlabs/puppetdb/query_eng/engine.clj#L1720), but are extracted later than they appear when the tree is traversed in [post-order](https://github.com/puppetlabs/puppetdb/blob/2126eb44069fb281330593b655fe95ffe97b72a2/src/puppetlabs/puppetdb/query_eng/engine.clj#L1726) and the :selected-params end up in an erroneous place in the final parameterized-plan's params. 

On the fact-contents endpoint the schema doesn't accept `to_string` as a column name. 

In addition to the unit tests, this change was tested manually with the following queries:
`["extract", [["function", "to_string", "value", "999999999"]], ["=","name", "uptime_seconds"]]`
```
["extract", [["function", "to_string", "value", "9999999"]], ["and",
  ["=", "name", "uptime_seconds"],
  ["in", "certname",
    ["extract", "certname",
      ["select_resources",
        ["and",
          ["=", "type", "Class"],
          ["=", "title", "Apache"]]]]]]]
```
**Description of the solution:** When traversing the tree in post-order, add :selection-params when they are firstly seen (in other words, modify the condition to add the :selection-params when the :selection map is firstly encountered, not in the end when the object is Query (object is Query only in the last iteration when root is visited)). For other endpoints, including fact-contents, allow `to_string` as a column name in schema.