### PR TITLE
(PDB-5105) Add console and cd4pe queries

### DIFF
--- a/locust/load-test/cd4pe.yaml
+++ b/locust/load-test/cd4pe.yaml
@@ -1,0 +1,21 @@
+---
+- path: "/pdb/query/v4/resources"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["extract",["parameters"],["and",["=","title","Puppet_enterprise::Master::Code_manager"]]]
+  alias: code manager resource
+- path: "/pdb/query/v4/resources"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["extract",["title","type","resource","file","certname","line","environment"],["and",["or",["and",["null?","file",false],["or",["~","file","impact_analysis_tests_prod/site/profile/manifests/nested.pp"],["~","file","impact_analysis_tests_prod/site/profile/manifests/nested/includes.pp"]]],["=","title","Profile::Nested"],["=","title","Profile::Nested::Includes"]],["=","environment","impact_analysis_tests_prod"]]]
+  alias: impact analysis 1
+- path: "/pdb/query/v4/resources"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["extract",["title","type","resource","file","certname","line","environment"],["and",["or",["and",["null?","file",false],["or",["~","file","impact_analysis_tests_prod/site/role/manifests/example2.pp"]]],["=","title","Role::Example2"]],["=","environment","impact_analysis_tests_prod"]]]
+  alias: impact analysis 2
+- path: "/pdb/query/v4/resources"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["extract",["title","type","resource","file","certname","line","environment"],["and",["or",["and",["null?","file",false],["or",["~","file","impact_analysis_tests_prod/modules/cd4pe"],["~","file","impact_analysis_tests_prod/modules/cd4pe_tests"],["~","file","impact_analysis_tests_prod/manifests/site.pp"],["~","file","impact_analysis_tests_prod/site/profile/manifests/base.pp"],["~","file","impact_analysis_tests_prod/site/profile/manifests/firewall.pp"],["~","file","impact_analysis_tests_prod/site/role/manifests/example.pp"],["~","file","impact_analysis_tests_prod/site/role/manifests/webserver.pp"]]],["=","title","Impact_analysis_tests_prod::Site"],["=","title","Profile::Base"],["=","title","Profile::Firewall"],["=","title","Role::Example"],["=","title","Role::Webserver"]],["=","environment","impact_analysis_tests_prod"]]]
+  alias: firewall analysis cd4pe

--- a/locust/load-test/console.yaml
+++ b/locust/load-test/console.yaml
@@ -1,0 +1,146 @@
+---
+- path: "/pdb/query/v4/fact-names"
+  method: GET
+  headers: {content-type: application/json}
+  query:
+  alias: fact names
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "nodes", ["extract", [["function", "count"]], ["=", "node_state", "active"]]]
+  alias: active nodes
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "nodes", ["extract", ["certname", "report_environment", "report_timestamp", "latest_report_hash", "latest_report_status", "latest_report_noop", "latest_report_noop_pending", "latest_report_corrective_change", "latest_report_job_id"], ["and", ["null?", "report_timestamp", true], ["=", "node_state", "active"]]]]
+  alias: node details
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "nodes", ["extract", [["function", "count"]], ["and", ["<", "report_timestamp", "2021-03-24T09:30:23.308Z"], ["=", "node_state", "active"]]]]
+  alias: count reports before timestamp
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "nodes", ["extract", [["function", "count"]], ["and", ["null?", "report_timestamp", true], ["=", "node_state", "active"]]]]
+  alias: nodes with a report
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "nodes", ["extract", [["function", "count"], "cached_catalog_status", "latest_report_status", "latest_report_noop", "latest_report_noop_pending", "latest_report_corrective_change"], ["and", [">=", "report_timestamp", "2021-03-24T09:30:23.308Z"], ["=", "node_state", "active"]], ["group_by", "cached_catalog_status", "latest_report_status", "latest_report_noop", "latest_report_noop_pending", "latest_report_corrective_change"]]]
+  alias: latest report stats
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "nodes", ["extract", ["certname"], ["and", [">", "report_timestamp", "2021-03-01T00:00:00Z"], ["=", "node_state", "active"]]]]
+  alias: node name by report timestamp
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "events", ["extract", ["corrective_change", ["function", "count"]], ["and", ["and", [">", "run_end_time", "2021-03-24T00:00:00Z"], ["<", "run_end_time", "2021-03-24T10:30:23Z"]], ["=", "node_state", "active"]], ["group_by", "corrective_change"]]]
+  alias: corrective changes
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "nodes", ["extract", [["function", "count"]], ["and", ["and", ["=", "latest_report_status", "failed"], [">=", "report_timestamp", "2021-03-24T09:31:59.338Z"], ["=", "latest_report_noop", false]], ["=", "node_state", "active"]]]]
+  alias: latest failed report
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "nodes", ["extract", ["certname", "report_environment", "report_timestamp", "latest_report_hash", "latest_report_status", "latest_report_noop", "latest_report_noop_pending", "latest_report_corrective_change", "latest_report_job_id"], ["and", ["and", ["=", "latest_report_status", "failed"], [">=", "report_timestamp", "2021-03-24T09:31:59.586Z"], ["=", "latest_report_noop", false]], ["=", "node_state", "active"]]]]
+  alias: node details for last failed report
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "nodes", ["extract", [["function", "count"]], ["and", ["<", "report_timestamp", "2021-03-24T09:31:59.586Z"], ["=", "node_state", "active"]]]]
+  alias: nodes count with reports earlier than
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "nodes", ["extract", [["function", "count"]], ["and", ["null?", "report_timestamp", true], ["=", "node_state", "active"]]]]
+  alias: nodes with no reports
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "nodes", ["extract", [["function", "count"], "cached_catalog_status", "latest_report_status", "latest_report_noop", "latest_report_noop_pending", "latest_report_corrective_change"], ["and", [">=", "report_timestamp", "2021-03-24T09:31:59.586Z"], ["=", "node_state", "active"]], ["group_by", "cached_catalog_status", "latest_report_status", "latest_report_noop", "latest_report_noop_pending", "latest_report_corrective_change"]]]
+  alias: nodes count with specific attributes
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "reports", ["extract", ["hash", "end_time", "certname", "status", "job_id", "noop", "noop_pending", "metrics", "environment", "corrective_change"]]]
+  alias: reports attributes
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "reports", ["extract", [["function", "count"]]]]
+  alias: reports count
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "reports", ["extract", ["resource_events", "certname"], ["=", "hash", "59f87cec2e662b083874b8d0fd122899684bf197"]]]
+  alias: specific report
+#- path: "/pdb/query/v4"
+#  method: POST
+#  headers: {content-type: application/json}
+#  query: ["from", "aggregate_event_counts", ["=", "latest_report?", true]]
+#  alias: aggregate event counts
+#- path: "/pdb/query/v4"
+#  method: POST
+#  headers: {content-type: application/json}
+#  query: ["from", "event_counts", ["=", "latest_report?", true]]
+#  alias: event counts
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "inventory", ["extract", ["certname"], ["=", "node_state", "active"]]]
+  alias: active nodes from inventory
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "nodes", ["extract", ["certname", "report_timestamp", "latest_report_hash"], ["=", "node_state", "active"]]]
+  alias: nodes details
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "facts", ["and", ["=", "certname", "leaky-hijacking.delivery.puppetlabs.net"], ["=", "node_state", "active"]]]
+  alias: facts for specific node
+#- path: "/pdb/query/v4"
+#  method: POST
+#  headers: {content-type: application/json}
+#  query: ["from", "packages", ["extract", [["function", "count"]], nil]]
+#  alias: packages count
+#- path: "/pdb/query/v4"
+#  method: POST
+#  headers: {content-type: application/json}
+#  query: ["from", "package_inventory", ["extract", ["package_name", "version", "provider", ["function", "count"]], ["and", ["=", ["node", "active"], "true"], ["in", ["package_name", "version", "provider"], ["from", "packages", ["extract", ["package_name", "version", "provider"], nil], ["order_by", ["package_name", "version", "provider"]], ["limit", 50], ["offset", 0]]]], ["group_by", "package_name", "version", "provider"]], ["order_by", ["package_name", "version", "provider"]]]
+#  alias: packages details
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "facts", ["and", ["and", ["or", ["=", "name", "pe_patch"], ["=", "name", "kernel"]], ["in", ["certname"], ["from", "resources", ["extract", "certname", ["and", ["=", "type", "Class"], ["=", "title", "Pe_patch"]]]]]], ["=", "node_state", "active"]]]
+  alias: specific facts
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "resources", ["extract", ["certname"], ["and", ["and", ["=", "type", "Class"], ["or", ["=", "title", "Puppet_enterprise::Profile::Certificate_authority"], ["or", ["=", "title", "Puppet_enterprise::Profile::Master"], ["=", "title", "Puppet_enterprise::Profile::Console"]], ["=", "title", "Puppet_enterprise::Profile::Puppetdb"]], ["subquery", "nodes", ["and", ["null?", "deactivated", true], ["null?", "expired", true]]]], ["=", "node_state", "active"]]]]
+  alias: specific resources
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "resources", ["extract", ["certname", "parameters"], ["and", ["and", ["=", "type", "Class"], ["and", ["=", "title", "Puppet_enterprise"], ["in", "certname", ["from", "resources", ["extract", ["certname"], ["and", ["=", "type", "Class"], ["or", ["=", "title", "Puppet_enterprise::Profile::Master"], ["=", "title", "Puppet_enterprise::Profile::Console"], ["=", "title", "Puppet_enterprise::Profile::Puppetdb"]], ["subquery", "nodes", ["and", ["null?", "deactivated", true], ["null?", "expired", true]]]]]]]], ["subquery", "nodes", ["and", ["null?", "deactivated", true], ["null?", "expired", true]]]], ["=", "node_state", "active"]]]]
+  alias: puppet_enterprise resource parameters
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "facts", ["extract", ["name", "value"], ["and", ["=", "certname", "leaky-hijacking.delivery.puppetlabs.net"], ["=", "node_state", "active"]]]]
+  alias: facts name and value for specific node
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "resources", ["extract", ["title", "parameters"], ["and", ["and", ["=", "type", "Class"], ["and", ["=", "certname", "leaky-hijacking.delivery.puppetlabs.net"], ["~", "title", "Puppet_enterprise"]], ["subquery", "nodes", ["and", ["null?", "deactivated", true], ["null?", "expired", true]]]], ["=", "node_state", "active"]]]]
+  alias: puppet_enterprise parameters for specific node
+- path: "/pdb/query/v4"
+  method: POST
+  headers: {content-type: application/json}
+  query: ["from", "resources", ["extract", ["title", "parameters"], ["and", ["and", ["=", "type", "Class"], ["and", ["=", "certname", "leaky-hijacking.delivery.puppetlabs.net"], ["~", "title", "Pe_repo"]], ["subquery", "nodes", ["and", ["null?", "deactivated", true], ["null?", "expired", true]]]], ["=", "node_state", "active"]]]]
+  alias: pe_repo parameters for specific node

--- a/locust/load-test/example.yaml
+++ b/locust/load-test/example.yaml
@@ -1,11 +1,11 @@
 # Example
+#  name: my custom call name, will be shown in the report
 #  path: path without the host. The host is set in cli as an option
 #  query: query should be hash for POST and string for GET
 #  method: GET/POST
 #  headers: any custom headers that will be sent with the request
 ---
 - path: "/pdb/query/v4/facts"
-  query: ["~", "certname", "host*"]
   limit: 100
   offset: 1
   method: GET
@@ -14,3 +14,4 @@
   query: ["~", "certname", "host"]
   method: POST
   headers: {content-type: application/json}
+  alias: example 2

--- a/locust/load-test/load-test.py
+++ b/locust/load-test/load-test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from locust import HttpUser, task, between
+from locust import HttpUser, task, tag
 import yaml, json, os
 
 class PuppetDbLoadTest(HttpUser):
@@ -11,24 +11,33 @@ class PuppetDbLoadTest(HttpUser):
         elif response.status_code != 200:
             print(
             "Method: " + opts['method'],
-            "Query: " + str(opts['query']),
+            "Query: " + str(opts.get('query')) ,
             "Response status: " + str(response.status_code),
             "Response body: " + response.text,
             end="\n-------------------------------------------\n", sep="\n" )
 
+    def get_name(self, opts):
+        if opts.get('alias'): return opts['alias']
+        if opts.get('query'): return str(opts['query'])
+        return opts['path']
+
     def get_request(self, opts):
         limit = opts.get('limit')
         offset = opts.get('offset')
-        url = opts['path'] + "?query=" + json.dumps(opts['query'])
-        if limit:
-            url = url + "&limit=" + str(limit)
-        if offset:
-            url = url + "&offset=" + str(offset)
-        with self.client.request(opts['method'], url, str(opts['query'])) as response:
+        url = opts['path']
+        if opts.get('query'):
+            url += "?query=" + json.dumps(opts['query'])
+        if limit and opts.get('query'):
+            url += "&limit=" + str(limit)
+        if offset and opts.get('query'):
+            url += "&offset=" + str(offset)
+        with self.client.request(opts['method'], url, self.get_name(opts)) as response:
             self.response_printer(opts, response)
 
     def post_request(self, opts):
-        query = {'query': opts['query']}
+        query = {}
+        if opts.get('query'):
+            query['query'] = opts['query']
         limit = opts.get('limit')
         offset = opts.get('offset')
         if limit:
@@ -36,13 +45,12 @@ class PuppetDbLoadTest(HttpUser):
         if offset:
             query['offset'] = offset
         headers = opts.get('headers')
-        with self.client.request(opts['method'], opts['path'], str(opts['query']), data=json.dumps(query), json=True, headers=headers) as response:
+        with self.client.request(opts['method'], opts['path'], self.get_name(opts), data=json.dumps(query), json=True, headers=headers) as response:
             self.response_printer(opts, response)
 
-    @task
-    def swarm(self):
+    def run_task(self, requests_file):
         dir_path = os.path.dirname(os.path.realpath(__file__))
-        with open(dir_path + '/config.yaml') as stream:
+        with open(dir_path + requests_file) as stream:
             config = yaml.safe_load(stream)
             for opts in config:
                 if opts['method'] == 'GET':
@@ -50,5 +58,23 @@ class PuppetDbLoadTest(HttpUser):
                 elif opts['method'] == 'POST':
                     self.post_request(opts)
 
+    @tag('example')
+    @task
+    def run_example_queries(self):
+        self.run_task('/example.yaml')
 
+    @tag('console')
+    @task
+    def run_console_queries(self):
+        self.run_task('/console.yaml')
 
+    @tag('cd4pe')
+    @task
+    def run_cd4pe_queries(self):
+        self.run_task('/cd4pe.yaml')
+
+    @tag('all')
+    @task
+    def run_all_queries(self):
+        self.run_task('/console.yaml')
+        self.run_task('/cd4pe.yaml')

--- a/locust/run-load-test
+++ b/locust/run-load-test
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys, subprocess, os
+from datetime import datetime
 
 def usage():
     usage = """
@@ -13,13 +14,16 @@ Defaults:
   -s [--spawn_rate] 1
   -t [--run_time]   1m
   -f [--locustfile] locust/load-test/load-test.py
-  --html            report.html
+  -T [--tags]       example
+  -c [--csv]        <current_date_time>
+  --html            <current_data_time>.html
 """
     print(usage)
 
 def add_default_args(program_args):
     defaults = [['--headless'], ['-H', 'http://localhost:8080'],
-           ["-u", '1'], ["-r", '1'], ["-t", '1m'], ['-f', locust_filepath], ['--html', 'report.html']]
+                ["-u", '1'], ["-r", '1'], ["-t", '1m'], ['-f', locust_filepath],
+                ['--html', f'{timestamp}.html'], ['--tags', 'example'], ['--csv', timestamp]]
     additional_args = []
     for default_arg in defaults:
         found = False
@@ -37,6 +41,7 @@ missing_defaults = []
 dir_path = os.path.dirname(os.path.realpath(__file__))
 workdir = os.getcwd()
 locust_filepath = os.path.join(dir_path, 'load-test', 'load-test.py')
+timestamp = datetime.now().strftime("%d-%m-%YT%H:%M:%S")
 
 sys_args = sys.argv[1:]
 if '--help' in sys_args:


### PR DESCRIPTION
Add different .yaml files for the console, cp4pe and example queries.
Introduced an optional alias field in the .yaml files for easy identification of the request.
Requests query field is now optional.