### PR TITLE
(docs) Fix release notes links

### DIFF
--- a/documentation/release_notes/release_notes_latest.markdown
+++ b/documentation/release_notes/release_notes_latest.markdown
@@ -4,20 +4,9 @@ layout: default
 canonical: "/puppetdb/latest/release_notes.html"
 ---
 
-[configure_postgres]: ./configure.html#using-postgresql
-[kahadb_corruption]: /puppetdb/4.2/trouble_kahadb_corruption.html
-[pg_trgm]: http://www.postgresql.org/docs/current/static/pgtrgm.html
-[upgrading]: ./api/query/v4/upgrading-from-v3.html
-[puppetdb-module]: https://forge.puppetlabs.com/puppetlabs/puppetdb
-[migrate]: /puppetdb/3.2/migrate.html
-[upgrades]: ./upgrade.html
-[metrics]: ./api/metrics/v1/changes-from-puppetdb-v3.html
-[pqltutorial]: ./api/query/tutorial-pql.html
-[stockpile]: https://github.com/puppetlabs/stockpile
-[queue_support_guide]: ./pdb_support_guide.html#message-queue
-[upgrade_policy]: ./versioning_policy.html#upgrades
-[facts]: ./api/query/v4/facts.html
-[puppet_apply]: ./connect_puppet_apply.html
+[configure_postgres]: ../configure.html#using-postgresql
+[metrics]: ../api/metrics/v1/changes-from-puppetdb-v3.html
+[puppet_apply]: ../connect_puppet_apply.html
 
 ---
 


### PR DESCRIPTION
Since our release notes were moved to a release notes folder, the old
links that start with `./` are no longer correct. This changes those
links to `../`.

Also removes unused links so that they are not incorrectly used in
future release notes.