### PR TITLE
(RE-14082) Monkey-patch docker ezbake build Ruby

### DIFF
--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -99,6 +99,10 @@ COPY . /puppetdb
 # manually copy over bootstrap.cfg to work around symlink issues on windows
 COPY resources/puppetlabs/puppetdb/bootstrap.cfg /puppetdb/resources/ext/config/bootstrap.cfg
 WORKDIR /puppetdb
+
+# Fixes a linux 5.6 - 5.10 kernel bug around copy_file_range syscall
+# https://github.com/docker/for-linux/issues/1015
+ENV RUBYOPT=-r/puppetdb/docker/ruby-docker-copy-patch
 RUN lein clean && lein install && \
     EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS=true EZBAKE_NODEPLOY=true COW=base-bionic-amd64.cow MOCK='' GEM_SOURCE=https://rubygems.org lein with-profile ezbake ezbake local-build && \
     mv /puppetdb/output/deb/bionic/*/*.deb /puppetdb.deb

--- a/docker/ruby-docker-copy-patch.rb
+++ b/docker/ruby-docker-copy-patch.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+# Fixes a linux 5.6 - 5.10 kernel bug around copy_file_range syscall
+# https://github.com/docker/for-linux/issues/1015
+
+module FileUtils
+  class Entry_
+    def copy_file(dest)
+      File.open(path) do |s|
+        File.open(dest, 'wb', s.stat.mode) do |d|
+          s.chmod s.lstat.mode
+          IO.copy_stream(s, d)
+          d.chmod(d.lstat.mode)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
FOSS port of pe-puppetdb's 0886afb401129df40da1d0965b91ee2c08c76e7a

There's a particularly gnarly bug in Linux kernels 5.6 to 5.10 that
can result in 0 byte files being written when copying files inside
containers in a specific workflow as described in:

docker/for-linux#1015

This impacts the packaging gem used by ezbake when it renders ERB
templates, resulting in 0 byte files critical to the execution of
the build process.

Using a different filesystem (like tmpfs) for /tmp as a workaround
didn't seem to work.

Since there is no way to explicitly control the kernel version in
environments like Travis, the best approach is to monkey-patch the
_Entry class in Ruby that supports FileUtils.cp, such that a no-op
mode change is performed on the source and destination files before
and after being written to prevent the 0 byte files from being
written. In local OSX testing, no-op modifying the source file prior
to copy is the solution, but other users reported that no-op
modifying the destination file worked for them -- both solutions are
therefore employed for completeness.

This is a really hacky solution, but it only impacts two specific
scenarios:

* Developer builds against any commit in a branch without using
  mismatched packages
* Travis CI PR testing