### PR TITLE
(maint) Include OS in gh action cache key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
       - uses: actions/cache@v2
         with:
-          key: ${{ matrix.flavor }}-${{ hashFiles('project.clj') }}
+          key: ${{ matrix.flavor }}-${{ runner.os }}-${{ hashFiles('project.clj') }}
           path: |
             ci/local/jdk
             vendor/bundle/ruby


### PR DESCRIPTION
...given, for example, the caching of the JDK.