### PR TITLE
(maint) Remove old ruby deps, update pql examples

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,20 +28,11 @@ group :test do
   # Add test-unit for ruby 2.2+ support (has been removed from stdlib)
   gem 'test-unit'
 
-  # Pinning for Ruby 1.9.3 support
-  gem 'json_pure', '~> 1.8'
-  # Pinning for Ruby < 2.2.0 support
-  gem 'activesupport', '~> 4.2'
+  gem 'rspec'
 
-  # addressable 2.5 requires public_suffix, which requires ruby 2.
-  gem 'addressable', '< 2.5.0'
-
-  # Pinning to work-around an incompatiblity with 2.14 in puppetlabs_spec_helper
-  gem 'rspec', '~> 3.1'
-  gem 'puppetlabs_spec_helper', '0.10.3', :require => false
-
-  # docker-api 1.32.0 requires ruby 2.0.0
-  gem 'docker-api', '1.31.0'
+  # FIXME: going to version 1.0.0 breaks a lot of rspec tests. The changelog
+  # doesn't list any breaking changes, so we'll need to investigate more.
+  gem 'puppetlabs_spec_helper', '0.10.3'
 
   case puppet_ref
   when "latest"

--- a/documentation/api/query/examples-pql.markdown
+++ b/documentation/api/query/examples-pql.markdown
@@ -53,10 +53,10 @@ nodes { certname ~ 'green' }
 
 ***
 
-### Querying for active nodes
+### Querying for inactive nodes
 
 ``` ruby
-nodes {deactivated is null and expired is null}
+nodes { node_state = "inactive" }
 ```
 
 *Output:*
@@ -68,7 +68,7 @@ nodes {deactivated is null and expired is null}
         "catalog_environment": "production",
         "catalog_timestamp": "2016-08-15T11:06:26.275Z",
         "certname": "foo.com",
-        "deactivated": null,
+        "deactivated": "2016-08-17T13:04:41.421Z",
         "expired": null,
         "facts_environment": "production",
         "facts_timestamp": "2016-08-15T11:06:26.140Z",
@@ -321,8 +321,7 @@ inventory[certname] { facts.mcollective.server.collectives.match("\d+") = "dc1" 
 Show active nodes that have the profile class `Profile::Remote_mgmt` applied to it.
 
 ``` ruby
-nodes { resources { type = "Class" and title = "Profile::Remote_mgmt" }
-        and expired is null and deactivated is null}
+nodes { resources { type = "Class" and title = "Profile::Remote_mgmt" } }
 ```
 
 *Output:*


### PR DESCRIPTION
Removes some old Ruby test dependencies, which should remove some spurious warning in Github.

Removes some _very old_ query documentation on querying for active nodes.