### PR TITLE
(PDB-5214) (Re)allow dotted projections with group_by and functions (wrt 6.18.0)

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -2175,12 +2175,15 @@
    into its function name. Throws an IllegalArgumentException if there is an
    invalid field or function"
   [query-rec column-or-fn-name]
-  (or (get-in query-rec [:projections column-or-fn-name :field])
-      (if (some #{column-or-fn-name} (keys pdb-fns->pg-fns))
-        (keyword column-or-fn-name)
-        (throw (IllegalArgumentException.
-                (tru "{0} is niether a valid column name nor function name"
-                     (pr-str column-or-fn-name)))))))
+  ;; Just split on dot for now (as a hack) - we'll use the strict
+  ;; parser once it's available (after 6.18.0 and 7.5.0)."
+  (let [[root] (str/split column-or-fn-name #"\." 2)]
+    (or (get-in query-rec [:projections root :field])
+        (if (some #{column-or-fn-name} (keys pdb-fns->pg-fns))
+          (keyword column-or-fn-name)
+          (throw (IllegalArgumentException.
+                  (tru "{0} is niether a valid column name nor function name"
+                       (pr-str column-or-fn-name))))))))
 
 (defn group-by-entries->fields
   "Convert a list of group by columns and functions to their true SQL field names."

--- a/test/puppetlabs/puppetdb/http/inventory_test.clj
+++ b/test/puppetlabs/puppetdb/http/inventory_test.clj
@@ -170,7 +170,12 @@
 
      ;; TODO figure out what behavior we want for queries with null w/o a dotted path
      ["null?" "facts" true]
-     #{})))
+     #{}
+
+     ["extract" [["function", "count"] "facts.domain"]
+      ["group_by" "facts.domain"]]
+     #{{:facts.domain "testing.com" :count 1}
+       {:facts.domain nil :count 1}})))
 
 (deftest-http-app inventory-queries
   [[version endpoint] inventory-endpoints
@@ -213,8 +218,8 @@
                     [["function" "count" "certname"]]
                       ["in" "facts.os.family" ["array" ["RedHat"]]]]
             {:keys [body status]} (query-response method endpoint query)]
-        (is (= status 500))
-        (is (= body "Value does not match schema: (not (map? nil))"))))
+        (is (= 500 status))
+        (is (= "Value does not match schema: (not (map? nil))" body))))
 
     (testing "inventory queries"
       (testing "well-formed queries"
@@ -224,7 +229,7 @@
                             (get-request endpoint (json/generate-string query))
                             (get-request endpoint))
                   {:keys [status body headers]} (*app* request)]
-              (is (= status http/status-ok))
+              (is (= http/status-ok status))
               (is (http/json-utf8-ctype? (headers "Content-Type")))
               (is (= (set result)
                      (set (json/parse-string (slurp body) true)))))))))))


### PR DESCRIPTION
Dotted projection arguments to group_by and functions were being
rejected.  Fix that, and add some initial tests.

  ["from" "inventory"
   ["extract" [["function" "count"] "facts.kernel"]
    ["=" "node_state" "active"]
    ["group_by" "facts.kernel"]]]