### PR TITLE
(maint) Fix integration tests

### DIFF
--- a/test/puppetlabs/puppetdb/integration/puppetserver_metrics.clj
+++ b/test/puppetlabs/puppetdb/integration/puppetserver_metrics.clj
@@ -35,7 +35,6 @@
               (is (= #{["puppetdb" "command" "replace_catalog"]
                        ["puppetdb" "command" "replace_facts"]
                        ["puppetdb" "command" "store_report"]
-                       ["puppetdb" "facts" "find"]
                        ["puppetdb" "query"]
                        ["puppetdb" "resource" "search"]}
                      (set (map :metric-id metrics)))))))))

--- a/test/puppetlabs/puppetdb/integration/reports.clj
+++ b/test/puppetlabs/puppetdb/integration/reports.clj
@@ -253,7 +253,7 @@
                   (filter #(= "notice" (:level %))
                           logs))))
 
-        (is (= 6 (count
+        (is (= 5 (count
                   (filter #(= "info" (:level %))
                           logs))))))))
 


### PR DESCRIPTION
[This puppet PR](https://github.com/puppetlabs/puppet/pull/8691) removed the node definition request that previously made a "facts find" call to PDB to gather the facts. Also an info message is no longer printed by puppet.