### PR TITLE
(PDB-5226) group by dotted SQL identifier

### DIFF
--- a/test/puppetlabs/puppetdb/admin_test.clj
+++ b/test/puppetlabs/puppetdb/admin_test.clj
@@ -81,11 +81,13 @@
                   first)))
        (is (= (tuc/munge-catalog example-catalog)
               (tuc/munge-catalog (get-catalogs example-certname))))
-       (is (= [(tur/update-report-pe-fields test-report)
-               (tur/update-report-pe-fields plan-report)]
-              (filter-reports [:and
-                   [:= :certname example-certname]
-                   [:null? :type false]])))
+       (let [expected [(tur/update-report-pe-fields test-report)
+                       (tur/update-report-pe-fields plan-report)]
+             actual (filter-reports [:and
+                                     [:= :certname example-certname]
+                                     [:null? :type false]])]
+         (is (= (count expected) (count actual)))
+         (is (= (set expected) (set actual))))
        (is (= (tuf/munge-facts example-facts)
               (tuf/munge-facts (get-factsets example-certname))))
 
@@ -107,11 +109,13 @@
 
        (is (= (tuc/munge-catalog example-catalog)
               (tuc/munge-catalog (get-catalogs example-certname))))
-       (is (= [(tur/update-report-pe-fields test-report)
-               (tur/update-report-pe-fields plan-report)]
-              (filter-reports [:and
-                               [:= :certname example-certname]
-                               [:null? :type false]])))
+       (let [expected [(tur/update-report-pe-fields test-report)
+                       (tur/update-report-pe-fields plan-report)]
+             actual (filter-reports [:and
+                                     [:= :certname example-certname]
+                                     [:null? :type false]])]
+         (is (= (count expected) (count actual)))
+         (is (= (set expected) (set actual))))
        (is (= (tuf/munge-facts example-facts)
               (tuf/munge-facts (get-factsets example-certname))))
 

--- a/test/puppetlabs/puppetdb/http/inventory_test.clj
+++ b/test/puppetlabs/puppetdb/http/inventory_test.clj
@@ -174,7 +174,7 @@
 
      ["extract" [["function", "count"] "facts.domain"]
       ["group_by" "facts.domain"]]
-     #{{:facts.domain "testing.com" :count 1}
+     #{{:facts.domain "testing.com" :count 2}
        {:facts.domain nil :count 1}})))
 
 (deftest-http-app inventory-queries


### PR DESCRIPTION
dotted fact paths should be grouped by their SQL identier "facts.foo"
instead of the actual SQL field `(fs.volatile||fs.stable)` like a
traditiional column. Fixes an error in a group by inventory-test.

Also fixes a transient in the admin-test where the query result order
could fail the test.