### PR TITLE
(maint) Fix report integration test

### DIFF
--- a/test/puppetlabs/puppetdb/integration/reports.clj
+++ b/test/puppetlabs/puppetdb/integration/reports.clj
@@ -253,7 +253,7 @@
                   (filter #(= "notice" (:level %))
                           logs))))
 
-        (is (= 5 (count
+        (is (= 6 (count
                   (filter #(= "info" (:level %))
                           logs))))))))
 


### PR DESCRIPTION
Due to this [PR](https://github.com/puppetlabs/puppet/pull/8733/files#diff-51e52bffe1de00c153bde14dea475f15abdcb6a1fdaf2691633dad8238e654cfR310) there is an extra log added that prints the environment when puppet starts. This causes the reports integration test to fail. 
@rbrw @austb @joshcooper Can you please have a look?