### PR TITLE
(PDB-4731) Invalidate extract clause

### DIFF
--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -2286,6 +2286,14 @@
       (throw (IllegalArgumentException. (tru "{0} is not a valid function"
                                              (pr-str f)))))))
 
+(defn invalidate-extract
+  [query-rec expr]
+  (doseq [elem expr]
+    (if (nil? (user-node->plan-node query-rec elem))
+      (throw (IllegalArgumentException. (tru "{0} is not a valid expression for \"extract\""
+                                             (pr-str elem))))))
+  nil)
+
 (defn user-node->plan-node
   "Create a query plan for `node` in the context of the given query (as `query-rec`)"
   [query-rec node]
@@ -2485,6 +2493,9 @@
             (-> query-rec
                 (assoc :group-by (group-by-entries->fields query-rec clauses))
                 (create-extract-node column expr))
+
+            [["extract" column & expr]]
+            (invalidate-extract query-rec expr)
 
             :else nil))
 

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -457,6 +457,24 @@
                  body))
     (is (= 400 status))))
 
+(deftest-http-app invalid-extract
+  [[version endpoint] endpoints
+   method [:get :post]]
+
+  (let [{:keys [status body]} (query-response method endpoint ["extract" [["function" "count"] "certname"]
+                                                               ["null?" "type" false]
+                                                               ["groupy_by" "certname"]])]
+    (is (re-matches #".* is not a valid expression for \"extract\".*"
+                    body))
+    (is (= 400 status)))
+
+  (let [{:keys [status body]} (query-response method endpoint ["extract" [["function" "count"] "certname"]
+                                                               ["null?" "type" false]
+                                                               ["some_invalid_string"]])]
+    (is (re-matches #".* is not a valid expression for \"extract\".*"
+                    body))
+    (is (= 400 status))))
+
 (deftest-http-app query-by-status
   [[version endpoint] endpoints
    method [:get :post]]


### PR DESCRIPTION
**Problem:** If a query with an `extract` clause contains a misspelled option, the clause is completely ignored resulting in a misleading response body.
      Eg. `["from", "reports", ["extract", [["function", "count", "certname"]], ["null?", "type", false], ["groupy_by", "certname"]]]`
will return all the reports because the `extract` will be ignored ( it contains `groupy_by` instead of `group_by`).
 
**What was done:** Instead of returning nil for a malformed `extract` clause (when converting the query to a sql plan), try to identify the misspelled part and log an appropriate error message.