### PR TITLE
(PDB-5256) Add details to message when AST validation fails

### DIFF
--- a/documentation/api/query/examples-pql.markdown
+++ b/documentation/api/query/examples-pql.markdown
@@ -243,7 +243,7 @@ report indicated a failure.
 
 ```
 inventory[certname, facts.os.family, facts.puppetversion] {
-  certname in nodes { latest_report_status = "failed" }
+  certname in nodes[certname] { latest_report_status = "failed" }
 }
 ```
 

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -129,12 +129,13 @@
                         (log/error e (trs "Unknown exception when processing ast to add report type filter(s)."))
                         (throw e))
                       (log/error e msg)
-                      ::failed))
+                      {:type ::failed, :message msg}))
                   (catch Exception e
                     (log/error e (trs "Unknown exception when processing ast to add report type filter(s)."))
                     (throw e)))]
-        (if (= ast ::failed)
-          (throw (ex-info "AST validation failed, but was successfully converted to SQL. Please file a PuppetDB ticket at https://tickets.puppetlabs.com"
+        (if (and (map? ast) (= (:type ast) ::failed))
+          (throw (ex-info (trs "AST validation failed, but was successfully converted to SQL. Please file a PuppetDB ticket at https://tickets.puppetlabs.com \n{0}"
+                               (:message ast))
                           {:kind ::dr/unrecognized-ast-syntax
                            :ast query
                            :sql (eng/compile-user-query->sql query-rec query options)}))

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -828,7 +828,7 @@
              ;; This is abusing the existence of PDB-4734 to throw an error from a malformed AST query
              (let [{:keys [status body]} (query-response method endpoint query)]
                 (is (= status http/status-internal-error))
-                (is (re-matches #"AST validation failed, but was successfully converted to SQL.*" body)))))))
+                (is (re-matches #"(?s)AST validation failed, but was successfully converted to SQL.*Unrecognized ast clause.*" body)))))))
 
     (testing "agent report filter can be disabled"
        (with-test-db


### PR DESCRIPTION
Example: 
`AST validation failed, but was successfully converted to SQL. Please file a PuppetDB ticket at https://tickets.puppetlabs.com
Unrecognized ast clause ["order_by" "certname"] in ast query ["extract" "certname" ["subquery" "reports" ["order_by" "certname"]]]`

Also updated docs that had invalid query as example.