### PR TITLE
(maint) Fix outdated index.html docs references

### DIFF
--- a/documentation/_puppetdb_nav.html
+++ b/documentation/_puppetdb_nav.html
@@ -3,7 +3,7 @@
 {% md %}
 
 * **General information**
-    * [Overview and requirements]({{puppetdb}}/index.html)
+    * [Overview and requirements]({{puppetdb}}/overview.html)
     * [Contributing to PuppetDB]({{puppetdb}}/CONTRIBUTING.html)
     * [Frequently asked questions]({{puppetdb}}/puppetdb-faq.html)
     * [Release notes]({{puppetdb}}/release_notes.html)
@@ -39,7 +39,7 @@
     * [Examples]({{puppetdb}}/api/query/examples-pql.html)
 
 * **API**
-    * [Overview]({{puppetdb}}/api/index.html)
+    * [Overview]({{puppetdb}}/api/overview.html)
     * [Query tutorial]({{puppetdb}}/api/query/tutorial.html)
     * [Curl tips]({{puppetdb}}/api/query/curl.html)
 * **Query API version 4**
@@ -48,7 +48,7 @@
     * [Entities]({{puppetdb}}/api/query/v4/entities.html)
     * [AST query language]({{puppetdb}}/api/query/v4/ast.html)
     * [Query paging]({{puppetdb}}/api/query/v4/paging.html)
-    * [Root endpoint]({{puppetdb}}/api/query/v4/index.html)
+    * [Root endpoint]({{puppetdb}}/api/query/v4/overview.html)
     * [Nodes endpoint]({{puppetdb}}/api/query/v4/nodes.html)
     * [Environments endpoint]({{puppetdb}}/api/query/v4/environments.html)
     * [Producers endpoint]({{puppetdb}}/api/query/v4/producers.html)

--- a/documentation/api/metrics/v1/mbeans.markdown
+++ b/documentation/api/metrics/v1/mbeans.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Metrics endpoint"
 layout: default
-canonical: "/puppetdb/latest/api/metrics/v1/index.html"
+canonical: "/puppetdb/latest/api/metrics/v1/overview.html"
 ---
 
 # Metrics endpoint

--- a/documentation/api/overview.markdown
+++ b/documentation/api/overview.markdown
@@ -1,7 +1,7 @@
 ---
 title: "API overview"
 layout: default
-canonical: "/puppetdb/latest/api/index.html"
+canonical: "/puppetdb/latest/api/overview.html"
 ---
 
 # API overview

--- a/documentation/api/query/v4/overview.markdown
+++ b/documentation/api/query/v4/overview.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Root endpoint"
 layout: default
-canonical: "/puppetdb/latest/api/query/v4/index.html"
+canonical: "/puppetdb/latest/api/query/v4/overview.html"
 ---
 # Root endpoint
 


### PR DESCRIPTION
This fixes the spots in the documentation markdown where `index.html` was not changed to `overview.html` in the previous docs bugfix commit