### PR TITLE
(maint) Fix certificates main

### DIFF
--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -8,7 +8,8 @@ unless (test_config[:skip_presuite_provisioning])
     when :fedora
       on master, "yum install -y ca-certificates"
     when :debian
-      on master, "apt-get install -y ca-certificates"
+      on master, "apt-get install -y ca-certificates libgnutls30"
+      on master, "apt-get update"
     end
   end
 


### PR DESCRIPTION
Recently a major root certificate expired and had to be replaced. This
caused postgres to fail to install, on platforms where we install PDB.
This commit adds a step to our presuite that fetches new CA certificates,
to ensure that next time a cert is rotated, we will fetch it automatically.