### PR TITLE
(maint) test: work around old redhat6 package

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -293,6 +293,11 @@ module PuppetDBExtensions
     return test_config[:os_families].has_key? 'debian10-64-1'
   end
 
+  def is_el6()
+    return test_config[:os_families].has_key?('redhat6-64-1') ||
+           test_config[:os_families].has_key?('centos6-64-1')
+  end
+
   def is_el8()
     return test_config[:os_families].has_key?('redhat8-64-1') ||
            test_config[:os_families].has_key?('centos8-64-1')

--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -4,6 +4,11 @@ unless (test_config[:skip_presuite_provisioning])
     os = test_config[:os_families][master.name]
     case os
     when :redhat
+      if is_el6
+        # workaround for old ca-certificates package, trick
+        # yum into looking for a newer redhat 6.y version's package
+        on master, "rm -f /etc/yum.repos.d/localmirror-extras.repo /etc/yum.repos.d/localmirror-optional.repo &&  sed -i 's/68/610/' /etc/yum.repos.d/localmirror-os.repo"
+      end
       on master, "yum install -y ca-certificates"
     when :fedora
       on master, "yum install -y ca-certificates"


### PR DESCRIPTION
The ca-certificates package available on redhat6 is quite old, so this
updates the yum repos to look for the package from a newer version of
redhat6