### PR TITLE
(PDB-5326) Add db storage for workspaces

### DIFF
--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -69,6 +69,6 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 79$' "$tmpdir/out"
+grep -qE ' 80$' "$tmpdir/out"
 
 test ! -e "$PDBBOX"/var/mq-migrated

--- a/resources/ext/cli/delete-reports.erb
+++ b/resources/ext/cli/delete-reports.erb
@@ -78,7 +78,7 @@ chown "$pg_user:$pg_user" "$tmp_dir"
 
 # Verify that the PuppetDB schema version it the expected value
 # so that we do not incorrectly delete the report data.
-expected_schema_ver=79
+expected_schema_ver=80
 su - "$pg_user" -s /bin/sh -c "$psql_cmd -p $pg_port -d $pdb_db_name -c 'COPY ( SELECT max(version) FROM schema_migrations ) TO STDOUT;' > $tmp_dir/schema_ver"
 actual_schema_ver="$(cat "$tmp_dir/schema_ver")"
 if test "$actual_schema_ver" -ne $expected_schema_ver; then

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -2038,6 +2038,19 @@
   (jdbc/do-commands
    "ALTER TABLE certnames ADD COLUMN catalog_inputs_hash bytea"))
 
+(defn add-workspaces-tables
+  []
+  (jdbc/do-commands
+   ["CREATE TABLE workspaces ("
+    "  uuid UUID PRIMARY KEY,"
+    "  updated TIMESTAMP WITH TIME ZONE NOT NULL)"]
+
+   ["CREATE TABLE workspace_memberships ("
+    "  workspace_uuid UUID,"
+    "  certname TEXT NOT NULL,"
+    "  PRIMARY KEY (workspace_uuid, certname),"
+    "  FOREIGN KEY (workspace_uuid) REFERENCES workspaces(uuid) ON DELETE CASCADE)"]))
+
 (def migrations
   "The available migrations, as a map from migration version to migration function."
   {00 require-schema-migrations-table
@@ -2100,7 +2113,8 @@
    76 add-report-partition-indexes-on-id
    77 add-catalog-inputs-pkey
    78 add-catalog-inputs-hash
-   79 add-report-partition-indexes-on-certname-end-time})
+   79 add-report-partition-indexes-on-certname-end-time
+   80 add-workspaces-tables})
    ;; Make sure that if you change the structure of reports
    ;; or resource events, you also update the delete-reports
    ;; cli command.

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -1514,3 +1514,153 @@
                               :same nil}]
                 :constraint-diff nil}
                (diff-schema-maps before-migration (schema-info-map *db*))))))))
+
+(deftest migration-80-adds-workspaces-tables
+  (testing "workspaces tables migration"
+    (jdbc/with-db-connection *db*
+      (clear-db-for-testing!)
+      (fast-forward-to-migration! 79)
+      (let [before-migration (schema-info-map *db*)]
+        (apply-migration-for-testing! 80)
+        (is (= {:index-diff
+                [{:left-only nil,
+                  :right-only
+                  {:schema "public",
+                   :table "workspace_memberships",
+                   :index "workspace_memberships_pkey",
+                   :index_keys ["workspace_uuid" "certname"],
+                   :type "btree",
+                   :unique? true,
+                   :functional? false,
+                   :is_partial false,
+                   :primary? true,
+                   :user "pdb_test"},
+                  :same nil}
+                 {:left-only nil,
+                  :right-only
+                  {:schema "public",
+                   :table "workspaces",
+                   :index "workspaces_pkey",
+                   :index_keys ["uuid"],
+                   :type "btree",
+                   :unique? true,
+                   :functional? false,
+                   :is_partial false,
+                   :primary? true,
+                   :user "pdb_test"},
+                  :same nil}],
+                :table-diff
+                [{:left-only nil,
+                  :right-only
+                  {:numeric_scale nil,
+                   :column_default nil,
+                   :character_octet_length 1073741824,
+                   :datetime_precision nil,
+                   :nullable? "NO",
+                   :character_maximum_length nil,
+                   :numeric_precision nil,
+                   :numeric_precision_radix nil,
+                   :data_type "text",
+                   :column_name "certname",
+                   :table_name "workspace_memberships"},
+                  :same nil}
+                 {:left-only nil,
+                  :right-only
+                  {:numeric_scale nil,
+                   :column_default nil,
+                   :character_octet_length nil,
+                   :datetime_precision nil,
+                   :nullable? "NO",
+                   :character_maximum_length nil,
+                   :numeric_precision nil,
+                   :numeric_precision_radix nil,
+                   :data_type "uuid",
+                   :column_name "workspace_uuid",
+                   :table_name "workspace_memberships"},
+                  :same nil}
+                 {:left-only nil,
+                  :right-only
+                  {:numeric_scale nil,
+                   :column_default nil,
+                   :character_octet_length nil,
+                   :datetime_precision 6,
+                   :nullable? "NO",
+                   :character_maximum_length nil,
+                   :numeric_precision nil,
+                   :numeric_precision_radix nil,
+                   :data_type "timestamp with time zone",
+                   :column_name "updated",
+                   :table_name "workspaces"},
+                  :same nil}
+                 {:left-only nil,
+                  :right-only
+                  {:numeric_scale nil,
+                   :column_default nil,
+                   :character_octet_length nil,
+                   :datetime_precision nil,
+                   :nullable? "NO",
+                   :character_maximum_length nil,
+                   :numeric_precision nil,
+                   :numeric_precision_radix nil,
+                   :data_type "uuid",
+                   :column_name "uuid",
+                   :table_name "workspaces"},
+                  :same nil}],
+                :constraint-diff
+                [{:left-only nil,
+                  :right-only
+                  {:constraint_name "certname IS NOT NULL",
+                   :table_name "workspace_memberships",
+                   :constraint_type "CHECK",
+                   :initially_deferred "NO",
+                   :deferrable? "NO"},
+                  :same nil}
+                 {:left-only nil,
+                  :right-only
+                  {:constraint_name "workspace_memberships_pkey",
+                   :table_name "workspace_memberships",
+                   :constraint_type "PRIMARY KEY",
+                   :initially_deferred "NO",
+                   :deferrable? "NO"},
+                  :same nil}
+                 {:left-only nil,
+                  :right-only
+                  {:constraint_name "workspace_memberships_workspace_uuid_fkey",
+                   :table_name "workspace_memberships",
+                   :constraint_type "FOREIGN KEY",
+                   :initially_deferred "NO",
+                   :deferrable? "NO"},
+                  :same nil}
+                 {:left-only nil,
+                  :right-only
+                  {:constraint_name "workspace_uuid IS NOT NULL",
+                   :table_name "workspace_memberships",
+                   :constraint_type "CHECK",
+                   :initially_deferred "NO",
+                   :deferrable? "NO"},
+                  :same nil}
+                 {:left-only nil,
+                  :right-only
+                  {:constraint_name "updated IS NOT NULL",
+                   :table_name "workspaces",
+                   :constraint_type "CHECK",
+                   :initially_deferred "NO",
+                   :deferrable? "NO"},
+                  :same nil}
+                 {:left-only nil,
+                  :right-only
+                  {:constraint_name "uuid IS NOT NULL",
+                   :table_name "workspaces",
+                   :constraint_type "CHECK",
+                   :initially_deferred "NO",
+                   :deferrable? "NO"},
+                  :same nil}
+                 {:left-only nil,
+                  :right-only
+                  {:constraint_name "workspaces_pkey",
+                   :table_name "workspaces",
+                   :constraint_type "PRIMARY KEY",
+                   :initially_deferred "NO",
+                   :deferrable? "NO"},
+                  :same nil}]}
+               (diff-schema-maps before-migration (schema-info-map *db*))))))))

--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.puppetdb.testutils.db
   (:require [clojure.data]
             [clojure.java.jdbc :as sql]
+            [clojure.pprint :refer [pprint]]
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.test]
@@ -531,3 +532,12 @@ ORDER BY idx.indrelid :: REGCLASS, i.relname;")
                         "\nRight Only:\n" (pprint-str right-only)
                         "\nSame:\n" (pprint-str same)))
                  diff-list)))
+
+(defn print-diff-schema-maps
+  "This function pretty prints the output from diff-schema-maps after changing
+  the internal sequences into vectors. This makes it easy to copy and paste
+  into a deftest that checks diff-schema-maps output"
+  [diff]
+  (pprint (reduce-kv (fn [m k v] (assoc m k (when (seq? v) (vec v))))
+                     {}
+                     diff)))


### PR DESCRIPTION
From first commit message:

This commit creates a new migration which prepares for the upcoming
workspaces feature by adding two new tables: workspaces and
workspace_membership. These tables track workspaces and which certnames
belong in which workspaces. Design specific notes:

- In the workspace_membership table, the certname column purposefully
  does not have a foreign key constraint because we want to potentially
  include deleted certnames in workspace_membership query results