### PR TITLE
(maint) Fix failing integration metrics test

### DIFF
--- a/test/puppetlabs/puppetdb/integration/puppetserver_metrics.clj
+++ b/test/puppetlabs/puppetdb/integration/puppetserver_metrics.clj
@@ -37,7 +37,11 @@
                        ["puppetdb" "command" "store_report"]
                        ["puppetdb" "query"]
                        ["puppetdb" "resource" "search"]}
-                     (set (map :metric-id metrics)))))))))
+                     (disj (set (map :metric-id metrics))
+                           ;; ["puppetdb" "facts" "find"] will only be in the set when
+                           ;; puppetlabs.puppetdb.integration.masterless is run first and
+                           ;; the integration tests are running against puppet#main after 118756370f
+                           ["puppetdb" "facts" "find"]))))))))
 
     (testing "PuppetDB metrics are updated for compressed commands"
       ;; the terminus is configured to send gzipped commands without a
@@ -66,6 +70,8 @@
             metrics-resp (svc-utils/get-ssl new-fact-metrics-url)]
         (is (= 200 (:status metrics-resp)))
         ;; assert that the new-fact-time metric has been updated and no values are 0.0
+        ;; FIXME: OneMinutRate, FiveMinuteRate, FifteenMinuteRate will all be 0.0 unless
+        ;;        puppetlabs.puppetdb.integration.masterless is run first
         (is (->> metrics-resp
                  :body
                  :value


### PR DESCRIPTION
Failing test case
```
lein test :only puppetlabs.puppetdb.integration.puppetserver-metrics/puppetserver-http-client-metrics

FAIL in (puppetserver-http-client-metrics) (puppetserver_metrics.clj:44)
Puppet Server status endpoint contains expected puppetdb metrics
expected: (= #{["puppetdb" "command" "replace_catalog"] ["puppetdb" "command" "store_report"] ["puppetdb" "command" "replace_facts"] ["puppetdb" "resource" "search"] ["puppetdb" "query"]} (set (map :metric-id metrics)))
  actual: (not (= #{["puppetdb" "command" "replace_catalog"] ["puppetdb" "command" "store_report"] ["puppetdb" "command" "replace_facts"] ["puppetdb" "resource" "search"] ["puppetdb" "query"]} #{["puppetdb" "facts" "find"] ["puppetdb" "command" "replace_catalog"] ["puppetdb" "command" "store_report"] ["puppetdb" "command" "replace_facts"] ["puppetdb" "resource" "search"] ["puppetdb" "query"]}))
```

Adds FIXME comments to describe some undesirable behavior we are seeing
the metrics because they are JVM global and persisting between tests.

Something between the commits `118756370f` and `4c0b8e038f` has caused
the tests in puppetlabs.puppetdb.integration.masterless to start calling
`["puppetdb" "facts" "find"]` (only on the `main` branch? this hasn't
failed on 6.x). It is likely caused by changes to how the environment is
loaded in PUP-11328, but it's unclear why it is not failing when testing
PuppetDB against puppetlabs/puppet `6.x`.


```
*   118756370f Josh Cooper 3 weeks ago Merge pull request #8803 from joshcooper/6x_main_merge_oct26
|\
| * e5fcef44cb Josh Cooper 3 weeks ago Merge remote-tracking branch 'upstream/6.x' into 6x_main_merge_oct26
|/|
| *   bb1017f923 Josh Cooper 3 weeks ago Merge pull request #8802 from GabrielNagy/PUP-11328/node-request-fallback
| |\
| | * 867691b617 Josh Cooper 3 weeks ago (PUP-11328) Get the environment's name without loading the environment
| | * 9d3e630a67 Gabriel Nagy 3 weeks ago (PUP-11328) Fallback to node request in configurer
| |/
| * aaae1177c9 Jenkins CI 3 weeks ago (packaging) Updating the puppet.pot file
| *   88905a5505 Gabriel Nagy 3 weeks ago Merge pull request #8784 from luchihoratiu/PUP-11204
| |\
| | * 430ffa30cc Luchian Nemes 4 weeks ago (PUP-11204) Allow `puppet lookup --facts` to receive any filename  (HEAD -> main)
* | | 4c0b8e038f Jenkins CI 3 weeks ago (maint) Merge up 45def53 to main
```