### PR TITLE
(maint) Disable jenkins perf data

### DIFF
--- a/ext/jenkins/beaker-tests.sh
+++ b/ext/jenkins/beaker-tests.sh
@@ -21,7 +21,6 @@ export PUPPETDB_USE_PROXIES=false
 export BEAKER_project=PuppetDB
 export BEAKER_department=sre-dept
 export BEAKER_PRESERVE_HOSTS=onfail
-export BEAKER_COLLECT_PERF_DATA=normal
 
 # Once the necessary PR (puppetlabs/ci-job-configs#2319) has been
 # merged, this logic can be removed.


### PR DESCRIPTION
The sysstat package is failing on redhat6, so disable this on `6.x`.
Since we are removing el6 builds/testing on `main`, this should be
switched back to on in the merge-up