### PR TITLE
(PDB-5391) Fix tests on Debian 11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ if ENV['NO_ACCEPTANCE'] != 'true'
       gem 'beaker', '~> 4.1'
     end
   end
-  gem 'beaker-hostgenerator', '~> 1.2.6'
+  gem 'beaker-hostgenerator', '~> 1.4'
   gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.2')
   gem 'beaker-vmpooler', *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1.3")
   gem 'beaker-puppet', '~> 1.0'

--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -293,6 +293,10 @@ module PuppetDBExtensions
     return test_config[:os_families].has_key? 'debian10-64-1'
   end
 
+  def is_bullseye()
+    return test_config[:os_families].has_key? 'debian11-64-1'
+  end
+
   def is_el6()
     return test_config[:os_families].has_key?('redhat6-64-1') ||
            test_config[:os_families].has_key?('centos6-64-1')
@@ -319,9 +323,12 @@ module PuppetDBExtensions
     when :install, :upgrade_latest
       test_config[:platform_version]
     when :upgrade_oldest
+      # Debian 11 only has builds starting in the 7 series
+      if is_bullseye
+        :puppet7
       # Redhat8, Redhat7-fips, Debian 10, Ubuntu 20
       # only have builds starting somewhere in the 6 series.
-      if is_el8 || is_rhel7fips || is_buster || is_focal
+      elsif is_el8 || is_rhel7fips || is_buster || is_focal
         :puppet6
       else
         :puppet5
@@ -336,6 +343,8 @@ module PuppetDBExtensions
     # account for bionic/rhel8 not having build before certian versions
     if is_bionic
       '5.2.4'
+    elsif is_bullseye
+      '7.9.0'
     elsif is_el8
       '6.0.3'
     elsif is_rhel7fips
@@ -424,6 +433,8 @@ module PuppetDBExtensions
       "#{version}stretch"
     elsif host['platform'].include?('debian-10')
       "#{version}buster"
+    elsif host['platform'].include?('debian-11')
+      "#{version}bullseye"
     else
       raise ArgumentError, "Unsupported platform: '#{host['platform']}'"
     end

--- a/acceptance/setup/pre_suite/05_clear_firewalls.rb
+++ b/acceptance/setup/pre_suite/05_clear_firewalls.rb
@@ -1,6 +1,7 @@
 unless (test_config[:skip_presuite_provisioning])
   step "Flushing iptables chains" do
     hosts.each do |host|
+      on host, 'apt-get install -y iptables' if is_bullseye
       on host, "iptables -F INPUT -t filter"
       on host, "iptables -F FORWARD -t filter"
     end


### PR DESCRIPTION
With a small additional change locally (not commited) to pull and
install puppetserver from our internal staging build servers, this
passes the install tests. Once puppetserver publishes a nightly build,
these acceptance tests will pass in CI.