### PR TITLE
(PDB-5422) Stop garbage collecting at startup

### DIFF
--- a/ext/bin/check-command-perf
+++ b/ext/bin/check-command-perf
@@ -86,7 +86,7 @@ pdb_id=$!
 
 printf "Waiting for PDB startup (log: %q)\n" "$tmpdir/log.txt" 1>&2
 
-while ! grep -Fq "Finished database garbage collection" "$tmpdir/log.txt"; do
+while ! grep -Fq "PuppetDB finished starting" "$tmpdir/log.txt"; do
     sleep 1
     if [ "$(grep -F "Error during service start!!!" "$tmpdir/log.txt")" ]; then
       echo "PDB failed during start-up." 1>&2

--- a/ext/bin/run-locust-load-tests
+++ b/ext/bin/run-locust-load-tests
@@ -62,7 +62,7 @@ kill_pdb
 pdb_script_pid=$!
 
 printf "Waiting for PDB startup (log: %q)\n" "$output_dir/pdb_log.txt" 2>&1
-while ! grep -Fq "Finished database garbage collection" "$output_dir/pdb_log.txt"; do
+while ! grep -Fq "PuppetDB finished starting" "$output_dir/pdb_log.txt"; do
     sleep 1
     printf "."
     if [ "$(grep -F "Error during service start!!!" "$output_dir/pdb_log.txt")" ]; then

--- a/ext/test/schema-mismatch-causes-pdb-shutdown
+++ b/ext/test/schema-mismatch-causes-pdb-shutdown
@@ -73,7 +73,7 @@ touch "$tmpdir/pdb-out" "$tmpdir/pdb-err"
 ./pdb services -c "$PDBBOX/conf.d" 1>"$tmpdir/pdb-out" 2>"$tmpdir/pdb-err"  & pdb_pid=$!
 
 # allow time for pdb to start before changing migration level
-while ! grep -F "Finished database garbage collection" "$tmpdir/pdb-out" > /dev/null
+while ! grep -F "PuppetDB finished starting" "$tmpdir/pdb-out" > /dev/null
 do
     echo 'Waiting for pdb to start...'
     cat "$tmpdir/pdb-out" "$tmpdir/pdb-err"

--- a/test/puppetlabs/puppetdb/acceptance/node_ttl.clj
+++ b/test/puppetlabs/puppetdb/acceptance/node_ttl.clj
@@ -23,7 +23,8 @@
          (-> (svc-utils/create-temp-config)
              (assoc :database *db*)
              (assoc-in [:database :node-ttl] "1s")
-             (assoc-in [:database :node-purge-ttl] "1s"))
+             (assoc-in [:database :node-purge-ttl] "1s")
+             (assoc-in [:database :gc-interval] "0.01"))
          (fn []
            (let [certname "foo.com"
                  catalog (-> (get-in wire-catalogs [8 :empty])


### PR DESCRIPTION
   Upon every startup, PuppetDB previously garbage collected every DB for
which GC was enabled. We no longer want to do this because GC can take a
very long time, upwards of 20 minutes on large installations. This patch
stops GC at startup from occuring by issuing an initial delay to the GC
job scheduler. This initial delay is simply the :gc-interval from the
provided DB config.

Previously, the inital GC job would prune an unlimited number of
partitions, and all subsequent GC would prune partitions incrementally.
Now GC will always prune partitions incrementally.

Some tests expected GC to run upon PDB starting up, so those tests were
changed to have a :gc-interval of "0.01" minutes in order to trigger GC
very quickly. This way, the tests still confirm GC works and they can be
mostly kept in their original state.

Some test scripts were determining if PDB finished starting up by
grep-ing PDB output for "Finished database garbage collection". With
this patch, PDB startup completion should be checked by grep-ing for
"PuppetDB finished starting".

The global promise under the key :initial-gc-finished? is removed.