### PR TITLE
(docs) Add known issue for 6.20.0 and 7.9.0

### DIFF
--- a/documentation/known_issues.markdown
+++ b/documentation/known_issues.markdown
@@ -10,6 +10,17 @@ canonical: "/puppetdb/latest/known_issues.html"
 
 PuppetDB's bugs and feature requests are managed in [Puppet's issue tracker][tracker]. Search this database if you're having problems and please report any new issues to us!
 
+## PuppetDB fact-contents queries take longer than usual
+
+PuppetDB 6.20.0 and 7.9.0 contain [a
+change](https://tickets.puppetlabs.com/browse/PDB-5259) to the fact-contents
+query intended to reduce the reads required by Postgres, and improve
+performance on larger datasets. The changes cause a performance regression when
+used with PostgreSQL JIT compilation enabled. If you have JIT enabled, either
+by setting it in PostgreSQL 11 or running the default settings on PostgreSQL
+12+, you should disable it by setting `jit = off` in your `postgresql.conf`.
+[PDB-5450](https://tickets.puppetlabs.com/browse/PDB-5450)
+
 ## PuppetDB returns an error from the status endpoint
 
 In PuppetDB 6.11.0, 6.11.1, and 6.11.2, when PuppetDB cannot connect to the

--- a/documentation/release_notes_6.markdown
+++ b/documentation/release_notes_6.markdown
@@ -11,6 +11,7 @@ canonical: "/puppetdb/latest/release_notes.html"
 [metrics]: ./api/metrics/v1/changes-from-puppetdb-v3.markdown
 [puppet-apply]: ./connect_puppet_apply.markdown
 [api-overview]: ./api/query/v4/overview.markdown
+[known-issues]: ./known_issues.markdown
 
 ---
 
@@ -23,7 +24,7 @@ Released January 20 2022
 ### New features and improvements
 
 * Improved performance of the "deactivate node" command. ([PDB-5378](https://tickets.puppetlabs.com/browse/PDB-5378))
-* Improved performance of the fact-contents endpoint. Testing against a database of 10,000 mocked nodes, there was an observed 84% decrease in time taken to complete a difficult query. ([PDB-5259](https://tickets.puppetlabs.com/browse/PDB-5259)
+* Improved performance of the fact-contents endpoint. Testing against a database of 10,000 mocked nodes, there was an observed 84% decrease in time taken to complete a difficult query. This optimization has a [known issue][known-issues] with PostgreSQL JIT compilation. ([PDB-5259](https://tickets.puppetlabs.com/browse/PDB-5259))
 
 ### Bug Fixes
 


### PR DESCRIPTION
PDB-5259 has an issue with PostgreSQL JIT compilation, which was
reported in PDB-5450. The workaround is to disable JIT compilation
(which is the default in PG 11, and can be set in PG 12+).