### PR TITLE
(maint) Add clj-kondo linter config

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {puppetlabs.puppetdb.schema/defn-validated schema.core/defn}}


### PR DESCRIPTION
clj-kondo is a popular Clojure linter used by clojure-lsp. There are certain common macros in the PDB codebase that clj-kondo does not recognize, causing it to emit tons of error messages. The `:lint-as` clj-kondo config option can help avoid these superfluous error messages be telling clj-kondo how to lint these macros.