### PR TITLE
(PT-1027) Add desired policy storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,11 @@ jobs:
       env: PDB_TEST=core+ext/openjdk11/pg-14
       script: *run-core-and-ext-tests
 
+    - stage: ❧ pdb tests
+      name: core+ext jdk-11 pg-11 (experimental)
+      env: PDB_TEST=core+ext/openjdk11/pg-11 PDB_EXPERIMENTAL_FEATURES=all
+      script: *run-core-and-ext-tests
+
     # Legacy testing, we do not promise support for jdk 8 or pg 9.6
     - stage: ❧ pdb tests
       name: core+ext jdk-8 pg-11
@@ -111,6 +116,11 @@ jobs:
     - stage: ❧ pdb tests
       name: int pup-main srv-main jdk-11 pg-11 rich
       env: PDB_TEST=int/openjdk11/pup-main/srv-main/pg-11/rich
+      script: *run-integration-tests
+
+    - stage: ❧ pdb tests
+      name: int pup-main srv-main jdk-11 pg-11 rich (experimental)
+      env: PDB_TEST=int/openjdk11/pup-main/srv-main/pg-11/rich PDB_EXPERIMENTAL_FEATURES=all
       script: *run-integration-tests
 
     # === integration with Platform 6 branches

--- a/ext/test/top-level-cli
+++ b/ext/test/top-level-cli
@@ -41,8 +41,13 @@ rc=0
 cat "$tmpdir/out" "$tmpdir/err"
 test "$rc" -eq 0
 grep -F 'Available subcommands:' "$tmpdir/out"
-grep -E 'Display version information' "$tmpdir/out"
-test $(wc -c < "$tmpdir/err") -eq $expected_help_warnings
+grep -F 'Display version information' "$tmpdir/out"
+
+if ! test $(wc -c < "$tmpdir/err") -eq "$expected_help_warnings"; then
+    echo 'ERROR: Unpected1 help warnings:' 1>&2
+    cat "$tmpdir/err"
+    false
+fi
 
 rc=0
 ./pdb version 1>"$tmpdir/out" 2>"$tmpdir/err" || rc=$?

--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -69,6 +69,15 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 80$' "$tmpdir/out"
+case "${PDB_EXPERIMENTAL_FEATURES:-}" in
+    all|all\ *|*\ all|policies|policies\ *|*\ policies)
+        expected_migration=81
+        ;;
+    *)
+        expected_migration=80
+        ;;
+esac
+
+grep -qE " $expected_migration"'$' "$tmpdir/out"
 
 test ! -e "$PDBBOX"/var/mq-migrated

--- a/pdb
+++ b/pdb
@@ -3,8 +3,20 @@
 set -e
 
 jar="${PDB_JAR:-target/puppetdb.jar}"
-bcprov="${BCPROV_JAR:-$HOME/.m2/repository/org/bouncycastle/bcprov-jdk15on/1.68/bcprov-jdk15on-1.68.jar}"
-bcpkix="${BCPKIX_JAR:-$HOME/.m2/repository/org/bouncycastle/bcpkix-jdk15on/1.68/bcpkix-jdk15on-1.68.jar}"
+
+if test "$BCPROV_JAR"; then
+    bcprov="$BCPROV_JAR"
+else
+    bcprov_ver=$(lein deps :query org.bouncycastle/bcprov-jdk15on 2>/dev/null)
+    bcprov="$HOME/.m2/repository/org/bouncycastle/bcprov-jdk15on/$bcprov_ver/bcprov-jdk15on-$bcprov_ver.jar"
+fi
+
+if test "$BCPKIX_JAR"; then
+    bcpkix="$BCPKIX_JAR"
+else
+    bcpkix_ver=$(lein deps :query org.bouncycastle/bcpkix-jdk15on 2>/dev/null)
+    bcpkix="$HOME/.m2/repository/org/bouncycastle/bcpkix-jdk15on/$bcpkix_ver/bcpkix-jdk15on-$bcpkix_ver.jar"
+fi
 
 if ! test -e "$jar"; then
     printf 'Unable to find the puppetdb jar %q; have you run "lein uberjar"?\n' \
@@ -23,6 +35,5 @@ if ! test -e "$bcpkix"; then
            "$bcpkix" 1>&2
     exit 2
 fi
-
 
 exec java -cp "$jar:$bcprov:$bcpkix" clojure.main -m puppetlabs.puppetdb.core "$@"

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -28,6 +28,28 @@
 (defn throw-cli-error [msg]
   (throw (ex-info msg {:type ::cli-error :message msg})))
 
+(def ^:private valid-experimental-feature? #{"all" "policies"})
+
+(defn parse-experimental-features [s]
+  (let [valid? (fn valid? [x]
+                 (or (valid-experimental-feature? x)
+                     ;; Logging not available yet?
+                     (binding [*out* *err*]
+                       (println (trs "Ignoring invalid PDB_EXPERIMENTAL_FEATURE {0}" x))
+                       false)))]
+    (if-not s
+      #{}
+      (as-> (str/split s #"[\t ]+")
+          features
+        (filter valid? features)
+        (set features)
+        (if (features "all")
+          (disj valid-experimental-feature? "all")
+          features)))))
+
+(def experimental-features
+  (parse-experimental-features (System/getenv "PDB_EXPERIMENTAL_FEATURES")))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
 

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -14,6 +14,16 @@
    [java.security KeyStore]
    [java.util.regex Pattern]))
 
+(deftest experimental-feature-parsing
+  (is (= #{} (conf/parse-experimental-features "")))
+  (is (= #{"policies"} (conf/parse-experimental-features "policies")))
+  (is (= #{"policies"} (conf/parse-experimental-features " policies")))
+  (is (= #{"policies"} (conf/parse-experimental-features "policies ")))
+  (is (= #{"policies"} (conf/parse-experimental-features " policies ")))
+  (is (= #{"policies"} (conf/parse-experimental-features "foo policies")))
+  (is (= #{"policies"} (conf/parse-experimental-features "all")))
+  (is (= #{"policies"} (conf/parse-experimental-features "all policies"))))
+
 (deftest puppetdb-configuration
   (testing "puppetdb-configuration"
     (testing "should convert disable-update-checking value to boolean, if it is specified"


### PR DESCRIPTION
This may be roughly right, and I'm raising it so that the other policy storage can go ahead and build upon it, relying on `config/experimental-features` and the support for migrations with `:strict-order?`.  I've marked it as a work in progress because I still need to add some tests, and we need to decide if we want to move the migration-table related changes to 6.x.