### PR TITLE
(PDB-5467) Always pass :messages to request-shutdown

### DIFF
--- a/src/puppetlabs/puppetdb/cli/services.clj
+++ b/src/puppetlabs/puppetdb/cli/services.clj
@@ -916,7 +916,7 @@
   (let [{:keys [database developer read-database emit-cmd-events?]} config
         {:keys [cmd-event-mult cmd-event-ch]} context
         ;; Assume that the exception has already been reported.
-        shutdown-for-ex (exceptional-shutdown-requestor request-shutdown nil 2)
+        shutdown-for-ex (exceptional-shutdown-requestor request-shutdown [] 2)
         write-dbs-config (conf/write-databases config)
         emit-cmd-events? (or (conf/pe? config) emit-cmd-events?)
         maybe-send-cmd-event! (partial maybe-send-cmd-event! emit-cmd-events? cmd-event-ch)
@@ -1037,7 +1037,7 @@
                                   request-shutdown
                                   (get-in config [:global :upgrade-and-exit?]))]
       (when upgrade?
-        (request-shutdown {::tk/exit {:status 0}}))
+        (request-shutdown {::tk/exit {:status 0 :messages []}}))
       (reset! (:shutdown-request context) nil)
       context)
     (catch ExceptionInfo ex

--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -909,7 +909,7 @@
     (with-final [{:keys [command-chan scf-write-dbs q maybe-send-cmd-event!]} globals
                  {:keys [response-chan response-pub]} context
                  ;; Assume that the exception has already been reported.
-                 shutdown-for-ex (exceptional-shutdown-requestor request-shutdown nil 2)
+                 shutdown-for-ex (exceptional-shutdown-requestor request-shutdown [] 2)
                  cmd-concurrency (conf/mq-thread-count config)
 
                  command-pool (create-command-handler-threadpool cmd-concurrency)


### PR DESCRIPTION
Some of the invocations of request-shutdown pass an exit map with no
:messges, which is disallowed by tk's schema check.  The resulting
exception can cause pdb to crash with a stackoverflow, so pass []
instead, when there are no messages.