### PR TITLE
(PDB-5466) Allow database config passwords to be INI integers

### DIFF
--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -65,9 +65,9 @@
      :connection-username String
      :user String
      :username String
-     :password String
+     :password (s/pred #(or (str %) (int? %)))
      :migrator-username String
-     :migrator-password String
+     :migrator-password (s/pred #(or (str %) (int? %)))
      :syntax_pgs String
      :read-only? (pls/defaulted-maybe String "false")
      :partition-conn-min (pls/defaulted-maybe s/Int 1)

--- a/src/puppetlabs/puppetdb/schema.clj
+++ b/src/puppetlabs/puppetdb/schema.clj
@@ -142,7 +142,8 @@
     org.joda.time.Seconds (comp time/seconds coerce-to-int)
     Boolean (comp #(Boolean/valueOf %) str)
     Long long
-    clojure.lang.PersistentVector blocklist->vector}))
+    clojure.lang.PersistentVector blocklist->vector
+    java.lang.String str}))
 
 (defn convert-to-schema
   "Convert `data` to the format specified by `schema`"

--- a/test/puppetlabs/puppetdb/config_test.clj
+++ b/test/puppetlabs/puppetdb/config_test.clj
@@ -295,7 +295,13 @@
                                   :connection-migrator-username "connection-migration-user-value")
           ssl-connection {:database {:classname   "something"
                                   :subname     "stuff?ssl=true"
-                                  :username    "someone"}}]
+                                  :username    "someone"}}
+          numeric-passwords {:database {:classname "something"
+                                        :username "someone"
+                                        :subname "stuff"
+                                        :password 12345
+                                        :migrator-username "admin"
+                                        :migrator-password 12345}}]
 
       (testing "migrator-username"
         (let [config (configure-dbs no-migrator)]
@@ -334,7 +340,12 @@
       (testing "ssl-connection-with-password"
         (let [config (configure-dbs (assoc-in ssl-connection [:database :password] "password"))]
           (is (= "password" (get-in config [:database :migrator-password])))
-          (is (= "password" (get-in config [:read-database :migrator-password]))))))))
+          (is (= "password" (get-in config [:read-database :migrator-password])))))
+
+      (testing "numeric passwords"
+        (let [config (configure-dbs numeric-passwords)]
+          (is (= "12345" (get-in config [:database :password])))
+          (is (= "12345" (get-in config [:database :migrator-password]))))))))
 
 (deftest database-user-preferred-to-username-on-mismatch
   (let [config (configure-dbs {:database {:classname "something"


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/PDB-5466