### PR TITLE
Bump environ version to 1.1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -77,7 +77,7 @@
      [org.clojure/test.check "0.9.0"]
      [com.gfredericks/test.chuck "0.2.7"
       :exclusions [com.andrewmcveigh/cljs-time]]
-     [environ "1.0.2"]
+     [environ "1.1.0"]
      [riddley "0.1.12"]
      [io.forward/yaml "1.0.5"]
 


### PR DESCRIPTION
This was failing in jar-jar tests when run with puppetserver

```
Possibly confusing dependencies found:
[puppetlabs/pe-puppetdb-extensions "6.20.3-20220314.225728-4"] -> [environ "1.0.2"]
 overrides
[puppetlabs/pe-puppetserver "2019.8.11.18" :classifier "test"] -> [puppetlabs/code-manager "2019.8.0.62"] -> [environ "1.1.0"]
 and
[puppetlabs/pe-puppetserver "2019.8.11.18"] -> [puppetlabs/code-manager "2019.8.0.62"] -> [environ "1.1.0"]

Consider using these exclusions:
[puppetlabs/pe-puppetserver "2019.8.11.18" :classifier "test" :exclusions [environ]]
[puppetlabs/pe-puppetserver "2019.8.11.18" :exclusions [environ]]
```

Longer-term, since it is a shared dependency, it should be moved into
clj-parent