### PR TITLE
(PDB-5260) Avoid recursive rules to mitigate slow PQL parsing

### DIFF
--- a/resources/puppetlabs/puppetdb/pql/pql-grammar.ebnf
+++ b/resources/puppetlabs/puppetdb/pql/pql-grammar.ebnf
@@ -61,7 +61,8 @@ expr-not     = ( not, [<whitespace>], expr-not ) | expr-rest;
 subquery = entity, [<whitespace>], where;
 
 (* Conditional expression *)
-condexpression  = (condexpregexp | condexpregexparray | condexpinequality | condexpmatch | condexpnotmatch| condexpnotregexp | condexpin);
+condexpression  = (condexpregexp | condexpregexparray | condexpinequality
+                   | condexpmatch | condexpnotmatch| condexpnotregexp | condexpin);
 <condexpregexp> = field, [<whitespace>], condregexp, [<whitespace>], valueregexp;
 <condexpregexparray> = field, [<whitespace>], condregexparray, [<whitespace>], valueregexparray;
 <condexpinequality> = field, [<whitespace>], condinequality, [<whitespace>], valueordered;
@@ -77,17 +78,17 @@ condisnotnull = <'is not null'>;
 
 (* Conditional expression parts *)
 groupedfieldlist = <lbracket>, [<whitespace>], fieldlist, [<whitespace>], <rbracket>;
-<fieldlist>      = (field | function), [ [<whitespace>], <','>, [<whitespace>], fieldlist ];
+<fieldlist>      = (field | function) {[<whitespace>] <','> [<whitespace>] (field | function)};
 function         = functionname, [<whitespace>], groupedarglist;
 <functionname>   = 'count' | 'avg' | 'sum' | 'min' | 'max' | 'to_string';
 
 groupedarglist = <lparens>, [<whitespace>], [arglist], [<whitespace>], <rparens>;
 <arglist>      = (field | string), [ [<whitespace>], <','>, [<whitespace>], stringlist ];
-<stringlist>   = string , [ [<whitespace>], <','>, [<whitespace>], stringlist ];
+<stringlist>   = string {[<whitespace>] <','> [<whitespace>] string};
 
 (* Represents a field from an entity *)
 field = #'[a-zA-Z0-9_]+\??' | (dottedfield, fieldpath);
-<fieldpath> = <'.'>, (quotedfield | standardfield | matchfield) , [fieldpath];
+<fieldpath> = (<'.'> (quotedfield | standardfield | matchfield))+;
 <quotedfield> = #'\".*?\"(?=\.|\s)';
 <matchfield> = #'match\(.*?\)';
 <standardfield> = #'[^\s\.\",\[\]!<=>~]+(\[\d+\])?';
@@ -107,10 +108,10 @@ field = #'[a-zA-Z0-9_]+\??' | (dottedfield, fieldpath);
 <valuein>          = query | groupedliterallist;
 
 groupedregexplist = <lbracket>, [<whitespace>], regexplist, [<whitespace>], <rbracket>;
-<regexplist>      = string, [ [<whitespace>], <','>, [<whitespace>], regexplist ];
+<regexplist>      = string {[<whitespace>] <','> [<whitespace>] string};
 
 groupedliterallist = <lbracket>, [<whitespace>], literallist, [<whitespace>], <rbracket>;
-<literallist>      = literal, [ [<whitespace>], <','>, [<whitespace>], literallist ];
+<literallist>      = literal {[<whitespace>] <','> [<whitespace>] literal};
 
 (* Boolean operators *)
 <and> = <'and'>;


### PR DESCRIPTION
Avoid recursion in some of our rules to avoid *very* bad performance
for, as an example, a large number of 'or' filter clauses.

Before the change, this PQL query would saturate the CPU for many
minutes before running out of memory and crashing the test program:

  (str "nodes[] { certname in [\""
       (str/join "\", \""
                 (repeat 5000 "heavy-empire.delivery.puppetlabs.net"))
       "\"] }"))

After the change, that same query finishes in a couple of seconds on a
fairly slow laptop.  While that still seems slow, it's a huge
improvement.

For what it's worth, for that particular query, the important change
is the one to <literallist>.

From https://github.com/Engelberg/instaparse/blob/4d1903b059e77dc0049dfbc75af9dce995756148/docs/Performance.md:

  Prefer using * and + over recursion to describe simple
  repetition. For example, the rule:

   <A> = 'a'+

  can be internally optimized in ways that

   <A> = 'a' A | 'a'

  cannot.