### PR TITLE
(PDB-5483) Fix set transaction read write error on hot standby

### DIFF
--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -648,10 +648,7 @@
        ;; level to fail (because the pending transaction already
        ;; includes that select).
        (.setIsolateInternalQueries true))
-     (->> [(when read-only? "set transaction read write;")
-           "update pg_settings set setting = false"
-           "  where name = 'jit';"
-           (when read-only? "set transaction read only;")
+     (->> ["set session jit = off;"
            (when expected-schema
              (block-on-schema-mismatch expected-schema))]
           (str/join " ")

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -648,7 +648,11 @@
        ;; level to fail (because the pending transaction already
        ;; includes that select).
        (.setIsolateInternalQueries true))
-     (->> ["set session jit = off;"
+     (->> ["DO $$ BEGIN"
+           "IF (SELECT CAST(setting AS FLOAT) FROM pg_settings WHERE name = 'server_version') > 11 THEN"
+           "SET SESSION jit = off;"
+           "END IF;"
+           "END $$;"
            (when expected-schema
              (block-on-schema-mismatch expected-schema))]
           (str/join " ")

--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -649,7 +649,7 @@
        ;; includes that select).
        (.setIsolateInternalQueries true))
      (->> ["DO $$ BEGIN"
-           "IF (SELECT CAST(setting AS FLOAT) FROM pg_settings WHERE name = 'server_version') > 11 THEN"
+           "IF CAST((SELECT setting FROM pg_settings WHERE name = 'server_version_num') AS INTEGER) >= 110000 THEN"
            "SET SESSION jit = off;"
            "END IF;"
            "END $$;"


### PR DESCRIPTION
Fixes upgrade error introduced in #3643 (which seems to be the original intention):
 `adding a "set session jit = off;" to the hikaricp connection init string.`

Ref: https://www.postgresql.org/docs/current/hot-standby.html#HOT-STANDBY-USERS

```
Transaction management commands that explicitly set non-read-only state: 
(SET TRANSACTION READ WRITE) are explicitly denied while configured as hot standby, 
but you can change a run time parameter settings using SET
```

Tested this against both PostgreSQL 9.6.24 and latest 14.x