### PR TITLE
(PE-33853) Update clj parent to 5.0.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def pdb-version "7.11.0-SNAPSHOT")
 
-(def clj-parent-version "4.9.8")
+(def clj-parent-version "5.0.0")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))
@@ -161,8 +161,10 @@
                  [org.clojure/core.memoize]
                  [org.clojure/java.jdbc]
                  [org.clojure/tools.macro]
+                 [org.clojure/tools.namespace]
                  [org.clojure/math.combinatorics "0.1.1"]
                  [org.clojure/tools.logging]
+                 [org.clojure/tools.nrepl]
 
                  ;; Puppet specific
                  [puppetlabs/comidi]
@@ -171,7 +173,6 @@
                  [puppetlabs/kitchensink]
                  [puppetlabs/stockpile "0.0.4"]
                  [puppetlabs/structured-logging]
-                 [puppetlabs/tools.namespace "0.2.4.1"]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-webserver-jetty9]
                  [puppetlabs/trapperkeeper-metrics]
@@ -211,9 +212,6 @@
                  [commons-io]
                  [compojure]
                  [ring/ring-core]
-
-                 ;; conflict resolution
-                 [org.clojure/tools.nrepl "0.2.13"]
 
                  ;; fixing a illegal reflective access
                  [org.tcrawley/dynapath "1.0.0"]]

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -1,4 +1,5 @@
 (ns puppetlabs.puppetdb.utils
+  (:refer-clojure :exclude [update-vals])
   (:require [clojure.string :as str]
             [puppetlabs.puppetdb.cli.util :refer [err-exit-status]]
             [puppetlabs.kitchensink.core :as kitchensink]


### PR DESCRIPTION
...and switch to upstream tools.namespace.  If upstream still can't
handle spaces in the classpath, then let's pursue it there.

The only change in the puppetlabs fork was this in loader-classpath:

  -     #(java.io.File. (.getPath ^java.net.URL %))
  +     #(java.io.File. (.toURI ^java.net.URL %))

https://github.com/puppetlabs/tools.namespace/commit/6ab30bc2be773bb64850ce9460cec22f9d3fdf9e