### PR TITLE
(maint) update clj-parent to 4.11.0, update code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @puppetlabs/puppetdb
-/docker/ @puppetlabs/pupperware
+* @puppetlabs/dumpling

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def pdb-version "6.21.1-SNAPSHOT")
 
-(def clj-parent-version "4.9.8")
+(def clj-parent-version "4.11.0")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
This updates clj-parent to 4.11.0, to incorporate the most recent updates, and updates the CODEOWNERS file to be correct.