### PR TITLE
(PE-34097) update clj-parent to 4.11.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def pdb-version "6.21.1-SNAPSHOT")
 
-(def clj-parent-version "4.11.0")
+(def clj-parent-version "4.11.1")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
This brings in jetty, version 9.4.48 which contains a few security fixes as well as dependency updates.