### PR TITLE
(PE-34097) update clj-parent to 5.1.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def pdb-version "7.11.0-SNAPSHOT")
 
-(def clj-parent-version "5.1.0")
+(def clj-parent-version "5.1.1")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
This change in clj-parent brings in a new version of tk-jetty9 that uses a newer
version of Jetty (9.4.48).  This change includes several security fixes,
bug fixes as well as dependency updates.