### PR TITLE
(PE-34257) update clj-parent to 5.2.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def pdb-version "7.11.1-SNAPSHOT")
 
-(def clj-parent-version "5.1.1")
+(def clj-parent-version "5.2.1")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
This updates clj-parent to 5.2.1 to include a new version of the postgres driver
to address CVE-2022-31197