### PR TITLE
(PE-34257) update clj-parent to 4.11.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def pdb-version "6.22.1-SNAPSHOT")
 
-(def clj-parent-version "4.11.1")
+(def clj-parent-version "4.11.2")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
This updates the clj-parent reference to 4.11.2 to bring in a newer
version of the postgres driver to address CVE-2022-31197.