### PR TITLE
(maint) Format recieved-time before translation

### DIFF
--- a/src/puppetlabs/puppetdb/command.clj
+++ b/src/puppetlabs/puppetdb/command.clj
@@ -274,7 +274,7 @@
              (maybe-send-cmd-event! cmdref ::ingested)
              (log/debug (trs "[{0}-{1}] ''{2}'' command enqueued for {3}"
                              id
-                             (time/to-long received)
+                             (str (time/to-long received))
                              command
                              certname))))
     (finally


### PR DESCRIPTION
Previously, the received-time would be formatted by the translation
library, which adds commas to the integer
```
2022-08-24 10:38:48,975 DEBUG [qtp1365504513-29] [p.p.command] [0-1,661,362,728,961] 'configure expiration' command enqueued for new-host
```

The purpose of this received-time is to correlate it with a later log
message (in which we do not include the commas)
```
2022-08-24 10:38:48,991 INFO  [cmd-proc-thread-1] [p.p.command] [0-1661362728961-1560874645000] [7 ms] 'configure expiration' command processed for new-host
```

So we now format this integer as a string to avoid additional formatting
by the translation library
```
2022-08-24 10:39:51,447 DEBUG [qtp1480434848-35] [p.p.command] [1-1661362791430] 'configure expiration' command enqueued for new-host
```