### PR TITLE
(PE-34636) update clj-parent to 5.2.5, bc references

### DIFF
--- a/ci/bin/prep-and-run-in
+++ b/ci/bin/prep-and-run-in
@@ -25,7 +25,7 @@ if [ "$host_type" = travis ] && [[ "$OSTYPE" != darwin* ]]; then
     # See https://github.com/pyenv/pyenv/issues/789 When using the
     # system python pyenv prepends /usr/bin to the path which breaks
     # anything that tries to override system defaults, like rvm/rbenv
-    pyenv global 3.7.6
+    pyenv global 3.7.13
 
     # Have to purge some of the existing pg bits so the 11 install
     # won't fail with errors like this:

--- a/ci/bin/run
+++ b/ci/bin/run
@@ -26,7 +26,7 @@ case "$flavor" in
         case "$flavor" in
             core|core+ext)
                 # Run core lein tests with ephemeral PuppetDB and PostgreSQL sandboxes
-                # Leiningen dev profile adds org.bouncycastle/bcpkix-jdk15on dependency
+                # Leiningen dev profile adds org.bouncycastle/bcpkix-jdk18on dependency
                 ext/bin/boxed-core-tests \
                     -- lein with-profiles "${LEIN_PROFILES:-dev}" test
                 ;;

--- a/ext/bin/dep-diff
+++ b/ext/bin/dep-diff
@@ -73,7 +73,7 @@ Usage:
   ds)
 
 (defn strip-bc-scope [dep]
-  (if (#{'org.bouncycastle/bcutil-jdk15on 'org.bouncycastle/bcpkix-jdk15on 'org.bouncycastle/bcprov-jdk15on}
+  (if (#{'org.bouncycastle/bcutil-jdk18on 'org.bouncycastle/bcpkix-jdk18on 'org.bouncycastle/bcprov-jdk18on}
        (first dep))
     (letfn [(strip [remainder]
               (when (seq remainder)

--- a/pdb
+++ b/pdb
@@ -14,7 +14,7 @@ set -eo pipefail
 dep-ver()
 {
     # Example:
-    #  [org.bouncycastle/bcpkix-jdk15on "1.70"]
+    #  [org.bouncycastle/bcpkix-jdk18on "1.71"]
     local artifact="$1" deps="$2"
     artifact_rx="${artifact//./\\.}"' "([0-9.]+)"'
     [[ $deps =~ $artifact_rx ]]
@@ -33,8 +33,8 @@ ensure-cache()
             exit 2
         fi
         local deps=$(lein deps :tree)
-        dep-ver org.bouncycastle/bcpkix-jdk15on "$deps" > ./pdb.bcpkix
-        dep-ver org.bouncycastle/bcprov-jdk15on "$deps" > ./pdb.bcprov
+        dep-ver org.bouncycastle/bcpkix-jdk18on "$deps" > ./pdb.bcpkix
+        dep-ver org.bouncycastle/bcprov-jdk18on "$deps" > ./pdb.bcprov
     fi
     cache_checked=true
 }
@@ -54,23 +54,23 @@ bcprov=''
 bcpkix=''
 
 # Load Bouncy Castle Crypto package jar from a custom location or Maven cache
-# https://mavenlibs.com/maven/dependency/org.bouncycastle/bcprov-jdk15on
+# https://mavenlibs.com/maven/dependency/org.bouncycastle/bcprov-jdk18on
 if test "$BCPROV_JAR"; then
     bcprov="$BCPROV_JAR"
 else
     ensure-cache
     bcprov_ver=$(<./pdb.bcprov)
-    bcprov="$HOME/.m2/repository/org/bouncycastle/bcprov-jdk15on/$bcprov_ver/bcprov-jdk15on-$bcprov_ver.jar"
+    bcprov="$HOME/.m2/repository/org/bouncycastle/bcprov-jdk18on/$bcprov_ver/bcprov-jdk18on-$bcprov_ver.jar"
 fi
 
 # Load another necessary Bouncy Castle jar from a custom location or Maven cache
-# https://mavenlibs.com/maven/dependency/org.bouncycastle/bcpkix-jdk15on
+# https://mavenlibs.com/maven/dependency/org.bouncycastle/bcpkix-jdk18on
 if test "$BCPKIX_JAR"; then
     bcpkix="$BCPKIX_JAR"
 else
     ensure-cache
     bcpkix_ver=$(<./pdb.bcpkix)
-    bcpkix="$HOME/.m2/repository/org/bouncycastle/bcpkix-jdk15on/$bcpkix_ver/bcpkix-jdk15on-$bcpkix_ver.jar"
+    bcpkix="$HOME/.m2/repository/org/bouncycastle/bcpkix-jdk18on/$bcpkix_ver/bcpkix-jdk18on-$bcpkix_ver.jar"
 fi
 
 # Validate that PuppetDB jar and Bouncy Castle jars exist

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def pdb-version "7.11.2-SNAPSHOT")
 
-(def clj-parent-version "5.2.1")
+(def clj-parent-version "5.2.5")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))
@@ -259,7 +259,7 @@
                         :injections [(do
                                        (require 'schema.core)
                                        (schema.core/set-fn-validation! true))]}
-             :dev [:defaults {:dependencies [[org.bouncycastle/bcpkix-jdk15on]]
+             :dev [:defaults {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]
                               :plugins [[jonase/eastwood "0.3.14"
                                          :exclusions [org.clojure/clojure]]
                                         ]}]
@@ -293,7 +293,7 @@
 
                                                ;; ezbake does not use the uberjar profile so we need
                                                ;; to duplicate this dependency here
-                                               [org.bouncycastle/bcpkix-jdk15on nil]
+                                               [org.bouncycastle/bcpkix-jdk18on nil]
 
                                                ;; we need to explicitly pull in our parent project's
                                                ;; clojure version here, because without it, lein
@@ -321,7 +321,7 @@
              ; We only want to include bouncycastle in the FOSS uberjar.
              ; PE should be handled by selecting the proper bouncycastle jar
              ; at runtime (standard/fips)
-             :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk15on]]
+             :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]
                        :aot ~pdb-aot-namespaces}}
 
   :jar-exclusions [#"leiningen/"]


### PR DESCRIPTION
This updates clj-parent to 5.2.5 which includes an updated set of bouncycastle dependencies off the renamed `18on` series of libraries.  All references to `15on` were changed to `18on` appropriately.