### PR TITLE
(maint) bump clj-parent to 5.2.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def pdb-version "7.11.2-SNAPSHOT")
 
-(def clj-parent-version "5.2.5")
+(def clj-parent-version "5.2.8")
 
 (defn true-in-env? [x]
   (#{"true" "yes" "1"} (System/getenv x)))


### PR DESCRIPTION
This brings in new versions of `trapperkeeper-webserver-jetty9` `trapperkeeper-metrics` and `dujour-version-check` which have recently been updated to migrate to the bouncycastle `18on` versions from the `15on` versions.