### PR TITLE
fix docker build by forcing older version of public_suffix

### DIFF
--- a/docker/puppetdb/Dockerfile
+++ b/docker/puppetdb/Dockerfile
@@ -93,6 +93,7 @@ RUN apt-get update && \
     curl --output /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
     chmod 0755 /usr/local/bin/lein && \
     /usr/local/bin/lein && \
+    gem install --no-doc public_suffix -v 4.0.7 && \
     gem install --no-doc bundler fpm
 
 COPY . /puppetdb


### PR DESCRIPTION
Similar to a PR I've done on puppetserver https://github.com/puppetlabs/puppetserver/pull/2670

Currently docker build fail with the following error:
```
#12 41.61 	The last version of public_suffix (< 6.0, >= 2.0.2) to support your Ruby & RubyGems was 4.0.7. Try installing it with `gem install public_suffix -v 4.0.7` and then running the current command again
```

This PR fix this by forcing the public_suffix ruby gem to 4.0.7