### PR TITLE
(doc) Metrics v2 API

### DIFF
--- a/documentation/api/metrics/v2/jolokia.markdown
+++ b/documentation/api/metrics/v2/jolokia.markdown
@@ -9,8 +9,10 @@ canonical: "/puppetdb/latest/api/metrics/v2/jolokia.html"
 By default, PuppetDB has two optional web APIs for
 [Java Management Extension (JMX)](https://docs.oracle.com/javase/tutorial/jmx/index.html)
 metrics, namely [managed beans (MBeans)](https://docs.oracle.com/javase/tutorial/jmx/mbeans/) and Jolokia.
+
+The Jolokia API is enabled by default. You must use `https://` to access `metrics/v2` for any service, and you must present authorization in the form of a Puppet certificate.
+
 For the older MBeans metrics API, see [the `/metrics/v1` documentation](../v1/mbeans.markdown).
-The Jolokia API is enabled by default with access restricted to localhost.
 
 ## Jolokia endpoints
 

--- a/documentation/puppetdb.ditamap
+++ b/documentation/puppetdb.ditamap
@@ -113,6 +113,10 @@
       <topicref href="api/metrics/v1/changes-from-puppetdb-v3.markdown" format="markdown"/>
     </topichead>
 
+    <topichead navtitle="Metrics API version 2">
+      <topicref href="api/metrics/v2/jolokia.markdown" format="markdown"/>
+    </topichead>
+  
     <topichead navtitle="Command API">
       <topicref href="api/command/v1/commands.markdown" format="markdown"/>
     </topichead>


### PR DESCRIPTION
Add metric v2 api to TOC
Update access requirement per CVE-2020-7943

Jira: DOCUMENT-1363