### PR TITLE
(PDB-5547) Schedule gc jobs separately

### DIFF
--- a/documentation/configure.markdown
+++ b/documentation/configure.markdown
@@ -268,6 +268,41 @@ compaction process reclaims space and deletes unnecessary rows. If not
 supplied, the default is every 60 minutes.  If set to zero, all
 database GC processes will be disabled.
 
+### `gc-interval-expire-nodes`
+
+This controls how often, in minutes, to expire nodes that are no longer
+submitting commands. If not supplied, this value defaults to `gc-interval`.
+
+### `gc-interval-purge-nodes`
+
+This controls how often, in minutes, to remove nodes that have been expired or
+deactivated for longer than `node-purge-ttl`. If not supplied, this value
+defaults to `gc-interval`.
+
+### `gc-interval-purge-reports`
+
+This controls how often, in minutes, to remove reports and that have been
+expired or deactivated for longer than `reports-ttl` or `resource-events-ttl`
+respectively. If not supplied, this value defaults to `gc-interval`.
+
+### `gc-interval-packages`
+
+This controls how often, in minutes, to remove packages that are no longer
+associated with any nodes. If not supplied, this value defaults to
+`gc-interval`.
+
+### `gc-interval-catalogs`
+
+This controls how often, in minutes, to remove catalog data that is no longer
+associated with any nodes. If not supplied, this value defaults to
+`gc-interval`.
+
+### `gc-interval-fact-paths`
+
+This controls how often, in minutes, to remove fact paths that are no longer
+associated with any factsets. If not supplied, this value defaults to 24 hours
+or `gc-interval`, which ever is longer.
+
 ### `node-ttl`
 
 Mark as 'expired' nodes that haven't seen any activity (no new catalogs,

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -103,6 +103,12 @@
   (merge per-database-config-in
          (all-optional
            {:gc-interval (pls/defaulted-maybe (s/cond-pre String s/Int) "60")
+            :gc-interval-expire-nodes (s/cond-pre String s/Int)
+            :gc-interval-purge-nodes (s/cond-pre String s/Int)
+            :gc-interval-purge-reports (s/cond-pre String s/Int)
+            :gc-interval-packages (s/cond-pre String s/Int)
+            :gc-interval-fact-paths (s/cond-pre String s/Int)
+            :gc-interval-catalogs (s/cond-pre String s/Int)
             :report-ttl (pls/defaulted-maybe String report-ttl-default)
             :node-purge-gc-batch-limit (pls/defaulted-maybe s/Int 25)
             :node-ttl (pls/defaulted-maybe String "7d")
@@ -146,6 +152,12 @@
   "Schema for parsed/processed database config that includes write database params"
   (merge per-database-config-out
          {:gc-interval (s/cond-pre String s/Int)
+          (s/optional-key :gc-interval-expire-nodes) (s/cond-pre String s/Int)
+          (s/optional-key :gc-interval-purge-nodes) (s/cond-pre String s/Int)
+          (s/optional-key :gc-interval-purge-reports) (s/cond-pre String s/Int)
+          (s/optional-key :gc-interval-packages) (s/cond-pre String s/Int)
+          (s/optional-key :gc-interval-fact-paths) (s/cond-pre String s/Int)
+          (s/optional-key :gc-interval-catalogs) (s/cond-pre String s/Int)
           :report-ttl Period
           :node-purge-gc-batch-limit (s/constrained s/Int (complement neg?))
           :node-ttl Period
@@ -380,21 +392,33 @@
         (throw-cli-error
          (trs "gc-interval must be a number: {0}" x)))))
 
-(defn gc-interval->period
-  "Converts a gc-interval (either a number or String) in minutes into a Period.
-  Supports fractional minutes by converting to milliseconds"
-  [config]
-  (update config
-          :gc-interval
-          (fn [minutes]
-            (let [ms (* 60 1000 (ensure-long-or-double minutes))]
-              (t/millis (cond
-                          (> ms 1) ms
-                          (> ms 0) 1
-                          (< ms 0) (throw-cli-error
-                                    (trs "gc-interval cannot be negative: {0}"
-                                         minutes))
-                          :else 0))))))
+(defn interval->period [minutes]
+  (let [ms (* 60 1000 (ensure-long-or-double minutes))]
+    (t/millis (cond
+               (> ms 1) ms
+               (> ms 0) 1
+               (< ms 0) (throw-cli-error
+                         (trs "gc-interval cannot be negative: {0}"
+                              minutes))
+               :else 0))))
+
+(defn gc-intervals->periods
+  [{:keys [gc-interval] :as config}]
+  (let [one-day  (-> 24 t/hours .toPeriod)
+        gc-interval-period (interval->period gc-interval)
+        get-period (fn [custom] (interval->period (or custom gc-interval)))
+        get-paths-period (fn [custom]
+                           (interval->period (or custom (if (t/period-longer? one-day gc-interval-period)
+                                                          (* 24 60)
+                                                          gc-interval))))]
+    (-> config
+        (update :gc-interval-expire-nodes get-period)
+        (update :gc-interval-purge-nodes get-period)
+        (update :gc-interval-purge-reports get-period)
+        (update :gc-interval-packages get-period)
+        (update :gc-interval-catalogs get-period)
+        (update :gc-interval-fact-paths get-paths-period)
+        (assoc :gc-interval gc-interval-period))))
 
 (defn using-ssl? [config]
   (and
@@ -431,7 +455,7 @@
       pls/convert-blacklist-settings-to-blocklist
       convert-blocklist-config
       (coerce-and-validate-final-config per-write-database-config-out)
-      gc-interval->period
+      gc-intervals->periods
       default-events-ttl
       (prefer-db-user-on-username-mismatch (name section-key))
       ensure-migrator-info

--- a/src/puppetlabs/puppetdb/config.clj
+++ b/src/puppetlabs/puppetdb/config.clj
@@ -380,7 +380,10 @@
         (throw-cli-error
          (trs "gc-interval must be a number: {0}" x)))))
 
-(defn gc-interval->ms [config]
+(defn gc-interval->period
+  "Converts a gc-interval (either a number or String) in minutes into a Period.
+  Supports fractional minutes by converting to milliseconds"
+  [config]
   (update config
           :gc-interval
           (fn [minutes]
@@ -428,7 +431,7 @@
       pls/convert-blacklist-settings-to-blocklist
       convert-blocklist-config
       (coerce-and-validate-final-config per-write-database-config-out)
-      gc-interval->ms
+      gc-interval->period
       default-events-ttl
       (prefer-db-user-on-username-mismatch (name section-key))
       ensure-migrator-info

--- a/test/puppetlabs/puppetdb/admin_clean_test.clj
+++ b/test/puppetlabs/puppetdb/admin_clean_test.clj
@@ -66,6 +66,8 @@
     (is (= HttpURLConnection/HTTP_OK (:status (post-clean ["purge_reports"]))))
     (is (= HttpURLConnection/HTTP_OK (:status (post-clean ["purge_resource_events"]))))
     (is (= HttpURLConnection/HTTP_OK (:status (post-clean ["gc_packages"]))))
+    (is (= HttpURLConnection/HTTP_OK (:status (post-clean ["gc_catalogs"]))))
+    (is (= HttpURLConnection/HTTP_OK (:status (post-clean ["gc_fact_paths"]))))
     (is (= HttpURLConnection/HTTP_OK (:status (post-clean ["other"]))))
     (is (= HttpURLConnection/HTTP_BAD_REQUEST (:status (post-clean ["?"]))))))
 
@@ -180,6 +182,8 @@
    "purge_nodes" (counters/value (:node-purges @cli-svc/admin-metrics))
    "purge_reports" (counters/value (:report-purges @cli-svc/admin-metrics))
    "gc_packages" (counters/value (:package-gcs @cli-svc/admin-metrics))
+   "gc_catalogs" (counters/value (:catalog-gcs @cli-svc/admin-metrics))
+   "gc_fact_paths" (counters/value (:fact-path-gcs @cli-svc/admin-metrics))
    "other" (counters/value (:other-cleans @cli-svc/admin-metrics))})
 
 (defn- clean-timer-counts []
@@ -191,13 +195,18 @@
                     (:report-purge-time @cli-svc/admin-metrics))
    "gc_packages" (number-recorded
                   (:package-gc-time @cli-svc/admin-metrics))
+   "gc_catalogs" (number-recorded
+                  (:catalog-gc-time @cli-svc/admin-metrics))
+   "gc_fact_paths" (number-recorded
+                  (:fact-path-gc-time @cli-svc/admin-metrics))
    "other" (number-recorded
             (:other-clean-time @cli-svc/admin-metrics))})
 
 (defn- check-counts [get-counts]
   (with-pdb-with-no-gc
     (doseq [requested (combinations ["expire_nodes" "purge_nodes"
-                                     "purge_reports" "gc_packages" "other"]
+                                     "purge_reports" "gc_packages" "other"
+                                     "gc_catalogs" "gc_fact_paths"]
                                     3)]
       (let [requested (set requested)
             before (get-counts)

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -16,14 +16,13 @@
                      db-config->clean-request
                      init-with-db
                      init-write-dbs
-                     invoke-periodic-gc
                      maybe-check-for-updates
                      query]]
             [puppetlabs.puppetdb.testutils.db
              :refer [*db* clear-db-for-testing! with-test-db
                      with-unconnected-test-db]]
             [puppetlabs.puppetdb.testutils.cli
-             :refer [example-certname example-report example-facts get-factsets]]
+             :refer [example-certname example-report get-factsets]]
             [puppetlabs.puppetdb.command :refer [enqueue-command]]
             [puppetlabs.puppetdb.config :as conf]
             [puppetlabs.puppetdb.jdbc :as jdbc]
@@ -519,57 +518,6 @@
                         (set (get-temporal-partitions "reports"))))
                  (is (= (->> event-parts (sort-by :table) (drop 1) set)
                         (set (get-temporal-partitions "resource_events")))))))))))))
-
-(deftest fact-path-gc-delay
-  (svc-utils/with-single-quiet-pdb-instance
-    (let [shutdown-mock (tu/call-counter)
-          invoke-gc (fn [last-gc-run]
-                      (invoke-periodic-gc *db*
-                                         {:node-ttl (time/parse-period "30d")
-                                          :node-purge-ttl (time/parse-period "14d")
-                                          :report-ttl (time/parse-period "14d")
-                                          :resource-events-ttl (time/parse-period "14d")}
-                                         ["expire_nodes" "purge_nodes" "purge_reports"
-                                          "purge_resource_events" "gc_packages" "other"]
-                                         shutdown-mock
-                                         (ReentrantLock.)
-                                         (atom nil)
-                                         (atom last-gc-run)
-                                         (-> 24 time/hours time/ago)))]
-      (sync-command-post (svc-utils/pdb-cmd-url)
-                         example-certname
-                         "replace facts"
-                         cmd-consts/latest-facts-version
-                         (assoc example-facts
-                                :producer_timestamp (-> 60 time/days time/ago)))
-
-      (is (< 0
-             (count (jdbc/with-transacted-connection *db*
-                      (jdbc/query ["select * from fact_paths"])))))
-
-      (jdbc/with-transacted-connection *db*
-        (scf-store/delete-certname! example-certname))
-
-      ;; invoke a gc where last-gc-run is less than 24 hours
-      (invoke-gc (-> 10 time/hours time/ago))
-
-
-      ;; the fact paths should not have been garbage collected
-      (is (< 0
-             (count (jdbc/with-transacted-connection *db*
-                      (jdbc/query ["select * from fact_paths"])))))
-
-      ;; invoke a gc where last-gc-run is greater than 24 hours
-      (invoke-gc (-> 25 time/hours time/ago))
-
-      ;; the fact paths should have been garbage collected
-      (is (= 0
-             (count (jdbc/with-transacted-connection *db*
-                      (jdbc/query ["select * from fact_paths"])))))
-
-      ;; sanity check that the gc runs were not failures
-      (is (= 0 (tu/times-called shutdown-mock))))))
-
 (deftest initialize-db
   (testing "when establishing migration database connections"
     (let [con-mig-user "conn-migration-user-value"

--- a/test/puppetlabs/puppetdb/command_broadcast_test.clj
+++ b/test/puppetlabs/puppetdb/command_broadcast_test.clj
@@ -86,7 +86,7 @@
         (let [admin-metrics (list-metrics :puppetlabs.puppetdb.admin)
               ;; filter out non-broadcast metrics created in the registry during other tests
               broadcast-metrics (filter #(re-find (re-pattern (str "pg1" "|" "pg2")) (str %)) admin-metrics)
-              expected-count 13 ;; 13 per pg admin metrics registered in services.clj
+              expected-count 17 ;; 17 per pg admin metrics registered in services.clj
               [pg-1 pg-2] (vals (group-by #(subs (str %) 1 9) broadcast-metrics))]
           (is (= expected-count (count pg-1)))
           (is (= (count pg-1) (count pg-2)))))


### PR DESCRIPTION
Split the gc into multiple jobs to allow them to be scheduled at different intervals.

Run the gc routines on Postgres on a threadpool with a single worker thread to ensure gc jobs don't compete for PG's resources.