### PR TITLE
(maint) Add support for postgres 15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,11 @@ jobs:
       env: PDB_TEST=core+ext/openjdk17/pg-14
       script: *run-core-and-ext-tests
 
+    - stage: ❧ pdb tests
+      name: core+ext jdk-11 pg-15
+      env: PDB_TEST=core+ext/openjdk11/pg-15
+      script: *run-core-and-ext-tests
+
     # Legacy testing, we do not promise support for jdk 8 or pg 9.6
     - stage: ❧ pdb tests
       name: core+ext jdk-8 pg-11

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1353,7 +1353,7 @@
                 {:latest_report_id report-id
                  :latest_report_timestamp producer-timestamp}
                 [(str "certname = ?"
-                      "AND ( latest_report_timestamp < ?"
+                      " AND ( latest_report_timestamp < ?"
                       "      OR latest_report_timestamp is NULL )")
                  node producer-timestamp]))
 

--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -163,11 +163,13 @@
         (jdbc/do-commands-outside-txn
          (format "drop database if exists %s" template-name)
          (format "create database %s" template-name)))
-      (jdbc/with-db-connection (db-admin-config template-name)
-        (jdbc/do-commands-outside-txn
-         "create extension if not exists pg_trgm"
-         "create extension if not exists pgcrypto"))
-      (let [cfg (routine-db-config template-name)]
+      (let [cfg (routine-db-config template-name)
+            owner (jdbc/double-quote (:user cfg))]
+        (jdbc/with-db-connection (db-admin-config template-name)
+          (jdbc/do-commands-outside-txn
+           "create extension if not exists pg_trgm"
+           "create extension if not exists pgcrypto"
+           (format "grant create on schema public to %s" owner)))
         (jdbc/with-db-connection cfg
           (initialize-schema)))
       (reset! template-created true))))


### PR DESCRIPTION
Two changes to Postgres in 15.0 caused issues with PuppetDB.

  > Remove PUBLIC creation permission on the public schema

First, the default create grant on public was removed, which means we need to grant create on the template table or it will be unable to create any tables, previously we only explicitely granted create on the individual tables we create for tests, but not the original template table.

  > Prevent numeric literals from having non-numeric trailing characters

Second our string concatenation for updating the lastest_report information created a string with no space between the parameter and the AND causing an error to be thrown due to trailing characters on "$3A"

```
"... certname = ?AND ..."
```