### PR TITLE
(PDB-5568) Fix order by clause compilation

### DIFF
--- a/src/puppetlabs/puppetdb/query/paging.clj
+++ b/src/puppetlabs/puppetdb/query/paging.clj
@@ -8,7 +8,6 @@
             [clojure.string :as string]
             [puppetlabs.kitchensink.core :as kitchensink
              :refer [seq-contains? order-by-expr? parse-int]]
-            [puppetlabs.puppetdb.honeysql :as h]
             [puppetlabs.puppetdb.schema :as pls]
             [schema.core :as s]
             [puppetlabs.i18n.core :refer [tru]]))
@@ -236,7 +235,7 @@
 (defn dealias-order-by
   [{:keys [projections] :as _query-rec} paging-options]
   (let [alias-map (->> projections
-                       (kitchensink/mapvals (comp h/extract-sql :field))
+                       (kitchensink/mapvals :field)
                        (kitchensink/mapkeys keyword))
         rename-field (fn [order-by-pair]
                        (update order-by-pair 0 (partial get alias-map)))]

--- a/test/puppetlabs/puppetdb/http/inventory_test.clj
+++ b/test/puppetlabs/puppetdb/http/inventory_test.clj
@@ -9,6 +9,7 @@
             [flatland.ordered.map :as omap]
             [puppetlabs.puppetdb.testutils.http :refer [*app*
                                                         query-response
+                                                        vector-param
                                                         deftest-http-app]]
             [puppetlabs.puppetdb.testutils :refer [get-request
                                                    assert-success!]]
@@ -214,6 +215,11 @@
       (let [response (query-response method endpoint)]
         (assert-success! response)
         (slurp (:body response))))
+
+    (testing "order by jsonb value successful"
+      (let [{:keys [body status]} (query-response method endpoint nil {:order_by (vector-param method [{"field" "trusted"}])})]
+        (is (= 200 status))
+        (is (= 3 (count (json/parse-string (slurp body) true))))))
 
     (testing "broken query should not output error's stacktrace"
       (let [query ["extract"


### PR DESCRIPTION
Prior to the upgrade to honeysql v2 (PDB-5519), we handled constructing the order by clauses separately from the rest of the query. This meant we needed to extract the sql from raw requests to create an SQL string ahead of time. Now we are letting the paging components stay in the main query until honeysql constructs the whole query at once at the end. This means that during dealiasing we can simply select the honeysql field from the query map with no futher alterations.