### PR TITLE
(maint) Change minimum upgrade_oldest version

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -326,12 +326,8 @@ module PuppetDBExtensions
       # Debian 11 only has builds starting in the 7 series
       if is_bullseye
         :puppet7
-      # Redhat8, Redhat7-fips, Debian 10, Ubuntu 20
-      # only have builds starting somewhere in the 6 series.
-      elsif is_el8 || is_rhel7fips || is_buster || is_focal
-        :puppet6
       else
-        :puppet5
+        :puppet6
       end
     end
   end
@@ -341,9 +337,7 @@ module PuppetDBExtensions
   # platform version returned by puppet_repo_version above
   def oldest_supported
     # account for bionic/rhel8 not having build before certian versions
-    if is_bionic
-      '5.2.4'
-    elsif is_bullseye
+    if is_bullseye
       '7.9.0'
     elsif is_el8
       '6.0.3'
@@ -354,7 +348,7 @@ module PuppetDBExtensions
     elsif is_focal
       '6.12.0'
     else
-      '5.2.0'
+      '6.0.0'
     end
   end
 

--- a/acceptance/setup/pre_suite/75_clean_out_puppet5_repos.rb
+++ b/acceptance/setup/pre_suite/75_clean_out_puppet5_repos.rb
@@ -2,20 +2,16 @@ if (test_config[:install_mode] == :upgrade_oldest) \
     && !(test_config[:skip_presuite_provisioning])
 
   step "Clean out puppet5 repos to prepare for puppet6 upgrade" do
-    # skip this step for rhel8 beacause it only installs puppet6 in upgrade_oldest
-    if test_config[:install_mode] == :upgrade_oldest && !(is_el8 || is_rhel7fips || is_buster || is_focal)
+    # skip this step for bullseye beacause it only installs puppet7 in upgrade_oldest
+    if test_config[:install_mode] == :upgrade_oldest && !(is_bullseye)
       databases.each do |database|
 
-        # need to remove puppet5 repos to avoid conflicts when upgrading
-        uninstall_package(database, "puppet5-release")
-        uninstall_package(database, "puppet5-nightly-release")
+        # need to remove puppet6 repos to avoid conflicts when upgrading
+        uninstall_package(database, "puppet6-release")
+        uninstall_package(database, "puppet6-nightly-release")
 
-        # init the puppet6 repos to allow it to find the puppet6 collection
-        unless is_bullseye
-          initialize_repo_on_host(database, test_config[:os_families][database.name], test_config[:nightly])
-          # install puppet 6 directly to prepare for upgrade
-          install_puppet_agent_on(database, {:puppet_collection => "puppet6"})
-        end
+        initialize_repo_on_host(database, test_config[:os_families][database.name], test_config[:nightly])
+        install_puppet_agent_on(database, {:puppet_collection => "puppet7"})
 
         on(database, puppet('resource', 'host', 'updates.puppetlabs.com', 'ensure=present', "ip=127.0.0.1") )
         if get_os_family(database) == :debian


### PR DESCRIPTION
The postgresql module has a Deferred usage now, which is not available until Puppet 6.

We only promise to support upgrades from X-1 to X, so this bumps the "oldest" version to `6.0.0` from 5.2.0.