### PR TITLE
require-jdk: migrate from AdoptOpenJDK API to Adoptium

### DIFF
--- a/ext/bin/require-jdk
+++ b/ext/bin/require-jdk
@@ -89,7 +89,7 @@ esac
 # Get OpenJDK tarball from official source
 curl -sSLo "$tmpdir/jdk.tar.gz" \
      -f --retry 3 \
-     "https://api.adoptopenjdk.net/v3/binary/latest/${ver#openjdk}/ga/$adoptos/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk"
+     "https://api.adoptium.net/v3/binary/latest/${ver#openjdk}/ga/$adoptos/x64/jdk/hotspot/normal/eclipse?project=jdk"
 
 # Extract OpenJDK from tarball
 (cd "$tmpdir"


### PR DESCRIPTION
The AdoptOpenJDK API has been deprecated for some time in favour of the Eclipse Temurin API

retargetted #3755 to the 7.x branch