### PR TITLE
(maint) Install puppetdb module 7.10.0 on platform5

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -429,6 +429,15 @@ module PuppetDBExtensions
     end
   end
 
+  def install_puppetdb_module(hosts, puppet_platform)
+    command = "puppet module install puppetlabs/puppetdb"
+    # Use the older 7.10.0 version of puppetdb module on puppet5 because
+    # it depends on puppetlabs-postgresql < 8, which does not use Deferred
+    # (which does not exist in puppet5).
+    command << " -v 7.10.0" if puppet_platform == :puppet5
+    on hosts, command
+  end
+
   def install_puppetdb(host, version=nil)
     manifest = <<-EOS
     class { 'puppetdb::globals':

--- a/acceptance/setup/pre_suite/50_install_modules.rb
+++ b/acceptance/setup/pre_suite/50_install_modules.rb
@@ -4,6 +4,6 @@ extend Beaker::DSL::InstallUtils
 
 unless (test_config[:skip_presuite_provisioning])
   step "Install the puppetdb module and dependencies" do
-    on databases, "puppet module install puppetlabs/puppetdb"
+    install_puppetdb_module(databases, puppet_repo_version)
   end
 end


### PR DESCRIPTION
For 6.x, the acceptance suite running with INSTALL_TYPE upgrade_oldest will install puppet5 on el7 hosts in order to test upgrading from puppet5. However it currently installs the puppetlabs-puppetdb module latest to install puppetdb, and head of that module depends on puppetlabs-postgresql module <9 which pulls in 8.2.1 which makes use of Deferred, which isn't available in puppet5...

So if we're installing the puppetdb module for platform5, install version 7.5.0 which depends on postgresql module <8 that doesn't use Deferred.