### PR TITLE
(PDB-5553) Remove foreign keys from report partitions

### DIFF
--- a/src/puppetlabs/puppetdb/jdbc.clj
+++ b/src/puppetlabs/puppetdb/jdbc.clj
@@ -3,6 +3,7 @@
   (:require [clojure.java.jdbc :as sql]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [honey.sql :as hsql]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.time :as pl-time]
             [puppetlabs.puppetdb.jdbc.internal :refer [limit-result-set!]]
@@ -73,6 +74,11 @@
                              (if (coll? sql) (str/join sql) sql)
                              params)
                       {:multi? true}))
+
+(defn do-hsql
+  [honeysql-command]
+  (sql/db-do-prepared *db* true
+                      (hsql/format honeysql-command)))
 
 (defn do-commands-outside-txn [& commands]
   (let [^Connection conn (:connection *db*)

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -1981,7 +1981,8 @@
   [date]
   (let [date-suffix (diff-date-suffix date)
         formatted-start-of-day (get-formatted-start-of-day date)
-        formatted-start-of-next-day (get-formatted-start-of-day (.plusDays date 1))]
+        formatted-start-of-next-day (get-formatted-start-of-day (.plusDays date 1))
+        table-name (format "reports_%s" date-suffix)]
     [{:left-only
       {:constraint_name
        (format "(((producer_timestamp >= '%s'::timestamp with time zone) AND (producer_timestamp < '%s'::timestamp with time zone)))" formatted-start-of-day formatted-start-of-next-day)
@@ -1998,8 +1999,39 @@
        :constraint_type "PRIMARY KEY"
        :initially_deferred "NO"
        :deferrable? "NO"}
+      :same nil}
+     {:left-only
+      {:constraint_name (format "reports_prod_fkey_%s" date-suffix)
+       :table_name table-name
+       :constraint_type "FOREIGN KEY"
+       :initially_deferred "NO"
+       :deferrable? "NO"}
+      :right-only nil
+      :same nil}
+     {:left-only
+      {:constraint_name (format "reports_certname_fkey_%s" date-suffix)
+       :table_name table-name
+       :constraint_type "FOREIGN KEY"
+       :initially_deferred "NO"
+       :deferrable? "NO"}
+      :right-only nil
+      :same nil}
+     {:left-only
+      {:constraint_name (format "reports_status_fkey_%s" date-suffix)
+       :table_name table-name
+       :constraint_type "FOREIGN KEY"
+       :initially_deferred "NO"
+       :deferrable? "NO"}
+      :right-only nil
+      :same nil}
+     {:left-only
+      {:constraint_name (format "reports_env_fkey_%s" date-suffix)
+       :table_name table-name
+       :constraint_type "FOREIGN KEY"
+       :initially_deferred "NO"
+       :deferrable? "NO"}
+      :right-only nil
       :same nil}]))
-
 
 (deftest migration-82-reports-declarative-partitioning
   (testing "reports table declarative partitioning migration"
@@ -2073,9 +2105,44 @@
                  :primary? false
                  :user "pdb_test"}
                 :same nil}]
-            exp-idx-diff (concat exp-reports-indices-diff
-                                 (generate-diff-sequence report-partition-day-index-diff-template))
-            exp-constraint-diff (generate-diff-sequence report-partition-day-constraint-diff-template)
+
+              exp-reports-constraint-diff
+              [{:left-only
+                {:constraint_name "reports_prod_fkey",
+                 :table_name "reports",
+                 :constraint_type "FOREIGN KEY",
+                 :initially_deferred "NO",
+                 :deferrable? "NO"},
+                :right-only nil,
+                :same nil}
+               {:left-only
+                {:constraint_name "reports_certname_fkey",
+                 :table_name "reports",
+                 :constraint_type "FOREIGN KEY",
+                 :initially_deferred "NO",
+                 :deferrable? "NO"},
+                :right-only nil,
+                :same nil}
+               {:left-only
+                {:constraint_name "reports_status_fkey",
+                 :table_name "reports",
+                 :constraint_type "FOREIGN KEY",
+                 :initially_deferred "NO",
+                 :deferrable? "NO"},
+                :right-only nil,
+                :same nil}
+               {:left-only
+                {:constraint_name "reports_env_fkey",
+                 :table_name "reports",
+                 :constraint_type "FOREIGN KEY",
+                 :initially_deferred "NO",
+                 :deferrable? "NO"},
+                :right-only nil,
+                :same nil}]
+              exp-idx-diff (concat exp-reports-indices-diff
+                                   (generate-diff-sequence report-partition-day-index-diff-template))
+              exp-constraint-diff (concat exp-reports-constraint-diff
+                                          (generate-diff-sequence report-partition-day-constraint-diff-template))
             expected-diff
               {:index-diff (set exp-idx-diff)
                :table-diff nil

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -1983,21 +1983,23 @@
         formatted-start-of-day (get-formatted-start-of-day date)
         formatted-start-of-next-day (get-formatted-start-of-day (.plusDays date 1))]
     [{:left-only
-        {:constraint_name
-          (format "(((producer_timestamp >= '%s'::timestamp with time zone) AND (producer_timestamp < '%s'::timestamp with time zone)))" formatted-start-of-day formatted-start-of-next-day),
-          :table_name (format "reports_%s" date-suffix),
-          :constraint_type "CHECK",
-          :initially_deferred "NO",
-          :deferrable? "NO"},
-         :right-only nil,
-         :same nil}
-        {:left-only nil,
-         :right-only
-         {:constraint_name (format "reports_%s_pkey" date-suffix), :table_name (format "reports_%s" date-suffix),
-          :constraint_type "PRIMARY KEY",
-          :initially_deferred "NO",
-          :deferrable? "NO"},
-         :same nil}]))
+      {:constraint_name
+       (format "(((producer_timestamp >= '%s'::timestamp with time zone) AND (producer_timestamp < '%s'::timestamp with time zone)))" formatted-start-of-day formatted-start-of-next-day)
+       :table_name (format "reports_%s" date-suffix)
+       :constraint_type "CHECK"
+       :initially_deferred "NO"
+       :deferrable? "NO"}
+      :right-only nil
+      :same nil}
+     {:left-only nil
+      :right-only
+      {:constraint_name (format "reports_%s_pkey" date-suffix)
+       :table_name (format "reports_%s" date-suffix)
+       :constraint_type "PRIMARY KEY"
+       :initially_deferred "NO"
+       :deferrable? "NO"}
+      :same nil}]))
+
 
 (deftest migration-82-reports-declarative-partitioning
   (testing "reports table declarative partitioning migration"
@@ -2007,76 +2009,76 @@
       (let [before-migration (schema-info-map *db*)
             exp-reports-indices-diff
               [{:left-only
-                {:schema "public",
-                 :table "reports",
-                 :index "reports_hash_expr_idx",
-                 :index_keys ["encode(hash, 'hex'::text)"],
-                 :type "btree",
-                 :unique? true,
-                 :functional? true,
-                 :is_partial false,
-                 :primary? false,
-                 :user "pdb_test"},
-                :right-only nil,
+                {:schema "public"
+                 :table "reports"
+                 :index "reports_hash_expr_idx"
+                 :index_keys ["encode(hash, 'hex'::text)"]
+                 :type "btree"
+                 :unique? true
+                 :functional? true
+                 :is_partial false
+                 :primary? false
+                 :user "pdb_test"}
+                :right-only nil
                 :same nil}
-               {:left-only nil,
+               {:left-only nil
                 :right-only
-                {:schema "public",
-                 :table "reports",
-                 :index "reports_hash_expr_idx",
-                 :index_keys ["encode(hash, 'hex'::text)" "producer_timestamp"],
-                 :type "btree",
-                 :unique? true,
-                 :functional? true,
-                 :is_partial false,
-                 :primary? false,
-                 :user "pdb_test"},
+                {:schema "public"
+                 :table "reports"
+                 :index "reports_hash_expr_idx"
+                 :index_keys ["encode(hash, 'hex'::text)" "producer_timestamp"]
+                 :type "btree"
+                 :unique? true
+                 :functional? true
+                 :is_partial false
+                 :primary? false
+                 :user "pdb_test"}
                 :same nil}
                {:left-only
-                {:schema "public",
-                 :table "reports",
-                 :index "reports_pkey",
-                 :index_keys ["id"],
-                 :type "btree",
-                 :unique? true,
-                 :functional? false,
-                 :is_partial false,
-                 :primary? true,
-                 :user "pdb_test"},
-                :right-only nil,
+                {:schema "public"
+                 :table "reports"
+                 :index "reports_pkey"
+                 :index_keys ["id"]
+                 :type "btree"
+                 :unique? true
+                 :functional? false
+                 :is_partial false
+                 :primary? true
+                 :user "pdb_test"}
+                :right-only nil
                 :same nil}
-               {:left-only nil,
+               {:left-only nil
                 :right-only
-                {:schema "public",
-                 :table "reports",
-                 :index "reports_pkey",
-                 :index_keys ["id" "producer_timestamp"],
-                 :type "btree",
-                 :unique? true,
-                 :functional? false,
-                 :is_partial false,
-                 :primary? true,
-                 :user "pdb_test"},
+                {:schema "public"
+                 :table "reports"
+                 :index "reports_pkey"
+                 :index_keys ["id" "producer_timestamp"]
+                 :type "btree"
+                 :unique? true
+                 :functional? false
+                 :is_partial false
+                 :primary? true
+                 :user "pdb_test"}
                 :same nil}
-               {:left-only nil,
+               {:left-only nil
                 :right-only
-                {:schema "public",
-                 :table "reports",
-                 :index "idx_reports_compound_id",
-                 :index_keys ["producer_timestamp" "certname" "hash"],
-                 :type "btree",
-                 :unique? false,
-                 :functional? false,
-                 :is_partial true,
-                 :primary? false,
-                 :user "pdb_test"},
+                {:schema "public"
+                 :table "reports"
+                 :index "idx_reports_compound_id"
+                 :index_keys ["producer_timestamp" "certname" "hash"]
+                 :type "btree"
+                 :unique? false
+                 :functional? false
+                 :is_partial true
+                 :primary? false
+                 :user "pdb_test"}
                 :same nil}]
             exp-idx-diff (concat exp-reports-indices-diff
                                  (generate-diff-sequence report-partition-day-index-diff-template))
             exp-constraint-diff (generate-diff-sequence report-partition-day-constraint-diff-template)
             expected-diff
-              {:index-diff (set exp-idx-diff),
-               :table-diff nil,
+              {:index-diff (set exp-idx-diff)
+               :table-diff nil
                :constraint-diff (set exp-constraint-diff)}]
         (apply-migration-for-testing! 82)
         (let [raw-diff (diff-schema-maps before-migration (schema-info-map *db*))


### PR DESCRIPTION
We have not released this migration, otherwise a separate migration would be needed.

Postgres foreign keys are implemented with bidirectional triggers this means that even after we have detached the partition from the parent table, dropping it will still require access exclusive locks on all the tables that we reference with foreign keys.