### PR TITLE
(temp pr) Test puppetdb 7.x with HikariCP 5.x

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -203,7 +203,7 @@
                  [org.apache.commons/commons-lang3]
 
                  ;; Database connectivity
-                 [com.zaxxer/HikariCP]
+                 [com.zaxxer/HikariCP "5.0.1"]
                  [com.github.seancorfield/honeysql]
 
                  ;; WebAPI support libraries.


### PR DESCRIPTION
PR just for testing, bumping clj-parent to use HikariCP 5.x if puppetdb testing passes