### PR TITLE
(PDB-5592) Generate catalogs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -159,6 +159,7 @@
                  [org.clojure/core.async]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [org.clojure/core.memoize]
+                 [org.clojure/data.generators "1.0.0"]
                  [org.clojure/java.jdbc]
                  [org.clojure/tools.macro]
                  [org.clojure/tools.namespace]

--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -46,7 +46,7 @@
             [puppetlabs.puppetdb.utils :as utils :refer [println-err]]
             [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.client :as client]
-            [puppetlabs.puppetdb.random :refer [random-string random-bool]]
+            [puppetlabs.puppetdb.random :refer [random-string random-bool random-sha1]]
             [puppetlabs.puppetdb.time :as time :refer [now]]
             [puppetlabs.puppetdb.archive :as archive]
             [clojure.core.async :refer [go go-loop <! <!! chan] :as async]
@@ -101,7 +101,7 @@
   [catalog]
   (assoc catalog
          "catalog_uuid" (kitchensink/uuid)
-         "code_id" (kitchensink/utf8-string->sha1 (random-string 100))))
+         "code_id" (random-sha1)))
 
 (defn rand-catalog-mutation
   "Grabs one of the mutate-fns randomly and returns it"

--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -221,7 +221,8 @@
                ["-C" "--catalogs CATALOGS" "Path to a directory containing sample JSON catalogs (files must end with .json)"]
                ["-R" "--reports REPORTS" "Path to a directory containing sample JSON reports (files must end with .json)"]
                ["-A" "--archive ARCHIVE" "Path to a PuppetDB export tarball. Incompatible with -C, -F or -R"]
-               ["-i" (str "--runinterval RUNINTERVAL" "interval (in minutes)"
+               ["-i" "--runinterval RUNINTERVAL"
+                     (str "Interval (in minutes)"
                           " to use during simulation. This option"
                           " requires some temporary filesystem space, which"
                           " will be allocated in TMPDIR (if set in the"

--- a/src/puppetlabs/puppetdb/cli/generate.clj
+++ b/src/puppetlabs/puppetdb/cli/generate.clj
@@ -7,21 +7,27 @@
    Note that it is only necessary to generate a small set of initial sample
    data since benchmark will permute per node differences. So even if you want
    to benchmark 1000 nodes, you don't need to generate initial
-   catalog/fact/report json for 1000 nodes."
+   catalog/fact/report json for 1000 nodes.
+
+   TODO:
+   * facts
+   * reports"
   (:require
     [clojure.string :as string]
+    [clojure.data.generators :as dgen]
     [puppetlabs.i18n.core :refer [trs]]
     [puppetlabs.kitchensink.core :as kitchensink]
     [puppetlabs.puppetdb.cheshire :as json]
     [puppetlabs.puppetdb.cli.util :refer [exit run-cli-cmd]]
     [puppetlabs.puppetdb.export :as export]
     [puppetlabs.puppetdb.nio :refer [get-path]]
-    [puppetlabs.puppetdb.random :refer [random-resource random-sha1 random-pronouncable-word]]
+    [puppetlabs.puppetdb.random :as rnd]
     [puppetlabs.puppetdb.time :refer [now]]
     [puppetlabs.puppetdb.utils :as utils])
   (:import
     [java.nio.file.attribute FileAttribute]
-    [java.nio.file Files]))
+    [java.nio.file Files]
+    [org.apache.commons.lang3 RandomStringUtils]))
 
 (defn pseudonym
   "Generate a fictious but somewhat intelligible keyword name."
@@ -29,19 +35,84 @@
    (pseudonym prefix ordinal 6))
   ([prefix ordinal length]
    (let [mid-length (max (- length (count prefix) (count (str ordinal))) 1)]
-     (format "%s-%s-%s" prefix (random-pronouncable-word mid-length) ordinal))))
+     (format "%s-%s-%s" prefix (rnd/random-pronouncable-word mid-length) ordinal))))
+
+(defn build-to-size
+  "Build up list of strings to approximately size bytes."
+  [size generate-word-fn]
+  (loop [strings []]
+    (if (< (reduce + (map count strings)) size)
+      (recur (conj strings (generate-word-fn)))
+      strings)))
+
+(defn parameter-name
+  "Generate a fictious but somewhat intelligible snake case parameter name (as
+   used in puppet modules).
+
+   NOTE: size is not exact."
+  ([]
+   (parameter-name 6))
+  ([size]
+   (let [p-word-fn #(rnd/random-pronouncable-word 6 2 {:lowerb 1})
+         words (build-to-size size p-word-fn)]
+     (string/join "_" words))))
+
+(defn build-parameters
+  "Build a random map of resource parameter keyword and string values to
+   approximately size number of bytes."
+  [size]
+  (loop [parameters {}]
+    (let [current-size (->> (into [] cat parameters)
+                            (map count)
+                            (reduce +))]
+      (if (< current-size size)
+        (recur (assoc parameters
+                      (parameter-name
+                        (rnd/safe-sample-normal 20 5 {:lowerb 5}))
+                      (RandomStringUtils/randomAscii
+                        (rnd/safe-sample-normal 50 25 {:upperb size}))))
+        parameters))))
 
 (defn generate-classes
-  [number]
-  (map (fn [i] (random-resource "Class" (pseudonym "class" i))) (range number)))
+  [number title-size]
+  (map (fn [i] (rnd/random-resource "Class" (pseudonym "class" i title-size))) (range number)))
+
+(def builtin-puppet-types
+  "List of some built in puppet types for randomized resources."
+  ["Exec"
+   "File"
+   "Package"
+   "Service"
+   "User"])
+
+(defn random-type
+  "Return a built-in type 80% of the time, or a random defined type name."
+  []
+  (dgen/weighted
+    {;; 80%
+     #(rand-nth builtin-puppet-types), 4
+     ;; 20%
+     (fn [] (string/join "::" (repeatedly
+                               (inc (rand-int 4))
+                               #(string/capitalize
+                                  (rnd/random-pronouncable-word 10 4 {:lowerb 2}))))), 1}))
 
 (defn generate-resources
-  [number title-size]
+  [number avg-resource-size title-size]
+  (let [tag-word-fn #(rnd/random-pronouncable-word 15 7 {:lowerb 5 :upperb 100})]
     (map (fn [i]
-           (let [type-name (rand-nth ["File" "Exec" "Service"])
-                 title (pseudonym "resource" i title-size)]
-             (random-resource type-name title)))
-         (range number)))
+           (let [type-name (random-type)
+                 title (pseudonym "resource" i title-size)
+                 resource-size (rnd/safe-sample-normal avg-resource-size (quot avg-resource-size 4))
+                 tags-mean (-> (quot resource-size 5) (min 200))
+                 tags-size (rnd/safe-sample-normal tags-mean (quot tags-mean 2) {:lowerb 10})
+                 parameters-size (- resource-size tags-size)
+                 tags (build-to-size tags-size tag-word-fn)
+                 file (rnd/random-pp-path)
+                 parameters (build-parameters parameters-size)
+                 resource (rnd/random-resource type-name title {"tags" tags "file" file})]
+             (assoc resource "parameters" parameters)))
+         (range number))))
 
 (defn generate-edge
   ([source target]
@@ -55,13 +126,13 @@
   "Generate a set of edges associating each class with main-stage and randomly
    distributing remaining resources within the classes."
   [main-stage classes resources]
-  (let [class-map
+  (let [class-resources-map
           (reduce
             (fn [cmap r]
               (let [class-key (rand-nth classes)]
                 (update cmap class-key conj r)))
             {} resources)]
-    (->> class-map
+    (->> class-resources-map
          (map
            (fn [[cls cls-resources]]
              (concat
@@ -69,21 +140,21 @@
          flatten)))
 
 (defn generate-catalog
-  [certname num-classes, num-resources, title-size, _total-catalog-size, _depth]
-  (let [main-stage (random-resource "Stage" "main")
-        classes (generate-classes num-classes)
-        resources (generate-resources (- num-resources num-classes) title-size)
+  [certname {:keys [num-classes num-resources resource-size title-size]}]
+  (let [main-stage (rnd/random-resource "Stage" "main")
+        classes (generate-classes num-classes title-size)
+        resources (generate-resources (- num-resources num-classes) resource-size title-size)
         edges (generate-edges main-stage classes resources)]
     {:resources (reduce into [[main-stage] classes resources])
      :edges edges
      :producer_timestamp (now)
      :transaction_uuid (kitchensink/uuid)
      :certname certname
-     :hash (random-sha1)
+     :hash (rnd/random-sha1)
      :version (quot (System/currentTimeMillis) 1000)
      :producer "puppetmaster1"
      :catalog_uuid (kitchensink/uuid)
-     :code_id (random-sha1)}))
+     :code_id (rnd/random-sha1)}))
 
 (defn create-temp-dir
   "Generate a temp directory and return the Path object pointing to it."
@@ -108,14 +179,14 @@
   "Build up a dataset of sample PuppetDB facts, catalogs and reports based on
    given options and store them in the given output directory."
   [options]
-  (let [{:keys [num-hosts num-classes num-resources title-size output-dir]} options
+  (let [{:keys [num-hosts output-dir]} options
         output-path (-> (if (string/blank? output-dir)
                           (create-temp-dir)
                           (get-path output-dir))
                         .toAbsolutePath
                         .normalize)
-        hosts (map (fn [i] (format "host-%s-%s" (random-pronouncable-word) i)) (range num-hosts))
-        catalogs (map (fn [host] (generate-catalog host num-classes num-resources title-size nil nil)) hosts)
+        hosts (map (fn [i] (format "host-%s-%s" (rnd/random-pronouncable-word) i)) (range num-hosts))
+        catalogs (map (fn [host] (generate-catalog host options)) hosts)
         facts []
         reports []
         data {:catalogs
@@ -146,6 +217,9 @@
                 :parse-fn #(Integer/parseInt %)]
                ["-t" "--title-size TITLESIZE" "Number of characters in resource titles."
                 :default 20
+                :parse-fn #(Integer/parseInt %)]
+               ["-s" "--resource-size" "The average resource size in kB."
+                :default 50
                 :parse-fn #(Integer/parseInt %)]
                ["-n" "--num-hosts NUMHOSTS" "The number of sample hosts to generate data for."
                 :default 5

--- a/src/puppetlabs/puppetdb/cli/generate.clj
+++ b/src/puppetlabs/puppetdb/cli/generate.clj
@@ -1,0 +1,117 @@
+(ns puppetlabs.puppetdb.cli.generate
+  "Data Generation utility
+
+   This command-line tool can generate a base sampling of catalog, fact and
+   report files suitable for consumption by the PuppetDB benchmark utility.
+
+   Note that it is only necessary to generate a small set of initial sample
+   data since benchmark will permute per node differences. So even if you want
+   to benchmark 1000 nodes, you don't need to generate initial
+   catalog/fact/report json for 1000 nodes."
+  (:require
+    [clojure.java.io :as io]
+    [puppetlabs.i18n.core :refer [trs]]
+    [puppetlabs.kitchensink.core :as kitchensink]
+    [puppetlabs.puppetdb.cheshire :as json]
+    [puppetlabs.puppetdb.cli.util :refer [exit run-cli-cmd]]
+    [puppetlabs.puppetdb.export :as export]
+    [puppetlabs.puppetdb.nio :refer [get-path]]
+    [puppetlabs.puppetdb.time :refer [now]]
+    [puppetlabs.puppetdb.utils :as utils :refer [println-err]])
+  (:import
+    [java.nio.file.attribute FileAttribute]
+    [java.nio.file Files]))
+
+(defn generate-catalog
+  [certname num-classes, num-resources, title-size, _total-catalog-size, _depth]
+  {})
+
+(defn create-temp-dir
+  "Generate a temp directory and return the Path object pointing to it."
+  []
+  (let [temp-dir (get-path (or (System/getenv "TMPDIR")
+                               (System/getProperty "java.io.tmpdir")))]
+    (Files/createTempDirectory temp-dir
+                               "pdb-generate-"
+                               (into-array FileAttribute []))))
+
+(defn generate-files-from-wireformat-collection
+  "Store each PuppetDB object as a JSON blob.
+   Creates dir and generates filenames using the given namer fn."
+  [{:keys [dir namer col]}]
+  (.mkdir (.toFile dir))
+  (doseq [i col]
+    (let [file-name (namer i)
+          f (.toFile (.resolve dir file-name))]
+      (json/spit-json f i))))
+
+(defn generate
+  "Build up a dataset of sample PuppetDB facts, catalogs and reports based on
+   given options and store them in the given output directory."
+  [options]
+  (let [{:keys [num-hosts num-classes num-resources title-size output-dir]} options
+        output-path (-> (if (clojure.string/blank? output-dir)
+                          (create-temp-dir)
+                          (get-path output-dir))
+                        .toAbsolutePath
+                        .normalize)
+        hosts (map (fn [i] (format "host-%s-%s" (random-pronouncable-word) i)) (range num-hosts))
+        catalogs (map (fn [host] (generate-catalog host num-classes num-resources title-size nil nil)) hosts)
+        facts []
+        reports []
+        data {:catalogs
+               {:dir (.resolve output-path "catalogs")
+                :namer export/export-filename
+                :col catalogs}
+              :facts
+               {:dir (.resolve output-path "facts")
+                :namer #(str (:certname %) export/export-file-ext)
+                :col facts}
+              :reports
+               {:dir (.resolve output-path "reports")
+                :namer export/export-filename
+                :col reports}}]
+    (when-not (.exists (.toFile output-path))
+      (utils/throw-sink-cli-error (trs "Error: output path does not exist: {0}" output-path)))
+    (println (format "Generate from %s and store at %s" options output-path))
+    (doseq [[_kind d] data]
+      (generate-files-from-wireformat-collection d))))
+
+(defn- validate-cli!
+  [args]
+  (let [specs [["-c" "--num-classes NUMCLASSES" "Number of class resources to generate in catalogs."
+                :default 10
+                :parse-fn #(Integer/parseInt %)]
+               ["-r" "--num-resources NUMRESOURCES" "Number of resources to generate in catalogs."
+                :default 100
+                :parse-fn #(Integer/parseInt %)]
+               ["-t" "--title-size TITLESIZE" "Number of characters in resource titles."
+                :default 20
+                :parse-fn #(Integer/parseInt %)]
+               ["-n" "--num-hosts NUMHOSTS" "The number of sample hosts to generate data for."
+                :default 5
+                :parse-fn #(Integer/parseInt %)]
+               ["-o" "--output-dir OUTPUTDIR" "Directory to write output files to. Will allocate in TMPDIR (if set in the environment) or java.io.tmpdir if not given."]]
+        required []]
+    (utils/try-process-cli
+      (fn []
+        (-> args
+            (kitchensink/cli! specs required)
+            first)))))
+
+(defn generate-wrapper
+  "Generates a set of fact, catalog and report json files based on the given args."
+  [args]
+  (-> args
+      validate-cli!
+      generate))
+
+(defn cli
+  "Runs the generate command as directed by the command line args and
+  returns an appropriate exit status."
+  [args]
+  (run-cli-cmd #(generate-wrapper args))
+  0)
+
+(defn -main [& args]
+  (exit (cli args)))

--- a/src/puppetlabs/puppetdb/core.clj
+++ b/src/puppetlabs/puppetdb/core.clj
@@ -12,6 +12,7 @@
    "  upgrade                 Upgrade to latest version and exit"
    "  benchmark               Run development-only benchmarking tool"
    "  fact-storage-benchmark"
+   "  generate                Create sample data files for benchmarking"
    "  help                    Display usage summary"
    "For help on a given subcommand, invoke it with -h"])
 
@@ -41,7 +42,7 @@
     "upgrade" (run-resolved "services" 'cli [args {:upgrade-and-exit? true}])
     "services" (run-resolved "services" 'cli [args])
 
-    ("benchmark" "fact-storage-benchmark" "version")
+    ("benchmark" "fact-storage-benchmark" "version" "generate")
     (run-resolved subcommand 'cli [args])
 
     (do

--- a/src/puppetlabs/puppetdb/random.clj
+++ b/src/puppetlabs/puppetdb/random.clj
@@ -1,7 +1,8 @@
 (ns puppetlabs.puppetdb.random
   (:require
    [clojure.string :as string]
-   [clojure.walk :refer [keywordize-keys]])
+   [clojure.walk :refer [keywordize-keys]]
+   [puppetlabs.kitchensink.core :as kitchensink])
   (:import
    (org.apache.commons.lang3 RandomStringUtils)))
 
@@ -87,3 +88,9 @@
    "new_value"          (random-string)
    "message"            (random-string)
    })
+
+(defn random-sha1
+  "Generate a SHA1 hash of a random-string."
+  ([] (random-sha1 100))
+  ([str-size]
+   (kitchensink/utf8-string->sha1 (random-string str-size))))

--- a/src/puppetlabs/puppetdb/random.clj
+++ b/src/puppetlabs/puppetdb/random.clj
@@ -103,8 +103,7 @@
    ~68% of the returned values will fall within mean +/- standard-deviation.
    ~95% within two standard-deviations.
    ~99% within three...
-   https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule
-   "
+   https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule"
   [mean standard-deviation]
   (-> random .nextGaussian (* standard-deviation) (+ mean) int))
 

--- a/src/puppetlabs/puppetdb/random.clj
+++ b/src/puppetlabs/puppetdb/random.clj
@@ -21,6 +21,19 @@
   ([length]
    (.toLowerCase (RandomStringUtils/randomAlphabetic length))))
 
+(defn random-pronouncable-word
+  "Generate a random string of optional length that alternates consonants and
+   vowels to produce a loosely recognizable wordish thing."
+  ([] (random-pronouncable-word 6))
+  ([length]
+   (let [random-consonant #(RandomStringUtils/random 1 "bcdfghjklmnpqrstvwxz")
+         random-vowel #(RandomStringUtils/random 1 "aeiouy")]
+     (->> (for [i (range length)]
+           (if (even? i)
+             (random-consonant)
+             (random-vowel)))
+         (string/join "")))))
+
 (defn random-bool
   "Generate a random boolean"
   []

--- a/test/puppetlabs/puppetdb/cli/generate_test.clj
+++ b/test/puppetlabs/puppetdb/cli/generate_test.clj
@@ -1,0 +1,38 @@
+(ns puppetlabs.puppetdb.cli.generate-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.puppetdb.cli.generate :as generate]))
+
+(deftest generate-edges
+  (let [m {"type" "Stage" "title" "main"}
+        c [{"type" "Class" "title" "1"}
+           {"type" "Class" "title" "2"}
+           {"type" "Class" "title" "3"}]
+        r [{"type" "File" "title" "1"}
+           {"type" "File" "title" "2"}
+           {"type" "File" "title" "3"}
+           {"type" "File" "title" "4"}
+           {"type" "File" "title" "5"}
+           {"type" "File" "title" "6"}
+           {"type" "File" "title" "7"}]
+        e (generate/generate-edges m c r)]
+    (testing "an edge to each resource (and class resource)"
+      (is (= 10 (count e))))
+    (let [edge-test (fn [exp-source-type exp-target-type edges]
+                      (filter
+                        (fn [{:keys [relationship]
+                             {stype "type"} :source
+                             {ttype "type"} :target}]
+                          (and (= stype exp-source-type) (= ttype exp-target-type) (= relationship "contains")))
+                        edges))]
+      (testing "Stage main contains each class"
+        (is (= 3 (count (edge-test "Stage" "Class" e)))))
+      (testing "Classes contain rest of resources"
+        (is (= 7 (count (edge-test "Class" "File" e))))))))
+
+(deftest generate-catalog
+  (let [c (generate/generate-catalog "host-1" 2 10 20 nil nil)]
+    (is (contains? c :certname))
+    (testing "resource count matches num-resources options + main"
+      (is (= 11 (count (:resources c)))))
+    (testing "edge count matches num-resources option"
+      (is (= 10 (count (:edges c)))))))

--- a/test/puppetlabs/puppetdb/cli/generate_test.clj
+++ b/test/puppetlabs/puppetdb/cli/generate_test.clj
@@ -4,7 +4,8 @@
             [clojure.string :as string]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.cheshire :as json]
-            [puppetlabs.puppetdb.cli.generate :as generate]))
+            [puppetlabs.puppetdb.cli.generate :as generate]
+            [puppetlabs.puppetdb.nio :refer [get-path]]))
 
 (defn filter-edges
   ([exp-source-type exp-target-type edges]
@@ -67,32 +68,10 @@
     (testing "edge count matches num-resources option + 50%"
       (is (= 15 (count (:edges c)))))))
 
-(defmulti weigh class)
-(defmethod weigh clojure.lang.IPersistentMap
-  [mp]
-  (reduce (fn [size [k v]]
-            (+ size (count (str k)) (weigh v)))
-          0, mp))
-(defn- weigh-vec-set-or-seq
-  [a]
-  (reduce (fn [size e]
-            (+ size (weigh e)))
-          0, a))
-(defmethod weigh clojure.lang.IPersistentVector [vc] (weigh-vec-set-or-seq vc))
-(defmethod weigh clojure.lang.IPersistentSet [st] (weigh-vec-set-or-seq st))
-(defmethod weigh clojure.lang.ISeq [sq] (weigh-vec-set-or-seq sq))
-(defmethod weigh clojure.lang.Keyword [k] (count (str k)))
-(defmethod weigh String [s] (count s))
-(defmethod weigh Number [_] 4)
-(defmethod weigh Boolean [_] 1)
-(defmethod weigh org.joda.time.DateTime [_] 8)
-(defmethod weigh :default
-  [what] (throw (Exception. (format "Don't know how to weigh a %s of type %s" what (type what)))))
-
 (deftest generate-resources
   (let [resources (generate/generate-resources 100 500 20)
         key-weight 39 ;; size of base resource parameter keys which aren't stored in db
-        footprints (map #(- (weigh %) key-weight) resources)
+        footprints (map #(- (generate/weigh %) key-weight) resources)
         total-footprint (reduce + footprints)
         avg-footprint (quot total-footprint (count resources))]
     (is (= 100 (count resources)))
@@ -104,8 +83,8 @@
         c-with-blob (generate/add-blob catalog 100)]
     (testing "catalog is modified"
       (is (not= catalog c-with-blob))
-      (is (< (weigh catalog) 5000))
-      (is (> (weigh c-with-blob) 50000)))
+      (is (< (generate/weigh catalog) 5000))
+      (is (> (generate/weigh c-with-blob) 50000)))
     (testing "blob parameter is added"
       (let [resources (:resources c-with-blob)
             resources-with-blobs (filter
@@ -135,7 +114,8 @@
                  :additional-edge-percent additional-edge-percent
                  :avg-blob-count 0
                  :blob-size 100
-                 :output-dir (.toString tmpdir)}
+                 :output-dir (.toString tmpdir)
+                 :silent true}
         additional-edge-% (/ additional-edge-percent 100.0)
         num-edges (+ num-resources (int (* num-resources additional-edge-%)))]
     (testing "without blobs"
@@ -143,13 +123,13 @@
         (generate/generate options)
         (let [catalog-dir (.toFile (.resolve tmpdir "catalogs"))
               catalogs (map #(json/parse-string (slurp %)) (.listFiles catalog-dir))
-              total-weight (->> catalogs (map weigh) (reduce +))]
+              total-weight (->> catalogs (map generate/weigh) (reduce +))]
           (testing "generation of files"
             (is (< 250000 total-weight 500000))
             (doseq [cat catalogs]
               (is (= (+ num-resources 1) (count (get cat "resources"))))
               (is (= num-edges (count (get cat "edges"))))
-              (is (< 50000 (weigh cat) 100000)
+              (is (< 50000 (generate/weigh cat) 100000))
               (let [resources (get cat "resources")
                     ;; Ignore the size of the base resource keys as they are
                     ;; not stored in the database.
@@ -158,7 +138,7 @@
                                  (map (fn [r]
                                         (let [key-weight (reduce + (map count (keys r)))]
                                           {:r r
-                                           :w (- (weigh r) key-weight)}))
+                                           :w (- (generate/weigh r) key-weight)}))
                                       resources))
                     avg-resource-footprint (quot (reduce + (map :w footprints)) (count resources))
                     min-footprint (first footprints)
@@ -166,7 +146,7 @@
                 (is (< (* resource-size 0.5) avg-resource-footprint (* resource-size 1.5)))
                 ;; Class resources aren't varied much.
                 (is (< 25 (:w min-footprint) 150) (format "Odd min-footprint %s" min-footprint))
-                (is (< resource-size (:w max-footprint) (* resource-size 2.5)) (format "Odd max-footprint %s" max-footprint)))))))
+                (is (< resource-size (:w max-footprint) (* resource-size 2.5)) (format "Odd max-footprint %s" max-footprint))))))
         (finally (shell/sh "rm" "-rf" (.toString tmpdir)))))
     (testing "with blobs"
       (try
@@ -178,6 +158,25 @@
             (doseq [cat catalogs]
                 (is (= (+ num-resources 1) (count (get cat "resources"))))
                 (is (= num-edges (count (get cat "edges")))))
-            (let [total-weight (->> catalogs (map weigh) (reduce +))]
+            (let [total-weight (->> catalogs (map generate/weigh) (reduce +))]
               (is (> total-weight 700000)))))
         (finally (shell/sh "rm" "-rf" (.toString tmpdir)))))))
+
+(deftest summarize
+  (let [num-classes 10
+        num-resources 100
+        title-size 20
+        resource-size 500
+        additional-edge-percent 50
+        options {:num-hosts 5
+                 :num-classes num-classes
+                 :num-resources num-resources
+                 :title-size title-size
+                 :resource-size resource-size
+                 :additional-edge-percent additional-edge-percent
+                 :avg-blob-count 0
+                 :blob-size 100}
+        data (generate/generate-data options (get-path "/dev/null"))
+        output (with-out-str (generate/summarize data))]
+    (is (re-find #":catalogs: 5\b" output))
+    (is (re-find #":facts: 0\b" output))))

--- a/test/puppetlabs/puppetdb/cli/generate_test.clj
+++ b/test/puppetlabs/puppetdb/cli/generate_test.clj
@@ -1,5 +1,8 @@
 (ns puppetlabs.puppetdb.cli.generate-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.java.shell :as shell]
+            [clojure.set :as cset]
+            [clojure.test :refer :all]
+            [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.cli.generate :as generate]))
 
 (defn filter-edges
@@ -28,16 +31,32 @@
            {"type" "File" "title" "5"}
            {"type" "File" "title" "6"}
            {"type" "File" "title" "7"}]
-        g (generate/generate-catalog-graph m c r 50)
+        g (generate/generate-catalog-graph m c r 0)
         e (:edges g)]
     (testing "an edge to each resource (and class resource)"
-      (is (= 14 (count e))))
+      (is (= 10 (count e))))
     (testing "Stage main contains each class"
       (is (= 3 (count (filter-edges "Stage" "Class" e)))))
-    (testing "There is an additional relation between two classes"
-      (is (= 1 (count (filter-edges "Class" "Class" :any e)))))
     (testing "Classes contain rest of resources"
-      (is (= 7 (count (filter-edges "Class" "File" e)))))))
+      (is (= 7 (count (filter-edges "Class" "File" e)))))
+    (testing "With a percentage of additional edges"
+      (let [g (generate/generate-catalog-graph m c r 50)
+            e (:edges g)]
+        (testing "there is a containment edge for each class and resource and an additional % of classes and resources have an extra edge (rounded down)"
+          (is (= 14 (count e))))
+        (testing "Stage main contains each class"
+          (is (= 3 (count (filter-edges "Stage" "Class" e)))))
+        (testing "There is an additional relation between two classes"
+          (is (= 1 (count (filter-edges "Class" "Class" :any e)))))
+        (testing "Classes contain rest of resources"
+          (is (= 7 (count (filter-edges "Class" "File" e)))))
+        (testing "There are any additional three non-containment edges between resources"
+          (let [extras (->> (cset/union
+                              (set (filter-edges "Class" "File" :any e))
+                              (set (filter-edges "File" "Class" :any e))
+                              (set (filter-edges "File" "File" :any e)))
+                            (filter #(not= (:relation %) :contains)))]
+            (is (= 3 (count extras)))))))))
 
 (deftest generate-catalog
   (let [c (generate/generate-catalog "host-1" {:num-classes 2 :num-resources 10 :title-size 20 :resource-size 200 :additional-edge-percent 50})]
@@ -46,3 +65,75 @@
       (is (= 11 (count (:resources c)))))
     (testing "edge count matches num-resources option + 50%"
       (is (= 15 (count (:edges c)))))))
+
+(defmulti weigh class)
+(defmethod weigh clojure.lang.IPersistentMap
+  [mp]
+  (reduce (fn [size [k v]]
+            (+ size (count k) (weigh v)))
+          0, mp))
+(defmethod weigh clojure.lang.IPersistentVector
+  [vc]
+  (reduce (fn [size e]
+            (+ size (weigh e)))
+          0, vc))
+(defmethod weigh String [s] (count s))
+(defmethod weigh Number [_] 4)
+(defmethod weigh Boolean [_] 1)
+(defmethod weigh :default
+  [what] (throw (Exception. (format "Don't know how to weigh a %s of type %s" what (type what)))))
+
+(deftest generate-resources
+  (let [resources (generate/generate-resources 100 500 20)
+        key-weight 39 ;; size of base resource parameter keys which aren't stored in db
+        footprints (map #(- (weigh %) key-weight) resources)
+        total-footprint (reduce + footprints)
+        avg-footprint (quot total-footprint (count resources))]
+    (is (= 100 (count resources)))
+    (is (< 400 avg-footprint 600))
+    (is (< 40000 total-footprint  60000))
+    ))
+
+(deftest generate
+  (let [tmpdir (generate/create-temp-dir)
+        num-classes 10
+        num-resources 100
+        title-size 20
+        resource-size 500
+        additional-edge-percent 50
+        options {:num-hosts 5
+                 :num-classes num-classes
+                 :num-resources num-resources
+                 :title-size title-size
+                 :resource-size resource-size
+                 :additional-edge-percent additional-edge-percent
+                 :output-dir (.toString tmpdir)}
+        additional-edge-% (/ additional-edge-percent 100.0)
+        num-edges (+ num-resources (int (* num-resources additional-edge-%)))]
+    (try
+      (generate/generate options)
+      (let [catalog-dir (.toFile (.resolve tmpdir "catalogs"))]
+        (testing "generation of files"
+          (doseq [f (.listFiles catalog-dir)]
+            (let [cat (json/parse-string (slurp f))]
+              (is (= (+ num-resources 1) (count (get cat "resources"))))
+              (is (= num-edges (count (get cat "edges"))))
+              (let [resources (get cat "resources")
+                    ;; Ignore the size of the base resource keys as they are
+                    ;; not stored in the database.
+                    footprints (sort
+                                 #(< (:w %1) (:w %2))
+                                 (map (fn [r]
+                                        (let [key-weight (reduce + (map count (keys r)))]
+                                          {:r r
+                                           :w (- (weigh r) key-weight)}))
+                                      resources))
+                    avg-resource-footprint (quot (reduce + (map :w footprints)) (count resources))
+                    min-footprint (first footprints)
+                    max-footprint (last footprints)]
+                (is (< (* resource-size 0.5) avg-resource-footprint  (* resource-size 1.5)))
+                ;; Class resources aren't varied much.
+                (is (< 25 (:w min-footprint) 150) (format "Odd min-footprint %s" min-footprint))
+                (is (< resource-size (:w max-footprint) (* resource-size 2.5)) (format "Odd max-footprint %s" max-footprint))
+                )))))
+      (finally (shell/sh "rm" "-rf" (.toString tmpdir))))))

--- a/test/puppetlabs/puppetdb/cli/generate_test.clj
+++ b/test/puppetlabs/puppetdb/cli/generate_test.clj
@@ -30,7 +30,7 @@
         (is (= 7 (count (edge-test "Class" "File" e))))))))
 
 (deftest generate-catalog
-  (let [c (generate/generate-catalog "host-1" 2 10 20 nil nil)]
+  (let [c (generate/generate-catalog "host-1" {:num-classes 2 :num-resources 10 :title-size 20 :resource-size 200})]
     (is (contains? c :certname))
     (testing "resource count matches num-resources options + main"
       (is (= 11 (count (:resources c)))))

--- a/test/puppetlabs/puppetdb/cli/generate_test.clj
+++ b/test/puppetlabs/puppetdb/cli/generate_test.clj
@@ -2,7 +2,21 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetdb.cli.generate :as generate]))
 
-(deftest generate-edges
+(defn filter-edges
+  ([exp-source-type exp-target-type edges]
+   (filter-edges exp-source-type exp-target-type :contains edges))
+  ([exp-source-type exp-target-type exp-relation edges]
+   (filter
+     (fn [{:keys [relation]
+          {stype "type"} :source
+          {ttype "type"} :target}]
+       (and (= stype exp-source-type)
+            (= ttype exp-target-type)
+            (or (= exp-relation :any)
+                (= relation exp-relation))))
+     edges)))
+
+(deftest generate-catalog-graph
   (let [m {"type" "Stage" "title" "main"}
         c [{"type" "Class" "title" "1"}
            {"type" "Class" "title" "2"}
@@ -14,25 +28,21 @@
            {"type" "File" "title" "5"}
            {"type" "File" "title" "6"}
            {"type" "File" "title" "7"}]
-        e (generate/generate-edges m c r)]
+        g (generate/generate-catalog-graph m c r 50)
+        e (:edges g)]
     (testing "an edge to each resource (and class resource)"
-      (is (= 10 (count e))))
-    (let [edge-test (fn [exp-source-type exp-target-type edges]
-                      (filter
-                        (fn [{:keys [relationship]
-                             {stype "type"} :source
-                             {ttype "type"} :target}]
-                          (and (= stype exp-source-type) (= ttype exp-target-type) (= relationship "contains")))
-                        edges))]
-      (testing "Stage main contains each class"
-        (is (= 3 (count (edge-test "Stage" "Class" e)))))
-      (testing "Classes contain rest of resources"
-        (is (= 7 (count (edge-test "Class" "File" e))))))))
+      (is (= 14 (count e))))
+    (testing "Stage main contains each class"
+      (is (= 3 (count (filter-edges "Stage" "Class" e)))))
+    (testing "There is an additional relation between two classes"
+      (is (= 1 (count (filter-edges "Class" "Class" :any e)))))
+    (testing "Classes contain rest of resources"
+      (is (= 7 (count (filter-edges "Class" "File" e)))))))
 
 (deftest generate-catalog
-  (let [c (generate/generate-catalog "host-1" {:num-classes 2 :num-resources 10 :title-size 20 :resource-size 200})]
+  (let [c (generate/generate-catalog "host-1" {:num-classes 2 :num-resources 10 :title-size 20 :resource-size 200 :additional-edge-percent 50})]
     (is (contains? c :certname))
     (testing "resource count matches num-resources options + main"
       (is (= 11 (count (:resources c)))))
-    (testing "edge count matches num-resources option"
-      (is (= 10 (count (:edges c)))))))
+    (testing "edge count matches num-resources option + 50%"
+      (is (= 15 (count (:edges c)))))))

--- a/test/puppetlabs/puppetdb/random_test.clj
+++ b/test/puppetlabs/puppetdb/random_test.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.test :refer :all]
    [puppetlabs.puppetdb.random
-    :refer [random-bool
+    :refer [distribute
+            random-bool
             random-node-name
             random-pp-path
             random-pronouncable-word
@@ -63,3 +64,55 @@
       (is (re-matches (re-pattern (str exp-regex-str "{3}")) (random-pronouncable-word)))
       (is (re-matches (re-pattern (str exp-regex-str "{4}")) (random-pronouncable-word 8)))
       (is (re-matches (re-pattern (str exp-regex-str "{3}" consonants)) (random-pronouncable-word 7))))))
+
+(deftest test-distribute
+  (let [v5 (vec (map {} (range 5)))
+        v20 (vec (map {} (range 20)))
+        v100 (vec (map {} (range 100)))
+        poke (fn [e]
+               (let [{:keys [counter] :or {counter 0}} e]
+                 (assoc e :counter (+ 1 counter))))
+        tally (fn [v]
+                (let [tcount (fn [a {:keys [counter] :or {counter 0}}] (+ a counter))]
+                  (reduce tcount 0 v)))
+        options {:debug false}]
+    (testing "zero"
+      (let [dv5 (distribute v5 poke 0 options)
+            dv20 (distribute v20 poke 0 options)
+            dv100 (distribute v100 poke 0 options)]
+        (is (= dv5 v5))
+        (is (= dv20 v20))
+        (is (= dv100 v100))))
+    (testing "poke fractionally per"
+      (let [dv5 (distribute v5 poke 0.5 options)
+            dv20 (distribute v20 poke 0.5 options)
+            dv100 (distribute v100 poke 0.5 options)]
+        (is (<= 1 (tally dv5) 3))
+        (is (<= 7 (tally dv20) 13))
+        (is (<= 35 (tally dv100) 65))))
+    (testing "poke avg once per"
+      (let [dv5 (distribute v5 poke 1 options)
+            dv20 (distribute v20 poke 1 options)
+            dv100 (distribute v100 poke 1 options)]
+        (is (<= 4 (tally dv5) 6))
+        (is (<= 14 (tally dv20) 26))
+        (is (<= 70 (tally dv100) 130))))
+    (testing "poke avg twice per"
+      (let [dv5 (distribute v5 poke 2 options)
+            dv20 (distribute v20 poke 2 options)
+            dv100 (distribute v100 poke 2 options)]
+        (is (<= 7 (tally dv5) 13))
+        (is (<= 28 (tally dv20) 52 ))
+        (is (<= 140 (tally dv100) 260))))
+    (testing "poke avg ten times per"
+      (let [dv5 (distribute v5 poke 10 options)
+            dv20 (distribute v20 poke 10 options)
+            dv100 (distribute v100 poke 10 options)]
+        (is (<= 35 (tally dv5) 65))
+        (is (<= 140 (tally dv20) 260))
+        (is (<= 700 (tally dv100) 1300))))
+    (testing "overrides"
+        (let [dv20 (distribute v20 poke 1
+                               (merge options
+                                      {:standard-deviation 10 :lowerb 5 :upperb 50}))]
+          (is (<= 5 (tally dv20 ) 50))))))

--- a/test/puppetlabs/puppetdb/random_test.clj
+++ b/test/puppetlabs/puppetdb/random_test.clj
@@ -5,6 +5,7 @@
     :refer [random-bool
             random-node-name
             random-pp-path
+            random-pronouncable-word
             random-sha1
             random-string
             random-string-alpha
@@ -54,3 +55,11 @@
     (is (string? (random-sha1)))
     (is (re-matches #"[\da-z]{40}" (random-sha1)))
     (is (re-matches #"[\da-z]{40}" (random-sha1 1000)))))
+
+(deftest test-random-pronouncable-word
+  (let [consonants "[bcdfghjklmnpqrstvwxz]"
+        exp-regex-str (format "(?:%s[aeiouy])" consonants)]
+    (testing "returns a random pronouncable word string"
+      (is (re-matches (re-pattern (str exp-regex-str "{3}")) (random-pronouncable-word)))
+      (is (re-matches (re-pattern (str exp-regex-str "{4}")) (random-pronouncable-word 8)))
+      (is (re-matches (re-pattern (str exp-regex-str "{3}" consonants)) (random-pronouncable-word 7))))))

--- a/test/puppetlabs/puppetdb/random_test.clj
+++ b/test/puppetlabs/puppetdb/random_test.clj
@@ -5,6 +5,7 @@
     :refer [random-bool
             random-node-name
             random-pp-path
+            random-sha1
             random-string
             random-string-alpha
             random-type-name]]))
@@ -47,3 +48,9 @@
   (testing "should return a random path"
     (is (string? (random-pp-path)))
     (is (= 54 (count (random-pp-path))))))
+
+(deftest test-random-sha1
+  (testing "returns a random sha1 hash"
+    (is (string? (random-sha1)))
+    (is (re-matches #"[\da-z]{40}" (random-sha1)))
+    (is (re-matches #"[\da-z]{40}" (random-sha1 1000)))))


### PR DESCRIPTION
Adds a generate command to generate sample data files to be used to seed a benchmark.
First pass at catalog generation to accompany it.