### PR TITLE
(maint) PuppetDB 8: bump supported db to PG 14

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1856,7 +1856,7 @@
 ;; A db version that is "allowed" but not supported is deprecated
 (def oldest-allowed-db [11 0])
 
-(def oldest-supported-db [11 0])
+(def oldest-supported-db [14 0])
 
 (defn timestamp-of-newest-record [entity certname]
   (let [query {:select [:producer_timestamp]


### PR DESCRIPTION
- PostgreSQL 11 will EOL in 6 months, 12 in 18 months, and 13 in 2.5 years. PG 11 and 12 are not supported long enough for Puppet Platform 8.
- While PG 13 may be supported long enough for Puppet Platform 8, garbage collection is more efficient and less likely to conflict with other operations when using PG 14+