### PR TITLE
(PDB-5642) Un-conditionalize log slow PQL warning

### DIFF
--- a/src/puppetlabs/puppetdb/http/query.clj
+++ b/src/puppetlabs/puppetdb/http/query.clj
@@ -314,7 +314,7 @@
         result (pql/parse-pql-query query)
         elapsed (/ (- (System/nanoTime) start) 1000000.0)
         max-pql-limit 1000]
-    (when (and log-queries? (> elapsed max-pql-limit))
+    (when (> elapsed max-pql-limit)
       (log/warn (trs "Parsing PQL took {0} ms for PDBQuery:{1}:{2}" elapsed query-uuid (pr-str query))))
     result))
 


### PR DESCRIPTION
Users should not need to opt-in to this warning