### PR TITLE
(PDB-5636) update ezbake to 2.4.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -312,7 +312,7 @@
                                                ;; in the final package.
                                                [puppetlabs/puppetdb ~pdb-version :exclusions [com.zaxxer/HikariCP]]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "2.4.1"]]}
+                      :plugins [[puppetlabs/lein-ezbake "2.4.2"]]}
              :testutils {:source-paths ^:replace ["test"]
                          :resource-paths ^:replace []
                          ;; Something else may need adjustment, but


### PR DESCRIPTION
This updates lein-ezbake to 2.4.2 to add build target support for ubuntu 2204