### PR TITLE
(PDB-5636) enable ssh-config option

### DIFF
--- a/ext/jenkins/beaker-tests.sh
+++ b/ext/jenkins/beaker-tests.sh
@@ -47,6 +47,6 @@ HYPERVISOR="${HYPERVISOR:-vmpooler}"
 
 export BEAKER_OPTIONS=acceptance/options/${PUPPETDB_DATABASE}.rb
 export BEAKER_CONFIG=acceptance/hosts.cfg
-bundle exec beaker-hostgenerator $LAYOUT --hypervisor $HYPERVISOR > $BEAKER_CONFIG
+bundle exec beaker-hostgenerator $LAYOUT --hypervisor $HYPERVISOR --global-config {ssh={config=true}} > $BEAKER_CONFIG
 
 bundle exec rake beaker:acceptance


### PR DESCRIPTION
This adds an option so that netssh will look in the local ssh config for settings, which will allow authentication to external test hosts correctly