### PR TITLE
(maint) Add clj-yaml as a dev dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -79,6 +79,7 @@
       :exclusions [com.andrewmcveigh/cljs-time]]
      [riddley "0.1.12"]
      [io.forward/yaml "1.0.5"]
+     [clj-commons/clj-yaml "1.0.26"]
 
      ;; Only needed for :integration tests
      [puppetlabs/trapperkeeper-filesystem-watcher nil]]


### PR DESCRIPTION
This was removed from trapperkeeper due to a CVE, but it is used in our testing