### PR TITLE
(PE-36120) Do not kill connections when no migrations pending

### DIFF
--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -2555,8 +2555,8 @@
    (if-not user
      (do
        (log/info
-        (trs "Disconnecting all {0} connections to {1} database before migrating"
-             user db-name))
+        (trs "Disconnecting all non-migrator connections to {0} database before migrating"
+             db-name))
        (doseq [user users]
          ;; Because the revoke may not actually produce an error when
          ;; it doesn't work.


### PR DESCRIPTION
Previous behavior would cause compilers to be disconnected from
postgresql ever time the primary's pe-puppetdb was restarted. This was because the
restart invokes the migration code path, which, in PE with a
migrator-account set leads to connection blocking even when the
migration itself is ultimately a noop.

Now it tests whether any migrations are pending before calling
call-with-connections-blocked-during-migration. This change also means
that update-schema will return nil in this case, and initialize-schema
will return false, which is a change from previous noop migrations where
initialize-schema would have returned true.

---

Also tweaked a log message in call-with-connections-blocked-during-migration.

I think this carried over from the last refactor; since user is null
here, we end up printing "Disconnecting all null connections" in the
log. Changed it to non-migrator, since I believe that is effectively
what we are doing here.