### PR TITLE
(PE-36193) PDB benchmark can use ssl

### DIFF
--- a/documentation/load_testing_tool.markdown
+++ b/documentation/load_testing_tool.markdown
@@ -65,14 +65,35 @@ which may significantly skew performance on the primary server. If you would lik
 the benchmark tool on an agent this can be achieved following the instructions
 below.
 
-* On the primary server, modify `/etc/puppetlabs/puppetdb/conf.d/jetty.ini`.
-In the `[jetty]` section, set either:
-    * `host=0.0.0.0 # http access from all agents`
-    * `host=<agent ip address> # access from specific agent`
+#### Running over https
+
+For authentication, you will use the agent's Puppet certificates from /etc/puppetlabs/puppet/ssl.
+
+* On the primary server, modify `/etc/puppetlabs/puppetdb/certificate-allowlist` to include the agent's certificate name (the host fqdn).
+* On the agent, modify the config.ini you will use with the bechmark tool to instead provide ssl host/port and certificate information:
+
+      [jetty]
+      ssl-host=<host name here>
+      ssl-port=<ssl port here (defaults to 8081)>
+      ssl-cert=<path to the agent's /etc/puppetlabs/puppet/ssl/certs pem file>
+      ssl-key=<path to the agent's /etc/puppetlabs/puppet/ssl/private_keys pem file>
+      ssl-ca-cert=/etc/puppetlabs/puppet/ssl/certs/ca.pem
 
 * Install java on the agent
-* On the agent, in the `config.ini` file set the port to the puppetdb port for
-http traffic (defaults to 8080)
+
+After these steps have been completed you should be able to run the benchmark
+tool on the agent using the `java -cp ...` command described above.
+
+#### Running over http *(insecure)*
+
+This is not recommended, as the configuration change will allow http
+connections from *any* source.
+
+* On the primary server, modify `/etc/puppetlabs/puppetdb/conf.d/jetty.ini`.
+In the `[jetty]` section set:
+    * `host=0.0.0.0 # open http access`
+
+* Install java on the agent
 
 After these steps have been completed you should be able to run the benchmark
 tool on the agent using the `java -cp ...` command described above.

--- a/src/puppetlabs/puppetdb/client.clj
+++ b/src/puppetlabs/puppetdb/client.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.puppetdb.client
   (:require [clojure.tools.logging :as log]
-            [clj-http.client :as http-client]
+            [puppetlabs.http.client.sync :as http-client]
             [puppetlabs.puppetdb.command.constants :refer [command-names]]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.schema :refer [defn-validated]]
@@ -30,13 +30,21 @@
     command :- s/Str
     version :- s/Int
     payload]
-   (submit-command-via-http! base-url certname command version payload nil))
+   (submit-command-via-http! base-url certname command version payload nil {}))
+  ([base-url
+    certname :- s/Str
+    command :- s/Str
+    version :- s/Int
+    payload
+    timeout]
+   (submit-command-via-http! base-url certname command version payload timeout {}))
   ([base-url
     certname :- s/Str
     command :- s/Str
     version :- s/Int
     payload :- {s/Any s/Any}
-    timeout]
+    timeout
+    ssl-opts :- {s/Keyword s/Str}]
    (let [body (json/generate-string payload)
          url-params (utils/cmd-url-params {:command command
                                            :version version
@@ -45,12 +53,16 @@
                                                                    :producer_timestamp
                                                                    str)
                                            :timeout timeout})
-         url (str (utils/base-url->str base-url) url-params)]
-     (http-client/post url {:body body
-                            :throw-exceptions false
-                            :content-type :json
-                            :character-encoding "UTF-8"
-                            :accept :json}))))
+         url (str (utils/base-url->str base-url) url-params)
+         post-opts (merge {:body body
+                           :as :text
+                           :headers {"Content-Type" "application/json"}}
+                    ;       :throw-exceptions false
+                    ;       :content-type :json
+                    ;       :character-encoding "UTF-8"
+                    ;       :accept :json}
+                          (select-keys ssl-opts [:ssl-cert :ssl-key :ssl-ca-cert]))]
+     (http-client/post url post-opts))))
 
 (defn-validated submit-catalog
   "Send the given wire-format `catalog` (associated with `host`) to a
@@ -58,13 +70,16 @@
   [base-url :- utils/base-url-schema
    certname :- s/Str
    command-version :- s/Int
-   catalog-payload]
+   catalog-payload
+   ssl-opts]
   (let [result (submit-command-via-http!
                  base-url
                  certname
                  (command-names :replace-catalog)
                  command-version
-                 catalog-payload)]
+                 catalog-payload
+                 nil
+                 ssl-opts)]
     (when-not (= HttpURLConnection/HTTP_OK (:status result))
       (log/error result))))
 
@@ -74,28 +89,39 @@
   [base-url :- utils/base-url-schema
    certname :- s/Str
    command-version :- s/Int
-   report-payload]
+   report-payload
+   ssl-opts]
   (let [result (submit-command-via-http!
                  base-url
                  certname
                  (command-names :store-report)
                  command-version
-                 report-payload)]
+                 report-payload
+                 nil
+                 ssl-opts)]
     (when-not (= HttpURLConnection/HTTP_OK (:status result))
       (log/error result))))
 
 (defn-validated submit-facts
   "Send the given wire-format `facts` (associated with `host`) to a
    command-processing endpoint located at `puppetdb-host`:`puppetdb-port`."
-  [base-url :- utils/base-url-schema
-   certname :- s/Str
-   facts-version :- s/Int
-   fact-payload]
-  (let [result  (submit-command-via-http!
-                  base-url
-                  certname
-                  (command-names :replace-facts)
-                  facts-version
-                  fact-payload)]
-    (when-not (= HttpURLConnection/HTTP_OK (:status result))
-      (log/error result))))
+  ([base-url :- utils/base-url-schema
+    certname :- s/Str
+    facts-version :- s/Int
+    fact-payload]
+   (submit-facts base-url certname facts-version fact-payload {}))
+  ([base-url :- utils/base-url-schema
+    certname :- s/Str
+    facts-version :- s/Int
+    fact-payload
+    ssl-opts]
+   (let [result  (submit-command-via-http!
+                   base-url
+                   certname
+                   (command-names :replace-facts)
+                   facts-version
+                   fact-payload
+                   nil
+                   ssl-opts)]
+     (when-not (= HttpURLConnection/HTTP_OK (:status result))
+       (log/error result)))))

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -246,8 +246,8 @@
           (throw ex))))))
 
 (defn pdb-cmd-base-url
-  [host port & [version]]
-  {:protocol "http"
+  [host port & [version protocol]]
+  {:protocol (or protocol "http")
    :host host
    :port port
    :prefix "/pdb/cmd"

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -245,36 +245,12 @@
             (flush-and-exit 0))
           (throw ex))))))
 
-(defn pdb-query-base-url
-  [host port & [version]]
-  {:protocol "http"
-   :host host
-   :port port
-   :prefix "/pdb/query"
-   :version (or version :v4)})
-
-(defn pdb-admin-base-url
-  [host port & [version]]
-  {:protocol "http"
-   :host host
-   :port port
-   :prefix "/pdb/admin"
-   :version (or version :v1)})
-
 (defn pdb-cmd-base-url
   [host port & [version]]
   {:protocol "http"
    :host host
    :port port
    :prefix "/pdb/cmd"
-   :version (or version :v1)})
-
-(defn pdb-meta-base-url
-  [host port & [version]]
-  {:protocol "http"
-   :host host
-   :port port
-   :prefix "/pdb/meta"
    :version (or version :v1)})
 
 (defn metrics-base-url

--- a/test/puppetlabs/puppetdb/cli/benchmark_test.clj
+++ b/test/puppetlabs/puppetdb/cli/benchmark_test.clj
@@ -21,13 +21,14 @@
    [java.nio.file Files]))
 
 (defn mock-submit-record-fn [submitted-records entity]
-  (fn [base-url _certname version payload-string]
+  (fn [base-url _certname version payload-string ssl-opts]
     (swap! submitted-records conj
            {:entity entity
             :base-url base-url
             :version version
             :payload-string payload-string
-            :payload (keywordize-keys payload-string)})))
+            :payload (keywordize-keys payload-string)
+            :ssl-opts ssl-opts})))
 
 (defn call-with-benchmark-status
   [config cli-args f]


### PR DESCRIPTION
    (maint) Remove unused base-url functions

This look to have disappeared from use years ago when the cli tooling
changed.

---

    (PE-36193) Use puppetlabs.http.client in puppetdb.client

Replaces use of clj-http.client with our puppetlabs.hhtp.client that
provides for https communication when provided certs.  Specifically,
this is to allow benchmark to use https for it's pdb commands. Threads
pdb jetty ssl opts to through to the new http client from benchmark
invocation.

---

    (PE-36193) Update benchmark docs for https

* Adds documentation for using benchmark over https.
* Marks https as the preferred configuration if you are going to run
benchmark off the primary.
* The http configuration docs incorrectly specified that you could lock
down http access to a single agent by setting puppetdb's jetty.host to
the agent ip. The host setting tells puppetdb which interfaces to listen
on on the primary, not which ip's to allow requests from.
* Emphasized that opening http is not recommended as this is insecure and
allows http access from any source.