### PR TITLE
(maint) Remove beaker-hostgenerator --global-config ssh for smallstep

### DIFF
--- a/ext/jenkins/beaker-tests.sh
+++ b/ext/jenkins/beaker-tests.sh
@@ -47,6 +47,6 @@ HYPERVISOR="${HYPERVISOR:-vmpooler}"
 
 export BEAKER_OPTIONS=acceptance/options/${PUPPETDB_DATABASE}.rb
 export BEAKER_CONFIG=acceptance/hosts.cfg
-bundle exec beaker-hostgenerator $LAYOUT --hypervisor $HYPERVISOR --global-config {ssh={config=true}} > $BEAKER_CONFIG
+bundle exec beaker-hostgenerator $LAYOUT --hypervisor $HYPERVISOR > $BEAKER_CONFIG
 
 bundle exec rake beaker:acceptance


### PR DESCRIPTION
7.x acceptance job is passing while main is not, and this is one visible
 difference, though it's not clear why it would matter.