### PR TITLE
(maint) update ezbake to 2.5.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -313,7 +313,7 @@
                                                ;; in the final package.
                                                [puppetlabs/puppetdb ~pdb-version :exclusions [com.zaxxer/HikariCP]]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "2.5.0"]]}
+                      :plugins [[puppetlabs/lein-ezbake "2.5.2"]]}
              :testutils {:source-paths ^:replace ["test"]
                          :resource-paths ^:replace []
                          ;; Something else may need adjustment, but


### PR DESCRIPTION
This updates ezbake to 2.5.2, which does two things:
* it enables builds of the el9 platform
* it adds in tzdata-java as a dependency on the el platforms

tzdata-java was strangely removed as a dependency from openjdk, so this adds it in as a dependendency to ensure we don't release a broken package.