### PR TITLE
(docs) Document known issue with RedHat 8's openjdk 11

### DIFF
--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -15,7 +15,7 @@ layout: default
 [module]: http://forge.puppet.com/puppetlabs/puppetdb
 [postgres_ssl]: ./postgres_ssl.markdown
 [package_repos]: https://puppet.com/docs/puppet/latest/install_puppet.html#enable_the_puppet_platform_repository
-
+[known-issues]: ./known_issues.markdown
 
 > **Note:** If you are running Puppet Enterprise version 3.0 or later, you do
 > not need to install PuppetDB, as it is already installed as part of PE.
@@ -51,6 +51,11 @@ module.
 **Ubuntu 18.04**
 * Enable the [universe repository](https://help.ubuntu.com/community/Repositories/Ubuntu), which contains packages necessary for PuppetDB
 * Ensure Java 8 is installed
+
+**RHEL 8**
+* RedHat's openjdk 11 package's dependency on tzdata-java was broken, see
+  PuppetDB's [known issues][known-issues] for more more information and a
+  workaround.
 
 ## Step 1: Install and configure Puppet
 

--- a/documentation/known_issues.markdown
+++ b/documentation/known_issues.markdown
@@ -4,6 +4,18 @@ layout: default
 canonical: "/puppetdb/latest/known_issues.html"
 ---
 # Known issues
+
+## Issues with specific operating systems
+
+### RHEL 8 - Java 11
+
+RedHat's openjdk 11 package dropped its dependency on tzdata-java. This is a
+bug upstream, see
+[Red Hat bug 2224427](https://bugzilla.redhat.com/show_bug.cgi?id=2224427) for
+more information and to see if this issue has been resolved. If you run into a
+problem starting the application due to a missing timezone database file,
+install `tzdata-java` manually and retry.
+
 ## Bugs and feature requests
 
 [tracker]: https://tickets.puppetlabs.com/browse/PDB


### PR DESCRIPTION
Document RedHat 8 issue that OpenJDK 11.0.20.0.8-1 does not include tzdata-java.

Bug 2224427 - https://bugzilla.redhat.com/show_bug.cgi?id=2224427)