### PR TITLE
(maint) Update ezbake to 2.5.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -313,7 +313,7 @@
                                                ;; in the final package.
                                                [puppetlabs/puppetdb ~pdb-version :exclusions [com.zaxxer/HikariCP]]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "2.5.2"]]}
+                      :plugins [[puppetlabs/lein-ezbake "2.5.3"]]}
              :testutils {:source-paths ^:replace ["test"]
                          :resource-paths ^:replace []
                          ;; Something else may need adjustment, but


### PR DESCRIPTION
contains a fix to allow package builds on el9