### PR TITLE
(maint) acceptance: install tzdata-java on el8

### DIFF
--- a/acceptance/setup/pre_suite/20_install_puppet.rb
+++ b/acceptance/setup/pre_suite/20_install_puppet.rb
@@ -2,6 +2,9 @@ test_name "Install Puppet" do
   unless (test_config[:skip_presuite_provisioning])
     if is_el8 && ([:upgrade_latest].include? test_config[:install_mode])
       on(hosts, 'update-crypto-policies --set LEGACY')
+
+      # Work around RedHat Bug 2224427
+      on(hosts, 'yum install -y tzdata-java')
     end
 
     step "Install Puppet" do


### PR DESCRIPTION
With the release of openjdk-headless 11.0.20.0.8-2.el8 tzdata-java is no longer included as a dependency of openjdk. This is a bug in RedHat's packages
https://bugzilla.redhat.com/show_bug.cgi?id=2224427

PuppetServer fails to start when the package is missing. EZBake has been adjusted to depend on the package in future releases, but there's nothing we can do for older releases, so to test upgrade_latest we must install the package ourselves.