### PR TITLE
(maint) format timestamp with ISO formatter

### DIFF
--- a/src/puppetlabs/puppetdb/client.clj
+++ b/src/puppetlabs/puppetdb/client.clj
@@ -4,6 +4,7 @@
             [puppetlabs.puppetdb.command.constants :refer [command-names]]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.schema :refer [defn-validated]]
+            [puppetlabs.puppetdb.time :as t]
             [puppetlabs.puppetdb.utils :as utils]
             [schema.core :as s])
   (:import
@@ -51,7 +52,7 @@
                                            :certname certname
                                            :producer-timestamp (-> payload
                                                                    :producer_timestamp
-                                                                   str)
+                                                                   t/to-string)
                                            :timeout timeout})
          url (str (utils/base-url->str base-url) url-params)
          post-opts (merge {:body body


### PR DESCRIPTION
in the pe-puppetdb tests, this `str` call was leaving in a space between the date and time that wasn't working as a URL parameter. Switch to using the to-string function which formats the timestamp with ISO 8601 formatting, which uses a T to separate the date and time.