### PR TITLE
(PE-36947) Allow for Puppet::Util::Puppetdb to flush config

### DIFF
--- a/puppet/lib/puppet/util/puppetdb.rb
+++ b/puppet/lib/puppet/util/puppetdb.rb
@@ -23,6 +23,11 @@ module Puppet::Util::Puppetdb
   class SoftWriteFailError < Puppet::Error
   end
 
+  # Flushes the Puppetdb class's @config instance so that we can pick up
+  # updated configuration since the last time Puppetdb.config was called.
+  def self.clear_config
+    @config = nil
+  end
 
   def self.config
     @config ||= Puppet::Util::Puppetdb::Config.load


### PR DESCRIPTION
This provides a hook for flushing the Puppetdb classes @config variable. This in turn means the next time Puppetdb.config is callled it will reload the configuration file.
This becomes important if in some command using this utility, we have accessed the Puppetdb.config, then go on to update puppet's puppetdb.conf with new information, and need to then take additional operations with Puppetdb.config that should be based on the new configuration state.