### PR TITLE
(PE-37178) bionic tests - install pg from archive

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -542,11 +542,14 @@ module PuppetDBExtensions
   end
 
   def postgres_manifest
+    # bionic is EOL, so its pgdg repo has been remove
+    manage_package_repo = ! is_bionic
+
     manifest = <<-EOS
       # create the puppetdb database
       class { '::puppetdb::database::postgresql':
       listen_addresses            => 'localhost',
-      manage_package_repo         =>  true,
+      manage_package_repo         => #{manage_package_repo},
       postgres_version            => '11',
       database_name               => 'puppetdb',
       database_username           => 'puppetdb',

--- a/acceptance/setup/pre_suite/40_install_deps.rb
+++ b/acceptance/setup/pre_suite/40_install_deps.rb
@@ -17,5 +17,10 @@ unless (test_config[:skip_presuite_provisioning])
       on master, "dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
       on master, "dnf -qy module disable postgresql"
     end
+  elsif is_bionic
+    # bionic is EOL, so get postgresql from the archive
+    on master, 'echo "deb https://apt-archive.postgresql.org/pub/repos/apt bionic-pgdg main" >> /etc/apt/sources.list'
+    on master, 'curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -'
+    on master, 'apt update'
   end
 end


### PR DESCRIPTION
Ubuntu 18 went EOL in May 2023, so it no longer has official pgdg repos for its packages. Setup the archive repo for tests before support is removed from Puppet