### PR TITLE
(GH-3912) add include_catalog_edges config to terminus

### DIFF
--- a/documentation/puppetdb_connection.markdown
+++ b/documentation/puppetdb_connection.markdown
@@ -72,6 +72,16 @@ This setting can let the Puppet Server stay partially available during a PuppetD
 
 The default value is false.
 
+### `include_catalog_edges`
+
+This setting tells the PuppetDB terminus whether or not it should include
+resource edges in catalogs sent to PuppetDB. For users who do not need catalog
+edge information, this can improve the performance of PuppetDB command
+processing. If you do not want to store information about catalog edges, set
+this value to `false`.
+
+The default value is true.
+
 ### `include_unchanged_resources` (PE only)
 
 > **Warning:** This setting is intended for use only in Puppet Enterprise (PE).

--- a/documentation/release_notes_8.markdown
+++ b/documentation/release_notes_8.markdown
@@ -6,10 +6,27 @@ canonical: "/puppetdb/latest/release_notes.html"
 
 [benchmark]: ./load_testing_tool.markdown
 [query-timeout-parameter]: ./api/query/v4/overview.markdown#url-parameters
+[terminus-config]: ./puppetdb_connection.markdown
 
 ---
 
 # PuppetDB: Release notes
+
+## PuppetDB 8.2.1 (unreleased)
+
+Release date undetermined, and contributors pending
+
+### New features and improvements
+
+* The PuppetDB terminus now supports the
+  [`include_catalog_edges`][terminus-config] configuration option. Setting this
+  value to false will omit all resource edges from the catalog submitted to
+  PuppetDB.
+  ([GitHub #3912](https://github.com/puppetlabs/puppetdb/issues/3912))
+
+### Contributors
+
+Austin Blatt, and ...
 
 ## PuppetDB 8.2.0
 

--- a/eastwood.clj
+++ b/eastwood.clj
@@ -20,7 +20,8 @@
 (disable-warning
  {:linter :deprecations
   :symbol-matches
-  #{#"^#'puppetlabs\.puppetdb\.jdbc/call-with-array-converted-query-rows$"
+  #{#"^#'puppetlabs\.kitchensink\.core/cn-for-cert$"
+    #"^#'puppetlabs\.puppetdb\.jdbc/call-with-array-converted-query-rows$"
     #"^#'puppetlabs\.puppetdb\.testutils\.services/call-with-puppetdb-instance$"
     #"^#'puppetlabs\.puppetdb\.testutils\.services/with-puppetdb-instance$"
     #"^#'puppetlabs\.trapperkeeper\.testutils\.logging/atom-appender$"

--- a/puppet/lib/puppet/indirector/catalog/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/catalog/puppetdb.rb
@@ -116,8 +116,14 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
       stringify_version(data)
       hashify_tags(data)
       sort_unordered_metaparams(data)
-      munge_edges(data)
-      synthesize_edges(data, catalog)
+
+      if Puppet::Util::Puppetdb.config.include_catalog_edges?
+        munge_edges(data)
+        synthesize_edges(data, catalog)
+      else
+        remove_edges(data)
+      end
+
       change_name_to_certname(data)
       filter_keys(data)
       add_transaction_uuid(data, extra_request_data[:transaction_uuid])
@@ -357,6 +363,11 @@ class Puppet::Resource::Catalog::Puppetdb < Puppet::Indirector::REST
 
       hash
     end
+  end
+
+  def remove_edges(hash)
+    # edges is not an optional key in the wireformat, so we must at least send an empty list
+    hash['edges'] = []
   end
 
   def map_aliases_to_title(hash)

--- a/puppet/lib/puppet/util/puppetdb/config.rb
+++ b/puppet/lib/puppet/util/puppetdb/config.rb
@@ -13,6 +13,7 @@ module Puppet::Util::Puppetdb
         :soft_write_failure          => false,
         :server_url_timeout          => 30,
         :include_unchanged_resources => false,
+        :include_catalog_edges       => true,
         :min_successful_submissions  => 1,
         :submit_only_server_urls     => "",
         :command_broadcast           => false,
@@ -63,6 +64,7 @@ module Puppet::Util::Puppetdb
         !([:server_urls,
            :ignore_blacklisted_events,
            :include_unchanged_resources,
+           :include_catalog_edges,
            :soft_write_failure,
            :server_url_timeout,
            :min_successful_submissions,
@@ -77,6 +79,7 @@ module Puppet::Util::Puppetdb
 
       config_hash[:server_url_timeout] = config_hash[:server_url_timeout].to_i
       config_hash[:include_unchanged_resources] = Puppet::Util::Puppetdb.to_bool(config_hash[:include_unchanged_resources])
+      config_hash[:include_catalog_edges] = Puppet::Util::Puppetdb.to_bool(config_hash[:include_catalog_edges])
       config_hash[:soft_write_failure] = Puppet::Util::Puppetdb.to_bool(config_hash[:soft_write_failure])
 
       config_hash[:submit_only_server_urls] = convert_and_validate_urls(config_hash[:submit_only_server_urls].split(",").map {|s| s.strip})
@@ -127,6 +130,10 @@ module Puppet::Util::Puppetdb
 
     def include_unchanged_resources?
       config[:include_unchanged_resources]
+    end
+
+    def include_catalog_edges?
+      config[:include_catalog_edges]
     end
 
     def soft_write_failure

--- a/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/catalog/puppetdb_spec.rb
@@ -788,6 +788,22 @@ describe Puppet::Resource::Catalog::Puppetdb do
           end
         end
       end
+
+      context "with catalog edges turned off" do
+        before :each do
+          Puppet::Util::Puppetdb.config.stubs(:include_catalog_edges?).returns(false)
+        end
+
+        it "should omit all edges" do
+          other_resource = Puppet::Resource.new(:exec, 'noone', :parameters => {:alias => 'completely_different', :path => '/anything'})
+          resource[:require] = 'Exec[completely_different]'
+          Puppet[:code] = [resource, other_resource].map(&:to_manifest).join
+
+          result, inputs = subject.munge_catalog(catalog, Time.now.utc)
+
+          result['edges'].should be_empty
+        end
+      end
     end
 
     describe "#redact_sensitive_params" do

--- a/test/puppetlabs/puppetdb/integration/reports.clj
+++ b/test/puppetlabs/puppetdb/integration/reports.clj
@@ -248,7 +248,7 @@
                             (set (:tags e)))))
                   logs))
 
-        (is (= 4 (count
+        (is (= 5 (count
                   (filter #(= "notice" (:level %))
                           logs))))
 


### PR DESCRIPTION
Add configuration option to the terminus, `include_catalog_edges` that, when set to `false`, will disable sending any catalog edges to PuppetDB. Profiling of PuppetDB command processing has shown catalog edges can take as much as one third of the total time to process a catalog. Users with many nodes that don't use edges in their queries could benefit quite substantially from using this option. It is not enabled by default to maintain backwards compatibility during PuppetDB 8.

Resolves #3912.