### PR TITLE
(maint) Sync initial-hosts on benchmark re-execution

### DIFF
--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -367,12 +367,12 @@
 
 (def random-cmd-delay safe-sample-normal)
 
-(defn send-facts [url certname version catalog opts]
-  (client/submit-facts url certname version catalog (assoc opts :post post-json-via-jdk)))
-(defn send-catalog [url certname version catalog opts]
-  (client/submit-catalog url certname version catalog (assoc opts :post post-json-via-jdk)))
-(defn send-report [url certname version catalog opts]
-  (client/submit-report url certname version catalog (assoc opts :post post-json-via-jdk)))
+(defn send-facts [url certname version payload opts]
+  (client/submit-facts url certname version payload (assoc opts :post post-json-via-jdk)))
+(defn send-catalog [url certname version payload opts]
+  (client/submit-catalog url certname version payload (assoc opts :post post-json-via-jdk)))
+(defn send-report [url certname version payload opts]
+  (client/submit-report url certname version payload (assoc opts :post post-json-via-jdk)))
 
 (defn start-command-sender
   "Start a command sending process in the background. Reads host-state maps from

--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -50,7 +50,29 @@
    benchmark --offset 100000 --numhosts 100000
    benchmark --offset 200000 --numhosts 100000
    ...
-   ```"
+   ```
+   
+   ### Re-running Benchmark
+
+   There is a potential performance issue when re-running benchmark in that the
+   initial host-maps of catalog/facts/report is a random selection from the base
+   sample data. This causes substantial churn when PuppetDB has to replace the
+   previous catalog/factset while processing all the commands from the first
+   node interval.
+
+   To avoid this, benchmark encodes the certname from the original catalog file
+   in the catalog version string, and then queries out an index of certname,
+   version to resync the initial host-maps with the correct catalog/factset
+   files.
+
+   There are a couple of caveats here. If there is more than one catalog or
+   factset file with that certname in the sample data, then initial host-maps
+   are again non-deterministic and likely to cause churn.
+
+   Generally the sample data will have multiple reports for a given cert, but
+   report differences do not produce the same performance hit as catalog and
+   facts, so this should be a negligble change in performance between first and
+   second interval simulation."
   (:require [puppetlabs.puppetdb.catalog.utils :as catutils]
             [puppetlabs.puppetdb.cli.util :refer [exit run-cli-cmd]]
             [puppetlabs.trapperkeeper.logging :as logutils]

--- a/src/puppetlabs/puppetdb/utils.clj
+++ b/src/puppetlabs/puppetdb/utils.clj
@@ -261,6 +261,14 @@
    :prefix "/pdb/cmd"
    :version (or version :v1)})
 
+(defn pdb-query-base-url
+  [host port & [version protocol]]
+  {:protocol (or protocol "http")
+   :host host
+   :port port
+   :prefix "/pdb/query"
+   :version (or version :v4)})
+
 (defn metrics-base-url
   [host port & [version]]
   {:protocol "http"
@@ -278,6 +286,10 @@
      (format "&producer-timestamp=%s" producer-timestamp))
    (when timeout
      (format "&secondsToWaitForCompletion=%s" timeout))))
+
+(defn query-url-params
+  [{:keys [query]}]
+  (format "?query=%s" (java.net.URLEncoder/encode query "UTF-8")))
 
 (defn assoc-if-exists
   "Assoc only if the key is already present"


### PR DESCRIPTION
When benchmark starts, it generates a list of initial host-maps based on
random selections from the catalog/factset/report sample data. This
means that every time benchmark is run a new set of catalogs and facts
are going to be pushed to PuppetDB. This can cause a great deal of
initial load replacing the catalogs and facts wholesale until PuppetDB
has caught up to processing one entire simulated node interval.

This makes it impractical to stop and restart benchmark when working
with large simulated runs.

This patch attempts to improve this be encoding the certname of the
original sample file in the catalog version string. We then query
catalogs certname, version fields, and form an index of certname ->
original-certname. This index is then used to ensure that the set of
initial hostmaps is regenerated from the same base catalog and facteset
so there should not be excess churn when benchmark begins pushing
commands.