### PR TITLE
benchmark: warn when simulation deadline missed

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -274,10 +274,6 @@
                                                ;; to duplicate this dependency here
                                                [org.bouncycastle/bcpkix-jdk18on nil]
 
-                                               ;; pin tk-metrics so that jetty9 is not pulled in
-                                               ;; until tk-metrics is updated in clj-parent
-                                               [puppetlabs/trapperkeeper-metrics "2.0.1"]
-
                                                ;; we need to explicitly pull in our parent project's
                                                ;; clojure version here, because without it, lein
                                                ;; brings in its own version, and older versions of


### PR DESCRIPTION
Add a log message, no more often than every 5 seconds, that prints out how many commands missed their deadline.

Each simulation thread must produce a host-state every ms-per-thread in order for the overall benchmark rate to be correct. Previously, if the simulation threads were doing more work than they could complete within their deadline, benchmark would silently fall behind the requested rate.