### PR TITLE
Improve query performance on the certnames table

### DIFF
--- a/ext/test/upgrade-and-exit
+++ b/ext/test/upgrade-and-exit
@@ -83,6 +83,6 @@ psql -U puppetdb puppetdb -c 'select max(version) from schema_migrations;' \
      > "$tmpdir/out"
 cat "$tmpdir/out"
 # This must be updated every time we add a new migration
-grep -qE ' 84$' "$tmpdir/out"
+grep -qE ' 85$' "$tmpdir/out"
 
 test ! -e "$PDBBOX"/var/mq-migrated

--- a/resources/ext/cli/delete-reports.erb
+++ b/resources/ext/cli/delete-reports.erb
@@ -78,7 +78,7 @@ chown "$pg_user:$pg_user" "$tmp_dir"
 
 # Verify that the PuppetDB schema version is the expected value
 # so that we do not incorrectly delete the report data.
-expected_schema_ver=84
+expected_schema_ver=85
 su - "$pg_user" -s /bin/sh -c "$psql_cmd -p $pg_port -d $pdb_db_name -c 'COPY ( SELECT max(version) FROM schema_migrations ) TO STDOUT;' > $tmp_dir/schema_ver"
 actual_schema_ver="$(cat "$tmp_dir/schema_ver")"
 if test "$actual_schema_ver" -ne $expected_schema_ver; then

--- a/src/puppetlabs/puppetdb/query/population.clj
+++ b/src/puppetlabs/puppetdb/query/population.clj
@@ -26,14 +26,14 @@
   "The number of expired/deactivated nodes"
   []
   {:post [(number? %)]}
-  (-> "select count(*) as c from certnames where deactivated is not null or expired is not null"
+  (-> "select count(*) as c from certnames_status where deactivated is not null or expired is not null"
       (first-query-result :c)))
 
 (defn num-active-nodes
   "The number of unique certnames in the population"
   []
   {:post [(number? %)]}
-  (-> "select count(*) as c from certnames where deactivated is null and expired is null"
+  (-> "select count(*) as c from certnames_status where deactivated is null and expired is null"
       (first-query-result :c)))
 
 (defn avg-resource-per-node

--- a/src/puppetlabs/puppetdb/query/summary_stats.clj
+++ b/src/puppetlabs/puppetdb/query/summary_stats.clj
@@ -18,7 +18,7 @@
 
    :node_activity
    "select count(*), expired is null and deactivated is null as active
-    from certnames group by active"
+    from certnames_status group by active"
 
    :fact_path_counts_by_depth
    "select depth, count(*) as count

--- a/src/puppetlabs/puppetdb/query_eng.clj
+++ b/src/puppetlabs/puppetdb/query_eng.clj
@@ -244,7 +244,7 @@
          (when log-queries
            ;; Log origin and AST of incoming query
            (log/infof "PDBQuery:%s:%s"
-                      query-id (-> (sorted-map :origin origin :ast query)
+                      query-id (-> (sorted-map :origin origin :ast query :opts options)
                                    json/generate-string)))
          (jdbc/with-db-connection scf-read-db
            (when query-monitor-id
@@ -526,7 +526,9 @@
           ;; Log origin and AST of incoming query
           (let [{:keys [origin query]} query-map]
             (log/infof "PDBQuery:%s:%s"
-                       query-id (-> (sorted-map :origin origin :ast query)
+                       query-id (-> (sorted-map :origin origin
+                                                :ast query
+                                                :opts (select-keys query-options [:limit :offset :order_by]))
                                     json/generate-string))))
 
         (try

--- a/src/puppetlabs/puppetdb/scf/migrate.clj
+++ b/src/puppetlabs/puppetdb/scf/migrate.clj
@@ -2346,6 +2346,10 @@
     ["INSERT INTO certnames_status"
      " (SELECT certname, deactivated, expired FROM certnames)"]
 
+   ["CREATE INDEX IF NOT EXISTS certnames_status_not_active_idx"
+    " ON certnames_status(certname)"
+    " WHERE (deactivated IS NOT NULL OR expired IS NOT NULL)"]
+
     ["ALTER TABLE certnames"
      "  DROP COLUMN deactivated,"
      "  DROP COLUMN expired"]))

--- a/test/puppetlabs/puppetdb/admin_clean_test.clj
+++ b/test/puppetlabs/puppetdb/admin_clean_test.clj
@@ -135,7 +135,7 @@
 (defn purgeable-nodes [node-purge-ttl]
   (let [horizon (time/to-timestamp (time/ago node-purge-ttl))]
     (jdbc/query-to-vec
-     "select * from certnames where deactivated < ? or expired < ?"
+     "select * from certnames_status where deactivated < ? or expired < ?"
      horizon horizon)))
 
 (deftest node-purge-batch-limits

--- a/test/puppetlabs/puppetdb/cli/services_test.clj
+++ b/test/puppetlabs/puppetdb/cli/services_test.clj
@@ -326,7 +326,7 @@
 (defn purgeable-nodes [node-purge-ttl]
   (let [horizon (time/to-timestamp (time/ago node-purge-ttl))]
     (jdbc/query-to-vec
-     "select * from certnames where deactivated < ? or expired < ?"
+     "select * from certnames_status where deactivated < ? or expired < ?"
      horizon horizon)))
 
 (deftest node-purge-gc-batch-limit

--- a/test/puppetlabs/puppetdb/query/population_test.clj
+++ b/test/puppetlabs/puppetdb/query/population_test.clj
@@ -2,7 +2,7 @@
   (:require [puppetlabs.puppetdb.query.population :as pop]
             [clojure.test :refer :all]
             [puppetlabs.puppetdb.jdbc :as jdbc]
-            [puppetlabs.puppetdb.scf.storage :refer [deactivate-node!]]
+            [puppetlabs.puppetdb.scf.storage :refer [add-certnames deactivate-node!]]
             [puppetlabs.puppetdb.scf.storage-utils :as sutils :refer [to-jdbc-varchar-array]]
             [puppetlabs.puppetdb.testutils.db :refer [*db* with-test-db]]
             [puppetlabs.puppetdb.time :refer [now to-timestamp]]))
@@ -15,37 +15,38 @@
         (is (= 0 (pop/num-resources))))
 
       (testing "should only count current resources"
-        (jdbc/insert-multi! :certnames
-                            [{:certname "h1" :id 1}
-                             {:certname "h2" :id 2}])
+        (add-certnames ["h1" "h2"])
+        (let [certname-ids (into {} (map (juxt :certname :id)) (jdbc/query-to-vec "SELECT certname, id from certnames"))
+              h1-cert-id (get certname-ids "h1")
+              h2-cert-id (get certname-ids "h2")]
 
-        (deactivate-node! "h2")
+          (deactivate-node! "h2")
 
-        (jdbc/insert-multi!
-          :catalogs
-          [{:id 1 :hash (sutils/munge-hash-for-storage "c1")
-            :api_version 1 :catalog_version "1"
-            :certname "h1" :producer_timestamp (to-timestamp (now))}
-           {:id 2 :hash (sutils/munge-hash-for-storage "c2")
-            :api_version 1 :catalog_version "1"
-            :certname "h2" :producer_timestamp (to-timestamp (now))}])
+          (jdbc/insert-multi!
+           :catalogs
+           [{:id 1 :hash (sutils/munge-hash-for-storage "c1")
+             :api_version 1 :catalog_version "1"
+             :certname "h1" :producer_timestamp (to-timestamp (now))}
+            {:id 2 :hash (sutils/munge-hash-for-storage "c2")
+             :api_version 1 :catalog_version "1"
+             :certname "h2" :producer_timestamp (to-timestamp (now))}])
 
-        (jdbc/insert-multi!
-          :resource_params_cache
-          [{:resource (sutils/munge-hash-for-storage "01") :parameters nil}
-           {:resource (sutils/munge-hash-for-storage "02") :parameters nil}
-           {:resource (sutils/munge-hash-for-storage "03") :parameters nil}])
+          (jdbc/insert-multi!
+           :resource_params_cache
+           [{:resource (sutils/munge-hash-for-storage "01") :parameters nil}
+            {:resource (sutils/munge-hash-for-storage "02") :parameters nil}
+            {:resource (sutils/munge-hash-for-storage "03") :parameters nil}])
 
-        (jdbc/insert-multi!
-         :catalog_resources
-          [{:certname_id 1 :resource (sutils/munge-hash-for-storage "01") :type "Foo" :title "Bar" :exported true :tags (to-jdbc-varchar-array [])}
-           ;; c2's resource shouldn'sutils/munge-hash-for-storage t be counted, as they don't correspond to an active node
-           {:certname_id 2 :resource (sutils/munge-hash-for-storage "01") :type "Foo" :title "Baz" :exported true :tags (to-jdbc-varchar-array [])}
-           {:certname_id 1 :resource (sutils/munge-hash-for-storage "02") :type "Foo" :title "Boo" :exported true :tags (to-jdbc-varchar-array [])}
-           {:certname_id 1 :resource (sutils/munge-hash-for-storage "03") :type "Foo" :title "Goo" :exported true :tags (to-jdbc-varchar-array [])}])
+          (jdbc/insert-multi!
+           :catalog_resources
+           [{:certname_id h1-cert-id :resource (sutils/munge-hash-for-storage "01") :type "Foo" :title "Bar" :exported true :tags (to-jdbc-varchar-array [])}
+            ;; c2's resource shouldn'sutils/munge-hash-for-storage t be counted, as they don't correspond to an active node
+            {:certname_id h2-cert-id :resource (sutils/munge-hash-for-storage "01") :type "Foo" :title "Baz" :exported true :tags (to-jdbc-varchar-array [])}
+            {:certname_id h1-cert-id :resource (sutils/munge-hash-for-storage "02") :type "Foo" :title "Boo" :exported true :tags (to-jdbc-varchar-array [])}
+            {:certname_id h1-cert-id :resource (sutils/munge-hash-for-storage "03") :type "Foo" :title "Goo" :exported true :tags (to-jdbc-varchar-array [])}])
 
-        (sutils/vacuum-analyze *db*)
-        (is (= 4 (pop/num-resources)))))))
+          (sutils/vacuum-analyze *db*)
+          (is (= 4 (pop/num-resources))))))))
 
 (deftest node-count
   (with-test-db
@@ -54,9 +55,7 @@
         (is (= 0 (pop/num-active-nodes))))
 
       (testing "should only count active nodes"
-        (jdbc/insert-multi! :certnames
-                            [{:certname "h1"}
-                             {:certname "h2"}])
+        (add-certnames ["h1" "h2"])
 
         (is (= 2 (pop/num-active-nodes)))
 
@@ -72,31 +71,32 @@
         (is (= 0 (pop/pct-resource-duplication))))
 
       (testing "should equal (total-unique) / total"
-        (jdbc/insert-multi! :certnames
-                            [{:certname "h1"}
-                             {:certname "h2"}])
+        (add-certnames ["h1" "h2"])
+        (let [certname-ids (into {} (map (juxt :certname :id)) (jdbc/query-to-vec "SELECT certname, id from certnames"))
+              h1-cert-id (get certname-ids "h1")
+              h2-cert-id (get certname-ids "h2")]
 
-        (jdbc/insert-multi!
-         :catalogs
-          [{:id 1 :hash (sutils/munge-hash-for-storage "c1") :api_version 1
-            :transaction_uuid (sutils/munge-uuid-for-storage "68b08e2a-eeb1-4322-b241-bfdf151d294b")
-            :catalog_version "1" :certname "h1" :producer_timestamp (to-timestamp (now))}
-           {:id 2 :hash (sutils/munge-hash-for-storage "c2") :api_version 1
-            :transaction_uuid (sutils/munge-uuid-for-storage "68b08e2a-eeb1-4322-b241-bfdf151d294b")
-            :catalog_version "1" :certname "h2" :producer_timestamp (to-timestamp (now))}])
+          (jdbc/insert-multi!
+           :catalogs
+           [{:id 1 :hash (sutils/munge-hash-for-storage "c1") :api_version 1
+             :transaction_uuid (sutils/munge-uuid-for-storage "68b08e2a-eeb1-4322-b241-bfdf151d294b")
+             :catalog_version "1" :certname "h1" :producer_timestamp (to-timestamp (now))}
+            {:id 2 :hash (sutils/munge-hash-for-storage "c2") :api_version 1
+             :transaction_uuid (sutils/munge-uuid-for-storage "68b08e2a-eeb1-4322-b241-bfdf151d294b")
+             :catalog_version "1" :certname "h2" :producer_timestamp (to-timestamp (now))}])
 
-        (jdbc/insert-multi!
-         :resource_params_cache
-          [{:resource (sutils/munge-hash-for-storage "01") :parameters nil}
-           {:resource (sutils/munge-hash-for-storage "02") :parameters nil}
-           {:resource (sutils/munge-hash-for-storage "03") :parameters nil}])
+          (jdbc/insert-multi!
+           :resource_params_cache
+           [{:resource (sutils/munge-hash-for-storage "01") :parameters nil}
+            {:resource (sutils/munge-hash-for-storage "02") :parameters nil}
+            {:resource (sutils/munge-hash-for-storage "03") :parameters nil}])
 
-        (jdbc/insert-multi!
-         :catalog_resources
-          [{:certname_id 1 :resource  (sutils/munge-hash-for-storage "01") :type "Foo" :title "Bar" :exported true :tags (to-jdbc-varchar-array [])}
-           {:certname_id 2 :resource  (sutils/munge-hash-for-storage "01") :type "Foo" :title "Baz" :exported true :tags (to-jdbc-varchar-array [])}
-           {:certname_id 1 :resource  (sutils/munge-hash-for-storage "02") :type "Foo" :title "Boo" :exported true :tags (to-jdbc-varchar-array [])}
-           {:certname_id 1 :resource  (sutils/munge-hash-for-storage "03") :type "Foo" :title "Goo" :exported true :tags (to-jdbc-varchar-array [])}])
+          (jdbc/insert-multi!
+           :catalog_resources
+           [{:certname_id h1-cert-id :resource  (sutils/munge-hash-for-storage "01") :type "Foo" :title "Bar" :exported true :tags (to-jdbc-varchar-array [])}
+            {:certname_id h2-cert-id :resource  (sutils/munge-hash-for-storage "01") :type "Foo" :title "Baz" :exported true :tags (to-jdbc-varchar-array [])}
+            {:certname_id h1-cert-id :resource  (sutils/munge-hash-for-storage "02") :type "Foo" :title "Boo" :exported true :tags (to-jdbc-varchar-array [])}
+            {:certname_id h1-cert-id :resource  (sutils/munge-hash-for-storage "03") :type "Foo" :title "Goo" :exported true :tags (to-jdbc-varchar-array [])}]))
 
         (let [total  4
               unique 3

--- a/test/puppetlabs/puppetdb/query_eng_test.clj
+++ b/test/puppetlabs/puppetdb/query_eng_test.clj
@@ -68,7 +68,7 @@
 
 (deftest test-plan-cte
   (is (re-matches
-       #"WITH inactive_nodes AS \(SELECT certname FROM certnames WHERE \(deactivated IS NOT NULL AND deactivated > '\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ'\) OR \(expired IS NOT NULL and expired > '\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ'\)\), not_active_nodes AS \(SELECT certname FROM certnames WHERE \(deactivated IS NOT NULL\) OR \(expired IS NOT NULL\)\) SELECT table.foo AS \"foo\" FROM table WHERE \(\? = \?\)"
+       #"WITH inactive_nodes AS \(SELECT certname FROM certnames_status WHERE \(deactivated IS NOT NULL AND deactivated > '\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ'\) OR \(expired IS NOT NULL and expired > '\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ'\)\), not_active_nodes AS \(SELECT certname FROM certnames_status WHERE \(deactivated IS NOT NULL\) OR \(expired IS NOT NULL\)\) SELECT table.foo AS \"foo\" FROM table WHERE \(\? = \?\)"
        (-> {:projections {"foo" {:type :string
                                  :queryable? true
                                  :field :table.foo}}

--- a/test/puppetlabs/puppetdb/scf/migrate_partitioning_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_partitioning_test.clj
@@ -24,7 +24,7 @@
     (apply-migration-for-testing! 73)
 
     (is (= {:index-diff (into
-                         [{:left-only {:schema "public"
+                         #{{:left-only {:schema "public"
                                        :table "resource_events"
                                        :index "resource_events_timestamp_idx"
                                        :index_keys ["\"timestamp\""]
@@ -110,6 +110,18 @@
                            :same nil}
                           {:left-only {:schema "public"
                                        :table "resource_events"
+                                       :index "resource_events_status_idx"
+                                       :index_keys ["status"]
+                                       :type "btree"
+                                       :unique? false
+                                       :functional? false
+                                       :is_partial false
+                                       :primary? false
+                                       :user "pdb_test"}
+                           :right-only nil
+                           :same nil}
+                          {:left-only {:schema "public"
+                                       :table "resource_events"
                                        :index "resource_events_resource_timestamp"
                                        :index_keys ["resource_type" "resource_title" "\"timestamp\""]
                                        :type "btree"
@@ -134,7 +146,7 @@
                                        :primary? false
                                        :user "pdb_test"}
                            :right-only nil
-                           :same nil}]
+                           :same nil}}
                          cat
                          (map
                           (fn [part-name]
@@ -226,6 +238,18 @@
                                {:left-only nil
                                 :right-only {:schema "public"
                                              :table table-name
+                                             :index (str "resource_events_status_idx_" part-name)
+                                             :index_keys ["status"]
+                                             :type "btree"
+                                             :unique? false
+                                             :functional? false
+                                             :is_partial false
+                                             :primary? false
+                                             :user "pdb_test"}
+                                :same nil}
+                               {:left-only nil
+                                :right-only {:schema "public"
+                                             :table table-name
                                              :index (str "resource_events_resource_timestamp_" part-name)
                                              :index_keys ["resource_type" "resource_title" "\"timestamp\""]
                                              :type "btree"
@@ -237,7 +261,7 @@
                                 :same nil}]))
                           part-names))
             :table-diff (into
-                         [{:left-only nil
+                         #{{:left-only nil
                            :right-only {:numeric_scale nil
                                         :column_default nil
                                         :character_octet_length nil
@@ -262,7 +286,7 @@
                                         :data_type "text"
                                         :column_name "name"
                                         :table_name "resource_events"}
-                           :same nil}]
+                           :same nil}}
                          cat
                          (map (fn [part-name]
                                 (let [table-name (str "resource_events_" part-name)]
@@ -489,7 +513,7 @@
                                     :same nil}]))
                               part-names))
             :constraint-diff (into
-                              [{:left-only nil
+                              #{{:left-only nil
                                 :right-only {:constraint_name "event_hash IS NOT NULL"
                                              :table_name "resource_events"
                                              :constraint_type "CHECK"
@@ -516,7 +540,7 @@
                                             :initially_deferred "NO"
                                             :deferrable? "NO"}
                                 :right-only nil
-                                :same nil}]
+                                :same nil}}
                               cat
                               (map (fn [date-of-week]
                                      (let [part-name (str/lower-case (partitioning/date-suffix date-of-week))
@@ -586,7 +610,7 @@
                                                       :deferrable? "NO"}
                                          :same nil}]))
                                    dates))}
-           (diff-schema-maps before-migration (schema-info-map *db*))))))
+           (update-vals (diff-schema-maps before-migration (schema-info-map *db*)) set)))))
 
 (deftest migration-74-schema-diff
   (clear-db-for-testing!)
@@ -600,7 +624,7 @@
     (apply-migration-for-testing! 74)
 
     (is (= {:index-diff (into
-                          []
+                          #{}
                           cat
                           (map
                             (fn [part-name]
@@ -790,7 +814,7 @@
                                   :same nil}]))
                             part-names))
             :table-diff (into
-                          []
+                          #{}
                           cat
                           (map (fn [part-name]
                                  (let [table-name (str "reports_" part-name)]
@@ -1134,13 +1158,13 @@
                                      :same nil}]))
                                part-names))
             :constraint-diff (into
-                               [{:left-only {:constraint_name "certnames_reports_id_fkey"
+                               #{{:left-only {:constraint_name "certnames_reports_id_fkey"
                                              :table_name "certnames"
                                              :constraint_type "FOREIGN KEY"
                                              :initially_deferred "NO"
                                              :deferrable? "NO"}
                                  :right-only nil
-                                 :same nil}]
+                                 :same nil}}
                                cat
                                (map (fn [date-of-week]
                                       (let [part-name (str/lower-case (partitioning/date-suffix date-of-week))
@@ -1259,7 +1283,7 @@
                                                        :deferrable? "NO"}
                                           :same nil}]))
                                     dates))}
-           (diff-schema-maps before-migration (schema-info-map *db*))))))
+           (update-vals (diff-schema-maps before-migration (schema-info-map *db*)) set)))))
 
 (deftest migration-76-schema-diff
   (clear-db-for-testing!)
@@ -1308,20 +1332,7 @@
     (apply-migration-for-testing! 79)
 
     (is (= {:index-diff (into
-                          [{:left-only
-                            {:schema "public"
-                             :table "reports"
-                             :index "reports_certname_idx"
-                             :index_keys  ["certname"]
-                             :type "btree"
-                             :unique? false
-                             :functional? false
-                             :is_partial false
-                             :primary? false
-                             :user "pdb_test"}
-                            :right-only nil
-                            :same nil}
-                           {:left-only nil
+                          [{:left-only nil
                             :right-only
                             {:schema "public"
                              :table "reports"
@@ -1333,25 +1344,25 @@
                              :is_partial false
                              :primary? false
                              :user "pdb_test"}
+                            :same nil}
+                           {:left-only
+                            {:schema "public"
+                             :table "reports"
+                             :index "reports_certname_idx"
+                             :index_keys  ["certname"]
+                             :type "btree"
+                             :unique? false
+                             :functional? false
+                             :is_partial false
+                             :primary? false
+                             :user "pdb_test"}
+                            :right-only nil
                             :same nil}]
                           cat
                           (map
                             (fn [part-name]
                               (let [table-name (str "reports_" part-name)]
-                                 [{:left-only
-                                   {:schema "public"
-                                    :table table-name
-                                    :index (str "reports_certname_idx_" part-name)
-                                    :index_keys  ["certname"]
-                                    :type "btree"
-                                    :unique? false
-                                    :functional? false
-                                    :is_partial false
-                                    :primary? false
-                                    :user "pdb_test"}
-                                   :right-only nil
-                                   :same nil}
-                                  {:left-only nil
+                                 [{:left-only nil
                                    :right-only
                                    {:schema "public"
                                     :table table-name
@@ -1363,6 +1374,19 @@
                                     :is_partial false
                                     :primary? false
                                     :user "pdb_test"}
+                                   :same nil}
+                                  {:left-only
+                                   {:schema "public"
+                                    :table table-name
+                                    :index (str "reports_certname_idx_" part-name)
+                                    :index_keys  ["certname"]
+                                    :type "btree"
+                                    :unique? false
+                                    :functional? false
+                                    :is_partial false
+                                    :primary? false
+                                    :user "pdb_test"}
+                                   :right-only nil
                                    :same nil}]))
                             part-names))
             :table-diff nil

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -2199,6 +2199,19 @@
     (let [before-migration (schema-info-map *db*)]
       (apply-migration-for-testing! 85)
       (is (= {:index-diff [{:left-only nil
+                            :right-only
+                            {:schema "public"
+                             :table "certnames_status"
+                             :index "certnames_status_not_active_idx"
+                             :index_keys ["certname"]
+                             :type "btree"
+                             :unique? false
+                             :functional? false
+                             :is_partial true
+                             :primary? false
+                             :user "pdb_test"}
+                            :same nil}
+                           {:left-only nil
                             :right-only {:schema "public"
                                          :table "certnames_status"
                                          :index "certnames_status_pkey"

--- a/test/puppetlabs/puppetdb/scf/migrate_test.clj
+++ b/test/puppetlabs/puppetdb/scf/migrate_test.clj
@@ -664,7 +664,7 @@
                              new-info (assoc idx-info
                                              :table new-table
                                              :index new-name)
-                             new-id (assoc idx-id 0 new-table)]
+                             new-id [new-table new-name]]
                          (assert idx-info)
                          (update smap :indexes
                                  #(-> %
@@ -682,9 +682,9 @@
                                     (dissoc idx-id)
                                     (assoc new-id new-info)))))
           exp-smap (-> initial
-                       (rename-idx ["fact_values" ["value_integer"]]
+                       (rename-idx ["fact_values" "fact_values_value_integer_idx"]
                                    "facts" "facts_value_integer_idx")
-                       (rename-idx ["fact_values" ["value_float"]]
+                       (rename-idx ["fact_values" "fact_values_value_float_idx"]
                                    "facts" "facts_value_float_idx")
                        (move-col ["fact_values" "value_type_id"] "facts")
                        (move-col ["fact_values" "value"] "facts")
@@ -1801,32 +1801,18 @@
                  :primary? false,
                  :user "pdb_test"},
                 :same nil}
-               {:left-only
-                {:schema "public",
-                 :table "resource_events",
-                 :index "resource_events_pkey",
-                 :index_keys ["event_hash"],
-                 :type "btree",
-                 :unique? true,
-                 :functional? false,
-                 :is_partial false,
-                 :primary? true,
-                 :user "pdb_test"},
-                :right-only nil,
-                :same nil}
-               {:left-only nil,
-                :right-only
-                {:schema "public",
-                 :table "resource_events",
-                 :index "resource_events_pkey",
-                 :index_keys ["event_hash", "\"timestamp\""],
-                 :type "btree",
-                 :unique? true,
-                 :functional? false,
-                 :is_partial false,
-                 :primary? true,
-                 :user "pdb_test"},
-                :same nil}
+               {:left-only nil
+                :right-only {:index_keys [nil "\"timestamp\""]}
+                :same {:schema "public"
+                       :table "resource_events"
+                       :index "resource_events_pkey"
+                       :index_keys ["event_hash"]
+                       :type "btree"
+                       :unique? true
+                       :functional? false
+                       :is_partial false
+                       :primary? true
+                       :user "pdb_test"}}
                {:left-only nil,
                 :right-only
                 {:schema "public",
@@ -1878,6 +1864,18 @@
                  :is_partial true,
                  :primary? false,
                  :user "pdb_test"},
+                :same nil}
+               {:left-only nil
+                :right-only {:schema "public"
+                             :table "resource_events"
+                             :index "resource_events_status_idx"
+                             :index_keys ["status"]
+                             :type "btree"
+                             :unique? false
+                             :functional? false
+                             :is_partial false
+                             :primary? false
+                             :user "pdb_test"}
                 :same nil}
                {:left-only nil,
                 :right-only
@@ -2028,58 +2026,30 @@
       (fast-forward-to-migration! 81)
       (let [before-migration (schema-info-map *db*)
             exp-reports-indices-diff
-              [{:left-only
-                {:schema "public"
-                 :table "reports"
-                 :index "reports_hash_expr_idx"
-                 :index_keys ["encode(hash, 'hex'::text)"]
-                 :type "btree"
-                 :unique? true
-                 :functional? true
-                 :is_partial false
-                 :primary? false
-                 :user "pdb_test"}
-                :right-only nil
-                :same nil}
+              [{:left-only nil
+                :right-only {:index_keys [nil "producer_timestamp"]}
+                :same {:schema "public"
+                       :table "reports"
+                       :index "reports_hash_expr_idx"
+                       :index_keys ["encode(hash, 'hex'::text)"]
+                       :type "btree"
+                       :unique? true
+                       :functional? true
+                       :is_partial false
+                       :primary? false
+                       :user "pdb_test"}}
                {:left-only nil
-                :right-only
-                {:schema "public"
-                 :table "reports"
-                 :index "reports_hash_expr_idx"
-                 :index_keys ["encode(hash, 'hex'::text)" "producer_timestamp"]
-                 :type "btree"
-                 :unique? true
-                 :functional? true
-                 :is_partial false
-                 :primary? false
-                 :user "pdb_test"}
-                :same nil}
-               {:left-only
-                {:schema "public"
-                 :table "reports"
-                 :index "reports_pkey"
-                 :index_keys ["id"]
-                 :type "btree"
-                 :unique? true
-                 :functional? false
-                 :is_partial false
-                 :primary? true
-                 :user "pdb_test"}
-                :right-only nil
-                :same nil}
-               {:left-only nil
-                :right-only
-                {:schema "public"
-                 :table "reports"
-                 :index "reports_pkey"
-                 :index_keys ["id" "producer_timestamp"]
-                 :type "btree"
-                 :unique? true
-                 :functional? false
-                 :is_partial false
-                 :primary? true
-                 :user "pdb_test"}
-                :same nil}
+                :right-only {:index_keys [nil "producer_timestamp"]}
+                :same {:schema "public"
+                       :table "reports"
+                       :index "reports_pkey"
+                       :index_keys ["id"]
+                       :type "btree"
+                       :unique? true
+                       :functional? false
+                       :is_partial false
+                       :primary? true
+                       :user "pdb_test"}}
                {:left-only nil
                 :right-only
                 {:schema "public"
@@ -2174,7 +2144,20 @@
                  :is_partial false,
                  :primary? false,
                  :user "pdb_test"},
-                :same nil}],
+                :same nil}
+               {:left-only nil
+                :right-only
+                {:schema "public"
+                 :table "packages"
+                 :index "packages_name_trgm"
+                 :index_keys ["name"]
+                 :type "gin"
+                 :unique? false
+                 :functional? false
+                 :is_partial false
+                 :primary? false
+                 :user "pdb_test"}
+                :same nil}]
               :table-diff nil,
               :constraint-diff nil}
              (diff-schema-maps before-migration (schema-info-map *db*)))))))

--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -430,10 +430,10 @@ ORDER BY idx.indrelid :: REGCLASS, i.relname;")
   then the name of the index"
   [db]
   (jdbc/with-db-connection db
-    (let [indexes (sort-by (juxt :table :index_keys)
+    (let [indexes (sort-by (juxt :table :index)
                            (map db->index-map (jdbc/query-to-vec indexes-sql)))]
       (kitchensink/mapvals first
-                           (group-by (juxt :table :index_keys) indexes)))))
+                           (group-by (juxt :table :index) indexes)))))
 
 (def table-column-sql
   "SELECT c.table_name,

--- a/test/puppetlabs/puppetdb/testutils/db.clj
+++ b/test/puppetlabs/puppetdb/testutils/db.clj
@@ -7,7 +7,6 @@
             [clojure.test]
             [puppetlabs.puppetdb.cli.util :refer [err-exit-status]]
             [puppetlabs.puppetdb.cli.services :refer [validate-read-only-user]]
-            [puppetlabs.kitchensink.core :as kitchensink]
             [puppetlabs.puppetdb.config :as conf]
             [puppetlabs.puppetdb.jdbc :as jdbc]
             [puppetlabs.puppetdb.scf.migrate :refer [initialize-schema]]
@@ -430,10 +429,10 @@ ORDER BY idx.indrelid :: REGCLASS, i.relname;")
   then the name of the index"
   [db]
   (jdbc/with-db-connection db
-    (let [indexes (sort-by (juxt :table :index)
+    (let [index-key (juxt :table :index)
+          indexes (sort-by index-key
                            (map db->index-map (jdbc/query-to-vec indexes-sql)))]
-      (kitchensink/mapvals first
-                           (group-by (juxt :table :index) indexes)))))
+      (into {} (map (fn [v] [(index-key v) v])) indexes))))
 
 (def table-column-sql
   "SELECT c.table_name,
@@ -461,10 +460,10 @@ ORDER BY idx.indrelid :: REGCLASS, i.relname;")
   each PuppetDB created table+column in the database"
   [db]
   (jdbc/with-db-connection db
-    (let [tables (sort-by (juxt :table_name :column_name)
+    (let [table-key (juxt :table_name :column_name)
+          tables (sort-by table-key
                           (map db->table-map (jdbc/query-to-vec table-column-sql)))]
-      (kitchensink/mapvals first
-                           (group-by (juxt :table_name :column_name) tables)))))
+      (into {} (map (fn [v] [(table-key v) v])) tables))))
 
 (def constraints-sql
   "SELECT constraint_name,
@@ -498,11 +497,11 @@ ORDER BY idx.indrelid :: REGCLASS, i.relname;")
 (defn query-constraints
   [db]
   (jdbc/with-db-connection db
-    (let [constraints (sort-by (juxt :table_name :constraint_name)
+    (let [constraint-key (juxt :table_name :constraint_name)
+          constraints (sort-by constraint-key
                                (map db->constraint-map (concat (jdbc/query-to-vec constraints-sql)
                                                                (jdbc/query-to-vec check-constraints-sql))))]
-      (kitchensink/mapvals first
-                           (group-by (juxt :table_name :constraint_name) constraints)))))
+      (into {} (map (fn [v] [(constraint-key v) v])) constraints))))
 
 (defn schema-info-map [db-props]
   {:indexes (query-indexes db-props)


### PR DESCRIPTION
For most queries, the query engine will add an active nodes filter to
exclude deactivated and expired nodes from the results. Without this
index, that filter will generate a Seq Scan of the certnames table. If
that table is relatively small, and the write-rate of the database is
slow enough, the certnames table is almost entirely in the buffer cache
and the filter is quite quick. But when testing with a large number of
nodes, which creates a high write rate, the updating of the
latest_report_id dirties the certnames buffer cache pages quickly. If
queries are issued infrequently, the filter clause can create a lot of
reads and writes, which slow it down dramatically. This creates highly
variable query performance, in testing on 100,000 nodes it was as fast
as 80ms on repeated queries, and as slow as 16 seconds when issues
infrequently.

    ->  Seq Scan on certnames  (cost=0.00..82597.64 rows=1 width=10) (actual time=16869.675..16869.676 rows=0 loops=1)
          Filter: ((deactivated IS NOT NULL) OR (expired IS NOT NULL))
          Rows Removed by Filter: 100003
          Buffers: shared hit=427 read=80322 dirtied=10 written=45739

Add an index to sidestep the certnames table entirely.

    ->  Index Only Scan using certnames_not_active_idx on certnames  (cost=0.12..8.04 rows=1 width=10) (actual time=0.002..0.002 rows=0 loops=1)
          Heap Fetches: 0
          Buffers: shared hit=1

Not only did this stabilize the amount of time to query for active
nodes, it reduced the overall query time in a test install of 100,000
nodes from the at best 80ms above, to 0.4 to 1.6ms.