### PR TITLE
(PE-37632) unpin metrics

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -152,7 +152,7 @@
                  [puppetlabs/structured-logging]
                  [puppetlabs/trapperkeeper]
                  [com.puppetlabs/trapperkeeper-webserver-jetty10]
-                 [puppetlabs/trapperkeeper-metrics "2.0.1"]
+                 [puppetlabs/trapperkeeper-metrics]
                  [puppetlabs/trapperkeeper-status]
                  [puppetlabs/trapperkeeper-authorization]
 


### PR DESCRIPTION
With the recent update of clj-parent 7.3.7, the version of metrics is now managed along with the version of jetty. This removes the metrics pin as it is no longer appropriate.