### PR TITLE
(docs) Update Java version FAQ

### DIFF
--- a/documentation/puppetdb-faq.markdown
+++ b/documentation/puppetdb-faq.markdown
@@ -63,9 +63,8 @@ our team's previous experience with the language.
 
 ## Which versions of Java are supported?
 
-JDK 8 is officially supported, and JDK 10 is expected to work.  Other
-versions may work, and issues will be addressed on a best-effort
-basis, but support is not guaranteed.
+JDK 11 is officially supported. Other versions may work, and issues will be
+addressed on a best-effort basis, but support is not guaranteed.
 
 ## Which databases are supported?
 


### PR DESCRIPTION
This was missed when releasing 7.0.0, but has been the implemented reality (see 6a96dd05366229e9704de175a3b884404f025462) and documented requirement (see d778b926eae65c54aa37e761c4367b2df10afb08) since the first release in the 7 series.