### PR TITLE
(maint) Work around java install on older debian

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -874,6 +874,8 @@ EOS
       # Take new configuration file on debian to prevent tests from hanging
       # when this is used to upgrade puppet
       if get_os_family(database) == :debian
+        # Explicitly install ca-certificates-java before java to avoid error installing java on debian
+        database.install_package('ca-certificates-java')
         database.install_package('puppetserver', '-o Dpkg::Options::="--force-confnew"')
       else
         install_package(database, 'puppetserver')


### PR DESCRIPTION
There seems to have been a regression whereby installing java as part of puppetserver deps fails due to a file not being found from ca-certificates-java similar to https://github.com/adoptium/installer/issues/105 . This commit explicitly installs ca-certificates-java before installing puppetserver to work around the issue.