### PR TITLE
Log obsolete cmd message with producer_timestamp

### DIFF
--- a/test/puppetlabs/puppetdb/command_test.clj
+++ b/test/puppetlabs/puppetdb/command_test.clj
@@ -78,6 +78,7 @@
             [puppetlabs.trapperkeeper.services
              :refer [service-context]]
             [puppetlabs.puppetdb.client :as client]
+            [puppetlabs.stockpile.queue :as stock]
             [puppetlabs.puppetdb.threadpool :as pool])
   (:import
    (clojure.lang ExceptionInfo)
@@ -1627,6 +1628,8 @@
       (svc-utils/with-puppetdb-instance
         (let [{pdb-host :host pdb-port :port
                :or {pdb-host "127.0.0.1" pdb-port 8080}} (:jetty (get-config))
+              pdb (get-service svc-utils/*server* :PuppetDBServer)
+              q (:q (cli-svc/shared-globals pdb))
               base-url (utils/pdb-cmd-base-url pdb-host pdb-port :v1)
               facts {:certname "foo.com"
                      :environment "test"
@@ -1662,7 +1665,10 @@
 
             ;; check the first command was "bashed"
             (is (= #{{:id 0 :delete? true} {:id 1 :delete? nil}}
-                   (set (map #(select-keys % [:id :delete?]) val))))))))))
+                   (set (map #(select-keys % [:id :delete?]) val))))
+
+            ;; check that all commands removed from stockpile
+            (is (= 0 (stock/reduce q (fn [acc _] (inc acc)) 0)))))))))
 
 (deftest command-service-stats
   (svc-utils/with-puppetdb-instance


### PR DESCRIPTION
cmdref only represents the stockpile metadata about a command. To keep the timestamps distinct, its :producer_timestamp field is actually named :producer-ts, so this was always nil. It is also optional, so we need to pull the producer_timestamp out of the command body where it is not optional. Except for the deactivate node command, so we also need to provide a fallback.

Reviewing this PR with whitespace-only changes hidden is much easier.