### PR TITLE
(PDB-5743) Fix join-deps for latest_report_status

### DIFF
--- a/documentation/release_notes_8.markdown
+++ b/documentation/release_notes_8.markdown
@@ -12,6 +12,19 @@ canonical: "/puppetdb/latest/release_notes.html"
 
 # PuppetDB: Release notes
 
+## PuppetDB 8.5.1
+
+Released TBD.
+
+### Bug fixes
+
+* Fix an error when querying for `nodes` and `latest_report_status`
+  [GitHub #3966](https://github.com/puppetlabs/puppetdb/issues/3966)
+
+### Contributors
+
+Austin Blatt and ...
+
 ## PuppetDB 8.5.0
 
 Released April 11 2024

--- a/src/puppetlabs/puppetdb/query_eng/engine.clj
+++ b/src/puppetlabs/puppetdb/query_eng/engine.clj
@@ -353,7 +353,7 @@
                  "latest_report_status" {:type :string
                                          :queryable? true
                                          :field :report_statuses.status
-                                         :join-deps #{:report_statuses :reports}}
+                                         :join-deps #{:certnames :report_statuses :reports}}
                  "latest_report_corrective_change" {:type :boolean
                                                     :queryable? true
                                                     :field :reports.corrective_change

--- a/test/puppetlabs/puppetdb/http/nodes_test.clj
+++ b/test/puppetlabs/puppetdb/http/nodes_test.clj
@@ -123,7 +123,9 @@
     (testing "querying on latest report status works"
       (is-query-result' ["=" "latest_report_status" "success"] [])
       (is-query-result' ["=" "latest_report_status" "failure"] [])
-      (is-query-result' ["=" "latest_report_status" "unchanged"] [web1 db puppet]))
+      (is-query-result' ["=" "latest_report_status" "unchanged"] [web1 db puppet])
+      (is (= #{{:latest_report_status nil} {:latest_report_status "unchanged"}}
+             (query-result method endpoint ["extract" ["latest_report_status"]]))))
 
     (testing "querying on latest report noop works"
       (is-query-result' ["=" "latest_report_noop" true] [])


### PR DESCRIPTION
Without another reference to a field that depends on the certnames table, a query for latest_report_status will fail with the error.

    ERROR: missing FROM-clause entry for table "certnames"

latest_report_status needs the certnames table in order to know the latest_report_id that it needs to join against the reports table.

Fixes #3966