### PR TITLE
(maint) Update #location_for method to reflect RE usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,13 +10,13 @@ rescue Errno::ENOENT
   puppet_ref = File.read(gemfile_home + '/ext/test-conf/puppet-ref-default').strip
 end
 
-def location_for(place, fake_version = nil)
-  if place =~ /^(git:[^#]*)#(.*)/
-    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+def location_for(place)
+  if place =~ /^(git[:@][^#]*)#(.*)/
+    [{ git: $1, branch: $2, require: false }]
   elsif place =~ /^file:\/\/(.*)/
-    ['>= 0', { :path => File.expand_path($1), :require => false }]
+    ['>= 0', { path: File.expand_path($1), require: false }]
   else
-    [place, { :require => false }]
+    [place, { require: false }]
   end
 end
 


### PR DESCRIPTION
When I set
PACKAGING_LOCATION=git@github.com:e-gris/packaging.git#RE-16109, and
ran `bundle install` I got:

```
$ bundle install

[!] There was an error parsing `Gemfile`: Illformed requirement ["git@github.com:e-gris/packaging.git#RE-16109"]. Bundler cannot continue.

 #  from /home/eric_griswold/git/puppetlabs/puppetdb/Gemfile:25
 #  -------------------------------------------
 #  gem 'rake'
 >  gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
 #
 #  -------------------------------------------
```

Replacing that method with a copy we have elsewhere (vanagon, in this
case), I was able to set PACKAGING_LOCATION:

```
$ bundle install
[[ ... ]]
Using packaging 0 from git@github.com:e-gris/packaging.git (at
RE-16109@a8bb131)
```