### PR TITLE
(PDB-5768) Revert conflicting pins for now

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -131,7 +131,7 @@
   :dependencies [[org.postgresql/postgresql]
                  [org.clojure/clojure]
                  [org.clojure/core.async]
-                 [org.clojure/core.match "1.1.0"]
+                 [org.clojure/core.match "0.3.0-alpha4"]
                  [org.clojure/core.memoize]
                  [org.clojure/data.generators "1.1.0"]
                  [org.clojure/java.jdbc]

--- a/project.clj
+++ b/project.clj
@@ -162,7 +162,7 @@
                  [com.rpl/specter "1.1.4"]
                  [com.github.seancorfield/next.jdbc "1.3.939"]
                  [com.taoensso/nippy :exclusions [org.tukaani/xz]]
-                 [digest "1.4.10"]
+                 [digest "1.4.3"]
                  [fast-zip "0.4.0"]
                  [instaparse]
                  [murphy "0.5.2"]

--- a/project.clj
+++ b/project.clj
@@ -137,7 +137,7 @@
                  [org.clojure/java.jdbc]
                  [org.clojure/tools.macro]
                  [org.clojure/tools.namespace]
-                 [org.clojure/math.combinatorics "0.3.0"]
+                 [org.clojure/math.combinatorics "0.1.1"]
                  [org.clojure/tools.logging]
                  [org.clojure/tools.nrepl]
 


### PR DESCRIPTION
These upgrades conflicted with pins elsewhere, e.g. digest in kitchensink, so revert them until we can revisit a broader upgrade (and related migrations to clj-parent).