### PR TITLE
(PDB-5782): Updated ezbake build version to support debian-12-x86_64 build for puppetdb

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -281,7 +281,7 @@
                                                ;; in the final package.
                                                [puppetlabs/puppetdb ~pdb-version]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "2.5.5"]]}
+                      :plugins [[puppetlabs/lein-ezbake "2.6.2"]]}
              :testutils {:source-paths ^:replace ["test"]
                          :resource-paths ^:replace []
                          ;; Something else may need adjustment, but


### PR DESCRIPTION
Updated ezbake (via PR https://github.com/puppetlabs/ezbake/pull/629) build version from 2.5.5 to [2.6.2](https://repo.clojars.org/puppetlabs/lein-ezbake/2.6.2/), as this newer version includes the support for debian-12-x86_64.

This will be used to build puppetdb for debian-12-x86_64