### PR TITLE
Add configuration options to filter facts out in puppetdb termini

### DIFF
--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -31,6 +31,18 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
           package_inventory = inventory['packages'] if inventory.respond_to?(:keys)
           facts.values.delete('_puppet_inventory_1')
 
+          fact_names_blocklist = Puppet::Util::Puppetdb.config.fact_names_blocklist
+
+          fact_names_blocklist.each{|blocklisted_fact_name|
+            facts.values.delete(blocklisted_fact_name)
+          }
+
+          fact_names_blocklist_regexps = Puppet::Util::Puppetdb.config.fact_names_blocklist_regex
+
+          fact_names_blocklist_regexps.each{|blocklisted_fact_name_regexp_str|
+            facts.values.reject!{|k,v| k =~ Regexp.new(blocklisted_fact_name_regexp_str)}
+          }
+
           payload_value = {
             "certname" => facts.name,
             "values" => facts.values,

--- a/puppet/lib/puppet/util/puppetdb/config.rb
+++ b/puppet/lib/puppet/util/puppetdb/config.rb
@@ -18,7 +18,9 @@ module Puppet::Util::Puppetdb
         :submit_only_server_urls     => "",
         :command_broadcast           => false,
         :sticky_read_failover        => false,
-        :verify_client_certificate   => true
+        :verify_client_certificate   => true,
+        :fact_names_blocklist        => "",
+        :fact_names_blocklist_regex  => ""
       }
 
       config_file ||= File.join(Puppet[:confdir], "puppetdb.conf")
@@ -71,7 +73,9 @@ module Puppet::Util::Puppetdb
            :submit_only_server_urls,
            :command_broadcast,
            :sticky_read_failover,
-           :verify_client_certificate].include?(k))
+           :verify_client_certificate,
+           :fact_names_blocklist,
+           :fact_names_blocklist_regex].include?(k))
       end
 
       parsed_urls = config_hash[:server_urls].split(",").map {|s| s.strip}
@@ -107,6 +111,10 @@ module Puppet::Util::Puppetdb
         raise "min_successful_submissions (#{config_hash[:min_successful_submissions]}) must be less than "\
           "or equal to the number of server_urls (#{config_hash[:server_urls].length})"
       end
+
+      config_hash[:fact_names_blocklist] = config_hash[:fact_names_blocklist].split(",").map {|s| s.strip}
+
+      config_hash[:fact_names_blocklist_regex] = config_hash[:fact_names_blocklist_regex].split(",").map {|s| s.strip}
 
       self.new(config_hash)
     rescue => detail
@@ -158,6 +166,14 @@ module Puppet::Util::Puppetdb
 
     def verify_client_certificate
       config[:verify_client_certificate]
+    end
+
+    def fact_names_blocklist
+      config[:fact_names_blocklist]
+    end
+
+    def fact_names_blocklist_regex
+      config[:fact_names_blocklist_regex]
     end
 
     # @!group Private instance methods


### PR DESCRIPTION
This changeset adds two configuration options used by the facts PuppetDB indirector:

  * fact_names_blocklist
  * fact_names_blocklist_regex

They can be used to configure a list of fact names that will never be sent to PuppetDB, based on exact fact names or regular expressions.

This MR obsoletes - https://github.com/puppetlabs/puppetdb/pull/2634