### PR TITLE
(PDB-5794): Updated ezbake build version to support debian-12-x86_64 build for puppetdb in 7.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ if ENV['NO_ACCEPTANCE'] != 'true'
       # use the pinned version
       gem 'beaker', '~> 4.1'
     end
-    gem 'beaker-hostgenerator', '~> 2.2.3'
+    gem 'beaker-hostgenerator', '~> 2.4'
     gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.2')
     gem 'beaker-vmpooler', *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1.3")
     gem 'beaker-puppet', '~> 1.0'

--- a/project.clj
+++ b/project.clj
@@ -313,7 +313,7 @@
                                                ;; in the final package.
                                                [puppetlabs/puppetdb ~pdb-version :exclusions [com.zaxxer/HikariCP]]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "2.5.5"]]}
+                      :plugins [[puppetlabs/lein-ezbake "2.6.2"]]}
              :testutils {:source-paths ^:replace ["test"]
                          :resource-paths ^:replace []
                          ;; Something else may need adjustment, but


### PR DESCRIPTION
Updated ezbake build version to support debian-12-x86_64 build for puppetdb in 7.x