### PR TITLE
Allow blocking structured facts

### DIFF
--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -16,6 +16,23 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
     trusted.to_h
   end
 
+  def filter_facts(obj, blacklist, blacklist_regexps, path = [])
+    regexps = blacklist_regexps.map { |re| Regexp.new(re) }
+    case obj
+    when Hash
+      obj.each_with_object({}) do |(k, v), h|
+        full_path = (path + [k]).join('.')
+        excluded = blacklist.include?(full_path) || regexps.any? { |re| full_path =~ re }
+        next if excluded
+        h[k] = filter_facts(v, blacklist, blacklist_regexps, path + [k])
+      end
+    when Array
+      obj.map.with_index { |v, i| filter_facts(v, blacklist, blacklist_regexps, path + [i.to_s]) }
+    else
+      obj
+    end
+  end
+
   def save(request)
     profile("facts#save", [:puppetdb, :facts, :save, request.key]) do
       current_time = Time.now
@@ -30,6 +47,19 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
           inventory = facts.values['_puppet_inventory_1']
           package_inventory = inventory['packages'] if inventory.respond_to?(:keys)
           facts.values.delete('_puppet_inventory_1')
+
+          fact_names_blacklist = Puppet::Util::Puppetdb.config.fact_names_blacklist
+
+          fact_names_blacklist.each{|blacklisted_fact_name|
+            facts.values.delete(blacklisted_fact_name)
+          }
+
+          fact_names_blacklist_regexps = Puppet::Util::Puppetdb.config.fact_names_blacklist_regex
+          facts.values = filter_facts(
+            facts.values,
+            fact_names_blacklist,
+            fact_names_blacklist_regexps
+          )
 
           payload_value = {
             "certname" => facts.name,

--- a/puppet/lib/puppet/util/puppetdb/config.rb
+++ b/puppet/lib/puppet/util/puppetdb/config.rb
@@ -18,7 +18,9 @@ module Puppet::Util::Puppetdb
         :submit_only_server_urls     => "",
         :command_broadcast           => false,
         :sticky_read_failover        => false,
-        :verify_client_certificate   => true
+        :verify_client_certificate   => true,
+        :fact_names_blacklist       => "",
+        :fact_names_blacklist_regex => ""
       }
 
       config_file ||= File.join(Puppet[:confdir], "puppetdb.conf")
@@ -71,7 +73,9 @@ module Puppet::Util::Puppetdb
            :submit_only_server_urls,
            :command_broadcast,
            :sticky_read_failover,
-           :verify_client_certificate].include?(k))
+           :verify_client_certificate,
+           :fact_names_blacklist,
+           :fact_names_blacklist_regex].include?(k))
       end
 
       parsed_urls = config_hash[:server_urls].split(",").map {|s| s.strip}
@@ -107,6 +111,10 @@ module Puppet::Util::Puppetdb
         raise "min_successful_submissions (#{config_hash[:min_successful_submissions]}) must be less than "\
           "or equal to the number of server_urls (#{config_hash[:server_urls].length})"
       end
+
+      config_hash[:fact_names_blacklist] = config_hash[:fact_names_blacklist].split(",").map {|s| s.strip}
+
+      config_hash[:fact_names_blacklist_regex] = config_hash[:fact_names_blacklist_regex].split(",").map {|s| s.strip}
 
       self.new(config_hash)
     rescue => detail
@@ -159,6 +167,15 @@ module Puppet::Util::Puppetdb
     def verify_client_certificate
       config[:verify_client_certificate]
     end
+
+    def fact_names_blacklist
+      config[:fact_names_blacklist]
+    end
+
+    def fact_names_blacklist_regex
+      config[:fact_names_blacklist_regex]
+    end
+
 
     # @!group Private instance methods
 


### PR DESCRIPTION
This patch works as well for structured facts, not like https://github.com/puppetlabs/puppetdb/pull/3998

This changeset adds two configuration options used by the facts PuppetDB indirector:

    fact_names_blocklist
    fact_names_blocklist_regex

They can be used to configure a list of fact names that will never be sent to PuppetDB, based on exact fact names or regular expressions.

This PR obsoletes: https://github.com/puppetlabs/puppetdb/pull/3998